### PR TITLE
Fix agent type mismatches and tool wrappers

### DIFF
--- a/convex/domains/agents/fastAgentPanelStreaming.ts
+++ b/convex/domains/agents/fastAgentPanelStreaming.ts
@@ -1757,7 +1757,7 @@ export const sendMessageInternal = internalAction({
     // Now we can safely access the results
     let responseText = await streamResult.text;
     const toolCalls = await streamResult.toolCalls;
-    let toolResults = await streamResult.toolResults;
+    let toolResults: any[] = (await streamResult.toolResults) ?? [];
 
     console.log('[sendMessageInternal] Text received, length:', responseText.length);
     console.log('[sendMessageInternal] Tool calls:', toolCalls?.length || 0);
@@ -1803,7 +1803,7 @@ export const sendMessageInternal = internalAction({
       await forced.consumeStream();
 
       const forcedCalls = await forced.toolCalls;
-      const forcedResults = await forced.toolResults;
+      const forcedResults = (await forced.toolResults) ?? [];
       const forcedText = await forced.text;
 
       if (forcedCalls) {
@@ -1846,7 +1846,7 @@ export const sendMessageInternal = internalAction({
         await strict.consumeStream();
 
         const strictCalls = await strict.toolCalls;
-        const strictResults = await strict.toolResults;
+        const strictResults = (await strict.toolResults) ?? [];
         const strictText = await strict.text;
 
         if (strictCalls) {
@@ -1976,7 +1976,7 @@ export const sendMessageInternal = internalAction({
 
       const forcedText = await forcedResult.text;
       const forcedToolCalls = await forcedResult.toolCalls;
-      const forcedToolResults = await forcedResult.toolResults;
+      const forcedToolResults = (await forcedResult.toolResults) ?? [];
 
       if (forcedToolCalls) {
         for (const call of forcedToolCalls) {

--- a/convex/domains/documents/fileSearch.ts
+++ b/convex/domains/documents/fileSearch.ts
@@ -28,7 +28,7 @@ async function ensureStoreForUser(ctx: any, userId: Id<"users">): Promise<string
     config: { displayName }
   });
 
-  const storeName = fileSearchStore.name;
+  const storeName = fileSearchStore.name || displayName;
 
   await ctx.runMutation(internal.fileSearchData.createFileSearchStore, {
     userId,

--- a/convex/fast_agents/delegation/delegationTools.ts
+++ b/convex/fast_agents/delegation/delegationTools.ts
@@ -349,14 +349,16 @@ The EntityResearchAgent has specialized tools for deep enrichment and will retur
         const threadId = await ensureThreadHelper(agent, ctx, task.threadId);
 
         try {
-          const result: any = await runWithTimeout(agent.generateText(
+          const generation = agent.generateText(
             { ...ctx, depth: nextDepth } as any,
             { threadId, userId: pickUserIdHelper(ctx) },
             {
               prompt: task.query,
               stopWhen: stepCountIs(8), // Slightly lower limit for parallel tasks
             }
-          ));
+          ) as Promise<any>;
+
+          const result: any = await runWithTimeout<any>(generation);
 
           return {
             task: task.query,

--- a/convex/fast_agents/subagents/sec_subagent/secAgent.ts
+++ b/convex/fast_agents/subagents/sec_subagent/secAgent.ts
@@ -8,9 +8,11 @@
  * - Regulatory compliance research
  */
 
-import { Agent, stepCountIs } from "@convex-dev/agent";
+import { Agent, createTool, stepCountIs } from "@convex-dev/agent";
 import { openai } from "@ai-sdk/openai";
 import { components } from "../../../_generated/api";
+import { internal } from "../../../_generated/api";
+import { z } from "zod";
 
 // Import SEC-specific tools
 import {
@@ -18,7 +20,16 @@ import {
   downloadSecFiling,
   getCompanyInfo,
 } from "./tools/secFilingTools";
-import { searchSecCompanies } from "./tools/secCompanySearch";
+
+const searchSecCompaniesTool = createTool({
+  description: "Find SEC companies by name and return potential matches with CIK, name, and ticker.",
+  args: z.object({
+    companyName: z.string().describe("Company name to search for"),
+  }),
+  handler: async (ctx, args) => {
+    return ctx.runAction(internal.tools.secCompanySearch.searchCompanies, args);
+  },
+});
 
 /**
  * Create an SEC Agent instance
@@ -102,7 +113,7 @@ Always structure responses with:
       searchSecFilings,
       downloadSecFiling,
       getCompanyInfo,
-      searchSecCompanies,
+      searchSecCompanies: searchSecCompaniesTool,
     },
     stopWhen: stepCountIs(8),
   });


### PR DESCRIPTION
## Summary
- default tool results arrays when streaming agent responses to align with expected types
- ensure file search store names always resolve to a string fallback
- wrap SEC company search action in a tool and loosen delegated agent generation typing to resolve type errors

## Testing
- npx eslint convex/domains/agents/fastAgentPanelStreaming.ts convex/domains/documents/fileSearch.ts convex/fast_agents/delegation/delegationTools.ts convex/fast_agents/subagents/sec_subagent/secAgent.ts (fails: existing lint errors unrelated to changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69238293caac8324ae055593c16c9b37)