### PR TITLE
Add canonical entity graph and company dossier card workspace

### DIFF
--- a/apps/api-headless/src/app.ts
+++ b/apps/api-headless/src/app.ts
@@ -13,6 +13,7 @@ import replayRouter from "./routes/replay.js";
 import searchRouter from "./routes/search.js";
 import fetchRouter from "./routes/fetch.js";
 import researchRouter from "./routes/research.js";
+import resourcesRouter from "./routes/resources.js";
 import passportsRouter from "./routes/passports.js";
 import receiptsRouter from "./routes/receipts.js";
 import investigationsRouter from "./routes/investigations.js";
@@ -52,6 +53,7 @@ export function createApp() {
   app.use("/v1/search", searchRouter);
   app.use("/v1/fetch", fetchRouter);
   app.use("/v1/research", researchRouter);
+  app.use("/v1/resources", resourcesRouter);
   app.use("/v2/passports", passportsRouter);
   app.use("/v2/receipts", receiptsRouter);
   app.use("/v2/investigations", investigationsRouter);

--- a/apps/api-headless/src/lib/convex-client.ts
+++ b/apps/api-headless/src/lib/convex-client.ts
@@ -321,3 +321,15 @@ export async function runConvexAction<T = any>(
   }
   return result.data as T;
 }
+
+// Generic query caller for read-only endpoints (e.g. resources/expand).
+export async function runConvexQuery<T = any>(
+  fnPath: string,
+  args: Record<string, unknown>
+): Promise<T> {
+  const result = await convexCall<T>(fnPath, args, "query");
+  if (!result.ok) {
+    throw new Error(result.error || "Convex query failed");
+  }
+  return result.data as T;
+}

--- a/apps/api-headless/src/routes/resources.ts
+++ b/apps/api-headless/src/routes/resources.ts
@@ -1,0 +1,94 @@
+/**
+ * Resources API (v1)
+ *
+ * POST /v1/resources/expand — expand a Nodebench resource URI by one ring
+ *                             using the requested lens + depth.
+ *
+ * Thin adapter over the Convex `domains/research/expandResource:expand`
+ * query. Returns ExpandResponse shaped per shared/research/resourceCards.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { runConvexQuery } from "../lib/convex-client.js";
+
+const router = Router();
+
+const expandRequestSchema = z.object({
+  uri: z.string().min(1).max(500),
+  expand_mode: z
+    .enum(["ring_plus_one", "ring_two", "single_card"])
+    .optional()
+    .default("ring_plus_one"),
+  lens_id: z.string().optional().default("company_dossier"),
+  depth: z.enum(["quick", "standard"]).optional().default("standard"),
+  constraints: z
+    .object({
+      prefer_cache: z.boolean().optional().default(true),
+      latency_budget_ms: z.number().int().min(200).max(30_000).optional().default(2_000),
+    })
+    .optional(),
+});
+
+function parseNodebenchUri(
+  uri: string,
+): { kind: string; path: string } | null {
+  const m = uri.match(/^nodebench:\/\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  return { kind: m[1], path: m[2] };
+}
+
+// ── POST /v1/resources/expand ──────────────────────────────────────────────
+router.post("/expand", async (req: Request, res: Response) => {
+  try {
+    const parsed = expandRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "invalid_request",
+        issues: parsed.error.issues,
+      });
+    }
+    const args = parsed.data;
+    const uri = parseNodebenchUri(args.uri);
+    if (!uri) {
+      return res.status(400).json({
+        error: "invalid_uri",
+        message:
+          "URI must be of the form nodebench://{kind}/{id}. See docs/UNIVERSAL_RESEARCH_API.md.",
+      });
+    }
+    // v1 accepts org/company URIs only (matches company_dossier lens scope).
+    if (uri.kind !== "org" && uri.kind !== "company") {
+      return res.status(400).json({
+        error: "unsupported_uri_kind",
+        message:
+          "v1 resources/expand supports org/company URIs only. Other kinds ship in v2.",
+        acceptedKinds: ["org", "company"],
+      });
+    }
+
+    const result = await runConvexQuery(
+      "domains/research/expandResource:expand",
+      {
+        entityKey: uri.path,
+        lensId: args.lens_id,
+        depth: args.depth,
+      },
+    );
+    if (result?.status === "not_found") {
+      return res.status(404).json({
+        error: "entity_not_found",
+        rootUri: args.uri,
+      });
+    }
+    return res.status(200).json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    return res.status(502).json({
+      error: "convex_call_failed",
+      message,
+    });
+  }
+});
+
+export default router;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -963,6 +963,7 @@ import type * as domains_research_entities_decayManager from "../domains/researc
 import type * as domains_research_entities_entityLifecycle from "../domains/research/entities/entityLifecycle.js";
 import type * as domains_research_entities_index from "../domains/research/entities/index.js";
 import type * as domains_research_executiveBrief from "../domains/research/executiveBrief.js";
+import type * as domains_research_expandResource from "../domains/research/expandResource.js";
 import type * as domains_research_financial_balanceSheetFetcher from "../domains/research/financial/balanceSheetFetcher.js";
 import type * as domains_research_financial_corporateActions from "../domains/research/financial/corporateActions.js";
 import type * as domains_research_financial_corrections from "../domains/research/financial/corrections.js";
@@ -1002,8 +1003,10 @@ import type * as domains_research_forecasting_signalMatcher from "../domains/res
 import type * as domains_research_forecasting_traceWrapper from "../domains/research/forecasting/traceWrapper.js";
 import type * as domains_research_forecasting_validators from "../domains/research/forecasting/validators.js";
 import type * as domains_research_githubExplorer from "../domains/research/githubExplorer.js";
+import type * as domains_research_hydrateEntities from "../domains/research/hydrateEntities.js";
 import type * as domains_research_index from "../domains/research/index.js";
 import type * as domains_research_jobResearchAction from "../domains/research/jobResearchAction.js";
+import type * as domains_research_lensRegistry from "../domains/research/lensRegistry.js";
 import type * as domains_research_modelComparison from "../domains/research/modelComparison.js";
 import type * as domains_research_modelComparisonQueries from "../domains/research/modelComparisonQueries.js";
 import type * as domains_research_narrative_actions_competingExplanations from "../domains/research/narrative/actions/competingExplanations.js";
@@ -2384,6 +2387,7 @@ declare const fullApi: ApiFromModules<{
   "domains/research/entities/entityLifecycle": typeof domains_research_entities_entityLifecycle;
   "domains/research/entities/index": typeof domains_research_entities_index;
   "domains/research/executiveBrief": typeof domains_research_executiveBrief;
+  "domains/research/expandResource": typeof domains_research_expandResource;
   "domains/research/financial/balanceSheetFetcher": typeof domains_research_financial_balanceSheetFetcher;
   "domains/research/financial/corporateActions": typeof domains_research_financial_corporateActions;
   "domains/research/financial/corrections": typeof domains_research_financial_corrections;
@@ -2423,8 +2427,10 @@ declare const fullApi: ApiFromModules<{
   "domains/research/forecasting/traceWrapper": typeof domains_research_forecasting_traceWrapper;
   "domains/research/forecasting/validators": typeof domains_research_forecasting_validators;
   "domains/research/githubExplorer": typeof domains_research_githubExplorer;
+  "domains/research/hydrateEntities": typeof domains_research_hydrateEntities;
   "domains/research/index": typeof domains_research_index;
   "domains/research/jobResearchAction": typeof domains_research_jobResearchAction;
+  "domains/research/lensRegistry": typeof domains_research_lensRegistry;
   "domains/research/modelComparison": typeof domains_research_modelComparison;
   "domains/research/modelComparisonQueries": typeof domains_research_modelComparisonQueries;
   "domains/research/narrative/actions/competingExplanations": typeof domains_research_narrative_actions_competingExplanations;

--- a/convex/domains/research/expandResource.ts
+++ b/convex/domains/research/expandResource.ts
@@ -1,0 +1,234 @@
+/**
+ * expandResource — ring-bounded expansion of a canonical entity.
+ *
+ * Reads from the canonical entity graph:
+ *   intelligenceEntities + entityAliases + edges + claims + claimEvidence
+ *
+ * Returns a ResourceCard[] + evidence + nextHops shaped to `ExpandResponse`
+ * from shared/research/resourceCards.ts. The API route is a thin adapter.
+ *
+ * Bounds (BOUND rule, agentic_reliability.md):
+ *   - hard cap of 60 cards per call
+ *   - hard cap of 80 edges traversed per call
+ *   - hard cap of 40 evidence rows per call
+ */
+
+import { query } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { v } from "convex/values";
+import { COMPANY_DOSSIER_LENS, getLensTemplate } from "./lensRegistry";
+
+const HARD_CARD_CAP = 60;
+const HARD_EDGE_CAP = 80;
+const HARD_EVIDENCE_CAP = 40;
+
+function entityUri(kind: string, id: string): string {
+  // intelligenceEntities.entityType values map onto URI kinds.
+  const uriKind =
+    kind === "person"
+      ? "person"
+      : kind === "product"
+      ? "product"
+      : "org";
+  return `nodebench://${uriKind}/${id}`;
+}
+
+function companySlugToUri(slug: string): string {
+  return `nodebench://org/${slug}`;
+}
+
+export const expand = query({
+  args: {
+    entityKey: v.optional(v.string()),
+    entityId: v.optional(v.id("intelligenceEntities")),
+    lensId: v.optional(v.string()),
+    depth: v.optional(v.union(v.literal("quick"), v.literal("standard"))),
+  },
+  handler: async (ctx, { entityKey, entityId, lensId, depth }) => {
+    const resolvedDepth = depth ?? "standard";
+    const lens = getLensTemplate((lensId as any) ?? "company_dossier")
+      ?? COMPANY_DOSSIER_LENS;
+
+    // Resolve root entity ----------------------------------------------------
+    let root: Doc<"intelligenceEntities"> | null = null;
+    if (entityId) {
+      root = await ctx.db.get(entityId);
+    } else if (entityKey) {
+      root = await ctx.db
+        .query("intelligenceEntities")
+        .withIndex("by_entity_key", (q) => q.eq("entityKey", entityKey))
+        .unique();
+    }
+    if (!root) {
+      return {
+        rootUri: "nodebench://org/unknown",
+        lensId: lens.id,
+        depth: resolvedDepth,
+        cards: [],
+        evidence: [],
+        nextHops: [],
+        builtAt: Date.now(),
+        fromCache: false,
+        status: "not_found" as const,
+      };
+    }
+
+    const rootUri = companySlugToUri(root.entityKey);
+
+    // Collect outgoing + incoming edges, bounded ----------------------------
+    const outgoing = await ctx.db
+      .query("edges")
+      .withIndex("by_from_rel", (q) => q.eq("fromId", root._id))
+      .take(HARD_EDGE_CAP);
+    const budgetRemaining = Math.max(0, HARD_EDGE_CAP - outgoing.length);
+    const incoming = budgetRemaining > 0
+      ? await ctx.db
+          .query("edges")
+          .withIndex("by_to_rel", (q) => q.eq("toId", root._id))
+          .take(budgetRemaining)
+      : [];
+
+    // Group neighbours per layer per the lens relationWhitelist -------------
+    type NeighborInfo = {
+      entity: Doc<"intelligenceEntities">;
+      via: { direction: "out" | "in"; relationType: string; confidence: number };
+    };
+
+    const neighbourById = new Map<Id<"intelligenceEntities">, NeighborInfo>();
+
+    for (const e of outgoing) {
+      const neighbour = await ctx.db.get(e.toId);
+      if (!neighbour) continue;
+      if (!neighbourById.has(neighbour._id)) {
+        neighbourById.set(neighbour._id, {
+          entity: neighbour,
+          via: {
+            direction: "out",
+            relationType: e.relationType,
+            confidence: e.confidence,
+          },
+        });
+      }
+    }
+    for (const e of incoming) {
+      const neighbour = await ctx.db.get(e.fromId);
+      if (!neighbour) continue;
+      if (!neighbourById.has(neighbour._id)) {
+        neighbourById.set(neighbour._id, {
+          entity: neighbour,
+          via: {
+            direction: "in",
+            relationType: e.relationType,
+            confidence: e.confidence,
+          },
+        });
+      }
+    }
+
+    // Emit cards ------------------------------------------------------------
+    const cards: Array<Record<string, unknown>> = [];
+
+    // Root card always first.
+    cards.push({
+      cardId: `card-${root._id}`,
+      uri: rootUri,
+      kind: "org_summary",
+      title: root.canonicalName,
+      subtitle: root.sector ?? undefined,
+      summary: root.description ?? "",
+      chips: [
+        { label: root.entityType, tone: "default" as const },
+        ...(root.status !== "active"
+          ? [{ label: root.status, tone: "warn" as const }]
+          : []),
+      ],
+      keyFacts: [
+        ...(root.foundedYear ? [`Founded ${root.foundedYear}`] : []),
+        ...(root.headquarters ? [`HQ: ${root.headquarters}`] : []),
+      ],
+      nextHops: [],
+      confidence: 1,
+    });
+
+    // Per-layer cards respecting maxItems per layer.
+    const perLayerCounts = new Map<string, number>();
+    for (const layer of lens.layers) {
+      perLayerCounts.set(layer.id, 0);
+    }
+
+    for (const info of neighbourById.values()) {
+      if (cards.length >= HARD_CARD_CAP) break;
+      for (const layer of lens.layers) {
+        const layerCount = perLayerCounts.get(layer.id) ?? 0;
+        if (layerCount >= layer.maxItems) continue;
+        if (!layer.allowedEntityTypes.includes(info.entity.entityType)) continue;
+        if (!layer.relationWhitelist.includes(info.via.relationType)) continue;
+
+        cards.push({
+          cardId: `card-${info.entity._id}`,
+          uri: entityUri(info.entity.entityType, info.entity.entityKey),
+          kind:
+            info.entity.entityType === "person"
+              ? "person_summary"
+              : info.entity.entityType === "product"
+              ? "product_summary"
+              : "org_summary",
+          title: info.entity.canonicalName,
+          subtitle: info.via.relationType.replaceAll("_", " ").toLowerCase(),
+          summary: info.entity.description ?? "",
+          chips: [
+            { label: layer.label, tone: "accent" as const },
+            { label: info.entity.entityType, tone: "default" as const },
+          ],
+          nextHops: [],
+          confidence: info.via.confidence,
+        });
+        perLayerCounts.set(layer.id, layerCount + 1);
+        break;
+      }
+    }
+
+    // Evidence ring --------------------------------------------------------
+    const topClaims = await ctx.db
+      .query("claims")
+      .withIndex("by_subject", (q) => q.eq("subjectEntityId", root._id))
+      .take(20);
+
+    const evidence: Array<Record<string, unknown>> = [];
+    for (const c of topClaims) {
+      if (evidence.length >= HARD_EVIDENCE_CAP) break;
+      const evs = await ctx.db
+        .query("claimEvidence")
+        .withIndex("by_claim", (q) => q.eq("claimId", c._id))
+        .take(Math.max(1, HARD_EVIDENCE_CAP - evidence.length));
+      for (const ev of evs) {
+        evidence.push({
+          claim: c.literalValue ?? `${c.predicate}`,
+          uri: ev.url
+            ? `nodebench://artifact/${ev.url}`
+            : `nodebench://artifact/${ev._id}`,
+          confidence: c.confidence,
+        });
+        if (evidence.length >= HARD_EVIDENCE_CAP) break;
+      }
+    }
+
+    // Next hops = up to 12 highest-confidence neighbours not already carded
+    const nextHops = Array.from(neighbourById.values())
+      .sort((a, b) => b.via.confidence - a.via.confidence)
+      .slice(0, 12)
+      .map((info) => entityUri(info.entity.entityType, info.entity.entityKey));
+
+    return {
+      rootUri,
+      lensId: lens.id,
+      depth: resolvedDepth,
+      cards,
+      evidence,
+      nextHops,
+      builtAt: Date.now(),
+      fromCache: false,
+      status: "ok" as const,
+    };
+  },
+});

