### PR TITLE
Wire captureRouter preview into ChatHome composer + canonical-host polish

### DIFF
--- a/docs/design/PRODUCT_SURFACES.md
+++ b/docs/design/PRODUCT_SURFACES.md
@@ -20,7 +20,7 @@ nodebenchai.com                  (the operating app: five tabs)
 |-- Inbox                        captures, nudges, unassigned, automations, alerts
 `-- Me                           preferences, context, files, credits
 
-nodebench.workspace              (deep-work surface, separately deployed)
+workspace.nodebenchai.com        (deep-work surface, separately deployed)
 `-- Deep workspaces opened from Chat / Reports / Inbox
     |-- Brief                    executive summary
     |-- Cards                    recursive exploration
@@ -53,13 +53,13 @@ follow-ups.
 ## Workspace URL Shape
 
 ```text
-nodebench.workspace/w/{workspaceId}?tab=brief
-nodebench.workspace/w/{workspaceId}?tab=cards
-nodebench.workspace/w/{workspaceId}?tab=notebook
-nodebench.workspace/w/{workspaceId}?tab=sources
-nodebench.workspace/w/{workspaceId}?tab=chat
-nodebench.workspace/w/{workspaceId}?tab=map
-nodebench.workspace/share/{shareId}
+workspace.nodebenchai.com/w/{workspaceId}?tab=brief
+workspace.nodebenchai.com/w/{workspaceId}?tab=cards
+workspace.nodebenchai.com/w/{workspaceId}?tab=notebook
+workspace.nodebenchai.com/w/{workspaceId}?tab=sources
+workspace.nodebenchai.com/w/{workspaceId}?tab=chat
+workspace.nodebenchai.com/w/{workspaceId}?tab=map
+workspace.nodebenchai.com/share/{shareId}
 ```
 
 ## Report Entry Mapping

--- a/docs/design/WORKSPACE_DEPLOY.md
+++ b/docs/design/WORKSPACE_DEPLOY.md
@@ -10,10 +10,9 @@ work surface. It is not a sixth tab in the main app.
 - Local route: `/workspace/w/{workspaceId}?tab={tab}`.
 - Workspace-host route: `/w/{workspaceId}?tab={tab}`.
 - Supported tabs: `brief`, `cards`, `notebook`, `sources`, `chat`, `map`.
-- Recognized workspace hosts:
-  - `nodebench.workspace`
-  - `workspace.nodebenchai.com`
-  - `nodebench-workspace.vercel.app`
+- Canonical workspace host: `workspace.nodebenchai.com`.
+- Accepted future alias: `nodebench.workspace`.
+- Accepted rollout alias: `nodebench-workspace.vercel.app`.
 
 `src/App.tsx` checks for the workspace host or `/workspace/*` path before the
 cockpit shell mounts, so Workspace owns its own header and tabs.
@@ -22,8 +21,8 @@ cockpit shell mounts, so Workspace owns its own header and tabs.
 
 ```text
 nodebenchai.com                  -> Home / Reports / Chat / Inbox / Me
-nodebench.workspace/w/acme       -> Workspace shell
-nodebench.workspace/share/abc    -> Workspace share surface
+workspace.nodebenchai.com/w/acme -> Workspace shell
+workspace.nodebenchai.com/share/abc -> Workspace share surface
 localhost:5173/workspace/w/acme  -> Local workspace shell
 ```
 
@@ -39,16 +38,15 @@ Report actions use this mapping:
 
 ### Preferred
 
-Deploy the same React bundle as a separate Vercel project or service alias with
-the custom domain `nodebench.workspace`. The bundle can route the bare workspace
-host directly to the chromeless workspace shell.
+Deploy the same React bundle with the custom domain
+`workspace.nodebenchai.com`. The bundle routes the bare workspace host directly
+to the chromeless workspace shell.
 
 ### DNS-Compatible Fallback
 
-If the `nodebench.workspace` domain is not available yet, use
-`workspace.nodebenchai.com` with the same host handling. `buildWorkspaceUrl`
-keeps production links on `https://nodebench.workspace/...` by default, and the
-host allowlist also accepts `workspace.nodebenchai.com` for rollout.
+If the `nodebench.workspace` domain becomes available later, keep it as an alias
+only. `buildWorkspaceUrl` keeps production links on
+`https://workspace.nodebenchai.com/...`.
 
 ## Vercel Rewrites
 
