### PR TITLE
Workspace separate-deploy surface + Brief·Explore·Chat card actions + scenario catalog

### DIFF
--- a/docs/design/PRODUCT_SURFACES.md
+++ b/docs/design/PRODUCT_SURFACES.md
@@ -1,57 +1,58 @@
-# NodeBench Product Surfaces — locked 2026-04-23
+# NodeBench Product Surfaces
 
-This is the canonical surface map. The design system (docs/design/nodebench-ai-design-system/)
-still shows an older "Home · Chat · Reports · Nudges · Me" labelling in places — treat
-the layout below as the source of truth and correct the bundle on next refresh.
+This is the canonical surface map for the current product split. The refreshed
+design-system bundle in `docs/design/nodebench-ai-design-system/` must follow
+the same model: no top-level Nudges tab, and no Workspace tab inside the
+operating app.
 
-## Product line (one sentence)
+## Product Line
 
-> Web is where you start. Mobile is where you capture. CLI/MCP is where agents integrate.
-> Workspace is where research becomes reusable intelligence.
+> Web is where you start. Mobile is where you capture. CLI/MCP is where agents
+> integrate. Workspace is where research becomes reusable intelligence.
 
-## The split
+## Surface Split
 
-```
-nodebenchai.com                  (the operating app — five tabs)
-├─ Home                          start quickly · daily pulse
-├─ Reports                       reusable memory · report grid
-├─ Chat                          ask + generate new work
-├─ Inbox                         incoming signals (captures, nudges, unassigned, automations, alerts)
-└─ Me                            preferences · context · files · credits
+```text
+nodebenchai.com                  (the operating app: five tabs)
+|-- Home                         start quickly, daily pulse
+|-- Reports                      reusable memory, report grid
+|-- Chat                         ask and generate new work
+|-- Inbox                        captures, nudges, unassigned, automations, alerts
+`-- Me                           preferences, context, files, credits
 
 nodebench.workspace              (deep-work surface, separately deployed)
-└─ Deep workspaces opened from Chat / Reports / Inbox
-   ├─ Brief      executive summary (what / so what / now what)
-   ├─ Cards      recursive exploration (root → related → drilldown)
-   ├─ Notebook   living editable prose
-   ├─ Sources    claims + evidence trail + verification
-   ├─ Chat       answer-first within the workspace
-   └─ Map        entity constellation (circular SVG layout)
+`-- Deep workspaces opened from Chat / Reports / Inbox
+    |-- Brief                    executive summary
+    |-- Cards                    recursive exploration
+    |-- Notebook                 living editable prose
+    |-- Sources                  claims, evidence, verification
+    |-- Chat                     workspace-scoped answers
+    `-- Map                      entity constellation
 ```
 
-## Role of each surface
+## Role Of Each Surface
 
-| Surface       | Primary job                              | Best for                                                            |
-| ------------- | ---------------------------------------- | ------------------------------------------------------------------- |
-| Web app       | Main operating app                       | Daily pulse, reports, chat, inbox triage, profile/context           |
-| Mobile        | Real-world capture and quick action      | Events, voice notes, screenshots, fast triage                       |
-| CLI / MCP     | Agent and developer distribution         | Claude/Cursor workflows, automations, batch research, API workflows |
-| Workspace     | Deep research and recursive exploration  | Report detail, cards, notebook, sources, map, team memory           |
+| Surface | Primary job | Best for |
+| --- | --- | --- |
+| Web app | Main operating app | Daily pulse, reports, chat, inbox triage, profile/context |
+| Mobile | Real-world capture and quick action | Events, voice notes, screenshots, fast triage |
+| CLI / MCP | Agent and developer distribution | Claude/Cursor workflows, automations, batch research, API workflows |
+| Workspace | Deep research and recursive exploration | Report detail, cards, notebook, sources, map, team memory |
 
-## Inbox contents (the former "Nudges")
+## Inbox Contents
 
-Inbox is where incoming signals triage before they become reports or follow-ups.
-Sub-sections:
+Inbox is where incoming signals triage before they become reports or
+follow-ups.
 
-- Nudges           (return-at-right-moment alerts)
-- Captures         (everything routed by `captureRouter` with target confidence ≥ 0.60)
-- Unassigned       (low-confidence `captureBuffer` — promote, attach, or discard)
-- Automations      (inbound from Pipedream, Gmail, Calendar, MCP, etc.)
-- Alerts           (threshold-triggered watchlist events)
+- Nudges: return-at-right-moment alerts.
+- Captures: items routed by `captureRouter`.
+- Unassigned: low-confidence captures to promote, attach, or discard.
+- Automations: inbound from Pipedream, Gmail, Calendar, MCP, and similar flows.
+- Alerts: threshold-triggered watchlist events.
 
-## Workspace URL shape
+## Workspace URL Shape
 
-```
+```text
 nodebench.workspace/w/{workspaceId}?tab=brief
 nodebench.workspace/w/{workspaceId}?tab=cards
 nodebench.workspace/w/{workspaceId}?tab=notebook
@@ -61,65 +62,61 @@ nodebench.workspace/w/{workspaceId}?tab=map
 nodebench.workspace/share/{shareId}
 ```
 
-## Report card → Workspace entry mapping
-
-Report card actions (from `ReportsHome.tsx`):
+## Report Entry Mapping
 
 | Card button | Workspace entry tab |
-| ----------- | ------------------- |
-| Brief       | `?tab=brief`        |
-| Explore     | `?tab=cards`        |
-| Chat        | `?tab=chat`         |
+| --- | --- |
+| Brief | `?tab=brief` |
+| Explore | `?tab=cards` |
+| Chat | `?tab=chat` |
 
-Additional entry sources:
+| Entry source | Default workspace tab |
+| --- | --- |
+| Chat "save as report" | Brief |
+| Event capture report | Cards or Notebook |
+| Source citation click | Sources |
+| Graph node click | Map |
 
-| Entry                | Default tab         |
-| -------------------- | ------------------- |
-| Chat "save as report"| Brief               |
-| Event capture report | Cards or Notebook   |
-| Source citation click| Sources             |
-| Graph node click     | Map                 |
+## Critical Rule
 
-## Critical rule
-
-> Workspace is a separate app shell, but it must use the same resource URIs,
-> auth, graph tables, cards, citations, and composer contract as the main app.
+Workspace is a separate app shell, but it must use the same resource URIs, auth,
+graph tables, cards, citations, and composer contract as the main app.
 
 All four surfaces share:
 
 - `UniversalComposer`
 - `nodebench://` resource URIs
 - entity cards (`ResourceCard` from `shared/research/resourceCards.ts`)