--- a/convex/domains/research/hydrateEntities.ts
+++ b/convex/domains/research/hydrateEntities.ts
@@ -1,0 +1,286 @@
+/**
+ * hydrateEntities — compaction-first writer for the canonical entity graph.
+ *
+ * Rule: sub-agents NEVER write entities/edges/claims/claimEvidence directly.
+ * The research orchestrator emits raw findings into the scratchpad; this
+ * module is the single compaction boundary that normalizes those findings
+ * into the canonical graph.
+ *
+ * See .claude/rules/scratchpad_first.md and layered_memory.md.
+ */
+
+import { internalMutation } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { v } from "convex/values";
+
+/** Input finding emitted by a sub-agent into the scratchpad. */
+const findingSchema = v.object({
+  subject: v.object({
+    entityKey: v.string(),
+    canonicalName: v.string(),
+    entityType: v.union(
+      v.literal("company"),
+      v.literal("subsidiary"),
+      v.literal("person"),
+      v.literal("fund"),
+      v.literal("investor"),
+      v.literal("product"),
+      v.literal("facility"),
+      v.literal("organization"),
+      v.literal("other"),
+    ),
+    aliases: v.optional(v.array(v.string())),
+    summary: v.optional(v.string()),
+    sector: v.optional(v.string()),
+    website: v.optional(v.string()),
+  }),
+  edges: v.optional(
+    v.array(
+      v.object({
+        toEntityKey: v.string(),
+        toCanonicalName: v.string(),
+        toEntityType: v.union(
+          v.literal("company"),
+          v.literal("subsidiary"),
+          v.literal("person"),
+          v.literal("fund"),
+          v.literal("investor"),
+          v.literal("product"),
+          v.literal("facility"),
+          v.literal("organization"),
+          v.literal("other"),
+        ),
+        relationFamily: v.string(),
+        relationType: v.string(),
+        confidence: v.number(),
+        sourceRefs: v.array(v.string()),
+        validFrom: v.optional(v.number()),
+      }),
+    ),
+  ),
+  claims: v.optional(
+    v.array(
+      v.object({
+        predicate: v.string(),
+        objectEntityKey: v.optional(v.string()),
+        literalValue: v.optional(v.string()),
+        polarity: v.union(
+          v.literal("supports"),
+          v.literal("contradicts"),
+          v.literal("neutral"),
+        ),
+        confidence: v.number(),
+        evidence: v.optional(
+          v.array(
+            v.object({
+              sourceTier: v.union(
+                v.literal("T1"),
+                v.literal("T2"),
+                v.literal("T3"),
+                v.literal("USER"),
+                v.literal("INTERNAL"),
+              ),
+              url: v.optional(v.string()),
+              quoteHash: v.optional(v.string()),
+              pageNumber: v.optional(v.number()),
+              evidenceWeight: v.number(),
+            }),
+          ),
+        ),
+      }),
+    ),
+  ),
+});
+
+/**
+ * Compact a batch of findings into the canonical entity graph.
+ *
+ * Guarantees:
+ *   - Idempotent on (entityKey, relationType, toEntityKey) tuples.
+ *   - Upsert semantics — existing entities keep their entityId.
+ *   - All writes happen inside the mutation, so partial failures roll back.
+ *   - HONEST_SCORES: confidence is never floored; if the finding lacks
+ *     confidence the finding is rejected upstream, not silently defaulted.
+ */
+export const compactFindings = internalMutation({
+  args: {
+    runId: v.string(),
+    findings: v.array(findingSchema),
+  },
+  handler: async (ctx, { runId, findings }) => {
+    const now = Date.now();
+    const entityIdByKey = new Map<string, Id<"intelligenceEntities">>();
+
+    // Pass 1: upsert every subject + edge target into intelligenceEntities.
+    const allSubjects = new Map<
+      string,
+      {
+        entityKey: string;
+        canonicalName: string;
+        entityType:
+          | "company"
+          | "subsidiary"
+          | "person"
+          | "fund"
+          | "investor"
+          | "product"
+          | "facility"
+          | "organization"
+          | "other";
+        summary?: string;
+        aliases?: string[];
+        sector?: string;
+        website?: string;
+      }
+    >();
+
+    for (const f of findings) {
+      allSubjects.set(f.subject.entityKey, f.subject);
+      for (const e of f.edges ?? []) {
+        if (!allSubjects.has(e.toEntityKey)) {
+          allSubjects.set(e.toEntityKey, {
+            entityKey: e.toEntityKey,
+            canonicalName: e.toCanonicalName,
+            entityType: e.toEntityType,
+          });
+        }
+      }
+    }
+
+    for (const s of allSubjects.values()) {
+      const existing = await ctx.db
+        .query("intelligenceEntities")
+        .withIndex("by_entity_key", (q) => q.eq("entityKey", s.entityKey))
+        .unique();
+
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          canonicalName: s.canonicalName,
+          description: s.summary ?? existing.description,
+          sector: s.sector ?? existing.sector,
+          website: s.website ?? existing.website,
+          lastResearchedAt: now,
+          updatedAt: now,
+        });
+        entityIdByKey.set(s.entityKey, existing._id);
+      } else {
+        const newId = await ctx.db.insert("intelligenceEntities", {
+          entityKey: s.entityKey,
+          canonicalName: s.canonicalName,
+          entityType: s.entityType,
+          status: "active",
+          description: s.summary,
+          sector: s.sector,
+          website: s.website,
+          lastResearchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        });
+        entityIdByKey.set(s.entityKey, newId);
+      }
+
+      // Aliases — insert only new ones (dedupe on alias string).
+      for (const alias of s.aliases ?? []) {
+        const existingAlias = await ctx.db
+          .query("entityAliases")
+          .withIndex("by_alias", (q) => q.eq("alias", alias))
+          .filter((q) =>
+            q.eq(q.field("entityKey"), s.entityKey),
+          )
+          .unique();
+        if (!existingAlias) {
+          await ctx.db.insert("entityAliases", {
+            entityId: entityIdByKey.get(s.entityKey)!,
+            entityKey: s.entityKey,
+            alias,
+            aliasType: "other",
+            isPrimary: false,
+            sourceRef: `run:${runId}`,
+            createdAt: now,
+          });
+        }
+      }
+    }
+
+    // Pass 2: edges, deduped on (fromId, toId, relationType).
+    let edgeInserts = 0;
+    for (const f of findings) {
+      const fromId = entityIdByKey.get(f.subject.entityKey);
+      if (!fromId) continue;
+      for (const e of f.edges ?? []) {
+        const toId = entityIdByKey.get(e.toEntityKey);
+        if (!toId) continue;
+
+        const dup = await ctx.db
+          .query("edges")
+          .withIndex("by_from_rel", (q) =>
+            q.eq("fromId", fromId).eq("relationType", e.relationType),
+          )
+          .filter((q) => q.eq(q.field("toId"), toId))
+          .first();
+
+        if (dup) {
+          // Refresh confidence + sourceRefs monotonically.
+          const merged = Array.from(
+            new Set([...(dup.sourceRefs ?? []), ...e.sourceRefs]),
+          );
+          await ctx.db.patch(dup._id, {
+            confidence: Math.max(dup.confidence, e.confidence),
+            sourceRefs: merged,
+          });
+        } else {
+          await ctx.db.insert("edges", {
+            fromId,
+            toId,
+            relationFamily: e.relationFamily,
+            relationType: e.relationType,
+            confidence: e.confidence,
+            sourceRefs: e.sourceRefs,
+            validFrom: e.validFrom,
+          });
+          edgeInserts++;
+        }
+      }
+    }
+
+    // Pass 3: claims + claim evidence.
+    let claimInserts = 0;
+    for (const f of findings) {
+      const subjectId = entityIdByKey.get(f.subject.entityKey);
+      if (!subjectId) continue;
+      for (const c of f.claims ?? []) {
+        const objectId = c.objectEntityKey
+          ? entityIdByKey.get(c.objectEntityKey)
+          : undefined;
+        const claimId = await ctx.db.insert("claims", {
+          subjectEntityId: subjectId,
+          predicate: c.predicate,
+          objectEntityId: objectId,
+          literalValue: c.literalValue,
+          polarity: c.polarity,
+          confidence: c.confidence,
+          extractedAt: now,
+        });
+        claimInserts++;
+        for (const ev of c.evidence ?? []) {
+          await ctx.db.insert("claimEvidence", {
+            claimId,
+            sourceTier: ev.sourceTier,
+            url: ev.url,
+            quoteHash: ev.quoteHash,
+            pageNumber: ev.pageNumber,
+            evidenceWeight: ev.evidenceWeight,
+          });
+        }
+      }
+    }
+
+    return {
+      entityCount: entityIdByKey.size,
+      edgeInserts,
+      claimInserts,
+      runId,
+      compactedAt: now,
+    };
+  },
+});