@@ -60,12 +58,12 @@ workspace subdomain keeps clean URLs:
   "rewrites": [
     {
       "source": "/w/:workspaceId",
-      "has": [{ "type": "host", "value": "nodebench.workspace" }],
+      "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
       "destination": "/w/:workspaceId"
     },
     {
       "source": "/share/:shareId",
-      "has": [{ "type": "host", "value": "nodebench.workspace" }],
+      "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
       "destination": "/share/:shareId"
     }
   ]

--- a/docs/design/nodebench-ai-design-system/README.md
+++ b/docs/design/nodebench-ai-design-system/README.md
@@ -27,8 +27,8 @@ The main web product is organized around **five operating surfaces**:
 
 `Nudges` are now a section inside Inbox, not a top-level surface.
 
-The separate deep-work surface is **Workspace**, deployed at a host like
-`nodebench.workspace`. Workspace is opened from Chat, Reports, and Inbox. Its
+The separate deep-work surface is **Workspace**, deployed at
+`workspace.nodebenchai.com`. Workspace is opened from Chat, Reports, and Inbox. Its
 tabs are `Brief`, `Cards`, `Notebook`, `Sources`, `Chat`, and `Map`.
 
 The mental model: `messy input -> answer or capture -> saved report -> deep
@@ -42,7 +42,7 @@ workspace -> verified memo or next action`.
    and feature grid seen on nodebenchai.com.
 3. **nodebench-mcp** (distribution lane, CLI/MCP) — command-line-adjacent, so
    not a visual UI kit, but typography and tone rules still apply.
-4. **nodebench.workspace** — the deep research environment for reusable
+4. **workspace.nodebenchai.com** — the deep research environment for reusable
    intelligence: Brief, Cards, Notebook, Sources, Chat, Map.
 
 ### Sources used

--- a/public/agent-setup.txt
+++ b/public/agent-setup.txt
@@ -1,15 +1,28 @@
-NodeBench MCP — open-source founder intelligence tools
+NodeBench CLI / MCP - open-source agent tools
+
+Human install page: https://www.nodebenchai.com/cli
+MCP page alias: https://www.nodebenchai.com/mcp
 npm: https://www.npmjs.com/package/nodebench-mcp
 source: https://github.com/HomenShum/nodebench-ai
 license: MIT
 
-Install:
+Claude Code:
   claude mcp add nodebench -- npx -y nodebench-mcp
 
-Verify (should return founder tools):
+Cursor or Windsurf:
+  Add a nodebench MCP server with command "npx" and args ["-y", "nodebench-mcp"].
+
+Local terminal:
+  npx nodebench-mcp
+
+Cloud sync:
+  npx nodebench-mcp --cloud
+
+Verify:
   discover_tools({ query: "founder", limit: 3 })
 
 Build founder profile:
   founder_deep_context_gather({ packetType: "weekly_reset" })
 
-Dashboard: https://www.nodebenchai.com/founder
+Web app: https://www.nodebenchai.com
+Workspace: https://workspace.nodebenchai.com

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,11 @@ User-agent: *
 Allow: /
 Allow: /memo/
 Allow: /developers
+Allow: /cli
+Allow: /mcp
+Allow: /install
+Allow: /agent-setup.txt
+Allow: /install.sh
 Allow: /api-docs
 Allow: /pricing
 Allow: /changelog

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -86,6 +86,21 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.nodebenchai.com/cli</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.nodebenchai.com/mcp</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.nodebenchai.com/agent-setup.txt</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://www.nodebenchai.com/api-docs</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/src/features/chat/views/ChatHome.tsx
+++ b/src/features/chat/views/ChatHome.tsx
@@ -27,6 +27,7 @@ import { useStreamingSearch, type ToolStage } from "@/hooks/useStreamingSearch";
 import { useConvexApi } from "@/lib/convexApi";
 import { buildOperatorContextHint, buildOperatorContextLabel } from "@/features/product/lib/operatorContext";
 import { ProductIntakeComposer, type ProductComposerMode } from "@/features/product/components/ProductIntakeComposer";
+import { ComposerRoutingPreview } from "@/features/product/components/ComposerRoutingPreview";
 import { ProductFileAssetPicker, type ProductFileAsset } from "@/features/product/components/ProductFileAssetPicker";
 import { SaveToNotebookButton } from "@/features/agents/components/SaveToNotebookButton";
 import { buildEntityPath } from "@/features/entities/lib/entityExport";