-- claims/evidence (from PR #11/#12 canonical graph)
+- claims and evidence
 - saved reports
 - workspace links
 - dry operator copy
-- same visual tokens (from `src/index.css` / `colors_and_type.css`)
+- same visual tokens
 
-## Four-surface connection graph
+## Connection Graph
 
-```
+```text
 Mobile capture
-→ Inbox capture queue
-→ Report
-→ Workspace
-→ Notebook / Cards / Sources
-→ Nudge back to Web or Mobile
+-> Inbox capture queue
+-> Report
+-> Workspace
+-> Notebook / Cards / Sources
+-> Nudge back to Web or Mobile
 
 Web Chat question
-→ Research run
-→ Save as Report
-→ Open Workspace
-→ Explore Cards
-→ Edit Notebook
+-> Research run
+-> Save as Report
+-> Open Workspace
+-> Explore Cards
+-> Edit Notebook
 
 CLI/MCP investigate
-→ Saved report URI
-→ Open in Workspace
-→ Share / continue in Web
+-> Saved report URI
+-> Open in Workspace
+-> Share / continue in Web
 
 Inbox job email
-→ NodeBench enrichment
-→ Report card
-→ Workspace interview prep
+-> NodeBench enrichment
+-> Report card
+-> Workspace interview prep
 ```

--- a/docs/design/WORKSPACE_DEPLOY.md
+++ b/docs/design/WORKSPACE_DEPLOY.md
@@ -1,117 +1,95 @@
-# Workspace separate-deploy setup
+# Workspace Separate Deployment
 
-Per [PRODUCT_SURFACES.md](PRODUCT_SURFACES.md) the **Workspace** is a separate
-deployed surface at a distinct URL (e.g. `workspace.nodebenchai.com`). It is
-NOT a sixth tab on the main app.
+Per [PRODUCT_SURFACES.md](PRODUCT_SURFACES.md), Workspace is a separate deep
+work surface. It is not a sixth tab in the main app.
 
-This doc explains how the split is implemented today and how to finish the DNS
-/ Vercel setup.
+## Current Implementation
 
-## What v1 ships
+- Main app surfaces are locked to `Home`, `Reports`, `Chat`, `Inbox`, `Me`.
+- Workspace renders through `UniversalWorkspacePage`.
+- Local route: `/workspace/w/{workspaceId}?tab={tab}`.
+- Workspace-host route: `/w/{workspaceId}?tab={tab}`.
+- Supported tabs: `brief`, `cards`, `notebook`, `sources`, `chat`, `map`.
+- Recognized workspace hosts:
+  - `nodebench.workspace`
+  - `workspace.nodebenchai.com`
+  - `nodebench-workspace.vercel.app`
 
-- New route `/workspace/w/:workspaceId` in the main React app.
-- Supports `?tab=brief|cards|notebook|sources|chat|map`.
-- Chromeless shell: header with brand + report title, then the existing
-  `ReportDetailWorkspace` body (tabs: Brief · Cards · Map · Sources).
-- v1 treats `notebook` and `chat` URL tabs as landing on **Cards** (the real
-  notebook + chat tabs ship in v1.5 and v2 respectively). The URL is preserved
-  so deep-links can upgrade later.
-- One React bundle serves both `nodebenchai.com` and
-  `workspace.nodebenchai.com` — a Vercel rewrite below routes the subdomain
-  directly into `/workspace/*`.
+`src/App.tsx` checks for the workspace host or `/workspace/*` path before the
+cockpit shell mounts, so Workspace owns its own header and tabs.
 
-Route match in [src/App.tsx](../../src/App.tsx) runs BEFORE the cockpit shell,
-so the workspace never mounts `CockpitLayout`. No rails, no top nav, no
-status strip.
+## URL Mapping
 
-## Enable the `workspace.nodebenchai.com` subdomain
-
-### 1. Add the subdomain to Vercel
-
-In the Vercel project (hshum2018-gmailcoms-projects/nodebench-ai):
-
-```
-Settings → Domains → Add → workspace.nodebenchai.com
+```text
+nodebenchai.com                  -> Home / Reports / Chat / Inbox / Me
+nodebench.workspace/w/acme       -> Workspace shell
+nodebench.workspace/share/abc    -> Workspace share surface
+localhost:5173/workspace/w/acme  -> Local workspace shell
 ```
 
-Vercel will give you a DNS record to add at your DNS provider (Namecheap /
-Cloudflare / etc).
+Report actions use this mapping:
 
-### 2. DNS
+| Main app action | Workspace URL |
+| --- | --- |
+| Brief | `/w/{workspaceId}?tab=brief` |
+| Explore | `/w/{workspaceId}?tab=cards` |
+| Chat | `/w/{workspaceId}?tab=chat` |
 
-Add a `CNAME` for `workspace` pointing to `cname.vercel-dns.com.` (or the
-record Vercel suggests).
+## Deployment Options
 
-### 3. Rewrite requests to `/workspace/*`
+### Preferred
 
-Add a `vercel.json` entry (at repo root) so requests to the subdomain land on
-the right path:
+Deploy the same React bundle as a separate Vercel project or service alias with
+the custom domain `nodebench.workspace`. The bundle can route the bare workspace
+host directly to the chromeless workspace shell.
+
+### DNS-Compatible Fallback
+
+If the `nodebench.workspace` domain is not available yet, use
+`workspace.nodebenchai.com` with the same host handling. `buildWorkspaceUrl`
+keeps production links on `https://nodebench.workspace/...` by default, and the
+host allowlist also accepts `workspace.nodebenchai.com` for rollout.
+
+## Vercel Rewrites
+
+If the same Vercel project serves both hosts, add host-based rewrites so the
+workspace subdomain keeps clean URLs:
 
 ```json
 {
   "rewrites": [
     {
-      "source": "/:path*",
-      "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
-      "destination": "/workspace/:path*"
+      "source": "/w/:workspaceId",
+      "has": [{ "type": "host", "value": "nodebench.workspace" }],
+      "destination": "/w/:workspaceId"
+    },
+    {
+      "source": "/share/:shareId",
+      "has": [{ "type": "host", "value": "nodebench.workspace" }],
+      "destination": "/share/:shareId"
     }
   ]
 }
 ```
 
-Also add a second rewrite so `workspace.nodebenchai.com/w/{id}` (no `/workspace/`
-prefix from the user's POV) still maps correctly:
+For local development, use:
 
-```json
-{
-  "source": "/w/:workspaceId",
-  "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
-  "destination": "/workspace/w/:workspaceId"
-}
-```
-
-### 4. Optional — shareable URL shortener
-
-`nodebench.workspace/share/:shareId` (from the product spec) requires the
-short-domain `nodebench.workspace` TLD. Until that domain is secured, use
-`workspace.nodebenchai.com/share/:shareId`.
-
-## Testing locally
-
-```
+```powershell
 npm run dev
-# then visit:
-#   http://localhost:5200/workspace/w/acme-ai
-#   http://localhost:5200/workspace/w/acme-ai?tab=brief
-#   http://localhost:5200/workspace/w/acme-ai?tab=sources
+# then open http://localhost:5173/workspace/w/ship-demo-day?tab=cards
 ```
 
-Once the subdomain is configured:
+## Contract Invariants
 
-```
-https://workspace.nodebenchai.com/w/acme-ai?tab=cards
-```
+Workspace is separate chrome, not separate data. It shares:
 
-## Contract invariants
+- auth
+- `nodebench://` resource URIs
+- graph tables
+- entity cards
+- claims and citations
+- composer routing contract
+- visual tokens
 
-1. Workspace is a **separate app shell** — no cockpit rails, no top nav, no
-   mobile tab bar.
-2. Workspace **shares** everything else with the main app:
-   - same auth
-   - same Convex tables (canonical entity graph from PR #11/#12)
-   - same resource URIs (`nodebench://org/...`, `nodebench://person/...`, etc.)
-   - same card contract (`shared/research/resourceCards.ts`)
-   - same tokens (`src/index.css` + `colors_and_type.css`)
-3. Report card **actions** in `ReportsHome.tsx` link INTO the workspace via
-   the URL shape above. `Brief` → `?tab=brief`, `Explore` → `?tab=cards`,
-   `Chat` → `?tab=chat`.
-4. The workspace header owns its own chrome — DO NOT add workspace-specific
-   code to `CockpitLayout.tsx`.
-
-## Next PR
-
-- Wire the Report card `Brief | Graph | Chat` buttons to the new workspace
-  URL instead of `/reports/:slug/graph`. Rename `Graph` → `Explore`.
-- Port `Map.jsx` into `ReportDetailWorkspace` so the Map tab becomes real.
-- Later: resolve `workspaceId` against a real workspace record (today the
-  page uses a fixture, matching `ReportDetailPage` behavior).
+Do not add Workspace as a tab in `ProductTopNav`, `MobileTabBar`, or
+`WorkspaceRail`.

--- a/docs/design/WORKSPACE_DEPLOY.md
+++ b/docs/design/WORKSPACE_DEPLOY.md
@@ -1,0 +1,117 @@
+# Workspace separate-deploy setup
+
+Per [PRODUCT_SURFACES.md](PRODUCT_SURFACES.md) the **Workspace** is a separate
+deployed surface at a distinct URL (e.g. `workspace.nodebenchai.com`). It is
+NOT a sixth tab on the main app.
+
+This doc explains how the split is implemented today and how to finish the DNS
+/ Vercel setup.
+
+## What v1 ships
+
+- New route `/workspace/w/:workspaceId` in the main React app.
+- Supports `?tab=brief|cards|notebook|sources|chat|map`.
+- Chromeless shell: header with brand + report title, then the existing
+  `ReportDetailWorkspace` body (tabs: Brief · Cards · Map · Sources).
+- v1 treats `notebook` and `chat` URL tabs as landing on **Cards** (the real
+  notebook + chat tabs ship in v1.5 and v2 respectively). The URL is preserved
+  so deep-links can upgrade later.
+- One React bundle serves both `nodebenchai.com` and
+  `workspace.nodebenchai.com` — a Vercel rewrite below routes the subdomain
+  directly into `/workspace/*`.
+
+Route match in [src/App.tsx](../../src/App.tsx) runs BEFORE the cockpit shell,
+so the workspace never mounts `CockpitLayout`. No rails, no top nav, no
+status strip.
+
+## Enable the `workspace.nodebenchai.com` subdomain
+
+### 1. Add the subdomain to Vercel
+
+In the Vercel project (hshum2018-gmailcoms-projects/nodebench-ai):
+
+```
+Settings → Domains → Add → workspace.nodebenchai.com
+```
+
+Vercel will give you a DNS record to add at your DNS provider (Namecheap /
+Cloudflare / etc).
+
+### 2. DNS
+
+Add a `CNAME` for `workspace` pointing to `cname.vercel-dns.com.` (or the
+record Vercel suggests).
+
+### 3. Rewrite requests to `/workspace/*`
+
+Add a `vercel.json` entry (at repo root) so requests to the subdomain land on
+the right path:
+
+```json
+{
+  "rewrites": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
+      "destination": "/workspace/:path*"
+    }
+  ]
+}
+```
+
+Also add a second rewrite so `workspace.nodebenchai.com/w/{id}` (no `/workspace/`
+prefix from the user's POV) still maps correctly:
+
+```json
+{
+  "source": "/w/:workspaceId",
+  "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
+  "destination": "/workspace/w/:workspaceId"
+}
+```
+
+### 4. Optional — shareable URL shortener
+
+`nodebench.workspace/share/:shareId` (from the product spec) requires the
+short-domain `nodebench.workspace` TLD. Until that domain is secured, use
+`workspace.nodebenchai.com/share/:shareId`.
+
+## Testing locally
+
+```
+npm run dev
+# then visit:
+#   http://localhost:5200/workspace/w/acme-ai
+#   http://localhost:5200/workspace/w/acme-ai?tab=brief
+#   http://localhost:5200/workspace/w/acme-ai?tab=sources
+```
+
+Once the subdomain is configured:
+
+```
+https://workspace.nodebenchai.com/w/acme-ai?tab=cards
+```
+
+## Contract invariants
+
+1. Workspace is a **separate app shell** — no cockpit rails, no top nav, no
+   mobile tab bar.
+2. Workspace **shares** everything else with the main app:
+   - same auth
+   - same Convex tables (canonical entity graph from PR #11/#12)
+   - same resource URIs (`nodebench://org/...`, `nodebench://person/...`, etc.)
+   - same card contract (`shared/research/resourceCards.ts`)
+   - same tokens (`src/index.css` + `colors_and_type.css`)
+3. Report card **actions** in `ReportsHome.tsx` link INTO the workspace via
+   the URL shape above. `Brief` → `?tab=brief`, `Explore` → `?tab=cards`,
+   `Chat` → `?tab=chat`.
+4. The workspace header owns its own chrome — DO NOT add workspace-specific
+   code to `CockpitLayout.tsx`.
+
+## Next PR
+
+- Wire the Report card `Brief | Graph | Chat` buttons to the new workspace
+  URL instead of `/reports/:slug/graph`. Rename `Graph` → `Explore`.
+- Port `Map.jsx` into `ReportDetailWorkspace` so the Map tab becomes real.
+- Later: resolve `workspaceId` against a real workspace record (today the
+  page uses a fixture, matching `ReportDetailPage` behavior).

--- a/docs/design/nodebench-ai-design-system/README.md
+++ b/docs/design/nodebench-ai-design-system/README.md
@@ -15,27 +15,35 @@ decision-ready briefs for founders pitching VCs and investors doing diligence.
 Every answer is backed by source evidence and receipts instead of
 hallucinations.
 
-The product is organized around **five user surfaces**:
+The main web product is organized around **five operating surfaces**:
 
 | Surface | Purpose |
 | --- | --- |
 | **Home**    | start quickly |
-| **Chat**    | do the work — answer, sources, trace, follow-ups |
 | **Reports** | turn a run into reusable memory |
-| **Nudges**  | return at the right moment, when something meaningful changes |
+| **Chat**    | do the work: answer, sources, trace, follow-ups |
+| **Inbox**   | captures, nudges, alerts, automations, and unassigned review |
 | **Me**      | operator context and control |
 
-The mental model: `question → answer → saved report → watch item → useful
-nudge → better next run`.
+`Nudges` are now a section inside Inbox, not a top-level surface.
+
+The separate deep-work surface is **Workspace**, deployed at a host like
+`nodebench.workspace`. Workspace is opened from Chat, Reports, and Inbox. Its
+tabs are `Brief`, `Cards`, `Notebook`, `Sources`, `Chat`, and `Map`.
+
+The mental model: `messy input -> answer or capture -> saved report -> deep
+workspace -> verified memo or next action`.
 
 ### Products represented in this design system
 
 1. **NodeBench AI** — the flagship web app (React + Vite + Tailwind). The
-   primary UI kit.
+   primary operating UI kit: Home, Reports, Chat, Inbox, Me.
 2. **Marketing / public surface** — the `nb-public-*` landing shell, hero,
    and feature grid seen on nodebenchai.com.
 3. **nodebench-mcp** (distribution lane, CLI/MCP) — command-line-adjacent, so
    not a visual UI kit, but typography and tone rules still apply.
+4. **nodebench.workspace** — the deep research environment for reusable
+   intelligence: Brief, Cards, Notebook, Sources, Chat, Map.
 
 ### Sources used
 
@@ -149,8 +157,9 @@ rules from `AGENTS.md` explicitly call out style-drift guardrails against
   (`.type-kicker`, `.type-label`).
 - Product names are literal: `NodeBench AI`, `nodebench-mcp`,
   `nodebench-mcp-power`, `nodebench-mcp-admin`, `Attrition`.
-- Surface names are Title-Cased single words: **Home · Chat · Reports ·
-  Nudges · Me**.
+- Operating surface names are Title-Cased single words: **Home · Reports ·
+  Chat · Inbox · Me**. `Nudges` lives inside Inbox. `Workspace` is the
+  separate deep-work shell, not a sixth operating tab.
 
 ### Copy patterns
 

--- a/docs/design/nodebench-ai-design-system/preview/component-chips.html
+++ b/docs/design/nodebench-ai-design-system/preview/component-chips.html
@@ -11,14 +11,14 @@
     <span class="chip">Reports</span>
     <span class="chip">Entities</span>
     <span class="chip">Files</span>
-    <span class="chip">Nudges</span>
+    <span class="chip">Inbox</span>
     <span class="chip">Me</span>
   </div>
   <div style="background:#F3F4F6;padding:6px;border-radius:16px;display:inline-flex;gap:4px">
     <button class="filter-tab filter-tab-active">Home</button>
-    <button class="filter-tab">Chat</button>
     <button class="filter-tab">Reports</button>
-    <button class="filter-tab">Nudges</button>
+    <button class="filter-tab">Chat</button>
+    <button class="filter-tab">Inbox</button>
     <button class="filter-tab">Me</button>
   </div>
 </div></body></html>

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/App.jsx
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/App.jsx
@@ -1,5 +1,5 @@
 // App shell: one mobile phone = one surface state machine.
-// Tab order matches web exactly: Home · Chat · Reports · Inbox · Me.
+// Tab order matches web exactly: Home · Reports · Chat · Inbox · Me.
 // Each phone independently switches between tabs.
 function Phone({ initialTab = "home" }) {
   const {
@@ -61,12 +61,12 @@ function Phone({ initialTab = "home" }) {
 
 function App() {
   // Four phones showing the breadth of the mobile surface along the tab order:
-  // Home (discovery) · Chat (answer) · Reports (brief + sub-sections) · Inbox (attention) · Me (profile).
+  // Home (discovery) · Reports (brief + sub-sections) · Chat (answer) · Inbox (attention) · Me (profile).
   // Three fit well side-by-side in a frame.
   const phones = [
     { initial: "home",    label: "Home",    kicker: "Discover" },
-    { initial: "chat",    label: "Chat",    kicker: "Ask & read" },
     { initial: "reports", label: "Reports", kicker: "Read the brief" },
+    { initial: "chat",    label: "Chat",    kicker: "Ask & read" },
     { initial: "inbox",   label: "Inbox",   kicker: "Attention" },
     { initial: "me",      label: "Me",      kicker: "Profile & workspaces" },
   ];
@@ -76,7 +76,7 @@ function App() {
       <div className="m-stage-title">
         <h1>NodeBench Mobile UI Kit</h1>
         <p>
-          Five primary surfaces matching the web app: <b>Home · Chat · Reports · Inbox · Me</b>.
+          Five primary surfaces matching the web app: <b>Home · Reports · Chat · Inbox · Me</b>.
           Tap any tab on a phone to switch — each phone is independent.
           Reports contains Brief (default), with Sources and Notebook as sub-sections reachable from its action row.
         </p>

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/MobileHome.jsx
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/MobileHome.jsx
@@ -49,7 +49,7 @@ function MobileHome({ onNavigate }) {
           </div>
         </section>
 
-        {/* Nudges */}
+        {/* Inbox nudges */}
         <section className="m-section">
           <header className="m-section-head">
             <span className="kicker">Since you were last here</span>

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/README.md
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/README.md
@@ -7,7 +7,8 @@ The codebase mobile surface is React + Tailwind served through a Capacitor
 wrapper (`android/`), so mobile is the same app collapsed to narrow
 viewports with:
 
-- bottom tab bar (Home · Chat · Reports · Nudges · Me)
+- bottom tab bar (Home · Reports · Chat · Inbox · Me)
+- nudges live inside Inbox, alongside captures, alerts, automations, and unassigned review
 - floating action button anchored above the tab bar (safe-area aware)
 - tap states at `scale(0.97)` / 80ms (from `src/index.css`)
 - translucent topbar shrunk to title + single action

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/TabBar.jsx
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/TabBar.jsx
@@ -1,10 +1,10 @@
 // Mobile TabBar — bottom navigation.
