### PR TITLE
fix(vercel): skip convex deploy on preview branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npx convex deploy --cmd 'npm run build'",
+  "buildCommand": "if [ \"$VERCEL_ENV\" = \"production\" ]; then npx convex deploy --cmd 'npm run build'; else npm run build; fi",
   "functions": {
     "api/search.js": {
       "maxDuration": 60


### PR DESCRIPTION
Preview deploys were failing with:

```
✖ Detected a non-production build environment and
  "CONVEX_DEPLOY_KEY" for a production Convex deployment.
```

Fix: branch the buildCommand on `VERCEL_ENV`. Only prod builds run `convex deploy`; preview + dev builds run plain `npm run build`.

Unblocks all non-main feature-branch previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)