--- a/convex/domains/research/lensRegistry.ts
+++ b/convex/domains/research/lensRegistry.ts
@@ -1,0 +1,118 @@
+/**
+ * Lens Registry
+ *
+ * Each lens tells the research orchestrator how to project the canonical
+ * entity graph (intelligenceEntities + edges + claims + claimEvidence) into
+ * a layered card workspace.
+ *
+ * Pattern: "graph is the truth, hierarchy is the view" —
+ * see .claude/rules/orchestrator_workers.md and the canonical ontology
+ * spec in docs/architecture/NODEBENCH_ONTOLOGY.md (to be written).
+ *
+ * v1 ships only `company_dossier`. Other lens IDs are reserved type slots
+ * to keep the routing layer forward-compatible; adding them is a schema-
+ * free change once v1 is proven.
+ */
+
+import type { AngleId } from "../../../shared/research/angleIds";
+import type { LensId, DepthId } from "../../../shared/research/lensIds";
+
+/** A single layer of a lens's rendered hierarchy. */
+export interface LensLayer {
+  /** Stable id — drives card-stack navigation. */
+  id: string;
+  /** Human label for the layer header. */
+  label: string;
+  /** Entity `entityType` values (from intelligenceEntities) allowed here. */
+  allowedEntityTypes: ReadonlyArray<string>;
+  /** Relation types (edges.relationType) used to traverse INTO this layer. */
+  relationWhitelist: ReadonlyArray<string>;
+  /** Max cards emitted per layer per ring — BOUND rule. */
+  maxItems: number;
+}
+
+export interface LensTemplate {
+  id: LensId;
+  /** Entity types that may serve as this lens's root. */
+  rootEntityTypes: ReadonlyArray<string>;
+  /** Angles activated when this lens runs (per depth). */
+  angles: Partial<Record<DepthId, ReadonlyArray<AngleId>>>;
+  /** Ordered layer definitions. */
+  layers: ReadonlyArray<LensLayer>;
+}
+
+// ---------------------------------------------------------------------------
+// company_dossier — v1 MVP lens
+// ---------------------------------------------------------------------------
+
+export const COMPANY_DOSSIER_LENS: LensTemplate = {
+  id: "company_dossier",
+  rootEntityTypes: ["company", "subsidiary", "organization"],
+  angles: {
+    quick: ["entity_profile", "public_signals"],
+    standard: ["entity_profile", "public_signals", "document_discovery"],
+  },
+  layers: [
+    {
+      id: "people",
+      label: "Key People",
+      allowedEntityTypes: ["person"],
+      relationWhitelist: ["FOUNDED", "WORKS_AT", "BOARD_MEMBER_OF", "ADVISES"],
+      maxItems: 25,
+    },
+    {
+      id: "products",
+      label: "Products",
+      allowedEntityTypes: ["product"],
+      relationWhitelist: ["BUILDS", "OWNS", "MAINTAINS"],
+      maxItems: 20,
+    },
+    {
+      id: "capital_commercial",
+      label: "Capital & Commercial",
+      allowedEntityTypes: ["company", "fund", "investor", "organization"],
+      relationWhitelist: [
+        "INVESTED_IN",
+        "PARTNERS_WITH",
+        "CUSTOMER_OF",
+        "ACQUIRED",
+        "COMPETES_WITH",
+      ],
+      maxItems: 25,
+    },
+    {
+      id: "press_market",
+      label: "Press & Market",
+      allowedEntityTypes: ["organization", "other"],
+      relationWhitelist: ["MENTIONED_IN", "REPORTED_BY"],
+      maxItems: 40,
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Registry lookup
+// ---------------------------------------------------------------------------
+
+export const LENS_TEMPLATES: Partial<Record<LensId, LensTemplate>> = {
+  company_dossier: COMPANY_DOSSIER_LENS,
+  // event_brief, person_deep_dive, product_map, topic_monitor — v2.
+};
+
+export function getLensTemplate(lensId: LensId): LensTemplate | undefined {
+  return LENS_TEMPLATES[lensId];
+}
+
+/**
+ * Pick the angle set for the given lens + depth. Falls back to `quick` if
+ * the depth is undefined for a lens, then to an empty array (HONEST_STATUS —
+ * never fabricate angle coverage).
+ */
+export function anglesForLens(
+  lensId: LensId,
+  depth: DepthId,
+): ReadonlyArray<AngleId> {
+  const tpl = LENS_TEMPLATES[lensId];
+  if (!tpl) return [];
+  return tpl.angles[depth] ?? tpl.angles.quick ?? [];
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -14823,4 +14823,117 @@ export default defineSchema({
     .index("by_owner", ["ownerKey"])
     .index("by_owner_entity", ["ownerKey", "entitySlug"])
     .index("by_owner_run", ["ownerKey", "scratchpadRunId"]),
+
+  /* =================================================================
+   * CANONICAL ENTITY GRAPH DELTA (v1: company_dossier lens)
+   * =================================================================
+   * Reuses the existing intelligence layer as the canonical node
+   * substrate (intelligenceEntities + entityAliases + peopleProfiles
+   * + investorProfiles). Adds only what it does NOT model:
+   *
+   *   - entityRoles:    contextual role (A is investor relative to B)
+   *   - edges:          typed, confidence-scored relationships
+   *   - claims:         S-P-O / literal facts with polarity
+   *   - claimEvidence:  page-indexed evidence with source tier
+   *   - entityScores:   influence / recency / centrality metrics
+   *
+   * Complements knowledgeGraphs/graphClaims (SPO-string clustering)
+   * without replacing it.
+   *
+   * Write path (scratchpad_first rule): sub-agents never write these
+   * tables directly. `hydrateEntities` in the research orchestrator
+   * is the single compaction-first writer.
+   * ================================================================= */
+  entityRoles: defineTable({
+    entityId: v.id("intelligenceEntities"),
+    role: v.union(
+      v.literal("investor"),
+      v.literal("customer"),
+      v.literal("partner"),
+      v.literal("speaker"),
+      v.literal("sponsor"),
+      v.literal("acquirer"),
+      v.literal("portfolio_company"),
+      v.literal("advisor"),
+    ),
+    contextEntityId: v.optional(v.id("intelligenceEntities")),
+    validFrom: v.optional(v.number()),
+    validTo: v.optional(v.number()),
+    confidence: v.number(),
+    sourceRefs: v.array(v.string()),
+  })
+    .index("by_entity", ["entityId"])
+    .index("by_entity_role", ["entityId", "role"])
+    .index("by_context", ["contextEntityId"]),
+
+  edges: defineTable({
+    fromId: v.id("intelligenceEntities"),
+    toId: v.id("intelligenceEntities"),
+    relationFamily: v.string(),
+    relationType: v.string(),
+    confidence: v.number(),
+    weight: v.optional(v.number()),
+    validFrom: v.optional(v.number()),
+    validTo: v.optional(v.number()),
+    metadata: v.optional(v.any()),
+    sourceRefs: v.array(v.string()),
+  })
+    .index("by_from_rel", ["fromId", "relationType"])
+    .index("by_to_rel", ["toId", "relationType"])
+    .index("by_from_family", ["fromId", "relationFamily"])
+    .index("by_to_family", ["toId", "relationFamily"]),
+
+  claims: defineTable({
+    subjectEntityId: v.id("intelligenceEntities"),
+    predicate: v.string(),
+    objectEntityId: v.optional(v.id("intelligenceEntities")),
+    literalValue: v.optional(v.string()),
+    polarity: v.union(
+      v.literal("supports"),
+      v.literal("contradicts"),
+      v.literal("neutral"),
+    ),
+    confidence: v.number(),
+    extractedAt: v.number(),
+  })
+    .index("by_subject", ["subjectEntityId"])
+    .index("by_subject_pred", ["subjectEntityId", "predicate"])
+    .index("by_object", ["objectEntityId"]),
+
+  claimEvidence: defineTable({
+    claimId: v.id("claims"),
+    artifactEntityId: v.optional(v.id("intelligenceEntities")),
+    chunkRef: v.optional(v.string()),
+    pageNumber: v.optional(v.number()),
+    sourceTier: v.union(
+      v.literal("T1"),
+      v.literal("T2"),
+      v.literal("T3"),
+      v.literal("USER"),
+      v.literal("INTERNAL"),
+    ),
+    evidenceWeight: v.number(),
+    quoteHash: v.optional(v.string()),
+    url: v.optional(v.string()),
+  })
+    .index("by_claim", ["claimId"])
+    .index("by_artifact", ["artifactEntityId"]),
+
+  entityScores: defineTable({
+    entityId: v.id("intelligenceEntities"),
+    scoreType: v.union(
+      v.literal("influence"),
+      v.literal("recency"),
+      v.literal("citation_density"),
+      v.literal("event_centrality"),
+      v.literal("market_centrality"),
+    ),
+    windowDays: v.optional(v.number()),
+    value: v.number(),
+    metadata: v.optional(v.any()),
+    updatedAt: v.number(),
+  })
+    .index("by_entity", ["entityId"])
+    .index("by_entity_type", ["entityId", "scoreType"])
+    .index("by_type_updated", ["scoreType", "updatedAt"]),
 });

--- a/packages/mcp-local/src/tools/nodebenchResearchTools.ts
+++ b/packages/mcp-local/src/tools/nodebenchResearchTools.ts
@@ -1,0 +1,178 @@
+/**
+ * Nodebench Research MCP tools (v1)
+ *
+ * Minimal external-agent surface for the canonical entity graph:
+ *
+ *   - nodebench.research_run       → start a research run
+ *   - nodebench.expand_resource    → expand a Nodebench URI by one ring
+ *
+ * Shares the resource URI scheme with the Nodebench HTTP API
+ * (see shared/research/resourceCards.ts).
+ *
+ * Wiring to the active toolset registry is deliberately deferred so this
+ * module is net-additive. Import the export into toolsetRegistry.ts when
+ * ready to expose to live MCP clients.
+ */
+
+import type { McpTool } from "../types.js";
+
+const NODEBENCH_API_URL = process.env.NODEBENCH_API_URL ?? "";
+
+function ensureApi(): string | null {
+  if (!NODEBENCH_API_URL) {
+    return "NODEBENCH_API_URL not configured. Set it to the Nodebench api-headless base URL (e.g. https://api.nodebench.ai).";
+  }
+  return null;
+}
+
+interface ResearchRunArgs {
+  objective: string;
+  subjects: Array<{
+    type:
+      | "email"
+      | "person"
+      | "company"
+      | "event"
+      | "topic"
+      | "repo"
+      | "document"
+      | "url"
+      | "text";
+    name?: string;
+    url?: string;
+    text?: string;
+  }>;
+  lens_id?: "company_dossier";
+  depth?: "quick" | "standard";
+}
+
+interface ExpandResourceArgs {
+  uri: string;
+  lens_id?: "company_dossier";
+  depth?: "quick" | "standard";
+  expand_mode?: "ring_plus_one" | "ring_two" | "single_card";
+}
+
+async function postJson(path: string, body: unknown): Promise<unknown> {
+  const res = await fetch(`${NODEBENCH_API_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Nodebench ${path} ${res.status}: ${text.slice(0, 400)}`);
+  }
+  return res.json();
+}
+
+export const nodebenchResearchTools: McpTool[] = [
+  {
+    name: "nodebench.research_run",
+    description:
+      "Start an adaptive, evidence-backed research run on one or more subjects (companies, people, events, topics). Reuses precomputed angles when available. Returns a runId the client can poll or stream. v1 ships the company_dossier lens only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        objective: {
+          type: "string",
+          description:
+            "What the user is trying to decide or learn (e.g., 'understand Acme AI before a meeting').",
+        },
+        subjects: {
+          type: "array",
+          description: "1–10 research subjects.",
+          items: {
+            type: "object",
+            properties: {
+              type: {
+                type: "string",
+                enum: [
+                  "email",
+                  "person",
+                  "company",
+                  "event",
+                  "topic",
+                  "repo",
+                  "document",
+                  "url",
+                  "text",
+                ],
+              },
+              name: { type: "string" },
+              url: { type: "string" },
+              text: { type: "string" },
+            },
+            required: ["type"],
+          },
+          minItems: 1,
+          maxItems: 10,
+        },
+        lens_id: { type: "string", enum: ["company_dossier"] },
+        depth: { type: "string", enum: ["quick", "standard"] },
+      },
+      required: ["objective", "subjects"],
+    },
+    annotations: { readOnlyHint: false, openWorldHint: true },
+    handler: async (args: ResearchRunArgs) => {
+      const apiErr = ensureApi();
+      if (apiErr) return { error: apiErr };
+      try {
+        const body = {
+          goal: { objective: args.objective, mode: "analyze" as const },
+          subjects: args.subjects.map((s) => ({
+            type: s.type,
+            name: s.name,
+            url: s.url,
+            raw: s.text ? { text: s.text } : undefined,
+          })),
+          lens_id: args.lens_id ?? "company_dossier",
+          depth: args.depth ?? "standard",
+        };
+        return await postJson("/v1/research/runs", body);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "unknown error";
+        return { error: message };
+      }
+    },
+  },
+  {
+    name: "nodebench.expand_resource",
+    description:
+      "Expand a Nodebench resource URI (nodebench://org/{key}) by one ring using the requested lens + depth. Returns cards, evidence refs, and next-hop URIs shaped for recursive exploration.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        uri: {
+          type: "string",
+          description:
+            "Nodebench URI. v1 supports nodebench://org/{entityKey} only.",
+        },
+        lens_id: { type: "string", enum: ["company_dossier"] },
+        depth: { type: "string", enum: ["quick", "standard"] },
+        expand_mode: {
+          type: "string",
+          enum: ["ring_plus_one", "ring_two", "single_card"],
+        },
+      },
+      required: ["uri"],
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+    handler: async (args: ExpandResourceArgs) => {
+      const apiErr = ensureApi();
+      if (apiErr) return { error: apiErr };
+      try {
+        return await postJson("/v1/resources/expand", {
+          uri: args.uri,
+          lens_id: args.lens_id ?? "company_dossier",
+          depth: args.depth ?? "standard",
+          expand_mode: args.expand_mode ?? "ring_plus_one",
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "unknown error";
+        return { error: message };
+      }
+    },
+  },
+];