@@ -3041,7 +3042,7 @@ export const ChatHome = memo(function ChatHome() {
                       autoFocus
                       mode={composerMode}
                       onModeChange={setComposerMode}
-                      showCaptureModes={false}
+                      showCaptureModes
                       showLensSelector={false}
                       onSaveCapture={handleSaveCapture}
                       captureSavePending={savingCapture}
@@ -3050,6 +3051,14 @@ export const ChatHome = memo(function ChatHome() {
                       secondaryActionLabel="Attach from Files"
                       secondaryActionAriaLabel="Reuse a file that already lives in your vault."
                       className="w-full max-w-none border-transparent bg-transparent shadow-none backdrop-blur-none"
+                    />
+                    <ComposerRoutingPreview
+                      text={input}
+                      files={pendingFiles}
+                      mode={composerMode}
+                      activeContextLabel={operatorContextLabel}
+                      compact
+                      className="mt-2"
                     />
                   </div>
                 </div>
@@ -3805,7 +3814,7 @@ export const ChatHome = memo(function ChatHome() {
               autoFocus={!conversation.activeSessionId}
               mode={composerMode}
               onModeChange={setComposerMode}
-              showCaptureModes={false}
+              showCaptureModes
               showLensSelector={false}
               onSaveCapture={handleSaveCapture}
               captureSavePending={savingCapture}
@@ -3815,6 +3824,14 @@ export const ChatHome = memo(function ChatHome() {
               secondaryActionLabel="Attach from Files"
               secondaryActionAriaLabel="Reuse a file that already lives in your vault."
               className="w-full max-w-none sm:mx-auto sm:max-w-[1100px] xl:max-w-[1180px]"
+            />
+            <ComposerRoutingPreview
+              text={input}
+              files={pendingFiles}
+              mode={composerMode}
+              activeContextLabel={operatorContextLabel}
+              compact={conversation.activeSessionId ? true : compactComposer}
+              className="mx-auto mt-2 w-full max-w-none sm:max-w-[1100px] xl:max-w-[1180px]"
             />
           </div>
         </div>

--- a/src/features/controlPlane/views/DevelopersPage.tsx
+++ b/src/features/controlPlane/views/DevelopersPage.tsx
@@ -195,13 +195,13 @@ export const DevelopersPage = memo(function DevelopersPage({
           style={stagger("0.05s")}
           className="text-3xl font-bold tracking-tight text-content"
         >
-          Built for builders
+          CLI, MCP, and API setup
         </h1>
         <p
           style={stagger("0.1s")}
           className="mt-3 max-w-xl text-base leading-relaxed text-content-secondary"
         >
-          Architecture, tools, and integrations under the hood.
+          Install NodeBench in Claude Code, Cursor, Windsurf, terminal workflows, and automation pipelines.
         </p>
 
         {/* Agent one-liner */}

--- a/src/features/product/lib/captureRouter.ts
+++ b/src/features/product/lib/captureRouter.ts
@@ -176,7 +176,7 @@ function inferTarget(
   const looksLikeEventContext =
     EVENT_MARKERS.test(context) || /\b(demo|conference|event|summit|meetup)\b/i.test(context);
   const looksLikeEventCapture =
-    /\b(?:met|talked to|spoke with)\s+[A-Z][A-Za-z.-]*(?:\s+[A-Z][A-Za-z.-]*)?\s+from\s+[A-Z]/.test(text);
+    /\b(?:met|talked to|spoke with)\s+[A-Z][A-Za-z.-]*(?:\s+[A-Z][A-Za-z.-]*)?\s+from\s+[A-Z]/i.test(text);
 
   if (EVENT_MARKERS.test(text) || looksLikeEventContext || looksLikeEventCapture) {
     return "active_event";
@@ -206,6 +206,7 @@ function scoreRoute(args: {
   if (args.claims.length > 0) score += 0.12;
   if (args.followUps.length > 0) score += 0.08;
   if (args.target !== "unassigned_buffer") score += 0.08;
+  if (args.target === "active_event" && args.entities.length >= 2) score += 0.04;
   if (args.intent === "ask_question" || args.intent === "expand_entity") score += 0.04;
   if (args.text.length > 240) score += 0.04;
   return Math.min(0.96, Number(score.toFixed(2)));
@@ -237,13 +238,13 @@ function extractEntities(
     if ("fileName" in source) add(source.fileName, "source", 0.7);
   }
 
-  const fromMatch = text.match(/\bfrom\s+([A-Z][A-Za-z0-9&.-]*(?:\s+[A-Z][A-Za-z0-9&.-]*){0,3})/);
+  const fromMatch = text.match(/\bfrom\s+([A-Z][A-Za-z0-9&-]*(?:\s+[A-Z][A-Za-z0-9&-]*){0,3})/);
   if (fromMatch) add(fromMatch[1], "company", 0.86);
 
-  const metMatch = text.match(/\b(?:met|talked to|spoke with|coffee with)\s+([A-Z][A-Za-z.-]*(?:\s+[A-Z][A-Za-z.-]*)?)/i);
+  const metMatch = text.match(/\b(?:met|talked to|spoke with|coffee with)\s+([A-Z][A-Za-z.-]*(?:\s+(?!from\b)[A-Z][A-Za-z.-]*)?)/i);
   if (metMatch) add(metMatch[1], "person", 0.82);
 
-  const capitalized = text.match(/\b[A-Z][A-Za-z0-9&.-]*(?:\s+[A-Z][A-Za-z0-9&.-]*){0,3}\b/g) ?? [];
+  const capitalized = text.match(/\b[A-Z][A-Za-z0-9&-]*(?:\s+[A-Z][A-Za-z0-9&-]*){0,3}\b/g) ?? [];
   for (const phrase of capitalized) {
     const first = phrase.split(/\s+/)[0];
     if (ENTITY_STOPWORDS.has(first)) continue;

--- a/src/features/workspace/data/scenarioCatalog.test.ts
+++ b/src/features/workspace/data/scenarioCatalog.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HERO_SCENARIO_TESTS,
+  PRODUCT_SURFACE_MODEL,
+  SCENARIO_MATRIX,
+} from "./scenarioCatalog";
+
+describe("scenario catalog", () => {
+  it("keeps the four-surface product model explicit", () => {
+    expect(PRODUCT_SURFACE_MODEL.map((surface) => surface.surface)).toEqual([
+      "Web app",
+      "Mobile",
+      "CLI / MCP",
+      "Workspace",
+    ]);
+  });
+
+  it("covers every surface in the scenario matrix", () => {
+    const primarySurfaces = new Set(SCENARIO_MATRIX.map((row) => row.primarySurface));
+
+    expect(primarySurfaces).toEqual(
+      new Set(["Mobile", "Web app", "Workspace", "CLI / MCP"]),
+    );
+    expect(SCENARIO_MATRIX.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it("keeps hero scenarios in the eval template shape", () => {
+    expect(HERO_SCENARIO_TESTS.map((scenario) => scenario.id)).toEqual([
+      "live-event-capture",
+      "recruiter-prep",
+      "founder-customer-discovery",
+      "investor-demo-day",
+      "research-report-workspace",
+    ]);
+
+    for (const scenario of HERO_SCENARIO_TESTS) {
+      expect(scenario.realLifeInput).toBeTruthy();
+      expect(scenario.inferredIntent).toBeTruthy();
+      expect(scenario.target).toBeTruthy();
+      expect(scenario.structuredOutput.length).toBeGreaterThan(0);
+      expect(scenario.ack).toBeTruthy();
+      expect(scenario.nextAction.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/features/workspace/lib/workspaceRouting.test.ts
+++ b/src/features/workspace/lib/workspaceRouting.test.ts
@@ -34,7 +34,7 @@ describe("workspaceRouting", () => {
     ).toBe("http://localhost:5173/workspace/w/demo-day?tab=brief");
   });
 
-  it("uses nodebench.workspace from the main production app", () => {
+  it("uses workspace.nodebenchai.com from the main production app", () => {
     expect(
       buildWorkspaceUrl({
         workspaceId: "demo-day",
@@ -42,6 +42,6 @@ describe("workspaceRouting", () => {
         hostname: "www.nodebenchai.com",
         protocol: "https:",
       }),
-    ).toBe("https://nodebench.workspace/w/demo-day?tab=chat");
+    ).toBe("https://workspace.nodebenchai.com/w/demo-day?tab=chat");
   });
 });

--- a/src/features/workspace/lib/workspaceRouting.ts
+++ b/src/features/workspace/lib/workspaceRouting.ts
@@ -1,10 +1,10 @@
 export type WorkspaceTab = "brief" | "cards" | "notebook" | "sources" | "chat" | "map";
 
-export const WORKSPACE_CANONICAL_HOST = "nodebench.workspace";
+export const WORKSPACE_CANONICAL_HOST = "workspace.nodebenchai.com";
 
 export const WORKSPACE_HOSTNAMES = [
   WORKSPACE_CANONICAL_HOST,
-  "workspace.nodebenchai.com",
+  "nodebench.workspace",
   "nodebench-workspace.vercel.app",
 ] as const;
 
@@ -66,4 +66,3 @@ export function buildWorkspaceUrl({
     tab,
   })}`;
 }
-

--- a/src/features/workspace/views/UniversalWorkspacePage.tsx
+++ b/src/features/workspace/views/UniversalWorkspacePage.tsx
@@ -542,7 +542,7 @@ function WorkspaceInspector({
         <div className="mt-4 rounded-md border border-black/[0.06] bg-[#f5f4f1] p-3 font-mono text-[11px] leading-6 text-gray-600">
           nodebenchai.com: Home / Reports / Chat / Inbox / Me
           <br />
-          nodebench.workspace: Brief / Cards / Notebook / Sources / Chat / Map
+          workspace.nodebenchai.com: Brief / Cards / Notebook / Sources / Chat / Map
         </div>
       </Panel>
 

--- a/src/layouts/ProductTopNav.tsx
+++ b/src/layouts/ProductTopNav.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useConvexAuth } from "convex/react";
 import { useAuthActions } from "@convex-dev/auth/react";
-import { ArrowUpRight, Moon, Search, Sun } from "lucide-react";
+import { ArrowUpRight, Moon, Search, Sun, Terminal } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { AskNodeBenchPill } from "@/features/agents/components/AskNodeBenchPill";
 import { buildCockpitPath, type CockpitSurfaceId } from "@/lib/registry/viewRegistry";
@@ -103,6 +103,16 @@ export const ProductTopNav = memo(function ProductTopNav({
               </kbd>
             </button>
           ) : null}
+          <button
+            type="button"
+            onClick={() => navigate("/cli")}
+            className="hidden h-10 items-center gap-2 rounded-full border border-black/[0.06] bg-white/70 px-3 text-[13px] font-medium text-gray-600 shadow-[0_16px_34px_-28px_rgba(15,23,42,0.2)] transition hover:border-black/[0.1] hover:bg-white hover:text-gray-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]/30 dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-gray-300 dark:shadow-[0_18px_42px_-30px_rgba(0,0,0,0.88)] dark:hover:border-white/[0.14] dark:hover:bg-white/[0.06] dark:hover:text-gray-100 lg:inline-flex"
+            aria-label="Open CLI and MCP install instructions"
+            title="CLI and MCP install"
+          >
+            <Terminal className="h-4 w-4" />
+            <span>CLI</span>
+          </button>
           <AskNodeBenchPill />
           <button
             type="button"

--- a/src/lib/registry/viewCapabilityRegistry.ts
+++ b/src/lib/registry/viewCapabilityRegistry.ts
@@ -1148,15 +1148,15 @@ export const VIEW_CAPABILITIES: Record<MainView, ViewCapability> = {
     viewId: "developers",
     title: "Developers",
     description:
-      "Developer portal — API documentation, integration guides, and SDK references for building on NodeBench.",
-    paths: ["/developers", "/docs/api"],
+      "Developer portal — CLI, MCP, API documentation, integration guides, and SDK references for building on NodeBench.",
+    paths: ["/developers", "/cli", "/mcp", "/install", "/docs/api"],
     dataEndpoints: [],
     actions: [
       { name: "browseEndpoints", description: "Browse available API endpoints and schemas" },
       { name: "testEndpoint", description: "Send a test request to an API endpoint" },
     ],
     relatedToolCategories: ["platform", "boilerplate"],
-    tags: ["developers", "api", "documentation", "sdk", "integration"],
+    tags: ["developers", "cli", "mcp", "api", "documentation", "sdk", "integration"],
     requiresAuth: false,
   },
 

--- a/src/lib/registry/viewRegistry.ts
+++ b/src/lib/registry/viewRegistry.ts
@@ -210,6 +210,7 @@ export const VIEW_REGISTRY: ViewRegistryEntry[] = [
     title: "Developers",
     subtitle: "Architecture, tools, and integrations under the hood",
     path: "/developers",
+    aliases: ["/cli", "/mcp", "/install"],
     component: lazyNamed(() => import("@/features/controlPlane/views/DevelopersPage"), "DevelopersPage"),
     group: "nested",
     navVisible: false,


### PR DESCRIPTION
Folds in post-PR #17 polish:

- ChatHome composer now shows live ComposerRoutingPreview under the input — users see which target the captureRouter would pick for their text + files
- showCaptureModes enabled on the main composer
- captureRouter regex polish (case-insensitive event matcher, tighter from-company pattern, slight score boost on 2+ entity event captures)
- Docs aligned on workspace.nodebenchai.com as canonical host (.workspace TLD not Vercel-registrable — kept as future alias)

Verification: npx tsc --noEmit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)