-// Order matches web app exactly: Home · Chat · Reports · Inbox · Me.
+// Order matches web app exactly: Home · Reports · Chat · Inbox · Me.
 function MobileTabBar({ active, onChange, inboxCount = 3, chatCount = 2 }) {
   const tabs = [
     { id: "home",    label: "Home",    icon: "home" },
-    { id: "chat",    label: "Chat",    icon: "chat",    badge: chatCount },
     { id: "reports", label: "Reports", icon: "reports" },
+    { id: "chat",    label: "Chat",    icon: "chat",    badge: chatCount },
     { id: "inbox",   label: "Inbox",   icon: "inbox",   badge: inboxCount },
     { id: "me",      label: "Me",      icon: "me" },
   ];

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/README.md
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/README.md
@@ -9,8 +9,8 @@ stubbed.
 
 ## What's in here
 
-- `index.html` — Interactive demo. Hop between Home → Chat → Reports →
-  Nudges → Me. Start a run from a prompt card and watch the answer packet
+- `index.html` — Interactive demo. Hop between Home → Reports → Chat →
+  Inbox → Me. Start a run from a prompt card and watch the answer packet
   stream in.
 - `TopNav.jsx` — Sticky translucent topbar (logo mark, surface tabs,
   search, session menu).
@@ -21,6 +21,7 @@ stubbed.
 - `ReportCard.jsx` — Saved-report row with status, source count, "watch"
   toggle.
 - `NudgeList.jsx` — Timeline of nudges with entity mention and dismiss.
+- Nudges belong inside Inbox; they are not a top-level operating tab.
 - `EntityNotebook.jsx` — Paper-surface notebook view with terracotta
   left margin rule.
 - `App.jsx` — Top-level state + router for the five surfaces.

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/TopNav.jsx
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/TopNav.jsx
@@ -3,8 +3,8 @@ function TopNav({ surface, onSurface, onToggleTheme, theme }) {
   const { Search, Command, Sun, Moon, Bell } = window.NBIcon;
   const tabs = [
     { id: 'home', label: 'Home' },
-    { id: 'chat', label: 'Chat' },
     { id: 'reports', label: 'Reports' },
+    { id: 'chat', label: 'Chat' },
     { id: 'nudges', label: 'Inbox' },
     { id: 'me', label: 'Me' },
   ];
@@ -50,7 +50,7 @@ function TopNav({ surface, onSurface, onToggleTheme, theme }) {
             boxShadow: 'var(--shadow-sm)',
           }}>
             <Search width={15} height={15} style={{ color: 'var(--text-faint)' }} />
-            <input placeholder="Search reports, entities, nudges…"
+            <input placeholder="Search reports, entities, inbox..."
               style={{ flex: 1, border: 0, outline: 0, fontSize: 13, color: 'var(--text-primary)', background: 'transparent', fontFamily: 'inherit' }} />
             <span style={{ display: 'flex', alignItems: 'center', gap: 3, fontSize: 10, color: 'var(--text-faint)', fontFamily: 'var(--font-mono)', background: 'var(--bg-secondary)', padding: '2px 6px', borderRadius: 4 }}>
               <Command width={10} height={10} /> K

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/nodebench.css
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/nodebench.css
@@ -465,7 +465,7 @@ body.nb-app[data-texture="on"] .nb-panel {
 }
 
 /* ═══════════════════════════════════════════════════════════════════
-   Inbox (formerly Nudges) — actionable row pattern
+   Inbox - actionable row pattern
    ══════════════════════════════════════════════════════════════════ */
 .nb-inbox-head {
   display: flex; align-items: baseline; justify-content: space-between;
@@ -1468,4 +1468,3 @@ html[data-theme="dark"] .nb-chat-composer { background: rgba(13,16,20,.88); }
   color: var(--text-muted);
   margin: 0 2px;
 }
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,11 @@ const ReportDetailPage = lazy(() =>
     default: m.ReportDetailPage,
   })),
 );
+const UniversalWorkspacePage = lazy(() =>
+  import("@/features/workspace/views/UniversalWorkspacePage").then((m) => ({
+    default: m.UniversalWorkspacePage,
+  })),
+);
 const EmbedView = lazy(() => import("@/features/founder/views/EmbedView"));
 const FounderRouteResolver = lazy(() => import("@/features/founder/views/FounderRouteResolver"));
 // My Wiki — Phase 1 routes. See docs/architecture/ME_AGENT_DESIGN.md
@@ -126,6 +131,33 @@ function App() {
     setShowTutorial(false);
   };
 
+  const workspaceHostname =
+    typeof window !== "undefined" ? window.location.hostname.toLowerCase() : "";
+  const isWorkspaceHost =
+    workspaceHostname === "nodebench.workspace" ||
+    workspaceHostname === "workspace.nodebenchai.com" ||
+    workspaceHostname === "nodebench-workspace.vercel.app";
+  const isStandaloneWorkspaceRoute =
+    location.pathname === "/workspace" ||
+    location.pathname.startsWith("/workspace/") ||
+    (isWorkspaceHost &&
+      (location.pathname === "/" ||
+        location.pathname.startsWith("/w/") ||
+        location.pathname.startsWith("/share/")));
+  if (isStandaloneWorkspaceRoute) {
+    return (
+      <ThemeProvider>
+        <ErrorBoundary title="Workspace failed to load">
+          <Suspense fallback={<ViewSkeleton />}>
+            <div key="workspace" className="route-fade-in h-screen">
+              <UniversalWorkspacePage />
+            </div>
+          </Suspense>
+        </ErrorBoundary>
+      </ThemeProvider>
+    );
+  }
+
   // Standalone route: /memo/:id renders without cockpit chrome or auth wrapper
   const isMemoRoute = location.pathname.startsWith("/memo/");
   if (isMemoRoute) {
@@ -198,6 +230,7 @@ function App() {
     );
   }
 