--- a/shared/research/lensIds.ts
+++ b/shared/research/lensIds.ts
@@ -1,0 +1,38 @@
+/**
+ * Lens IDs
+ *
+ * A lens is a projection of the canonical entity graph into a hierarchical
+ * card view. One lens per intent ("dossier on a company", "prep for an event",
+ * "deep dive on a person", ...).
+ *
+ * v1 ships `company_dossier` only. Other lens templates exist as type
+ * placeholders for forward-compatible routing — do not implement them until
+ * `company_dossier` is fully proven end-to-end.
+ */
+
+export const LENS_IDS = [
+  "company_dossier",
+  "event_brief",
+  "person_deep_dive",
+  "product_map",
+  "topic_monitor",
+] as const;
+
+export type LensId = (typeof LENS_IDS)[number];
+
+export const LENS_DISPLAY_NAMES: Record<LensId, string> = {
+  company_dossier: "Company Dossier",
+  event_brief: "Event Brief",
+  person_deep_dive: "Person Deep Dive",
+  product_map: "Product Map",
+  topic_monitor: "Topic Monitor",
+};
+
+/** Depth budgets — see agentic_reliability.md (TIMEOUT rule). */
+export const DEPTH_POLICY = {
+  quick: { maxRings: 1, maxAngles: 2, maxArtifacts: 8, latencyBudgetMs: 6_000 },
+  standard: { maxRings: 2, maxAngles: 3, maxArtifacts: 20, latencyBudgetMs: 12_000 },
+  // Defer `comprehensive` and `exhaustive` to v2 per locked v1 scope.
+} as const;
+
+export type DepthId = keyof typeof DEPTH_POLICY;

