### PR TITLE
Lock 5-tab product surface (Bell → Inbox icon + stale comment cleanup)

### DIFF
--- a/src/layouts/MobileTabBar.tsx
+++ b/src/layouts/MobileTabBar.tsx
@@ -8,7 +8,7 @@
 
 import { memo } from "react";
 import { useLocation } from "react-router-dom";
-import { Bell, FileText, Home, MessageSquare, User } from "lucide-react";
+import { FileText, Home, Inbox, MessageSquare, User } from "lucide-react";
 import type { CockpitSurfaceId } from "@/lib/registry/viewRegistry";
 import { cn } from "@/lib/utils";
 
@@ -28,7 +28,7 @@ const TABS: readonly {
   { id: "ask", label: "Home", icon: Home },
   { id: "packets", label: "Reports", icon: FileText },
   { id: "workspace", label: "Chat", icon: MessageSquare },
-  { id: "history", label: "Inbox", icon: Bell },
+  { id: "history", label: "Inbox", icon: Inbox },
   { id: "connect", label: "Me", icon: User },
 ];
 

--- a/src/layouts/WorkspaceRail.tsx
+++ b/src/layouts/WorkspaceRail.tsx
@@ -9,6 +9,7 @@ import {
   ChevronRight,
   FileText,
   Home,
+  Inbox,
   LogIn,
   MessageSquare,
   Search,
@@ -34,7 +35,7 @@ const SURFACE_SHORTCUTS: SurfaceShortcut[] = [
   { id: "ask", label: "Home", icon: Home, color: "currentColor" },
   { id: "packets", label: "Reports", icon: FileText, color: "currentColor" },
   { id: "workspace", label: "Chat", icon: MessageSquare, color: "currentColor" },
-  { id: "history", label: "Inbox", icon: Bell, color: "currentColor" },
+  { id: "history", label: "Inbox", icon: Inbox, color: "currentColor" },
   { id: "connect", label: "Me", icon: User, color: "currentColor" },
 ];
 

--- a/src/lib/registry/viewRegistry.ts
+++ b/src/lib/registry/viewRegistry.ts
@@ -62,13 +62,19 @@ export type RouteGroup = "core" | "nested" | "internal" | "legacy";
 
 // ─── Cockpit surface model ──────────────────────────────────────────────────
 
+// Five-tab product lock — see docs/design/PRODUCT_SURFACES.md.
+//   Home · Reports · Chat · Inbox · Me
+// The internal surface id for Inbox is still "history" (legacy, 2026-Q1);
+// renaming the internal id is deferred to avoid churning routes + Convex logs.
+// The user-facing label is "Inbox" everywhere (SURFACE_TITLES, MobileTabBar,
+// WorkspaceRail, ProductTopNav) and the URL param is "inbox" (CANONICAL_SURFACE_PARAM).
 export type CockpitSurfaceId =
   | "ask"          // Home
   | "workspace"    // Chat
   | "packets"      // Reports
-  | "history"      // Nudges
+  | "history"      // Inbox (incl. Nudges as a sub-section)
   | "connect"      // Me
-  | "trace";       // Audit / trace / receipts
+  | "trace";       // Audit / trace / receipts (internal)
 
 export const CANONICAL_SURFACE_PARAM: Record<CockpitSurfaceId, string> = {
   ask: "home",


### PR DESCRIPTION
Per [docs/design/PRODUCT_SURFACES.md](docs/design/PRODUCT_SURFACES.md) (PR #15) the web surface lock is:

``Home · Reports · Chat · Inbox · Me``

The user-facing labels + URL params already said "Inbox" everywhere from a prior commit. This PR closes the remaining gaps:

- ``src/layouts/MobileTabBar.tsx`` — icon ``Bell`` → ``Inbox``
- ``src/layouts/WorkspaceRail.tsx`` — surface icon ``Bell`` → ``Inbox`` (individual nudge items in the popover keep Bell — each is a notification)
- ``src/lib/registry/viewRegistry.ts`` — document the 5-tab lock + note that the internal ``CockpitSurfaceId`` literal ``"history"`` stays (renaming would churn routes + Convex logs for no product win)

Nudges is a sub-section inside Inbox, not a top-level tab.

## Verification
- ``npx tsc --noEmit`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)