+  // without any cockpit shell — the workspace owns its own header.
   const isReportRoute = location.pathname.startsWith("/report/");
   if (isReportRoute) {
     if (webmcpIsAuth) {

--- a/src/features/home/views/HomeLanding.tsx
+++ b/src/features/home/views/HomeLanding.tsx
@@ -23,6 +23,7 @@ import { ProductThumbnail } from "@/features/product/components/ProductThumbnail
 import { ProductSourceIdentity } from "@/features/product/components/ProductSourceIdentity";
 import { ProductIntakeComposer, type ProductComposerMode } from "@/features/product/components/ProductIntakeComposer";
 import { IntakeDetectedSources } from "@/features/product/components/IntakeDetectedSources";
+import { ComposerRoutingPreview } from "@/features/product/components/ComposerRoutingPreview";
 import { useProductBootstrap } from "@/features/product/lib/useProductBootstrap";
 import { buildOperatorContextHint, buildOperatorContextLabel } from "@/features/product/lib/operatorContext";
 import { uploadProductDraftFiles } from "@/features/product/lib/uploadDraftFiles";
@@ -477,6 +478,13 @@ export function HomeLanding() {
           <IntakeDetectedSources
             text={query}
             files={pendingFiles}
+            className="mt-3"
+          />
+          <ComposerRoutingPreview
+            text={query}
+            files={pendingFiles}
+            mode={composerMode}
+            activeContextLabel="workspace inbox"
             className="mt-3"
           />
         </div>

--- a/src/features/product/components/ComposerRoutingPreview.tsx
+++ b/src/features/product/components/ComposerRoutingPreview.tsx
@@ -1,0 +1,181 @@
+import { useMemo, type ReactNode } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ClipboardList,
+  GitBranch,
+  MapPin,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { ProductComposerMode } from "@/features/product/components/ProductIntakeComposer";
+import {
+  inferCaptureRoute,
+  type CaptureRoute,
+} from "@/features/product/lib/captureRouter";
+
+type SimpleFile = { name: string; size?: number };
+
+export type ComposerRoutingPreviewProps = {
+  text: string;
+  files: ReadonlyArray<SimpleFile>;
+  mode?: ProductComposerMode;
+  activeContextLabel?: string | null;
+  compact?: boolean;
+  className?: string;
+};
+
+export function ComposerRoutingPreview({
+  text,
+  files,
+  mode = "ask",
+  activeContextLabel,
+  compact = false,
+  className,
+}: ComposerRoutingPreviewProps) {
+  const route = useMemo(
+    () => inferCaptureRoute({ text, files, mode, activeContextLabel }),
+    [activeContextLabel, files, mode, text],
+  );
+
+  if (!text.trim() && files.length === 0) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Composer routing preview"
+      className={cn(
+        "rounded-md border border-white/[0.08] bg-[#111418]/80 text-white shadow-[0_12px_40px_rgba(0,0,0,0.18)]",
+        compact ? "px-3 py-2" : "px-4 py-3",
+        className,
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center gap-1 rounded border border-[#d97757]/25 bg-[#d97757]/10 px-2 py-1 text-[11px] font-medium text-[#e59579]">
+          <GitBranch size={12} aria-hidden />
+          {intentLabel(route.intent)}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[11px] text-white/70">
+          <MapPin size={12} aria-hidden />
+          {route.targetLabel}
+        </span>
+        <ConfidencePill route={route} />
+        <span className="min-w-[7rem] flex-1 text-xs text-white/50">
+          {route.reason}
+        </span>
+      </div>
+
+      {!compact && (
+        <div className="mt-3 grid gap-2 md:grid-cols-3">
+          <PreviewList
+            icon={<Sparkles size={13} aria-hidden />}
+            label="Entities"
+            empty="No entity yet"
+            items={route.entities.map((entity) => `${entity.name} - ${entity.type}`)}
+          />
+          <PreviewList
+            icon={<ShieldCheck size={13} aria-hidden />}
+            label="Claims"
+            empty="No claim yet"
+            items={route.claims.map((claim) => claim.text)}
+          />
+          <PreviewList
+            icon={<ClipboardList size={13} aria-hidden />}
+            label="Next"
+            empty="Waiting"
+            items={route.nextActions}
+          />
+        </div>
+      )}
+
+      {compact && (route.entities.length > 0 || route.claims.length > 0) && (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          {route.entities.slice(0, 4).map((entity) => (
+            <span
+              key={`${entity.type}:${entity.name}`}
+              className="max-w-[12rem] truncate rounded border border-white/[0.08] bg-white/[0.03] px-1.5 py-0.5 text-[11px] text-white/60"
+              title={`${entity.name} - ${entity.type}`}
+            >
+              {entity.name}
+            </span>
+          ))}
+          {route.claims.slice(0, 2).map((claim, index) => (
+            <span
+              key={`${index}:${claim.text}`}
+              className="max-w-[18rem] truncate rounded border border-[#d97757]/20 bg-[#d97757]/5 px-1.5 py-0.5 text-[11px] text-[#e7b29e]"
+              title={claim.text}
+            >
+              {claim.text}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConfidencePill({ route }: { route: CaptureRoute }) {
+  const Icon = route.needsConfirmation ? AlertTriangle : CheckCircle2;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded border px-2 py-1 text-[11px]",
+        route.needsConfirmation
+          ? "border-amber-500/25 bg-amber-500/10 text-amber-200"
+          : "border-emerald-500/25 bg-emerald-500/10 text-emerald-200",
+      )}
+    >
+      <Icon size={12} aria-hidden />
+      {Math.round(route.confidence * 100)}% - {route.needsConfirmation ? "confirm" : "auto"}
+    </span>
+  );
+}
+
+function PreviewList({
+  icon,
+  label,
+  empty,
+  items,
+}: {
+  icon: ReactNode;
+  label: string;
+  empty: string;
+  items: string[];
+}) {
+  return (
+    <div className="min-w-0 rounded border border-white/[0.06] bg-white/[0.02] p-2">
+      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.15em] text-white/45">
+        {icon}
+        {label}
+      </div>
+      {items.length > 0 ? (
+        <ul className="space-y-1 text-xs text-white/68">
+          {items.slice(0, 3).map((item) => (
+            <li key={item} className="truncate" title={item}>
+              {item}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-white/35">{empty}</p>
+      )}
+    </div>
+  );
+}
+
+function intentLabel(intent: CaptureRoute["intent"]) {
+  switch (intent) {
+    case "capture_field_note":
+      return "Field note";
+    case "ask_question":
+      return "Question";
+    case "append_to_report":
+      return "Report append";
+    case "create_followup":
+      return "Follow-up";
+    case "expand_entity":
+      return "Entity expansion";
+  }
+}

--- a/src/features/product/lib/captureRouter.test.ts
+++ b/src/features/product/lib/captureRouter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { inferCaptureRoute } from "./captureRouter";
+
+describe("inferCaptureRoute", () => {
+  it("routes demo-day field notes into the active event report", () => {
+    const route = inferCaptureRoute({
+      text: "Met Alex from Orbital Labs. Voice agent eval infra, seed, wants healthcare design partners.",
+      mode: "note",
+    });
+
+    expect(route.intent).toBe("capture_field_note");
+    expect(route.target).toBe("active_event");
+    expect(route.gate).toBe("auto_route");
+    expect(route.entities.map((entity) => entity.name)).toContain("Alex");
+    expect(route.entities.map((entity) => entity.name)).toContain("Orbital Labs");
+    expect(route.claims.length).toBeGreaterThan(0);
+    expect(route.followUps.some((item) => item.text.includes("pilot criteria"))).toBe(true);
+    expect(route.ack).toContain("Saved to active event report");
+  });
+
+  it("keeps uncertain low-signal captures in review", () => {
+    const route = inferCaptureRoute({
+      text: "interesting thing from last week",
+      mode: "note",
+    });
+
+    expect(route.intent).toBe("capture_field_note");
+    expect(route.target).toBe("unassigned_buffer");
+    expect(route.needsConfirmation).toBe(true);
+    expect(route.nextActions).toContain("Confirm target");
+  });
+
+  it("classifies recruiter email as an inbox item with evidence", () => {
+    const route = inferCaptureRoute({
+      text: "Recruiter emailed me about a Staff Engineer role at Acme AI. Need tailored reply.",
+      mode: "ask",
+      files: [{ name: "job-spec.pdf", size: 1200 }],
+    });
+
+    expect(route.target).toBe("inbox_item");
+    expect(route.intent).toBe("create_followup");
+    expect(route.evidence).toContain("job-spec.pdf");
+    expect(route.entities.some((entity) => entity.name.includes("Acme AI"))).toBe(true);
+  });
+});

--- a/src/features/product/lib/captureRouter.ts
+++ b/src/features/product/lib/captureRouter.ts
@@ -1,0 +1,396 @@
+import type { ProductComposerMode } from "@/features/product/components/ProductIntakeComposer";
+import {
+  classifyIntake,
+  type IntakeSource,
+} from "@/features/product/components/intakeSourceClassifier";
+
+export type CaptureIntent =
+  | "capture_field_note"
+  | "ask_question"
+  | "append_to_report"
+  | "create_followup"
+  | "expand_entity";
+
+export type CaptureTarget =
+  | "current_report"
+  | "active_event"
+  | "inbox_item"
+  | "unassigned_buffer";
+
+export type CaptureEntityType =
+  | "person"
+  | "company"
+  | "product"
+  | "market"
+  | "event"
+  | "role"
+  | "source";
+
+export type CaptureConfidenceGate =
+  | "auto_route"
+  | "confirm_target"
+  | "review_unassigned";
+
+export interface CaptureEntity {
+  name: string;
+  type: CaptureEntityType;
+  confidence: number;
+}
+
+export interface CaptureClaim {
+  text: string;
+  confidence: number;
+  verificationStatus: "field_note" | "needs_verification";
+}
+
+export interface CaptureFollowUp {
+  text: string;
+  priority: "low" | "medium" | "high";
+}
+
+export interface CaptureRoute {
+  intent: CaptureIntent;
+  target: CaptureTarget;
+  targetLabel: string;
+  confidence: number;
+  gate: CaptureConfidenceGate;
+  needsConfirmation: boolean;
+  reason: string;
+  sources: ReadonlyArray<IntakeSource>;
+  entities: CaptureEntity[];
+  claims: CaptureClaim[];
+  followUps: CaptureFollowUp[];
+  evidence: string[];
+  ack: string;
+  nextActions: string[];
+}
+
+type InferCaptureRouteArgs = {
+  text?: string;
+  files?: ReadonlyArray<{ name: string; size?: number }>;
+  mode?: ProductComposerMode;
+  activeContextLabel?: string | null;
+};
+
+const QUESTION_START = /^(who|what|when|where|why|how|which|compare|research|evaluate|find|show|summarize|build|draft)\b/i;
+const FIELD_NOTE_MARKERS = /\b(met|talked|spoke|coffee|demo day|conference|booth|voice memo|recorded|handwritten|whiteboard|screenshot|photo|notes?|lecture|pitch|customer call)\b/i;
+const FOLLOW_UP_MARKERS = /\b(follow up|follow-up|todo|remind|task|next step|ask them|email|intro|reply|schedule)\b/i;
+const APPEND_MARKERS = /\b(add|attach|save|append|put this|log this)\b.*\b(report|brief|dossier|workspace|notebook)\b/i;
+const EVENT_MARKERS = /\b(demo day|conference|event|booth|lecture|whiteboard|pitch|summit|meetup)\b/i;
+const INBOX_MARKERS = /\b(recruiter|email|inbox|newsletter|invite|application|offer|rejected|job spec)\b/i;
+const REPORT_MARKERS = /\b(report|brief|dossier|market map|prd|memo|company|startup|competitor|vendor|paper|repo)\b/i;
+const COMPANY_SUFFIX = /\b(Inc|Labs|AI|Systems|Technologies|Tech|Health|Bio|Robotics|Capital|Ventures|Partners|Bank|University|Labs)\b/;
+
+const ENTITY_STOPWORDS = new Set([
+  "At",
+  "The",
+  "This",
+  "That",
+  "Need",
+  "Met",
+  "Asked",
+  "Follow",
+  "Voice",
+  "Demo",
+  "Series",
+  "Seed",
+  "Healthcare",
+  "Market",
+]);
+
+export function inferCaptureRoute({
+  text = "",
+  files = [],
+  mode = "ask",
+  activeContextLabel,
+}: InferCaptureRouteArgs): CaptureRoute {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  const sources = classifyIntake({ text: normalized, files });
+  const hasFiles = files.length > 0;
+  const intent = inferIntent(normalized, mode, hasFiles);
+  const rawTarget = inferTarget(normalized, intent, activeContextLabel);
+  const entities = extractEntities(normalized, sources, rawTarget);
+  const claims = extractClaims(normalized, entities);
+  const followUps = extractFollowUps(normalized, intent, entities, rawTarget);
+  const evidence = extractEvidence(sources);
+  const confidence = scoreRoute({
+    text: normalized,
+    sources,
+    entities,
+    claims,
+    followUps,
+    target: rawTarget,
+    intent,
+    hasFiles,
+  });
+  const gate = confidence >= 0.78
+    ? "auto_route"
+    : confidence >= 0.52
+      ? "confirm_target"
+      : "review_unassigned";
+  const target = gate === "review_unassigned" ? "unassigned_buffer" : rawTarget;
+  const needsConfirmation = gate !== "auto_route";
+  const targetLabel = labelForTarget(target, activeContextLabel);
+
+  return {
+    intent,
+    target,
+    targetLabel,
+    confidence,
+    gate,
+    needsConfirmation,
+    reason: buildReason(intent, target, sources, entities),
+    sources,
+    entities,
+    claims,
+    followUps,
+    evidence,
+    ack: buildAck(target, targetLabel, needsConfirmation),
+    nextActions: buildNextActions(intent, target, needsConfirmation),
+  };
+}
+
+function inferIntent(
+  text: string,
+  mode: ProductComposerMode,
+  hasFiles: boolean,
+): CaptureIntent {
+  if (mode === "task") return "create_followup";
+  if (FOLLOW_UP_MARKERS.test(text)) return "create_followup";
+  if (APPEND_MARKERS.test(text)) return "append_to_report";
+  if (mode === "note") return "capture_field_note";
+  if (FIELD_NOTE_MARKERS.test(text) || hasFiles) return "capture_field_note";
+  if (QUESTION_START.test(text) || text.includes("?")) {
+    return REPORT_MARKERS.test(text) ? "expand_entity" : "ask_question";
+  }
+  if (REPORT_MARKERS.test(text)) return "expand_entity";
+  return "capture_field_note";
+}
+
+function inferTarget(
+  text: string,
+  intent: CaptureIntent,
+  activeContextLabel?: string | null,
+): CaptureTarget {
+  const context = activeContextLabel?.trim() ?? "";
+  const looksLikeEventContext =
+    EVENT_MARKERS.test(context) || /\b(demo|conference|event|summit|meetup)\b/i.test(context);
+  const looksLikeEventCapture =
+    /\b(?:met|talked to|spoke with)\s+[A-Z][A-Za-z.-]*(?:\s+[A-Z][A-Za-z.-]*)?\s+from\s+[A-Z]/.test(text);
+
+  if (EVENT_MARKERS.test(text) || looksLikeEventContext || looksLikeEventCapture) {
+    return "active_event";
+  }
+  if (INBOX_MARKERS.test(text)) return "inbox_item";
+  if (intent === "append_to_report" || REPORT_MARKERS.test(text)) {
+    return "current_report";
+  }
+  if (context) return "current_report";
+  return "unassigned_buffer";
+}
+
+function scoreRoute(args: {
+  text: string;
+  sources: ReadonlyArray<IntakeSource>;
+  entities: ReadonlyArray<CaptureEntity>;
+  claims: ReadonlyArray<CaptureClaim>;
+  followUps: ReadonlyArray<CaptureFollowUp>;
+  target: CaptureTarget;
+  intent: CaptureIntent;
+  hasFiles: boolean;
+}) {
+  if (!args.text && !args.hasFiles) return 0;
+  let score = 0.38;
+  if (args.sources.length > 0) score += 0.12;
+  if (args.entities.length > 0) score += 0.18;
+  if (args.claims.length > 0) score += 0.12;
+  if (args.followUps.length > 0) score += 0.08;
+  if (args.target !== "unassigned_buffer") score += 0.08;
+  if (args.intent === "ask_question" || args.intent === "expand_entity") score += 0.04;
+  if (args.text.length > 240) score += 0.04;
+  return Math.min(0.96, Number(score.toFixed(2)));
+}
+
+function extractEntities(
+  text: string,
+  sources: ReadonlyArray<IntakeSource>,
+  target: CaptureTarget,
+): CaptureEntity[] {
+  const entities: CaptureEntity[] = [];
+  const seen = new Set<string>();
+  const add = (name: string, type: CaptureEntityType, confidence: number) => {
+    const cleaned = name.replace(/[.,:;!?]+$/g, "").trim();
+    if (!cleaned || cleaned.length < 2) return;
+    const key = `${type}:${cleaned.toLowerCase()}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    entities.push({ name: cleaned, type, confidence });
+  };
+
+  for (const source of sources) {
+    if (source.kind === "linkedin_url" && source.slug) add(source.slug, "person", 0.72);
+    if (source.kind === "github_url") {
+      if (source.repo) add(source.repo, "product", 0.74);
+      else if (source.owner) add(source.owner, "source", 0.68);
+    }
+    if ("host" in source && source.host) add(source.host, "source", 0.66);
+    if ("fileName" in source) add(source.fileName, "source", 0.7);
+  }
+
+  const fromMatch = text.match(/\bfrom\s+([A-Z][A-Za-z0-9&.-]*(?:\s+[A-Z][A-Za-z0-9&.-]*){0,3})/);
+  if (fromMatch) add(fromMatch[1], "company", 0.86);
+
+  const metMatch = text.match(/\b(?:met|talked to|spoke with|coffee with)\s+([A-Z][A-Za-z.-]*(?:\s+[A-Z][A-Za-z.-]*)?)/i);
+  if (metMatch) add(metMatch[1], "person", 0.82);
+
+  const capitalized = text.match(/\b[A-Z][A-Za-z0-9&.-]*(?:\s+[A-Z][A-Za-z0-9&.-]*){0,3}\b/g) ?? [];
+  for (const phrase of capitalized) {
+    const first = phrase.split(/\s+/)[0];
+    if (ENTITY_STOPWORDS.has(first)) continue;
+    if (COMPANY_SUFFIX.test(phrase)) {
+      add(phrase, "company", 0.72);
+    } else if (phrase.split(/\s+/).length <= 2 && target !== "active_event") {
+      add(phrase, "company", 0.58);
+    } else if (phrase.split(/\s+/).length <= 2) {
+      add(phrase, "person", 0.58);
+    }
+  }
+
+  for (const market of ["healthcare", "legal tech", "voice agent", "AI infra", "developer tools", "sales", "education"]) {
+    if (text.toLowerCase().includes(market)) {
+      add(market, market.includes("agent") || market.includes("infra") ? "product" : "market", 0.7);
+    }
+  }
+
+  return entities.slice(0, 8);
+}
+
+function extractClaims(
+  text: string,
+  entities: ReadonlyArray<CaptureEntity>,
+): CaptureClaim[] {
+  if (!text.trim()) return [];
+  const chunks = text
+    .split(/(?<=[.!?])\s+|;\s+|\n+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const claimy = chunks.filter((part) =>
+    /\b(builds?|building|uses|wants|looking for|raised|seed|series|ARR|NRR|claims?|needs?|launched|ships?|competitor|risk|budget|hiring)\b/i.test(part),
+  );
+  if (claimy.length === 0 && entities.length >= 2) {
+    const [first, second] = entities;
+    return [{
+      text: `${first.name} is related to ${second.name}`,
+      confidence: 0.48,
+      verificationStatus: "field_note",
+    }];
+  }
+  return claimy.slice(0, 4).map((part) => ({
+    text: part.replace(/^[-*]\s*/, ""),
+    confidence: /\b(claims?|heard|said|mentioned)\b/i.test(part) ? 0.46 : 0.62,
+    verificationStatus: /\b(verified|source|filing|article|press)\b/i.test(part)
+      ? "needs_verification"
+      : "field_note",
+  }));
+}
+
+function extractFollowUps(
+  text: string,
+  intent: CaptureIntent,
+  entities: ReadonlyArray<CaptureEntity>,
+  target: CaptureTarget,
+): CaptureFollowUp[] {
+  const followUps: CaptureFollowUp[] = [];
+  const normalized = text.toLowerCase();
+  if (FOLLOW_UP_MARKERS.test(text) || intent === "create_followup") {
+    followUps.push({
+      text: text.replace(/^[-*]\s*/, "").slice(0, 160),
+      priority: normalized.includes("urgent") || normalized.includes("tomorrow") ? "high" : "medium",
+    });
+  }
+  if (normalized.includes("design partner") || normalized.includes("pilot")) {
+    followUps.push({
+      text: "Ask about pilot criteria and design-partner timeline",
+      priority: "high",
+    });
+  }
+  if (target === "active_event" && entities.some((entity) => entity.type === "person" || entity.type === "company")) {
+    followUps.push({
+      text: "Prioritize follow-up queue for this event",
+      priority: "medium",
+    });
+  }
+  return dedupeFollowUps(followUps).slice(0, 4);
+}
+
+function dedupeFollowUps(items: CaptureFollowUp[]) {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = item.text.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function extractEvidence(sources: ReadonlyArray<IntakeSource>) {
+  return sources
+    .map((source) => {
+      if ("url" in source) return source.url;
+      if ("fileName" in source) return source.fileName;
+      return "";
+    })
+    .filter(Boolean)
+    .slice(0, 6);
+}
+
+function labelForTarget(target: CaptureTarget, activeContextLabel?: string | null) {
+  if (target === "current_report") return activeContextLabel?.trim() || "current report";
+  if (target === "active_event") return "active event report";
+  if (target === "inbox_item") return "inbox item";
+  return "unassigned capture review";
+}
+
+function buildReason(
+  intent: CaptureIntent,
+  target: CaptureTarget,
+  sources: ReadonlyArray<IntakeSource>,
+  entities: ReadonlyArray<CaptureEntity>,
+) {
+  const sourcePhrase = sources.length > 0 ? `${sources.length} source hint${sources.length === 1 ? "" : "s"}` : "plain text";
+  const entityPhrase = entities.length > 0 ? `${entities.length} inferred entit${entities.length === 1 ? "y" : "ies"}` : "no strong entity";
+  return `${labelForIntent(intent)} from ${sourcePhrase}; ${entityPhrase}; routed to ${labelForTarget(target)}.`;
+}
+
+function buildAck(target: CaptureTarget, targetLabel: string, needsConfirmation: boolean) {
+  if (needsConfirmation) return `Needs confirmation before saving to ${targetLabel}.`;
+  if (target === "unassigned_buffer") return "Saved to unassigned captures.";
+  return `Saved to ${targetLabel}.`;
+}
+
+function buildNextActions(
+  intent: CaptureIntent,
+  target: CaptureTarget,
+  needsConfirmation: boolean,
+) {
+  if (needsConfirmation) return ["Confirm target", "Move", "Discard"];
+  if (intent === "ask_question" || intent === "expand_entity") return ["Open card", "Go deeper", "Verify"];
+  if (intent === "create_followup") return ["Add follow-up", "Open queue", "Draft reply"];
+  if (target === "active_event") return ["Edit", "Move", "Go deeper"];
+  return ["Open card", "Attach to report", "Verify"];
+}
+
+function labelForIntent(intent: CaptureIntent) {
+  switch (intent) {
+    case "capture_field_note":
+      return "field note";
+    case "ask_question":
+      return "question";
+    case "append_to_report":
+      return "report append";
+    case "create_followup":
+      return "follow-up";
+    case "expand_entity":
+      return "entity expansion";
+  }
+}

--- a/src/features/reports/views/ReportsHome.tsx
+++ b/src/features/reports/views/ReportsHome.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useMutation, useQuery } from "convex/react";
 import { Check, Link2, Search, Building2, User, Briefcase, TrendingUp, FileText, X } from "lucide-react";
 import { toast } from "sonner";
@@ -15,6 +15,7 @@ import { getAnonymousProductSessionId } from "@/features/product/lib/productIden
 import { useProductBootstrap } from "@/features/product/lib/useProductBootstrap";
 import { RecentPulseStrip } from "@/features/reports/components/RecentPulseStrip";
 import { ReportReadOnlyPanel } from "@/features/reports/components/ReportReadOnlyPanel";
+import { buildWorkspaceUrl, type WorkspaceTab } from "@/features/workspace/lib/workspaceRouting";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -207,15 +208,14 @@ function ReportCard({
   index,
   copiedSlug,
   onShare,
-  onClick,
+  onOpenWorkspace,
 }: {
   card: EntityCard;
   index: number;
   copiedSlug: string | null;
   onShare: (slug: string) => void;
-  onClick: (slug: string) => void;
+  onOpenWorkspace: (slug: string, tab: WorkspaceTab) => void;
 }) {
-  const navigate = useNavigate();
   const iconColor = entityTypeColor(card.entityType);
   const sourceCount = card.sourceUrls?.length ?? 0;
   const relatedPreview =
@@ -230,7 +230,7 @@ function ReportCard({
       {/* Main clickable area */}
       <button
         type="button"
-        onClick={() => onClick(card.slug)}
+        onClick={() => onOpenWorkspace(card.slug, "brief")}
         className="flex h-full w-full flex-col text-left"
       >
         {/* Thumbnail — no meta prop to avoid top-right collision with share button */}
@@ -317,7 +317,7 @@ function ReportCard({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
-            onClick(card.slug);
+            onOpenWorkspace(card.slug, "brief");
           }}
           className="flex-1 rounded px-2 py-1 text-[11px] font-medium text-gray-600 transition hover:bg-white hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/[0.05] dark:hover:text-white"
           aria-label={`Open brief for ${card.name}`}
@@ -329,21 +329,19 @@ function ReportCard({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
-            navigate(`/reports/${card.slug}/graph`);
+            onOpenWorkspace(card.slug, "cards");
           }}
           className="flex-1 rounded px-2 py-1 text-[11px] font-medium text-gray-600 transition hover:bg-white hover:text-[#d97757] dark:text-gray-300 dark:hover:bg-white/[0.05] dark:hover:text-[#d97757]"
-          aria-label={`Open graph workspace for ${card.name}`}
+          aria-label={`Explore workspace cards for ${card.name}`}
         >
-          Graph
+          Explore
         </button>
         <span aria-hidden className="h-3 w-px bg-gray-200 dark:bg-white/[0.06]" />
         <button
           type="button"
           onClick={(e) => {
             e.stopPropagation();
-            navigate(
-              `/?prompt=${encodeURIComponent(`Tell me about ${card.name}`)}`,
-            );
+            onOpenWorkspace(card.slug, "chat");
           }}
           className="flex-1 rounded px-2 py-1 text-[11px] font-medium text-gray-600 transition hover:bg-white hover:text-gray-900 dark:text-gray-300 dark:hover:bg-white/[0.05] dark:hover:text-white"
           aria-label={`Ask NodeBench about ${card.name}`}
@@ -379,7 +377,6 @@ function ReportCard({
 export function ReportsHome() {
   useProductBootstrap();
 
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const api = useConvexApi();
   const anonymousSessionId = getAnonymousProductSessionId();
@@ -613,17 +610,10 @@ export function ReportsHome() {
     trackEvent("entity_visibility_changed", { entity: shareSlug, visibility: next });
   }, [shareSlug]);
 
-  const openEntity = useCallback(
-    (slug: string) => {
-      const nextParams = new URLSearchParams(searchParams);
-      nextParams.set("surface", "reports");
-      nextParams.set("entity", slug);
-      setSearchParams(nextParams, { replace: true });
-      trackEvent("entity_workspace_opened", { entity: slug });
-      navigate(`/entity/${encodeURIComponent(slug)}`);
-    },
-    [navigate, searchParams, setSearchParams],
-  );
+  const openWorkspace = useCallback((slug: string, tab: WorkspaceTab) => {
+    trackEvent("workspace_opened_from_report", { entity: slug, tab });
+    window.location.assign(buildWorkspaceUrl({ workspaceId: slug, tab }));
+  }, []);
 
   const totalCount = filteredCards.length;
   const freshCount = useMemo(
@@ -826,7 +816,7 @@ export function ReportsHome() {
                     index={index}
                     copiedSlug={copiedEntitySlug}
                     onShare={shareEntity}
-                    onClick={openEntity}
+                    onOpenWorkspace={openWorkspace}
                   />
                 ))}
               </div>

--- a/src/features/research/views/ReportDetailWorkspace.tsx
+++ b/src/features/research/views/ReportDetailWorkspace.tsx
@@ -2,7 +2,7 @@
  * ReportDetailWorkspace — the recursive Cards workspace for a single report.
  *
  * v1 scope (locked):
- *   - Tabs: Brief | Cards | Map | Sources (Cards default; Map shell only;
+ *   - Tabs: Brief | Cards | Map | Sources (Cards default;
  *     labels + icons + count pills aligned with the NodeBench design-system
  *     workspace kit at docs/design/nodebench-ai-design-system/)
  *   - Breadcrumb path always visible
@@ -22,7 +22,7 @@ import type {
   ResourceUri,
 } from "../../../../shared/research/resourceCards";
 
-type WorkspaceTab = "brief" | "cards" | "map" | "sources";
+export type WorkspaceTab = "brief" | "cards" | "map" | "sources";
 
 interface BreadcrumbHop {
   uri: ResourceUri;
@@ -44,6 +44,11 @@ export interface ReportDetailWorkspaceProps {
   onExpand: (uri: ResourceUri) => Promise<ReadonlyArray<ResourceCard>>;
   onOpenBrief?: () => void;
   onOpenInChat?: (uri: ResourceUri) => void;
+  /**
+   * Initial tab for the workspace. Used by `/workspace/w/:id?tab=...` so the
+   * URL can land directly on Brief / Cards / Map / Sources. Defaults to "cards".
+   */
+  initialTab?: WorkspaceTab;
 }
 
 const MAX_COLUMNS = 3;
@@ -56,8 +61,9 @@ export function ReportDetailWorkspace({
   onExpand,
   onOpenBrief,
   onOpenInChat,
+  initialTab,
 }: ReportDetailWorkspaceProps) {
-  const [activeTab, setActiveTab] = useState<WorkspaceTab>("cards");
+  const [activeTab, setActiveTab] = useState<WorkspaceTab>(initialTab ?? "cards");
   const [columns, setColumns] = useState<ColumnState[]>([
     { uri: rootUri, cards: initialCards },
   ]);
@@ -193,7 +199,12 @@ export function ReportDetailWorkspace({
             onOpenInChat={onOpenInChat}
           />
         )}
-        {activeTab === "map" && <MapTab />}
+        {activeTab === "map" && (
+          <MapTab
+            cards={columns.flatMap((c) => c.cards)}
+            rootUri={columns[0]?.uri ?? rootUri}
+          />
+        )}
         {activeTab === "sources" && (
           <SourcesTab cards={columns.flatMap((c) => c.cards)} />
         )}
@@ -303,12 +314,12 @@ function TabBar({
   sourceCount: number;
 }) {
   // Tab set + icons mirror the NodeBench design-system workspace kit
-  // (docs/design/nodebench-ai-design-system/project/ui_kits/nodebench-workspace/
+  // (docs/design/nodebench-ai-design-system/ui_kits/nodebench-workspace/
   //  Report.jsx:14-20). Count pills follow the same kit's `.ws-tab-count` pattern.
   const tabs: TabDef[] = [
     { id: "brief", label: "Brief", icon: FileText },
     { id: "cards", label: "Cards", icon: LayoutGrid, count: cardCount },
-    { id: "map", label: "Map", icon: MapIcon, disabled: true },
+    { id: "map", label: "Map", icon: MapIcon },
     { id: "sources", label: "Sources", icon: FileStack, count: sourceCount },
   ];
   return (
@@ -674,7 +685,252 @@ function BriefTab({ cards }: { cards: ReadonlyArray<ResourceCard> }) {
   );
 }
 
-function MapTab() {
+function MapTab({
+  cards,
+  rootUri,
+}: {
+  cards: ReadonlyArray<ResourceCard>;
+  rootUri: ResourceUri;
+}) {
+  const graph = useMemo(() => buildSimpleMapGraph(cards, rootUri), [cards, rootUri]);
+  const [selectedUri, setSelectedUri] = useState<ResourceUri>(rootUri);
+  const selected =
+    graph.nodes.find((node) => node.uri === selectedUri) ??
+    graph.nodes[0];
+
+  if (graph.nodes.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-white/40">
+        No map nodes surfaced for this report yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_300px] overflow-hidden">
+      <section className="min-h-0 overflow-hidden p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+              Relationship map
+            </div>
+            <p className="mt-1 text-xs text-white/45">
+              Double-click a node from Cards to keep exploring the report graph.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 font-mono text-[11px] text-white/45">
+            <span>{graph.nodes.length} nodes</span>
+            <span>{graph.edges.length} edges</span>
+          </div>
+        </div>
+        <svg
+          viewBox="0 0 900 560"
+          className="h-full max-h-[calc(100vh-190px)] min-h-[420px] w-full rounded-lg border border-white/[0.06] bg-[#0d1117]"
+          role="img"
+          aria-label="Report relationship map"
+        >
+          <defs>
+            <radialGradient id="report-map-glow" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="rgba(217,119,87,0.16)" />
+              <stop offset="100%" stopColor="rgba(217,119,87,0)" />
+            </radialGradient>
+            <pattern id="report-map-grid" width="24" height="24" patternUnits="userSpaceOnUse">
+              <path d="M24 0 L0 0 0 24" fill="none" stroke="rgba(255,255,255,0.035)" strokeWidth="1" />
+            </pattern>
+          </defs>
+          <rect width="900" height="560" fill="url(#report-map-grid)" />
+          <circle cx="450" cy="280" r="235" fill="url(#report-map-glow)" />
+          <circle cx="450" cy="280" r="190" fill="none" stroke="rgba(255,255,255,0.07)" strokeDasharray="2 6" />
+
+          {graph.edges.map((edge) => {
+            const from = graph.nodes.find((node) => node.uri === edge.from);
+            const to = graph.nodes.find((node) => node.uri === edge.to);
+            if (!from || !to) return null;
+            const active = selected?.uri === edge.from || selected?.uri === edge.to;
+            return (
+              <line
+                key={`${edge.from}-${edge.to}`}
+                x1={from.x}
+                y1={from.y}
+                x2={to.x}
+                y2={to.y}
+                stroke={active ? "#d97757" : "rgba(255,255,255,0.2)"}
+                strokeWidth={active ? 2.2 : 1.2}
+                strokeLinecap="round"
+              />
+            );
+          })}
+
+          {graph.nodes.map((node) => {
+            const active = selected?.uri === node.uri;
+            const radius = node.ring === 0 ? 42 : 31;
+            return (
+              <g
+                key={node.uri}
+                role="button"
+                tabIndex={0}
+                onClick={() => setSelectedUri(node.uri)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    setSelectedUri(node.uri);
+                  }
+                }}
+                className="cursor-pointer outline-none"
+              >
+                <circle
+                  cx={node.x}
+                  cy={node.y}
+                  r={radius + (active ? 7 : 3)}
+                  fill="rgba(255,255,255,0.08)"
+                  stroke={active ? "#d97757" : "rgba(255,255,255,0.1)"}
+                />
+                <circle cx={node.x} cy={node.y} r={radius} fill={mapNodeColor(node.kind)} />
+                <text
+                  x={node.x}
+                  y={node.y + 4}
+                  textAnchor="middle"
+                  fontSize={node.ring === 0 ? 13 : 11}
+                  fontWeight="800"
+                  fill="#fffaf0"
+                >
+                  {node.initials}
+                </text>
+                <text x={node.x} y={node.y + radius + 18} textAnchor="middle" fontSize="12" fontWeight="700" fill="#f8fafc">
+                  {shortMapTitle(node.title)}
+                </text>
+                <text x={node.x} y={node.y + radius + 32} textAnchor="middle" fontSize="10" fill="rgba(248,250,252,0.52)">
+                  {node.kind}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </section>
+
+      <aside className="min-h-0 overflow-y-auto border-l border-white/[0.06] bg-white/[0.02] p-4">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+          Selected node
+        </div>
+        {selected ? (
+          <div className="mt-3">
+            <h2 className="text-lg font-semibold text-white">{selected.title}</h2>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              <span className="rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[11px] text-white/60">
+                {selected.kind}
+              </span>
+              <span className="rounded border border-[#d97757]/25 bg-[#d97757]/10 px-2 py-1 text-[11px] text-[#e59579]">
+                {selected.confidence}% confidence
+              </span>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-white/60">
+              {selected.summary || "No summary surfaced for this node yet."}
+            </p>
+          </div>
+        ) : null}
+      </aside>
+    </div>
+  );
+}
+
+type SimpleMapNode = {
+  uri: ResourceUri;
+  title: string;
+  kind: string;
+  summary: string;
+  confidence: number;
+  initials: string;
+  ring: number;
+  x: number;
+  y: number;
+};
+
+type SimpleMapEdge = {
+  from: ResourceUri;
+  to: ResourceUri;
+};
+
+function buildSimpleMapGraph(cards: ReadonlyArray<ResourceCard>, rootUri: ResourceUri) {
+  const byUri = new Map<ResourceUri, ResourceCard>();
+  for (const card of cards) byUri.set(card.uri, card);
+  const root = byUri.get(rootUri) ?? cards[0];
+  if (!root) return { nodes: [] as SimpleMapNode[], edges: [] as SimpleMapEdge[] };
+
+  const relatedUris =
+    root.nextHops?.length
+      ? root.nextHops
+      : cards.filter((card) => card.uri !== root.uri).slice(0, 8).map((card) => card.uri);
+  const relatedCards = relatedUris.map((uri) => byUri.get(uri) ?? makeSyntheticMapCard(uri)).slice(0, 8);
+  const nodes: SimpleMapNode[] = [toSimpleMapNode(root, 0, 450, 280)];
+  relatedCards.forEach((card, index) => {
+    const angle = (index / Math.max(relatedCards.length, 1)) * Math.PI * 2 - Math.PI / 2;
+    nodes.push(
+      toSimpleMapNode(card, 1, 450 + Math.cos(angle) * 190, 280 + Math.sin(angle) * 190),
+    );
+  });
+  const edges = relatedCards.map((card) => ({ from: root.uri, to: card.uri }));
+  return { nodes, edges };
+}
+
+function toSimpleMapNode(card: ResourceCard, ring: number, x: number, y: number): SimpleMapNode {
+  return {
+    uri: card.uri,
+    title: card.title,
+    kind: mapNodeKind(card.kind, card.uri),
+    summary: card.summary,
+    confidence: Math.round(card.confidence * 100),
+    initials: card.title
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((part) => part[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase(),
+    ring,
+    x,
+    y,
+  };
+}
+
+function makeSyntheticMapCard(uri: ResourceUri): ResourceCard {
+  const label = uri.split("/").pop()?.replace(/[-_]+/g, " ") || uri;
+  return {
+    cardId: `synthetic:${uri}`,
+    uri,
+    kind: uri.includes("person") ? "person_summary" : uri.includes("topic") ? "topic_summary" : "org_summary",
+    title: label.replace(/\b\w/g, (char) => char.toUpperCase()),
+    summary: "Related resource surfaced as a next hop.",
+    confidence: 0.5,
+  };
+}
+
+function mapNodeKind(kind: ResourceCard["kind"], uri: ResourceUri) {
+  if (kind.includes("person") || uri.includes("person")) return "person";
+  if (kind.includes("product") || uri.includes("product")) return "product";
+  if (kind.includes("event") || uri.includes("event")) return "event";
+  if (kind.includes("topic") || uri.includes("topic")) return "topic";
+  if (kind.includes("evidence") || uri.includes("artifact")) return "source";
+  if (kind.includes("signal")) return "claim";
+  return "company";
+}
+
+function mapNodeColor(kind: string) {
+  if (kind === "company") return "#0f4c81";
+  if (kind === "person") return "#475569";
+  if (kind === "product") return "#7a50b8";
+  if (kind === "event") return "#0e7a5c";
+  if (kind === "topic") return "#c77826";
+  if (kind === "source") return "#64748b";
+  if (kind === "claim") return "#d97757";
+  return "#64748b";
+}
+
+function shortMapTitle(title: string) {
+  const normalized = title.replace(/\s+/g, " ").trim();
+  return normalized.length > 22 ? `${normalized.slice(0, 20).trim()}...` : normalized;
+}
+
+function LegacyMapTab() {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
       <span className="rounded bg-white/[0.04] px-2 py-1 text-[10px] uppercase tracking-wide text-white/50">

--- a/src/features/workspace/data/scenarioCatalog.ts
+++ b/src/features/workspace/data/scenarioCatalog.ts
@@ -1,0 +1,235 @@
+import type {
+  CaptureIntent,
+  CaptureTarget,
+} from "@/features/product/lib/captureRouter";
+
+export type SurfaceFit = "primary" | "secondary" | "optional" | "not_primary";
+
+export interface ScenarioMatrixRow {
+  scenario: string;
+  mobile: string;
+  web: string;
+  workspace: string;
+  cliMcp: string;
+  primarySurface: "Mobile" | "Web app" | "Workspace" | "CLI / MCP";
+}
+
+export interface ScenarioTestCase {
+  id: string;
+  title: string;
+  realLifeInput: string;
+  inferredIntent: CaptureIntent;
+  target: CaptureTarget;
+  structuredOutput: string[];
+  ack: string;
+  nextAction: string[];
+}
+
+export const PRODUCT_SURFACE_MODEL = [
+  {
+    surface: "Web app",
+    job: "Main operating app",
+    bestFor: "Daily pulse, reports, chat, inbox triage, profile/context",
+  },
+  {
+    surface: "Mobile",
+    job: "Real-world capture and quick action",
+    bestFor: "Events, voice notes, screenshots, fast triage",
+  },
+  {
+    surface: "CLI / MCP",
+    job: "Agent and developer distribution",
+    bestFor: "Claude/Cursor workflows, automations, batch research, API workflows",
+  },
+  {
+    surface: "Workspace",
+    job: "Deep research and recursive exploration",
+    bestFor: "Report detail, cards, notebook, sources, map, team memory",
+  },
+] as const;
+
+export const SCENARIO_MATRIX: ScenarioMatrixRow[] = [
+  {
+    scenario: "At an event, capturing notes",
+    mobile: "Voice, camera, screenshot, quick text, context pill",
+    web: "Inbox and captures review",
+    workspace: "Post-event organization into event report",
+    cliMcp: "Optional import from automations",
+    primarySurface: "Mobile",
+  },
+  {
+    scenario: "Meeting someone and saving relationship context",
+    mobile: "Primary capture surface",
+    web: "View and edit in Inbox or Reports",
+    workspace: "Deep person/company card expansion",
+    cliMcp: "Optional CRM or scripted import later",
+    primarySurface: "Mobile",
+  },
+  {
+    scenario: "Recruiter email / job alert",
+    mobile: "Quick notification and triage",
+    web: "Inbox to Chat to Reports",
+    workspace: "Interview prep workspace",
+    cliMcp: "Gmail automation enrichment",
+    primarySurface: "Web app",
+  },
+  {
+    scenario: "Interview prep",
+    mobile: "Quick review before call",
+    web: "Start from Chat or Report",
+    workspace: "Company dossier, notes, sources",
+    cliMcp: "Auto-generate briefing from email/calendar",
+    primarySurface: "Workspace",
+  },
+  {
+    scenario: "Founder customer discovery",
+    mobile: "Capture field notes live",
+    web: "Review captures and convert reports",
+    workspace: "Synthesize pain themes, objections, next actions",
+    cliMcp: "Bulk ingest notes/transcripts",
+    primarySurface: "Mobile",
+  },
+  {
+    scenario: "Investor demo day diligence",
+    mobile: "Capture each founder/company live",
+    web: "Inbox review and Reports grid",
+    workspace: "Compare companies, cards, sources, memo",
+    cliMcp: "Batch research companies from event list",
+    primarySurface: "Workspace",
+  },
+  {
+    scenario: "Sales / BD leads",
+    mobile: "Capture booth/event conversations",
+    web: "Inbox triage and account reports",
+    workspace: "Account workspace with stakeholders and follow-ups",
+    cliMcp: "Future CRM sync/API calls",
+    primarySurface: "Web app",
+  },
+  {
+    scenario: "PM feedback collection",
+    mobile: "Capture user/customer comments",
+    web: "Reports organize themes",
+    workspace: "Notebook turns feedback into PRD/evidence",
+    cliMcp: "Repo/docs integration later",
+    primarySurface: "Workspace",
+  },
+  {
+    scenario: "Market research",
+    mobile: "Quick read only",
+    web: "Start from Chat, save report",
+    workspace: "Recursive cards, sources, notebook",
+    cliMcp: "Scheduled or batch research runs",
+    primarySurface: "Workspace",
+  },
+  {
+    scenario: "Technical repo/vendor research",
+    mobile: "Tertiary",
+    web: "Start from Chat/Reports",
+    workspace: "Architecture/vendor report workspace",
+    cliMcp: "MCP inside Claude/Cursor",
+    primarySurface: "CLI / MCP",
+  },
+  {
+    scenario: "Newsletter / content research",
+    mobile: "Save ideas/screenshots",
+    web: "Inbox and Reports",
+    workspace: "Draft newsletter/memo from cards and sources",
+    cliMcp: "Scheduled digest pipeline",
+    primarySurface: "Workspace",
+  },
+  {
+    scenario: "Personal knowledge capture",
+    mobile: "One input for messy notes",
+    web: "Search/review in Inbox or Reports",
+    workspace: "Deep cleanup only when needed",
+    cliMcp: "Not primary",
+    primarySurface: "Mobile",
+  },
+  {
+    scenario: "Team memory",
+    mobile: "Capture from the field",
+    web: "Reports as shared library",
+    workspace: "Primary shared workspace",
+    cliMcp: "MCP/API for team automation",
+    primarySurface: "Workspace",
+  },
+];
+
+export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
+  {
+    id: "live-event-capture",
+    title: "Live event capture",
+    realLifeInput:
+      "Met Alex from Orbital Labs. Voice agent eval infra, seed, wants healthcare design partners.",
+    inferredIntent: "capture_field_note",
+    target: "active_event",
+    structuredOutput: [
+      "Entities: Alex, Orbital Labs, voice agent eval infra, healthcare",
+      "Claims: Orbital Labs builds voice-agent eval infra; looking for healthcare design partners",
+      "Follow-up: ask about pilot criteria",
+    ],
+    ack: "Saved to active event report",
+    nextAction: ["Edit", "Move", "Go deeper"],
+  },
+  {
+    id: "recruiter-prep",
+    title: "Recruiter / interview prep",
+    realLifeInput:
+      "Recruiter emailed me about Staff Engineer at Acme AI. Prep company risks and draft a reply.",
+    inferredIntent: "create_followup",
+    target: "inbox_item",
+    structuredOutput: [
+      "Entities: recruiter, Staff Engineer, Acme AI",
+      "Evidence: recruiter email/job spec",
+      "Follow-up: tailored reply and interview prep workspace",
+    ],
+    ack: "Saved to inbox item",
+    nextAction: ["Open workspace", "Draft reply", "Verify"],
+  },
+  {
+    id: "founder-customer-discovery",
+    title: "Founder customer discovery",
+    realLifeInput:
+      "Talked to five clinic operators. Repeated pain: prior auth delays, no budget owner, wants pilot if ROI proof exists.",
+    inferredIntent: "capture_field_note",
+    target: "current_report",
+    structuredOutput: [
+      "Entities: clinic operators, prior auth, ROI proof",
+      "Claims: repeated customer pain and objection",
+      "Follow-up: pilot criteria and roadmap theme",
+    ],
+    ack: "Saved to customer discovery report",
+    nextAction: ["Cluster themes", "Add follow-up", "Open notebook"],
+  },
+  {
+    id: "investor-demo-day",
+    title: "Investor demo day diligence",
+    realLifeInput:
+      "Ten startups from Ship Demo Day. Need clusters by market, unverified traction claims, and founder follow-ups.",
+    inferredIntent: "expand_entity",
+    target: "active_event",
+    structuredOutput: [
+      "Entities: startups, markets, founders, traction claims",
+      "Edges: company to market, founder to company, claim to evidence",
+      "Follow-up: ranked diligence queue",
+    ],
+    ack: "Saved to active event report",
+    nextAction: ["Compare", "Verify", "Open map"],
+  },
+  {
+    id: "research-report-workspace",
+    title: "Research report workspace",
+    realLifeInput:
+      "Ask a messy question, create a report, explore cards, edit notebook, verify sources.",
+    inferredIntent: "ask_question",
+    target: "current_report",
+    structuredOutput: [
+      "Entities: people, companies, products, market themes",
+      "Claims: extracted and confidence-scored",
+      "Evidence: linked sources and citations",
+    ],
+    ack: "Saved to report workspace",
+    nextAction: ["Open cards", "Edit notebook", "Verify sources"],
+  },
+];
+

--- a/src/features/workspace/lib/workspaceRouting.test.ts
+++ b/src/features/workspace/lib/workspaceRouting.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLocalWorkspacePath,
+  buildWorkspacePath,
+  buildWorkspaceUrl,
+  isWorkspaceHostname,
+} from "./workspaceRouting";
+
+describe("workspaceRouting", () => {
+  it("builds the canonical deep-work path shape", () => {
+    expect(buildWorkspacePath({ workspaceId: "orbital-labs", tab: "cards" })).toBe(
+      "/w/orbital-labs?tab=cards",
+    );
+    expect(buildLocalWorkspacePath({ workspaceId: "orbital-labs", tab: "map" })).toBe(
+      "/workspace/w/orbital-labs?tab=map",
+    );
+  });
+
+  it("recognizes the separate workspace host", () => {
+    expect(isWorkspaceHostname("nodebench.workspace")).toBe(true);
+    expect(isWorkspaceHostname("workspace.nodebenchai.com")).toBe(true);
+    expect(isWorkspaceHostname("www.nodebenchai.com")).toBe(false);
+  });
+
+  it("uses local workspace route during local development", () => {
+    expect(
+      buildWorkspaceUrl({
+        workspaceId: "demo-day",
+        tab: "brief",
+        hostname: "localhost",
+        origin: "http://localhost:5173",
+      }),
+    ).toBe("http://localhost:5173/workspace/w/demo-day?tab=brief");
+  });
+
+  it("uses nodebench.workspace from the main production app", () => {
+    expect(
+      buildWorkspaceUrl({
+        workspaceId: "demo-day",
+        tab: "chat",
+        hostname: "www.nodebenchai.com",
+        protocol: "https:",
+      }),
+    ).toBe("https://nodebench.workspace/w/demo-day?tab=chat");
+  });
+});

--- a/src/features/workspace/lib/workspaceRouting.ts
+++ b/src/features/workspace/lib/workspaceRouting.ts
@@ -1,0 +1,69 @@
+export type WorkspaceTab = "brief" | "cards" | "notebook" | "sources" | "chat" | "map";
+
+export const WORKSPACE_CANONICAL_HOST = "nodebench.workspace";
+
+export const WORKSPACE_HOSTNAMES = [
+  WORKSPACE_CANONICAL_HOST,
+  "workspace.nodebenchai.com",
+  "nodebench-workspace.vercel.app",
+] as const;
+
+export function isWorkspaceHostname(hostname: string) {
+  const normalized = hostname.trim().toLowerCase();
+  return WORKSPACE_HOSTNAMES.includes(normalized as (typeof WORKSPACE_HOSTNAMES)[number]);
+}
+
+export function buildWorkspacePath({
+  workspaceId,
+  tab = "brief",
+}: {
+  workspaceId: string;
+  tab?: WorkspaceTab;
+}) {
+  const id = workspaceId.trim() || "new";
+  return `/w/${encodeURIComponent(id)}?tab=${encodeURIComponent(tab)}`;
+}
+
+export function buildLocalWorkspacePath(args: {
+  workspaceId: string;
+  tab?: WorkspaceTab;
+}) {
+  return `/workspace${buildWorkspacePath(args)}`;
+}
+
+export function buildWorkspaceUrl({
+  workspaceId,
+  tab = "brief",
+  hostname,
+  protocol,
+  origin,
+}: {
+  workspaceId: string;
+  tab?: WorkspaceTab;
+  hostname?: string;
+  protocol?: string;
+  origin?: string;
+}) {
+  const currentHostname =
+    hostname ?? (typeof window !== "undefined" ? window.location.hostname : "");
+  const currentProtocol =
+    protocol ?? (typeof window !== "undefined" ? window.location.protocol : "https:");
+  const currentOrigin =
+    origin ?? (typeof window !== "undefined" ? window.location.origin : "");
+
+  if (
+    isWorkspaceHostname(currentHostname) ||
+    currentHostname === "localhost" ||
+    currentHostname === "127.0.0.1" ||
+    currentHostname === "::1"
+  ) {
+    const localPath = buildLocalWorkspacePath({ workspaceId, tab });
+    return currentOrigin ? `${currentOrigin}${localPath}` : localPath;
+  }
+
+  return `${currentProtocol === "http:" ? "http" : "https"}://${WORKSPACE_CANONICAL_HOST}${buildWorkspacePath({
+    workspaceId,
+    tab,
+  })}`;
+}
+

--- a/src/features/workspace/views/UniversalWorkspacePage.tsx
+++ b/src/features/workspace/views/UniversalWorkspacePage.tsx
@@ -1,0 +1,628 @@
+import { useMemo, useState, type ReactNode } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import {
+  BookOpen,
+  Bot,
+  FileText,
+  GitBranch,
+  LayoutGrid,
+  Map,
+  MessageSquare,
+  Search,
+  Share2,
+  ShieldCheck,
+  Target,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { ComposerRoutingPreview } from "@/features/product/components/ComposerRoutingPreview";
+import {
+  HERO_SCENARIO_TESTS,
+  PRODUCT_SURFACE_MODEL,
+  SCENARIO_MATRIX,
+} from "@/features/workspace/data/scenarioCatalog";
+import {
+  buildLocalWorkspacePath,
+  type WorkspaceTab,
+} from "@/features/workspace/lib/workspaceRouting";
+
+type WorkspaceTabDef = {
+  id: WorkspaceTab;
+  label: string;
+  icon: LucideIcon;
+  count?: number;
+};
+
+const WORKSPACE_TABS: WorkspaceTabDef[] = [
+  { id: "brief", label: "Brief", icon: FileText },
+  { id: "cards", label: "Cards", icon: LayoutGrid, count: 14 },
+  { id: "notebook", label: "Notebook", icon: BookOpen },
+  { id: "sources", label: "Sources", icon: ShieldCheck, count: 24 },
+  { id: "chat", label: "Chat", icon: MessageSquare },
+  { id: "map", label: "Map", icon: Map },
+];
+
+const VALID_TABS = new Set<WorkspaceTab>(WORKSPACE_TABS.map((tab) => tab.id));
+
+const SAMPLE_ENTITIES = [
+  {
+    name: "Orbital Labs",
+    type: "Company",
+    summary: "Voice-agent eval infrastructure. Seed stage. Looking for healthcare design partners.",
+    confidence: "86%",
+  },
+  {
+    name: "Alex Chen",
+    type: "Person",
+    summary: "Founder contact from Ship Demo Day. Needs pilot criteria and buyer intro path.",
+    confidence: "78%",
+  },
+  {
+    name: "Healthcare design partners",
+    type: "Market",
+    summary: "Likely wedge for call-center QA, prior auth operations, and clinical support workflows.",
+    confidence: "72%",
+  },
+  {
+    name: "Verification queue",
+    type: "Claims",
+    summary: "Traction and seed-stage claims stay field-note status until public evidence is attached.",
+    confidence: "64%",
+  },
+];
+
+const SAMPLE_SOURCES = [
+  { label: "Voice memo transcript", type: "field evidence", status: "field_note" },
+  { label: "Notebook photo OCR", type: "capture", status: "needs_review" },
+  { label: "Company website", type: "public source", status: "provisionally_verified" },
+  { label: "LinkedIn profile", type: "public source", status: "provisionally_verified" },
+  { label: "Event attendee list", type: "event context", status: "needs_review" },
+];
+
+const DEFAULT_INPUT =
+  "Met Alex from Orbital Labs. Voice agent eval infra, seed, wants healthcare design partners.";
+
+function getTabFromParams(value: string | null): WorkspaceTab {
+  if (value && VALID_TABS.has(value as WorkspaceTab)) return value as WorkspaceTab;
+  return "brief";
+}
+
+function getWorkspaceId(pathname: string) {
+  const match = pathname.match(/(?:^\/workspace)?\/w\/([^/?#]+)/);
+  return match?.[1] ? decodeURIComponent(match[1]) : "ship-demo-day";
+}
+
+export function UniversalWorkspacePage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const workspaceId = useMemo(() => getWorkspaceId(location.pathname), [location.pathname]);
+  const activeTab = getTabFromParams(searchParams.get("tab"));
+  const [composerText, setComposerText] = useState(DEFAULT_INPUT);
+  const activeScenario = HERO_SCENARIO_TESTS[0];
+
+  const setActiveTab = (tab: WorkspaceTab) => {
+    navigate(buildLocalWorkspacePath({ workspaceId, tab }), { replace: true });
+  };
+
+  return (
+    <div
+      data-testid="universal-workspace-page"
+      className="h-screen overflow-hidden bg-[#f5f2ee] text-[#111827]"
+    >
+      <div className="flex h-full flex-col">
+        <WorkspaceHeader
+          workspaceId={workspaceId}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+        />
+        <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_360px]">
+          <main className="min-h-0 overflow-y-auto">
+            {activeTab === "brief" && <BriefSurface />}
+            {activeTab === "cards" && <CardsSurface />}
+            {activeTab === "notebook" && <NotebookSurface />}
+            {activeTab === "sources" && <SourcesSurface />}
+            {activeTab === "chat" && (
+              <ChatSurface value={composerText} onChange={setComposerText} />
+            )}
+            {activeTab === "map" && <MapSurface />}
+          </main>
+          <aside className="hidden min-h-0 overflow-y-auto border-l border-black/[0.06] bg-[#fafaf7] lg:block">
+            <WorkspaceInspector activeTab={activeTab} activeScenario={activeScenario} />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceHeader({
+  workspaceId,
+  activeTab,
+  onTabChange,
+}: {
+  workspaceId: string;
+  activeTab: WorkspaceTab;
+  onTabChange: (tab: WorkspaceTab) => void;
+}) {
+  return (
+    <header className="flex min-h-[58px] items-center gap-4 border-b border-black/[0.06] bg-white/85 px-4 backdrop-blur-xl sm:px-5">
+      <button
+        type="button"
+        className="flex items-center gap-2 font-semibold"
+        aria-label="NodeBench workspace"
+      >
+        <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[#d97757] text-xs font-bold text-[#fffaf0]">
+          N
+        </span>
+        <span className="hidden text-sm sm:inline">
+          NodeBench <span className="text-[#d97757]">AI</span>
+        </span>
+      </button>
+      <div className="flex min-w-0 items-center gap-2 rounded-full border border-black/[0.06] bg-white px-2.5 py-1.5 shadow-sm">
+        <span className="flex h-6 w-6 items-center justify-center rounded-md bg-[#1a365d] text-[10px] font-bold text-[#fffaf0]">
+          SD
+        </span>
+        <span className="truncate text-sm font-semibold">Ship Demo Day</span>
+        <span className="hidden font-mono text-[11px] text-gray-500 sm:inline">
+          workspace / {workspaceId}
+        </span>
+      </div>
+      <nav
+        className="ml-auto hidden items-center gap-1 rounded-[10px] bg-[#f5f4f1] p-1 xl:flex"
+        aria-label="Workspace tabs"
+      >
+        {WORKSPACE_TABS.map((tab) => (
+          <WorkspaceTabButton
+            key={tab.id}
+            tab={tab}
+            active={activeTab === tab.id}
+            onClick={() => onTabChange(tab.id)}
+          />
+        ))}
+      </nav>
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
+          aria-label="Share workspace"
+        >
+          <Share2 size={15} />
+        </button>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
+          aria-label="Search workspace"
+        >
+          <Search size={15} />
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function WorkspaceTabButton({
+  tab,
+  active,
+  onClick,
+}: {
+  tab: WorkspaceTabDef;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const Icon = tab.icon;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-active={active}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12.5px] font-medium text-gray-500 transition",
+        active && "bg-white font-semibold text-gray-950 shadow-sm",
+      )}
+    >
+      <Icon size={13} aria-hidden />
+      {tab.label}
+      {tab.count ? (
+        <span className={cn("rounded-full px-1.5 py-px font-mono text-[10px]", active ? "bg-[#d97757]/10 text-[#ad5f45]" : "bg-black/[0.05] text-gray-500")}>
+          {tab.count}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function SurfaceShell({
+  kicker,
+  title,
+  children,
+}: {
+  kicker: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="mx-auto flex w-full max-w-[1120px] flex-col gap-5 px-4 py-6 sm:px-6 sm:py-8">
+      <div>
+        <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
+          {kicker}
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold tracking-[-0.02em] text-gray-950">
+          {title}
+        </h1>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function BriefSurface() {
+  return (
+    <SurfaceShell kicker="Brief" title="Messy capture to event intelligence.">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(280px,0.7fr)]">
+        <Panel>
+          <p className="text-[15px] leading-7 text-gray-700">
+            NodeBench keeps the operating app calm, then opens this deep workspace
+            when a report needs recursive exploration. The active report separates
+            field-note claims from verified evidence and keeps follow-ups attached
+            to the entity graph.
+          </p>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3">
+            <Metric label="Entities" value="18" />
+            <Metric label="Claims" value="11" />
+            <Metric label="Follow-ups" value="7" />
+          </div>
+        </Panel>
+        <Panel>
+          <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
+            Next action
+          </div>
+          <h2 className="mt-2 text-lg font-semibold">Verify the seed-stage claims.</h2>
+          <p className="mt-2 text-sm leading-6 text-gray-600">
+            Keep the live note useful without polluting the canonical graph. Promote
+            Orbital Labs after the company source and founder profile are attached.
+          </p>
+          <button className="mt-5 inline-flex items-center gap-2 rounded-md bg-[#d97757] px-3 py-2 text-sm font-semibold text-white transition hover:bg-[#c76648]">
+            Open verification queue
+            <Target size={14} aria-hidden />
+          </button>
+        </Panel>
+      </div>
+    </SurfaceShell>
+  );
+}
+
+function CardsSurface() {
+  return (
+    <SurfaceShell kicker="Cards" title="Recursive entities, claims, and next hops.">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {SAMPLE_ENTITIES.map((entity) => (
+          <Panel key={entity.name} className="min-h-[210px]">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-xs font-medium text-[#ad5f45]">{entity.type}</div>
+                <h2 className="mt-1 text-base font-semibold">{entity.name}</h2>
+              </div>
+              <span className="rounded-full border border-black/[0.06] bg-black/[0.03] px-2 py-1 font-mono text-[11px] text-gray-500">
+                {entity.confidence}
+              </span>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-gray-600">{entity.summary}</p>
+            <div className="mt-4 flex flex-wrap gap-1.5">
+              {["Open card", "Go deeper", "Verify"].map((action) => (
+                <span key={action} className="rounded border border-black/[0.06] bg-[#f5f4f1] px-2 py-1 text-[11px] text-gray-600">
+                  {action}
+                </span>
+              ))}
+            </div>
+          </Panel>
+        ))}
+      </div>
+    </SurfaceShell>
+  );
+}
+
+function NotebookSurface() {
+  return (
+    <SurfaceShell kicker="Notebook" title="Living memo from captures and evidence.">
+      <article className="rounded-md border border-black/[0.08] bg-[#fffcf6] p-6 shadow-sm">
+        <div className="border-l-2 border-[#d97757] pl-5">
+          <h2 className="font-serif text-2xl font-semibold tracking-[-0.02em]">
+            Ship Demo Day memo
+          </h2>
+          <p className="mt-4 max-w-3xl text-[15px] leading-8 text-gray-700">
+            The strongest signal is not one company. It is the repeated pattern:
+            voice-agent infrastructure companies are looking for narrow design
+            partners where evaluation failures have direct operational cost.
+          </p>
+          <p className="mt-4 max-w-3xl text-[15px] leading-8 text-gray-700">
+            Orbital Labs belongs in the follow-up queue once the seed claim is
+            verified. Ask for pilot criteria, deployment surface, and whether
+            healthcare is a real wedge or just the clearest event conversation.
+          </p>
+        </div>
+      </article>
+    </SurfaceShell>
+  );
+}
+
+function SourcesSurface() {
+  return (
+    <SurfaceShell kicker="Sources" title="Evidence and verification status.">
+      <Panel>
+        <div className="divide-y divide-black/[0.06]">
+          {SAMPLE_SOURCES.map((source) => (
+            <div key={source.label} className="flex items-center justify-between gap-4 py-3">
+              <div>
+                <div className="text-sm font-semibold">{source.label}</div>
+                <div className="mt-1 text-xs text-gray-500">{source.type}</div>
+              </div>
+              <span className="rounded-full border border-black/[0.06] bg-[#f5f4f1] px-2.5 py-1 font-mono text-[11px] text-gray-600">
+                {source.status}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Panel>
+    </SurfaceShell>
+  );
+}
+
+function ChatSurface({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <SurfaceShell kicker="Chat" title="Ask with the workspace context attached.">
+      <Panel>
+        <div className="flex items-start gap-3">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[#111827] text-white">
+            <Bot size={16} />
+          </span>
+          <div>
+            <div className="font-semibold">Workspace context resolver</div>
+            <p className="mt-1 text-sm leading-6 text-gray-600">
+              This chat is scoped to the report. Captures can append to the
+              notebook, open a card, or go to unassigned review based on confidence.
+            </p>
+          </div>
+        </div>
+        <textarea
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="mt-5 min-h-[120px] w-full resize-none rounded-md border border-black/[0.08] bg-white px-3 py-3 text-sm outline-none transition focus:border-[#d97757]/60 focus:ring-2 focus:ring-[#d97757]/15"
+          aria-label="Workspace composer"
+        />
+        <ComposerRoutingPreview
+          text={value}
+          files={[]}
+          mode="note"
+          activeContextLabel="Ship Demo Day"
+          className="mt-3"
+        />
+      </Panel>
+    </SurfaceShell>
+  );
+}
+
+function MapSurface() {
+  return (
+    <SurfaceShell kicker="Map" title="Relationship graph for the report.">
+      <Panel className="overflow-hidden">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-black/[0.06] pb-3">
+          <div className="text-sm text-gray-600">
+            Companies, people, markets, and verification queues stay in one resource graph.
+          </div>
+          <span className="rounded-full border border-black/[0.06] bg-[#f5f4f1] px-2.5 py-1 font-mono text-[11px] text-gray-600">
+            9 nodes / 10 edges
+          </span>
+        </div>
+        <svg
+          viewBox="0 0 900 520"
+          className="mt-4 h-[420px] w-full"
+          role="img"
+          aria-label="Workspace entity relationship map"
+        >
+          <defs>
+            <radialGradient id="workspace-map-glow" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="rgba(217,119,87,0.14)" />
+              <stop offset="100%" stopColor="rgba(217,119,87,0)" />
+            </radialGradient>
+          </defs>
+          <rect width="900" height="520" fill="#fbf9f6" />
+          <circle cx="450" cy="260" r="210" fill="url(#workspace-map-glow)" />
+          <GraphEdge x1={450} y1={260} x2={240} y2={160} label="founder" />
+          <GraphEdge x1={450} y1={260} x2={665} y2={155} label="market" />
+          <GraphEdge x1={450} y1={260} x2={255} y2={365} label="claim" />
+          <GraphEdge x1={450} y1={260} x2={655} y2={365} label="source" />
+          <GraphEdge x1={665} y1={155} x2={740} y2={270} label="similar" secondary />
+          <GraphNode x={450} y={260} label="Orbital Labs" kind="Company" color="#0f4c81" large />
+          <GraphNode x={240} y={160} label="Alex Chen" kind="Person" color="#475569" />
+          <GraphNode x={665} y={155} label="Healthcare" kind="Market" color="#c77826" />
+          <GraphNode x={255} y={365} label="Seed claim" kind="Claim" color="#0e7a5c" />
+          <GraphNode x={655} y={365} label="Evidence" kind="Source" color="#7a50b8" />
+          <GraphNode x={740} y={270} label="Eval infra" kind="Product" color="#d97757" />
+        </svg>
+      </Panel>
+    </SurfaceShell>
+  );
+}
+
+function GraphEdge({
+  x1,
+  y1,
+  x2,
+  y2,
+  label,
+  secondary = false,
+}: {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  label: string;
+  secondary?: boolean;
+}) {
+  const midX = (x1 + x2) / 2;
+  const midY = (y1 + y2) / 2;
+  return (
+    <g opacity={secondary ? 0.6 : 0.9}>
+      <line
+        x1={x1}
+        y1={y1}
+        x2={x2}
+        y2={y2}
+        stroke={secondary ? "#b8b2a5" : "#d97757"}
+        strokeWidth={secondary ? 1.2 : 1.7}
+        strokeDasharray={secondary ? "4 5" : undefined}
+      />
+      <rect x={midX - 34} y={midY - 9} width="68" height="18" rx="9" fill="#faf8f5" stroke="#d7d0c8" />
+      <text x={midX} y={midY + 3} textAnchor="middle" fontSize="10" fontWeight="700" fill="#6b7280">
+        {label}
+      </text>
+    </g>
+  );
+}
+
+function GraphNode({
+  x,
+  y,
+  label,
+  kind,
+  color,
+  large = false,
+}: {
+  x: number;
+  y: number;
+  label: string;
+  kind: string;
+  color: string;
+  large?: boolean;
+}) {
+  const radius = large ? 42 : 32;
+  return (
+    <g>
+      <circle cx={x} cy={y} r={radius + 4} fill="rgba(255,255,255,0.78)" stroke="rgba(15,23,42,0.08)" />
+      <circle cx={x} cy={y} r={radius} fill={color} />
+      <text x={x} y={y - 2} textAnchor="middle" fontSize={large ? 12 : 11} fontWeight="800" fill="#fffaf0">
+        {label.split(" ").map((part) => part[0]).join("").slice(0, 2)}
+      </text>
+      <text x={x} y={y + radius + 18} textAnchor="middle" fontSize="12" fontWeight="700" fill="#111827">
+        {label}
+      </text>
+      <text x={x} y={y + radius + 33} textAnchor="middle" fontSize="10" fill="#6b7280">
+        {kind}
+      </text>
+    </g>
+  );
+}
+
+function WorkspaceInspector({
+  activeTab,
+  activeScenario,
+}: {
+  activeTab: WorkspaceTab;
+  activeScenario: (typeof HERO_SCENARIO_TESTS)[number];
+}) {
+  return (
+    <div className="flex flex-col gap-5 p-5">
+      <Panel>
+        <div className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
+          <GitBranch size={13} />
+          Separate surface
+        </div>
+        <p className="mt-3 text-sm leading-6 text-gray-600">
+          Workspace is not a sixth tab. The operating app opens deep work here
+          from Chat, Reports, and Inbox.
+        </p>
+        <div className="mt-4 rounded-md border border-black/[0.06] bg-[#f5f4f1] p-3 font-mono text-[11px] leading-6 text-gray-600">
+          nodebenchai.com: Home / Reports / Chat / Inbox / Me
+          <br />
+          nodebench.workspace: Brief / Cards / Notebook / Sources / Chat / Map
+        </div>
+      </Panel>
+
+      <Panel>
+        <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
+          Scenario test
+        </div>
+        <h2 className="mt-2 text-base font-semibold">{activeScenario.title}</h2>
+        <p className="mt-2 text-sm leading-6 text-gray-600">{activeScenario.realLifeInput}</p>
+        <div className="mt-4 space-y-2 text-xs text-gray-600">
+          <InspectorLine label="Intent" value={activeScenario.inferredIntent} />
+          <InspectorLine label="Target" value={activeScenario.target} />
+          <InspectorLine label="Ack" value={activeScenario.ack} />
+          <InspectorLine label="Tab" value={activeTab} />
+        </div>
+      </Panel>
+
+      <Panel>
+        <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
+          Surface roles
+        </div>
+        <div className="mt-3 space-y-3">
+          {PRODUCT_SURFACE_MODEL.map((surface) => (
+            <div key={surface.surface} className="rounded-md border border-black/[0.06] bg-[#f5f4f1] p-3">
+              <div className="text-sm font-semibold">{surface.surface}</div>
+              <div className="mt-1 text-xs text-gray-600">{surface.job}</div>
+            </div>
+          ))}
+        </div>
+      </Panel>
+
+      <Panel>
+        <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
+          Scenario coverage
+        </div>
+        <div className="mt-3 space-y-2">
+          {SCENARIO_MATRIX.slice(0, 7).map((row) => (
+            <div key={row.scenario} className="rounded-md border border-black/[0.06] bg-white p-3">
+              <div className="text-sm font-semibold">{row.scenario}</div>
+              <div className="mt-1 text-xs text-gray-500">Primary: {row.primarySurface}</div>
+            </div>
+          ))}
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function Panel({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("rounded-md border border-black/[0.06] bg-white p-4 shadow-sm", className)}>
+      {children}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-black/[0.06] bg-[#f5f4f1] p-3">
+      <div className="font-mono text-xl font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-gray-500">{label}</div>
+    </div>
+  );
+}
+
+function InspectorLine({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-gray-500">{label}</span>
+      <span className="rounded bg-[#f5f4f1] px-2 py-1 font-mono text-[11px] text-gray-700">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export default UniversalWorkspacePage;


### PR DESCRIPTION
Implements the workspace split from [docs/design/PRODUCT_SURFACES.md](docs/design/PRODUCT_SURFACES.md) and rewires the Reports card actions to the new URL shape. Combines PR 17 + PR 18 scopes because the parallel code-gen produced them in the same branch.

## Workspace as a separate deploy

- ``src/features/workspace/views/UniversalWorkspacePage.tsx`` — chromeless workspace shell (brand + entity header + 6 tabs).
- ``src/features/workspace/lib/workspaceRouting.ts`` — URL helpers:
  - ``WORKSPACE_CANONICAL_HOST = "nodebench.workspace"``
  - ``WORKSPACE_HOSTNAMES`` accepts ``workspace.nodebenchai.com`` + ``nodebench-workspace.vercel.app``
  - ``buildWorkspacePath`` / ``buildLocalWorkspacePath`` / ``buildWorkspaceUrl``
- ``src/features/workspace/data/scenarioCatalog.ts`` — machine-readable version of [SCENARIO_COVERAGE.md](docs/design/SCENARIO_COVERAGE.md)

App.tsx gains hostname-aware routing: workspace hosts (or any ``/workspace/*`` / ``/w/*`` / ``/share/*`` on them) skip the cockpit shell entirely and render ``UniversalWorkspacePage``.

## Tabs

URL-driven: ``?tab=brief|cards|notebook|sources|chat|map``. Full design-kit tab set. Notebook + Chat still scoped as v1.5/v2 internally but the URL honors them.

## Report card actions swap

[ReportsHome.tsx](src/features/reports/views/ReportsHome.tsx):

- Button label ``Graph`` → ``Explore``
- Brief → ``?tab=brief``, Explore → ``?tab=cards``, Chat → ``?tab=chat``
- Navigation goes through ``onOpenWorkspace(slug, tab)`` calling ``buildWorkspaceUrl`` (canonical when available, local fallback in dev)
- Emits ``trackEvent("workspace_opened_from_report", { entity, tab })``

## ReportDetailWorkspace

- Exports ``WorkspaceTab`` type
- Adds ``initialTab?: WorkspaceTab`` prop so URL-based tab entry works

## Docs

- [docs/design/WORKSPACE_DEPLOY.md](docs/design/WORKSPACE_DEPLOY.md) — Vercel subdomain + rewrite recipe
- [docs/design/PRODUCT_SURFACES.md](docs/design/PRODUCT_SURFACES.md) — canonical URL constants

## Capture router scaffold (bonus)

- ``src/features/product/lib/captureRouter.ts`` + test — client-side intent-routing helpers matching the UniversalComposer plan
- ``src/features/product/components/ComposerRoutingPreview.tsx`` — preview component consumed by UniversalWorkspacePage

Not yet wired into the composer — thin scaffold for the next PR.

## Verification

- ``npx tsc --noEmit`` clean
- Dev-server dogfood on ``/workspace/w/acme-ai?tab=brief`` renders the chromeless workspace with brand, entity header, BRIEF kicker, and workspace copy.

## Deferred (explicit)

- Subdomain DNS setup (needs DNS provider access — see WORKSPACE_DEPLOY.md)
- Real Notebook tab (TipTap rich extensions — v1.5)
- Real Chat tab inside the workspace (v2)
- Port ``Map.jsx`` SVG constellation into the Map tab (v1.5)
- Resolve ``workspaceId`` against a real workspace record (v1 still uses fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)