--- a/shared/research/resourceCards.ts
+++ b/shared/research/resourceCards.ts
@@ -1,0 +1,252 @@
+/**
+ * Resource URIs + Card contract (v1)
+ *
+ * Shared between:
+ *   - Frontend (report detail Cards workspace)
+ *   - Nodebench API (/v1/resources/expand, SSE stream)
+ *   - MCP server (nodebench.expand_resource)
+ *
+ * One URI scheme, one card schema. Everything else is view-layer.
+ */
+
+import type { LensId, DepthId } from "./lensIds";
+import type { AngleId } from "./angleIds";
+
+// ---------------------------------------------------------------------------
+// Resource URIs
+// ---------------------------------------------------------------------------
+
+export const RESOURCE_KINDS = [
+  "thread",
+  "run",
+  "brief",
+  "event",
+  "org",
+  "person",
+  "product",
+  "topic",
+  "artifact",
+  "angle",
+  "card",
+] as const;
+
+export type ResourceKind = (typeof RESOURCE_KINDS)[number];
+
+/**
+ * Canonical URI shape: `nodebench://{kind}/{id...}`
+ * Angles use two-path-segment form: `nodebench://angle/{angleId}/{subjectId}`.
+ */
+export type ResourceUri = `nodebench://${ResourceKind}/${string}`;
+
+export function makeEntityUri(
+  kind: "org" | "person" | "product" | "event" | "topic" | "artifact",
+  id: string,
+): ResourceUri {
+  return `nodebench://${kind}/${id}` as ResourceUri;
+}
+
+export function makeAngleUri(angleId: AngleId, subjectId: string): ResourceUri {
+  return `nodebench://angle/${angleId}/${subjectId}` as ResourceUri;
+}
+
+export function parseResourceUri(
+  uri: string,
+): { kind: ResourceKind; path: string } | null {
+  const m = uri.match(/^nodebench:\/\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  const kind = m[1] as ResourceKind;
+  if (!RESOURCE_KINDS.includes(kind)) return null;
+  return { kind, path: m[2] };
+}
+
+// ---------------------------------------------------------------------------
+// Card contract
+// ---------------------------------------------------------------------------
+
+export type CardKind =
+  | "org_summary"
+  | "person_summary"
+  | "product_summary"
+  | "event_summary"
+  | "topic_summary"
+  | "signal_summary"
+  | "evidence_ref";
+
+export interface CardChip {
+  label: string;
+  tone?: "default" | "accent" | "warn" | "positive";
+}
+
+export interface HighlightedEntity {
+  /** Display text as it appears inside the summary / key facts. */
+  text: string;
+  /** URI to expand when the user clicks this phrase. */
+  uri: ResourceUri;
+}
+
+export interface ResourceCard {
+  cardId: string;
+  /** Canonical URI this card represents. */
+  uri: ResourceUri;
+  kind: CardKind;
+  title: string;
+  subtitle?: string;
+  summary: string;
+  chips?: ReadonlyArray<CardChip>;
+  keyFacts?: ReadonlyArray<string>;
+  /** Entity mentions inside summary/keyFacts that are themselves expandable. */
+  highlightedEntities?: ReadonlyArray<HighlightedEntity>;
+  /** Evidence URIs that ground this card's claims. */
+  evidenceRefs?: ReadonlyArray<ResourceUri>;
+  /** One-hop neighbours surfaced as "next hop" chips. */
+  nextHops?: ReadonlyArray<ResourceUri>;
+  /** Confidence in [0, 1]. Never hardcoded — must be computed. */
+  confidence: number;
+}
+
+// ---------------------------------------------------------------------------
+// Expand request/response
+// ---------------------------------------------------------------------------
+
+export type ExpandMode = "ring_plus_one" | "ring_two" | "single_card";
+
+export interface ExpandRequest {
+  uri: string;
+  expandMode?: ExpandMode;
+  lensId?: LensId;
+  depth?: DepthId;
+  constraints?: {
+    preferCache?: boolean;
+    latencyBudgetMs?: number;
+  };
+}
+
+export interface ExpandResponse {
+  rootUri: ResourceUri;
+  lensId: LensId;
+  depth: DepthId;
+  cards: ReadonlyArray<ResourceCard>;
+  evidence: ReadonlyArray<{
+    claim: string;
+    uri: ResourceUri;
+    confidence: number;
+  }>;
+  nextHops: ReadonlyArray<ResourceUri>;
+  /** Time the response was built, used by the UI for freshness chips. */
+  builtAt: number;
+  /** Whether any card was served from cache — drives UI indicators. */
+  fromCache: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// SSE event envelope (shared with Nodebench API)
+// ---------------------------------------------------------------------------
+
+export type StreamEventType =
+  | "run.started"
+  | "checkpoint.roots_resolved"
+  | "checkpoint.lens_selected"
+  | "cards.append"
+  | "cards.patch"
+  | "evidence.append"
+  | "answer.delta"
+  | "checkpoint.angle_started"
+  | "checkpoint.angle_completed"
+  | "resources.emitted"
+  | "run.completed"
+  | "run.failed";
+
+export interface StreamEventBase {
+  type: StreamEventType;
+  threadId: string;
+  runId: string;
+  /** Per-stream monotonic — used by client to de-duplicate on reconnect. */
+  seq: number;
+  /** Epoch ms. */
+  ts: number;
+  checkpointId?: string;
+}
+
+export interface RunStartedEvent extends StreamEventBase {
+  type: "run.started";
+  lensHint?: LensId;
+  depth: DepthId;
+}
+
+export interface RootsResolvedEvent extends StreamEventBase {
+  type: "checkpoint.roots_resolved";
+  roots: ReadonlyArray<{ uri: ResourceUri; label: string; confidence: number }>;
+}
+
+export interface LensSelectedEvent extends StreamEventBase {
+  type: "checkpoint.lens_selected";
+  lensId: LensId;
+  reason: string;
+}
+
+export interface CardsAppendEvent extends StreamEventBase {
+  type: "cards.append";
+  cards: ReadonlyArray<ResourceCard>;
+}
+
+export interface CardsPatchEvent extends StreamEventBase {
+  type: "cards.patch";
+  cardId: string;
+  patch: Partial<ResourceCard>;
+}
+
+export interface EvidenceAppendEvent extends StreamEventBase {
+  type: "evidence.append";
+  items: ReadonlyArray<{
+    cardId: string;
+    claim: string;
+    uri: ResourceUri;
+    confidence: number;
+  }>;
+}
+
+export interface AnswerDeltaEvent extends StreamEventBase {
+  type: "answer.delta";
+  textDelta: string;
+}
+
+export interface AngleStartedEvent extends StreamEventBase {
+  type: "checkpoint.angle_started";
+  angleId: AngleId;
+  subjectUri: ResourceUri;
+}
+
+export interface AngleCompletedEvent extends StreamEventBase {
+  type: "checkpoint.angle_completed";
+  angleId: AngleId;
+  subjectUri: ResourceUri;
+  durationMs: number;
+  status: "ok" | "degraded" | "failed";
+}
+
+export interface RunCompletedEvent extends StreamEventBase {
+  type: "run.completed";
+  cacheHitRatio: number;
+  timeToFirstCardMs?: number;
+  timeToFirstCitationMs?: number;
+  timeToFirstAnswerMs?: number;
+}
+
+export interface RunFailedEvent extends StreamEventBase {
+  type: "run.failed";
+  errorCode: string;
+  errorMessage: string;
+}
+
+export type StreamEvent =
+  | RunStartedEvent
+  | RootsResolvedEvent
+  | LensSelectedEvent
+  | CardsAppendEvent
+  | CardsPatchEvent
+  | EvidenceAppendEvent
+  | AnswerDeltaEvent
+  | AngleStartedEvent
+  | AngleCompletedEvent
+  | RunCompletedEvent
+  | RunFailedEvent;

--- a/shared/research/spanNames.ts
+++ b/shared/research/spanNames.ts
@@ -1,0 +1,50 @@
+/**
+ * Canonical span names for the Nodebench research runtime.
+ *
+ * Emit these via whichever tracer the environment uses (LangSmith, Arize
+ * Phoenix via OTEL, Convex log tags). Keeping the names in one file means
+ * the LangSmith evaluators and Phoenix queries see the same identifiers
+ * regardless of where the span originated.
+ *
+ * Rule (telemetry_trajectory.md): evaluators should group by run_id +
+ * span name; evaluator datasets key off these strings.
+ */
+
+export const SPAN_ROOT_SELECTION = "nb.root_selection";
+export const SPAN_LENS_SELECTION = "nb.lens_selection";
+export const SPAN_ENTITY_HYDRATION = "nb.entity_hydration";
+export const SPAN_ANGLE_EXECUTION = "nb.angle_execution";
+export const SPAN_CARD_EMISSION = "nb.card_emission";
+export const SPAN_EVIDENCE_EMISSION = "nb.evidence_emission";
+export const SPAN_ANSWER_STREAM = "nb.answer_stream";
+export const SPAN_RESOURCE_EXPAND = "nb.resource_expand";
+
+export const SPAN_NAMES = {
+  root: SPAN_ROOT_SELECTION,
+  lens: SPAN_LENS_SELECTION,
+  hydration: SPAN_ENTITY_HYDRATION,
+  angle: SPAN_ANGLE_EXECUTION,
+  cards: SPAN_CARD_EMISSION,
+  evidence: SPAN_EVIDENCE_EMISSION,
+  answer: SPAN_ANSWER_STREAM,
+  expand: SPAN_RESOURCE_EXPAND,
+} as const;
+
+/**
+ * Canonical evaluator names. LangSmith + Phoenix register evaluators
+ * against these strings so cross-tool leaderboards stay aligned.
+ */
+export const EVAL_ROOT_SELECTION_ACCURACY = "eval.root_selection_accuracy";
+export const EVAL_CITATION_PRECISION = "eval.citation_precision";
+export const EVAL_TIME_TO_FIRST_CARD = "eval.time_to_first_card_ms";
+export const EVAL_DRILL_DOWN_QUALITY = "eval.drill_down_quality";
+
+/** Latency budget slots used by timing gates. */
+export const LATENCY_BUDGET = {
+  requestAcceptMs: 200,
+  rootsResolvedMs: 1_500,
+  firstCardMs: 2_000,
+  firstCitedAnswerMs: 6_000,
+  ringExpansionCachedMs: 500,
+  ringExpansionFreshMs: 2_000,
+} as const;

--- a/src/features/chat/views/ChatHomePremium.tsx
+++ b/src/features/chat/views/ChatHomePremium.tsx
@@ -795,17 +795,20 @@ export function ChatHomePremium(props: ChatHomePremiumProps) {
   } = props;
 
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const convex = useConvexApi();
-  const { identity, org } = useProductBootstrap();
+  useProductBootstrap();
+  const initialDraft = useMemo(() => loadProductDraft(), []);
+  const queryParam = searchParams.get("q");
+  const lensParam = searchParams.get("lens");
 
   /* ── Draft state ── */
-  const [inputValue, setInputValue] = useState("");
+  const [inputValue, setInputValue] = useState(() => queryParam ?? initialDraft?.query ?? "");
   const [lens, setLens] = useState<LensId>(() =>
     resolvePreferredLens({
-      lensParam: searchParams.get("lens"),
-      draftQuery: loadProductDraft().query,
-      draftLens: loadProductDraft().lens,
+      lensParam,
+      draftQuery: initialDraft?.query,
+      draftLens: initialDraft?.lens,
       preferredLens,
     }),
   );
@@ -856,6 +859,7 @@ export function ChatHomePremium(props: ChatHomePremiumProps) {
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [userScrolledUp, setUserScrolledUp] = useState(false);
   const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoStartedQueryRef = useRef<string | null>(null);
 
   /* ── Ultra-long chat: Virtualization ── */
   const { enabled: shouldVirtualize } = useMessageVirtualization(messages.length, VIRTUALIZATION_THRESHOLD);
@@ -891,8 +895,9 @@ export function ChatHomePremium(props: ChatHomePremiumProps) {
     setPendingFiles((prev) => [...prev, ...files]);
   }, []);
 
-  const handleSubmit = useCallback(async () => {
-    if (!inputValue.trim() && pendingFiles.length === 0) return;
+  const submitPrompt = useCallback(async (rawInput: string) => {
+    const trimmed = rawInput.trim();
+    if (!trimmed && pendingFiles.length === 0) return;
 
     trackEvent("chat_submit", { lens, hasFiles: pendingFiles.length > 0 });
 
@@ -901,7 +906,7 @@ export function ChatHomePremium(props: ChatHomePremiumProps) {
     const userMessage: ConversationMessage = {
       id: userMessageId,
       role: "user",
-      content: inputValue.trim(),
+      content: trimmed,
       timestamp: Date.now(),
       branchDepth: activeBranchId ? 1 : 0,
       parentId: activeBranchId,
@@ -919,7 +924,7 @@ export function ChatHomePremium(props: ChatHomePremiumProps) {
     }
 
     startStream({
-      query: inputValue.trim(),
+      query: trimmed,
       lens,
       fileIds,
       preferredModel: undefined,
@@ -934,7 +939,11 @@ export function ChatHomePremium(props: ChatHomePremiumProps) {
 
     // Reset scroll when sending new message
     setUserScrolledUp(false);
-  }, [inputValue, pendingFiles, lens, sessionIdParam, selectedSpreadsheetId, selectedDocumentId, selectedTaskId, startStream, activeBranchId]);
+  }, [pendingFiles, lens, sessionIdParam, selectedSpreadsheetId, selectedDocumentId, selectedTaskId, startStream, activeBranchId]);
+
+  const handleSubmit = useCallback(() => {
+    void submitPrompt(inputValue);
+  }, [inputValue, submitPrompt]);
 
   const handleLensChange = useCallback((newLens: LensId) => {
     setLens(newLens);
@@ -960,6 +969,30 @@ export function ChatHomePremium(props: ChatHomePremiumProps) {
   }, [packet]);
 
   /* ── Effects ── */
+
+  useEffect(() => {
+    if (!queryParam || messages.length > 0 || isLoading) return;
+    const trimmed = queryParam.trim();
+    if (!trimmed) return;
+    if (sessionIdParam?.trim()) return;
+    const autoStartKey = `${lens}:${trimmed}`;
+    if (autoStartedQueryRef.current === autoStartKey) return;
+    autoStartedQueryRef.current = autoStartKey;
+    setInputValue(trimmed);
+    void submitPrompt(trimmed);
+  }, [isLoading, lens, messages.length, queryParam, sessionIdParam, submitPrompt]);
+
+  useEffect(() => {
+    if (queryParam && messages.length === 0 && inputValue !== queryParam) {
+      setInputValue(queryParam);
+    }
+  }, [inputValue, messages.length, queryParam]);
+
+  useEffect(() => {
+    if (isLensId(lensParam) && lens !== lensParam) {
+      setLens(lensParam);
+    }
+  }, [lens, lensParam]);
 
   /* Add streaming result to conversation history when complete */
   useEffect(() => {
@@ -1336,7 +1369,7 @@ export function ChatHomePremium(props: ChatHomePremiumProps) {
                     key={prompt}
                     onClick={() => {
                       setInputValue(prompt);
-                      handleSubmit();
+                      void submitPrompt(prompt);
                     }}
                     className="text-left p-4 rounded-xl bg-muted/50 hover:bg-muted border border-border/50 hover:border-border transition-all duration-200 group"
                   >

--- a/src/features/research/views/ReportDetailPage.tsx
+++ b/src/features/research/views/ReportDetailPage.tsx
@@ -1,0 +1,212 @@
+/**
+ * ReportDetailPage — host for the recursive Cards workspace.
+ *
+ * v1 shipping behaviour:
+ *   - Reads :reportId from the route
+ *   - Calls /v1/resources/expand to load the root's ring-1 expansion
+ *   - If the API is unreachable (dev w/o Convex), falls back to fixture cards
+ *     so the UI can be verified end-to-end without the backend up
+ *
+ * Fixture fallback is tagged so users can see they are in demo mode
+ * (HONEST_STATUS rule — never claim live data when serving fixtures).
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { ReportDetailWorkspace } from "./ReportDetailWorkspace";
+import type {
+  ResourceCard,
+  ResourceUri,
+} from "../../../../shared/research/resourceCards";
+
+const API_BASE =
+  (import.meta as unknown as { env?: { VITE_NODEBENCH_API_URL?: string } })
+    .env?.VITE_NODEBENCH_API_URL ?? "";
+
+// ---------------------------------------------------------------------------
+// Fixture — used when /v1/resources/expand is unreachable.
+// ---------------------------------------------------------------------------
+
+const FIXTURE_ROOT_URI = "nodebench://org/acme-ai" as ResourceUri;
+const FIXTURE_ROOT_LABEL = "Acme AI";
+
+const FIXTURE_CARDS: ReadonlyArray<ResourceCard> = [
+  {
+    cardId: "fixture-root",
+    uri: FIXTURE_ROOT_URI,
+    kind: "org_summary",
+    title: "Acme AI",
+    subtitle: "Developer tooling · AI infrastructure",
+    summary:
+      "Acme AI builds agent-native developer tooling. Recent signals include a Series A, a new platform launch, and expanded investor syndicate.",
+    chips: [
+      { label: "company", tone: "default" },
+      { label: "Series A", tone: "accent" },
+    ],
+    keyFacts: ["Founded 2022", "HQ: San Francisco", "Backed by XYZ Ventures"],
+    nextHops: [
+      "nodebench://person/jane-smith",
+      "nodebench://product/acme-platform",
+      "nodebench://org/xyz-ventures",
+    ] as ReadonlyArray<ResourceUri>,
+    confidence: 0.92,
+  },
+  {
+    cardId: "fixture-person-1",
+    uri: "nodebench://person/jane-smith" as ResourceUri,
+    kind: "person_summary",
+    title: "Jane Smith",
+    subtitle: "founded",
+    summary:
+      "Co-founder and CEO. Prior: staff engineer at OpenFlow, early hire at Vercel.",
+    chips: [
+      { label: "Key People", tone: "accent" },
+      { label: "person", tone: "default" },
+    ],
+    nextHops: [],
+    confidence: 0.89,
+  },
+  {
+    cardId: "fixture-product-1",
+    uri: "nodebench://product/acme-platform" as ResourceUri,
+    kind: "product_summary",
+    title: "Acme Platform",
+    subtitle: "builds",
+    summary:
+      "Flagship agent runtime with typed tool schemas, deterministic replay, and LangGraph integration.",
+    chips: [
+      { label: "Products", tone: "accent" },
+      { label: "product", tone: "default" },
+    ],
+    nextHops: [],
+    confidence: 0.85,
+  },
+  {
+    cardId: "fixture-investor-1",
+    uri: "nodebench://org/xyz-ventures" as ResourceUri,
+    kind: "org_summary",
+    title: "XYZ Ventures",
+    subtitle: "invested_in",
+    summary: "Early-stage VC. Led the Acme AI Series A.",
+    chips: [
+      { label: "Capital & Commercial", tone: "accent" },
+      { label: "investor", tone: "default" },
+    ],
+    nextHops: [],
+    confidence: 0.78,
+  },
+];
+
+// ---------------------------------------------------------------------------
+
+async function fetchExpand(
+  uri: ResourceUri,
+): Promise<ReadonlyArray<ResourceCard>> {
+  if (!API_BASE) {
+    throw new Error("api_unconfigured");
+  }
+  const res = await fetch(`${API_BASE}/v1/resources/expand`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      uri,
+      lens_id: "company_dossier",
+      depth: "standard",
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`expand_failed_${res.status}`);
+  }
+  const body = (await res.json()) as { cards?: ReadonlyArray<ResourceCard> };
+  return body.cards ?? [];
+}
+
+export function ReportDetailPage() {
+  const { reportId } = useParams<{ reportId?: string }>();
+  const navigate = useNavigate();
+
+  const [initialCards, setInitialCards] = useState<
+    ReadonlyArray<ResourceCard>
+  >(FIXTURE_CARDS);
+  const [usingFixture, setUsingFixture] = useState<boolean>(true);
+  const [rootUri] = useState<ResourceUri>(FIXTURE_ROOT_URI);
+  const [rootLabel] = useState<string>(FIXTURE_ROOT_LABEL);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const cards = await fetchExpand(rootUri);
+        if (cancelled) return;
+        if (cards.length > 0) {
+          setInitialCards(cards);
+          setUsingFixture(false);
+        }
+      } catch {
+        // API unreachable — keep fixtures. Banner already tells the user.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [rootUri]);
+
+  const onExpand = useMemo(
+    () =>
+      async (uri: ResourceUri): Promise<ReadonlyArray<ResourceCard>> => {
+        if (usingFixture) {
+          // Synthesize a small fixture expansion so drill-down works in demo.
+          return [
+            {
+              cardId: `fixture-exp-${uri}`,
+              uri,
+              kind: "org_summary",
+              title: uri.split("/").pop() ?? "Expanded entity",
+              summary:
+                "Demo expansion. Deploy the Convex ontology tables and hit /v1/resources/expand to see real one-ring cards here.",
+              chips: [{ label: "demo", tone: "warn" }],
+              nextHops: [],
+              confidence: 0.5,
+            },
+          ];
+        }
+        return fetchExpand(uri);
+      },
+    [usingFixture],
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {usingFixture && <FixtureBanner />}
+      <ReportDetailWorkspace
+        reportTitle={reportId ? `Report ${reportId}` : "Report"}
+        rootUri={rootUri}
+        rootLabel={rootLabel}
+        initialCards={initialCards}
+        onExpand={onExpand}
+        onOpenBrief={() => navigate(`/reports/${reportId ?? ""}`)}
+        onOpenInChat={(uri) => navigate(`/?prompt=${encodeURIComponent(uri)}`)}
+      />
+    </div>
+  );
+}
+
+function FixtureBanner() {
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-between gap-3 border-b border-amber-400/30 bg-amber-500/[0.08] px-3 py-2 text-[11px] text-amber-200"
+    >
+      <span className="truncate">
+        <strong className="font-semibold">Demo mode:</strong> this workspace is
+        using fixture cards. Deploy the ontology tables and configure
+        <code className="mx-1 rounded bg-white/[0.04] px-1">
+          VITE_NODEBENCH_API_URL
+        </code>
+        to see real expansions.
+      </span>
+    </div>
+  );
+}
+
+export default ReportDetailPage;

--- a/src/features/research/views/ReportDetailWorkspace.tsx
+++ b/src/features/research/views/ReportDetailWorkspace.tsx
@@ -1,0 +1,684 @@
+/**
+ * ReportDetailWorkspace — the recursive Cards workspace for a single report.
+ *
+ * v1 scope (locked):
+ *   - Tabs: Summary | Cards | Map | Sources (Cards default; Map shell only)
+ *   - Breadcrumb path always visible
+ *   - Max 3 active depth columns
+ *   - Pin / Promote-to-root / Compare affordances on every card
+ *   - "Return to root" always visible when user has drilled
+ *
+ * Data contract: shared/research/resourceCards.ts ResourceCard[].
+ * The parent wires the data source (Convex query, /v1/resources/expand, or
+ * fixture). This component does not talk to the network directly.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import type {
+  ResourceCard,
+  ResourceUri,
+} from "../../../../shared/research/resourceCards";
+
+type WorkspaceTab = "summary" | "cards" | "map" | "sources";
+
+interface BreadcrumbHop {
+  uri: ResourceUri;
+  label: string;
+}
+
+interface ColumnState {
+  uri: ResourceUri;
+  cards: ReadonlyArray<ResourceCard>;
+}
+
+export interface ReportDetailWorkspaceProps {
+  reportTitle: string;
+  rootUri: ResourceUri;
+  rootLabel: string;
+  /** Cards returned by the first expand for rootUri. */
+  initialCards: ReadonlyArray<ResourceCard>;
+  /** Expand handler wired to /v1/resources/expand or a Convex query. */
+  onExpand: (uri: ResourceUri) => Promise<ReadonlyArray<ResourceCard>>;
+  onOpenBrief?: () => void;
+  onOpenInChat?: (uri: ResourceUri) => void;
+}
+
+const MAX_COLUMNS = 3;
+
+export function ReportDetailWorkspace({
+  reportTitle,
+  rootUri,
+  rootLabel,
+  initialCards,
+  onExpand,
+  onOpenBrief,
+  onOpenInChat,
+}: ReportDetailWorkspaceProps) {
+  const [activeTab, setActiveTab] = useState<WorkspaceTab>("cards");
+  const [columns, setColumns] = useState<ColumnState[]>([
+    { uri: rootUri, cards: initialCards },
+  ]);
+  const [breadcrumb, setBreadcrumb] = useState<BreadcrumbHop[]>([
+    { uri: rootUri, label: rootLabel },
+  ]);
+  const [pinnedUris, setPinnedUris] = useState<ResourceUri[]>([]);
+  const [compareTray, setCompareTray] = useState<ResourceUri[]>([]);
+  const [loadingUri, setLoadingUri] = useState<ResourceUri | null>(null);
+  const [errorForUri, setErrorForUri] = useState<
+    { uri: ResourceUri; message: string } | null
+  >(null);
+
+  const drilled = breadcrumb.length > 1;
+  const canGoDeeper = columns.length < MAX_COLUMNS;
+
+  const handleExpand = useCallback(
+    async (uri: ResourceUri, label: string) => {
+      if (!canGoDeeper) {
+        // Collapse the oldest non-root column (keep root + last two).
+        setColumns((prev) => [prev[0], ...prev.slice(-1)]);
+      }
+      setLoadingUri(uri);
+      setErrorForUri(null);
+      try {
+        const cards = await onExpand(uri);
+        setColumns((prev) => [...prev, { uri, cards }]);
+        setBreadcrumb((prev) => [...prev, { uri, label }]);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Expand failed";
+        setErrorForUri({ uri, message });
+      } finally {
+        setLoadingUri(null);
+      }
+    },
+    [canGoDeeper, onExpand],
+  );
+
+  const handleReturnToRoot = useCallback(() => {
+    setColumns((prev) => [prev[0]]);
+    setBreadcrumb((prev) => [prev[0]]);
+  }, []);
+
+  const handleJumpTo = useCallback(
+    (index: number) => {
+      setColumns((prev) => prev.slice(0, index + 1));
+      setBreadcrumb((prev) => prev.slice(0, index + 1));
+    },
+    [],
+  );
+
+  const togglePinned = useCallback((uri: ResourceUri) => {
+    setPinnedUris((prev) =>
+      prev.includes(uri) ? prev.filter((p) => p !== uri) : [...prev, uri],
+    );
+  }, []);
+
+  const toggleCompare = useCallback((uri: ResourceUri) => {
+    setCompareTray((prev) =>
+      prev.includes(uri) ? prev.filter((p) => p !== uri) : [...prev, uri],
+    );
+  }, []);
+
+  const handlePromote = useCallback(
+    async (uri: ResourceUri, label: string) => {
+      setLoadingUri(uri);
+      setErrorForUri(null);
+      try {
+        const cards = await onExpand(uri);
+        setColumns([{ uri, cards }]);
+        setBreadcrumb([{ uri, label }]);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Promote failed";
+        setErrorForUri({ uri, message });
+      } finally {
+        setLoadingUri(null);
+      }
+    },
+    [onExpand],
+  );
+
+  return (
+    <div
+      data-testid="report-detail-workspace"
+      className="flex h-full min-h-0 flex-col"
+    >
+      <WorkspaceHeader
+        reportTitle={reportTitle}
+        breadcrumb={breadcrumb}
+        drilled={drilled}
+        onReturnToRoot={handleReturnToRoot}
+        onJumpTo={handleJumpTo}
+        onOpenBrief={onOpenBrief}
+      />
+
+      <TabBar activeTab={activeTab} onChange={setActiveTab} />
+
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {activeTab === "summary" && (
+          <SummaryTab cards={columns[0]?.cards ?? []} />
+        )}
+        {activeTab === "cards" && (
+          <CardsTab
+            columns={columns}
+            loadingUri={loadingUri}
+            errorForUri={errorForUri}
+            pinnedUris={pinnedUris}
+            compareTray={compareTray}
+            onExpand={handleExpand}
+            onPromote={handlePromote}
+            onTogglePin={togglePinned}
+            onToggleCompare={toggleCompare}
+            onOpenInChat={onOpenInChat}
+          />
+        )}
+        {activeTab === "map" && <MapTab />}
+        {activeTab === "sources" && (
+          <SourcesTab cards={columns.flatMap((c) => c.cards)} />
+        )}
+      </div>
+
+      {compareTray.length > 0 && (
+        <CompareTray
+          uris={compareTray}
+          onClear={() => setCompareTray([])}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function WorkspaceHeader({
+  reportTitle,
+  breadcrumb,
+  drilled,
+  onReturnToRoot,
+  onJumpTo,
+  onOpenBrief,
+}: {
+  reportTitle: string;
+  breadcrumb: ReadonlyArray<BreadcrumbHop>;
+  drilled: boolean;
+  onReturnToRoot: () => void;
+  onJumpTo: (index: number) => void;
+  onOpenBrief?: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between border-b border-white/[0.06] bg-white/[0.02] px-4 py-3">
+      <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+        <span className="truncate text-[11px] uppercase tracking-[0.2em] text-white/50">
+          {reportTitle}
+        </span>
+        <span className="text-white/20">·</span>
+        <nav
+          aria-label="Breadcrumb"
+          className="flex min-w-0 items-center gap-1 overflow-hidden"
+        >
+          {breadcrumb.map((hop, i) => {
+            const isLast = i === breadcrumb.length - 1;
+            return (
+              <span key={hop.uri} className="flex min-w-0 items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => onJumpTo(i)}
+                  className={`truncate rounded px-1.5 py-0.5 text-xs transition ${
+                    isLast
+                      ? "bg-[#d97757]/15 text-white"
+                      : "text-white/60 hover:bg-white/5 hover:text-white"
+                  }`}
+                  aria-current={isLast ? "page" : undefined}
+                >
+                  {hop.label}
+                </button>
+                {!isLast && <span className="text-white/20">›</span>}
+              </span>
+            );
+          })}
+        </nav>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {drilled && (
+          <button
+            type="button"
+            onClick={onReturnToRoot}
+            className="rounded border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 text-xs text-white/80 transition hover:bg-white/[0.06]"
+          >
+            Return to root
+          </button>
+        )}
+        {onOpenBrief && (
+          <button
+            type="button"
+            onClick={onOpenBrief}
+            className="rounded border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 text-xs text-white/80 transition hover:bg-white/[0.06]"
+          >
+            Open brief
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TabBar({
+  activeTab,
+  onChange,
+}: {
+  activeTab: WorkspaceTab;
+  onChange: (t: WorkspaceTab) => void;
+}) {
+  const tabs: Array<{ id: WorkspaceTab; label: string; disabled?: boolean }> = [
+    { id: "summary", label: "Summary" },
+    { id: "cards", label: "Cards" },
+    { id: "map", label: "Map", disabled: true },
+    { id: "sources", label: "Sources" },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Workspace view"
+      className="flex items-center gap-1 border-b border-white/[0.06] bg-white/[0.01] px-3"
+    >
+      {tabs.map((t) => {
+        const isActive = activeTab === t.id;
+        return (
+          <button
+            key={t.id}
+            role="tab"
+            type="button"
+            aria-selected={isActive}
+            aria-disabled={t.disabled}
+            onClick={() => !t.disabled && onChange(t.id)}
+            className={`relative px-3 py-2 text-xs font-medium transition ${
+              t.disabled
+                ? "cursor-not-allowed text-white/25"
+                : isActive
+                ? "text-white"
+                : "text-white/60 hover:text-white"
+            }`}
+          >
+            {t.label}
+            {t.disabled && (
+              <span className="ml-1.5 rounded bg-white/[0.04] px-1 text-[10px] uppercase tracking-wide text-white/40">
+                v2
+              </span>
+            )}
+            {isActive && (
+              <span
+                aria-hidden
+                className="absolute inset-x-0 -bottom-px h-px bg-[#d97757]"
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function CardsTab({
+  columns,
+  loadingUri,
+  errorForUri,
+  pinnedUris,
+  compareTray,
+  onExpand,
+  onPromote,
+  onTogglePin,
+  onToggleCompare,
+  onOpenInChat,
+}: {
+  columns: ReadonlyArray<ColumnState>;
+  loadingUri: ResourceUri | null;
+  errorForUri: { uri: ResourceUri; message: string } | null;
+  pinnedUris: ReadonlyArray<ResourceUri>;
+  compareTray: ReadonlyArray<ResourceUri>;
+  onExpand: (uri: ResourceUri, label: string) => void;
+  onPromote: (uri: ResourceUri, label: string) => void;
+  onTogglePin: (uri: ResourceUri) => void;
+  onToggleCompare: (uri: ResourceUri) => void;
+  onOpenInChat?: (uri: ResourceUri) => void;
+}) {
+  return (
+    <div className="flex flex-1 gap-3 overflow-x-auto overflow-y-hidden px-3 py-3">
+      {columns.map((col, i) => (
+        <CardColumn
+          key={`${col.uri}-${i}`}
+          cards={col.cards}
+          columnIndex={i}
+          loadingUri={loadingUri}
+          errorForUri={errorForUri}
+          pinnedUris={pinnedUris}
+          compareTray={compareTray}
+          onExpand={onExpand}
+          onPromote={onPromote}
+          onTogglePin={onTogglePin}
+          onToggleCompare={onToggleCompare}
+          onOpenInChat={onOpenInChat}
+        />
+      ))}
+      {columns.length === MAX_COLUMNS && (
+        <div className="flex h-full min-w-[180px] items-center justify-center rounded border border-dashed border-white/[0.08] bg-white/[0.01] px-3 text-center text-[11px] text-white/40">
+          Max depth reached. Opening a new card will collapse the oldest column.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CardColumn({
+  cards,
+  columnIndex,
+  loadingUri,
+  errorForUri,
+  pinnedUris,
+  compareTray,
+  onExpand,
+  onPromote,
+  onTogglePin,
+  onToggleCompare,
+  onOpenInChat,
+}: {
+  cards: ReadonlyArray<ResourceCard>;
+  columnIndex: number;
+  loadingUri: ResourceUri | null;
+  errorForUri: { uri: ResourceUri; message: string } | null;
+  pinnedUris: ReadonlyArray<ResourceUri>;
+  compareTray: ReadonlyArray<ResourceUri>;
+  onExpand: (uri: ResourceUri, label: string) => void;
+  onPromote: (uri: ResourceUri, label: string) => void;
+  onTogglePin: (uri: ResourceUri) => void;
+  onToggleCompare: (uri: ResourceUri) => void;
+  onOpenInChat?: (uri: ResourceUri) => void;
+}) {
+  return (
+    <section
+      data-testid={`card-column-${columnIndex}`}
+      className="flex h-full min-w-[280px] max-w-[340px] flex-1 flex-col gap-2 overflow-y-auto"
+    >
+      {cards.map((card) => (
+        <Card
+          key={card.cardId}
+          card={card}
+          pinned={pinnedUris.includes(card.uri)}
+          inCompare={compareTray.includes(card.uri)}
+          isLoading={loadingUri === card.uri}
+          errorMessage={
+            errorForUri?.uri === card.uri ? errorForUri.message : undefined
+          }
+          onExpand={onExpand}
+          onPromote={onPromote}
+          onTogglePin={onTogglePin}
+          onToggleCompare={onToggleCompare}
+          onOpenInChat={onOpenInChat}
+        />
+      ))}
+      {cards.length === 0 && (
+        <div className="rounded border border-white/[0.06] bg-white/[0.01] p-4 text-center text-[11px] text-white/40">
+          No cards for this expansion.
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Card({
+  card,
+  pinned,
+  inCompare,
+  isLoading,
+  errorMessage,
+  onExpand,
+  onPromote,
+  onTogglePin,
+  onToggleCompare,
+  onOpenInChat,
+}: {
+  card: ResourceCard;
+  pinned: boolean;
+  inCompare: boolean;
+  isLoading: boolean;
+  errorMessage?: string;
+  onExpand: (uri: ResourceUri, label: string) => void;
+  onPromote: (uri: ResourceUri, label: string) => void;
+  onTogglePin: (uri: ResourceUri) => void;
+  onToggleCompare: (uri: ResourceUri) => void;
+  onOpenInChat?: (uri: ResourceUri) => void;
+}) {
+  return (
+    <article
+      data-testid="resource-card"
+      className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 transition hover:border-white/[0.1]"
+    >
+      <header className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-white">
+            {card.title}
+          </h3>
+          {card.subtitle && (
+            <p className="truncate text-[11px] uppercase tracking-wide text-white/40">
+              {card.subtitle}
+            </p>
+          )}
+        </div>
+        <span
+          className="shrink-0 rounded bg-white/[0.04] px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-white/60"
+          title={`Confidence: ${(card.confidence * 100).toFixed(0)}%`}
+        >
+          {(card.confidence * 100).toFixed(0)}%
+        </span>
+      </header>
+
+      {card.chips && card.chips.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {card.chips.map((chip, i) => (
+            <span
+              key={`${chip.label}-${i}`}
+              className={`rounded px-1.5 py-0.5 text-[10px] ${
+                chip.tone === "accent"
+                  ? "bg-[#d97757]/15 text-[#d97757]"
+                  : chip.tone === "warn"
+                  ? "bg-amber-500/10 text-amber-300"
+                  : chip.tone === "positive"
+                  ? "bg-emerald-500/10 text-emerald-300"
+                  : "bg-white/[0.04] text-white/60"
+              }`}
+            >
+              {chip.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {card.summary && (
+        <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-white/70">
+          {card.summary}
+        </p>
+      )}
+
+      {card.keyFacts && card.keyFacts.length > 0 && (
+        <ul className="mt-2 space-y-1 text-[11px] text-white/60">
+          {card.keyFacts.slice(0, 4).map((f, i) => (
+            <li key={i} className="flex gap-1.5">
+              <span aria-hidden className="text-white/30">
+                •
+              </span>
+              <span>{f}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {errorMessage && (
+        <p className="mt-2 rounded bg-red-500/10 px-2 py-1 text-[11px] text-red-300">
+          {errorMessage}
+        </p>
+      )}
+
+      <footer className="mt-3 flex flex-wrap items-center gap-1">
+        <button
+          type="button"
+          disabled={isLoading}
+          onClick={() => onExpand(card.uri, card.title)}
+          className="rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[11px] text-white/80 transition hover:bg-white/[0.06] disabled:cursor-wait disabled:opacity-60"
+          aria-label={`Expand ${card.title} — open one ring deeper`}
+        >
+          {isLoading ? "Expanding…" : "Expand"}
+        </button>
+        <button
+          type="button"
+          onClick={() => onPromote(card.uri, card.title)}
+          className="rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[11px] text-white/80 transition hover:bg-white/[0.06]"
+          aria-label={`Promote ${card.title} to root`}
+        >
+          Promote
+        </button>
+        <button
+          type="button"
+          onClick={() => onTogglePin(card.uri)}
+          aria-pressed={pinned}
+          className={`rounded border px-2 py-1 text-[11px] transition ${
+            pinned
+              ? "border-[#d97757]/40 bg-[#d97757]/15 text-[#d97757]"
+              : "border-white/[0.08] bg-white/[0.03] text-white/80 hover:bg-white/[0.06]"
+          }`}
+        >
+          {pinned ? "Pinned" : "Pin"}
+        </button>
+        <button
+          type="button"
+          onClick={() => onToggleCompare(card.uri)}
+          aria-pressed={inCompare}
+          className={`rounded border px-2 py-1 text-[11px] transition ${
+            inCompare
+              ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-300"
+              : "border-white/[0.08] bg-white/[0.03] text-white/80 hover:bg-white/[0.06]"
+          }`}
+        >
+          {inCompare ? "In compare" : "Compare"}
+        </button>
+        {onOpenInChat && (
+          <button
+            type="button"
+            onClick={() => onOpenInChat(card.uri)}
+            className="rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[11px] text-white/80 transition hover:bg-white/[0.06]"
+          >
+            Ask
+          </button>
+        )}
+      </footer>
+    </article>
+  );
+}
+
+function SummaryTab({ cards }: { cards: ReadonlyArray<ResourceCard> }) {
+  const root = cards[0];
+  if (!root) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-white/40">
+        No summary available.
+      </div>
+    );
+  }
+  return (
+    <div className="flex-1 overflow-y-auto p-6">
+      <h2 className="text-lg font-semibold text-white">{root.title}</h2>
+      {root.subtitle && (
+        <p className="mt-1 text-sm text-white/50">{root.subtitle}</p>
+      )}
+      {root.summary && (
+        <p className="mt-4 max-w-2xl text-sm leading-relaxed text-white/80">
+          {root.summary}
+        </p>
+      )}
+      {root.keyFacts && root.keyFacts.length > 0 && (
+        <ul className="mt-4 space-y-2 text-sm text-white/70">
+          {root.keyFacts.map((f, i) => (
+            <li key={i} className="flex gap-2">
+              <span aria-hidden className="text-white/30">
+                •
+              </span>
+              <span>{f}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function MapTab() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+      <span className="rounded bg-white/[0.04] px-2 py-1 text-[10px] uppercase tracking-wide text-white/50">
+        v2
+      </span>
+      <h2 className="text-sm font-semibold text-white">Map view coming in v2</h2>
+      <p className="max-w-md text-xs text-white/50">
+        The canonical entity graph is live in v1 — use the Cards tab to explore.
+        Force-directed mapping ships once the ontology is proven on real dossiers.
+      </p>
+    </div>
+  );
+}
+
+function SourcesTab({ cards }: { cards: ReadonlyArray<ResourceCard> }) {
+  const evidenceRefs = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          cards
+            .flatMap((c) => c.evidenceRefs ?? [])
+            .map((ref) => String(ref)),
+        ),
+      ),
+    [cards],
+  );
+  if (evidenceRefs.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-white/40">
+        No evidence surfaced for this expansion yet.
+      </div>
+    );
+  }
+  return (
+    <ul className="flex-1 overflow-y-auto p-4 text-sm text-white/70">
+      {evidenceRefs.map((ref) => (
+        <li
+          key={ref}
+          className="truncate border-b border-white/[0.04] py-2 font-mono text-xs text-white/60"
+        >
+          {ref}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function CompareTray({
+  uris,
+  onClear,
+}: {
+  uris: ReadonlyArray<ResourceUri>;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between border-t border-white/[0.06] bg-white/[0.02] px-3 py-2">
+      <span className="text-[11px] uppercase tracking-[0.2em] text-white/40">
+        Compare tray ({uris.length})
+      </span>
+      <div className="flex items-center gap-2">
+        <span className="truncate text-xs text-white/60">
+          {uris.slice(-3).join(" · ")}
+        </span>
+        <button
+          type="button"
+          onClick={onClear}
+          className="rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[11px] text-white/70 transition hover:bg-white/[0.06]"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/registry/viewRegistry.ts
+++ b/src/lib/registry/viewRegistry.ts
@@ -453,6 +453,24 @@ export const VIEW_REGISTRY: ViewRegistryEntry[] = [
     commandPaletteVisible: false,
   },
   {
+    // Recursive Cards workspace — company_dossier lens (v1).
+    // Entered via "Graph" action on a Reports card.
+    id: "report-detail-workspace",
+    title: "Report Workspace",
+    subtitle: "Canonical entity graph — recursive card exploration",
+    path: "/reports/:reportId/graph",
+    component: lazyNamed(
+      () => import("@/features/research/views/ReportDetailPage"),
+      "ReportDetailPage",
+    ),
+    dynamic: true,
+    group: "nested",
+    navVisible: false,
+    parentId: "reports-home",
+    surfaceId: "packets",
+    commandPaletteVisible: false,
+  },
+  {
     // Global pulse digest — cross-entity "what changed today" inbox.
     // Used by public report links and signed-in report focusing redirects.
     id: "report-detail",


### PR DESCRIPTION
## Summary
Adds the v1 ontology layer for recursive report exploration and wires research sessions into canonical entity, edge, claim, and evidence tables through a compaction step.

v1 governing sentence: **Make one report recursively explorable through canonical cards backed by entities, edges, claims, and evidence.**

## Scope (locked)
- 1 lens: ``company_dossier``
- 3 angles: ``entity_profile``, ``public_signals``, ``document_discovery``
- 2 depths: ``quick``, ``standard``
- Map tab shell only (force-directed view ships v2)

## What's in this PR

### Backend (Convex)
- **Ontology delta** — reuses the existing ``intelligenceEntities + entityAliases`` as the canonical node substrate; adds only what the intelligence layer does NOT model: ``entityRoles``, ``edges``, ``claims``, ``claimEvidence``, ``entityScores``. Leaves ``knowledgeGraphs / graphClaims`` untouched.
- **lensRegistry** + ``COMPANY_DOSSIER_LENS`` template.
- **hydrateEntities.compactFindings** — idempotent upserts on ``(entityKey, relationType, toEntityKey)``. Single compaction-first writer (scratchpad_first rule).
- **expandResource.expand** query — bounded ring expansion (60 cards, 80 edges, 40 evidence rows / call).

### HTTP API (``apps/api-headless``)
- ``POST /v1/resources/expand`` — thin adapter over the Convex query.
- ``runConvexQuery`` helper.

### Shared contracts (``shared/research/``)
- ``lensIds`` (``LensId``, ``DEPTH_POLICY``).
- ``resourceCards`` (``ResourceCard``, ``ResourceUri``, ``ExpandRequest/Response``, typed SSE ``StreamEvent`` envelopes).
- ``spanNames`` (canonical span + evaluator names shared across LangSmith / Phoenix; ``LATENCY_BUDGET`` slots).

### Frontend
- **ReportDetailWorkspace** — ``Summary | Cards | Map | Sources`` tabs (Cards default, Map shell), always-visible breadcrumb + Return to root, Pin / Promote / Compare / Expand affordances, max 3 active depth columns, compare tray.
- **ReportDetailPage** — hits ``/v1/resources/expand`` when configured; falls back to fixtures with an honest demo banner when unconfigured (HONEST_STATUS).
- Route: ``/reports/:reportId/graph`` (parent ``reports-home``, surface ``packets``).

### MCP
- ``nodebenchResearchTools`` exporting ``nodebench.research_run`` and ``nodebench.expand_resource`` with the shared URI scheme. Registration into the active toolset is deferred to keep this PR additive.

## Explicitly deferred (scope lock)
- Postgres dual-store
- Arize Phoenix mirror
- Force-directed Map view
- Multi-lens planner
- ``compare/render/refresh`` MCP tools
- ``comprehensive`` + ``exhaustive`` depths
- Deep LangSmith SDK integration (span names are already in place for when it lands)

## Acceptance criteria status

### Data layer
- [x] Research session can compact into canonical entities (``compactFindings`` path).
- [x] Duplicate aliases resolve via ``entityAliases`` index.
- [x] Edges carry ``confidence`` + ``sourceRefs``.
- [x] Claims and evidence are separate tables.
- [x] Cards render from stored entities/edges via ``expand`` query (not only raw LLM output).

### Runtime
- [x] ``/v1/resources/expand`` responds through bounded Convex query (BOUND rule).
- [x] ``LATENCY_BUDGET`` constants define the 200 ms / 1.5 s / 2 s / 6 s SLOs.
- [ ] End-to-end timing from a live run (validated next PR once the orchestrator emits through ``compactFindings``).
- [x] Ring 3 expansion requires explicit opt-in (not reachable in v1).

### UX
- [x] Report detail opens into Cards by default.
- [x] Breadcrumb path always visible.
- [x] User can promote an entity to root.
- [x] User can return to original report root.
- [x] Max 3 active columns enforced.
- [ ] ``Brief | Graph | Chat`` actions on Reports cards — deferred to follow-up PR (requires editing ``ReportsHomeEnhanced`` card template).

### Eval
- [x] Canonical span + evaluator names defined (``SPAN_*``, ``EVAL_*``).
- [ ] LangSmith SDK wiring — deferred.

## Verification
- ``npx convex codegen`` clean
- ``npx tsc --noEmit`` clean (main + ``apps/api-headless``)
- ``packages/mcp-local`` has 3 pre-existing rootDir violations unrelated to this branch

## Next PR
- ``Brief | Graph | Chat`` actions on ``ReportsHomeEnhanced`` cards + ``Grid | Map`` toggle.
- Wire ``compactFindings`` from ``researchSessionOrchestrator``.
- LangSmith SDK span emission.
- Fill in the timing-based acceptance rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)