### PR TITLE
feat(mobile): MobileHomeSurface port — watchlist + nudges + threads

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"aa625586-5d06-4027-b6b5-35e8d9c369b7","pid":46640,"acquiredAt":1776886658260}
+{"sessionId":"88f85128-eefc-4d38-8085-d2f8be8c5321","pid":24836,"acquiredAt":1776998256856}

--- a/src/features/home/views/HomeLanding.tsx
+++ b/src/features/home/views/HomeLanding.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { MobileHomeSurface } from "./MobileHomeSurface";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useConvex, useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
@@ -429,7 +430,12 @@ export function HomeLanding() {
   };
 
   return (
-    <div className="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-[1120px] flex-col px-4 pb-24 pt-6 sm:px-6 sm:pb-12 sm:pt-10">
+    <>
+      {/* Mobile-viewport surface — matches
+          docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/MobileHome.jsx
+          Desktop shell below stays untouched via md:flex / md:hidden split. */}
+      <MobileHomeSurface />
+    <div className="mx-auto hidden min-h-[calc(100vh-4rem)] w-full max-w-[1120px] flex-col px-4 pb-24 pt-6 sm:px-6 sm:pb-12 sm:pt-10 md:flex">
       <section className="mx-auto w-full max-w-[760px] text-center">
         {/* "NEW RUN" pill removed — the composer below IS the CTA.
             Perplexity / Claude / ChatGPT all omit this label. If
@@ -720,6 +726,7 @@ export function HomeLanding() {
         </div>
       </section>
     </div>
+    </>
   );
 }
 

--- a/src/features/home/views/MobileHomeSurface.tsx
+++ b/src/features/home/views/MobileHomeSurface.tsx
@@ -1,0 +1,390 @@
+/**
+ * MobileHomeSurface — port of
+ * docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/MobileHome.jsx
+ *
+ * Mobile-only home greeting + watchlist + nudges + recent threads.
+ * Rendered above the desktop HomeLanding via a `md:hidden` wrapper so the
+ * desktop composer-first experience is untouched.
+ *
+ * Uses fixture data matching the DISCO scenario from the design kit's
+ * `data.jsx`. Replace the fixture with live queries once the user's
+ * watchlist + nudges + thread history are wired through Convex.
+ */
+import { useNavigate } from "react-router-dom";
+import { Bell, ChevronRight, FileText, MessageSquare, Search, UserPlus, AlertTriangle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useFastAgent } from "@/features/agents/context/FastAgentContext";
+
+type Trend = "up" | "down";
+
+interface WatchlistTile {
+  id: string;
+  name: string;
+  initials: string;
+  ticker: string;
+  value: string;
+  trend: Trend;
+  delta: string;
+  meta: string;
+  avatarGradient: string;
+}
+
+interface NudgeItem {
+  id: string;
+  title: string;
+  meta: string[];
+  kind: "source" | "claim" | "entity";
+  icon: LucideIcon;
+}
+
+interface ThreadItem {
+  id: string;
+  title: string;
+  meta: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture (mirrors design-kit data.jsx DISCO scenario)
+// ---------------------------------------------------------------------------
+
+const USER_FIRST_NAME = "Homen";
+
+const WATCHLIST: WatchlistTile[] = [
+  {
+    id: "disco",
+    name: "Disco Corp.",
+    initials: "DC",
+    ticker: "DC",
+    value: "$418M",
+    trend: "up",
+    delta: "+3.4%",
+    meta: "ARR \u00b7 signal fresh 4h",
+    avatarGradient: "linear-gradient(135deg, #1A365D, #0F4C81)",
+  },
+  {
+    id: "relay",
+    name: "Relay Legal",
+    initials: "RL",
+    ticker: "RLY",
+    value: "$212M",
+    trend: "up",
+    delta: "+1.8%",
+    meta: "Series D \u00b7 closed",
+    avatarGradient: "linear-gradient(135deg, #6B3BA3, #8B5CC1)",
+  },
+  {
+    id: "lexn",
+    name: "LexNode",
+    initials: "LX",
+    ticker: "LXN",
+    value: "$84M",
+    trend: "down",
+    delta: "-5.1%",
+    meta: "Signal stale 2d",
+    avatarGradient: "linear-gradient(135deg, #C77826, #E09149)",
+  },
+  {
+    id: "clio",
+    name: "Clio",
+    initials: "CL",
+    ticker: "CLO",
+    value: "$1.2B",
+    trend: "up",
+    delta: "+0.6%",
+    meta: "Market leader",
+    avatarGradient: "linear-gradient(135deg, #334155, #475569)",
+  },
+];
+
+const NUDGES: NudgeItem[] = [
+  {
+    id: "n1",
+    title: "New 10-K filed by Disco Corp.",
+    meta: ["SEC EDGAR", "15 min ago"],
+    kind: "source",
+    icon: FileText,
+  },
+  {
+    id: "n2",
+    title: "Churn claim: evidence now contradicts prior brief",
+    meta: ["Workspace \u00b7 Disco", "1h"],
+    kind: "claim",
+    icon: AlertTriangle,
+  },
+  {
+    id: "n3",
+    title: "Relay Legal added Eduardo Martinez as GM Americas",
+    meta: ["LinkedIn", "3h"],
+    kind: "entity",
+    icon: UserPlus,
+  },
+  {
+    id: "n4",
+    title: "Gartner refreshed eDiscovery Magic Quadrant",
+    meta: ["Gartner", "Today"],
+    kind: "source",
+    icon: FileText,
+  },
+];
+
+const THREADS: ThreadItem[] = [
+  { id: "t1", title: "What's the state of Disco's churn?", meta: "2m \u00b7 14 sources" },
+  { id: "t2", title: "Map the eDiscovery 2025 landscape", meta: "yesterday \u00b7 38 sources" },
+  { id: "t3", title: "Who's winning NAM mid-market?", meta: "3d \u00b7 21 sources" },
+  { id: "t4", title: "Pricing pages across top 8 vendors", meta: "1w \u00b7 42 sources" },
+];
+
+// ---------------------------------------------------------------------------
+
+export function MobileHomeSurface() {
+  const navigate = useNavigate();
+  const { open } = useFastAgent();
+
+  const openChat = (prefill?: string) => {
+    if (prefill) {
+      navigate(`/?prompt=${encodeURIComponent(prefill)}`);
+    } else {
+      open({});
+    }
+  };
+
+  return (
+    <div
+      data-testid="mobile-home-surface"
+      className="md:hidden flex min-h-[calc(100vh-56px)] flex-col gap-5 bg-[var(--bg-app,#fafafa)] px-4 pb-6 pt-4 text-[var(--fg-1,#111827)] dark:bg-[#0b0b0e] dark:text-white"
+    >
+      {/* Header — brand + entity breadcrumb + bell */}
+      <header className="flex items-center justify-between">
+        <div className="flex flex-col leading-tight">
+          <span className="text-[13px] font-semibold tracking-tight">
+            Node<em className="not-italic text-[#d97757]">Bench</em>
+          </span>
+          <span className="text-[11px] text-gray-500 dark:text-gray-400">
+            Disco Corp. · workspace
+          </span>
+        </div>
+        <button
+          type="button"
+          aria-label="Notifications"
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-gray-400"
+        >
+          <Bell size={15} />
+        </button>
+      </header>
+
+      {/* Greeting */}
+      <section>
+        <h2 className="text-[22px] font-semibold leading-tight tracking-[-0.015em]">
+          Good morning, {USER_FIRST_NAME}.
+        </h2>
+        <p className="mt-1 text-[13px] text-gray-500 dark:text-gray-400">
+          Four signals on your watchlist this morning.
+        </p>
+      </section>
+
+      {/* Tap-to-chat search */}
+      <button
+        type="button"
+        onClick={() => openChat()}
+        className="flex items-center gap-2 rounded-[14px] border border-gray-200 bg-white px-3 py-3 text-left text-[13px] shadow-sm transition active:scale-[0.99] dark:border-white/[0.08] dark:bg-white/[0.02]"
+      >
+        <Search size={15} className="text-gray-400" aria-hidden />
+        <span className="flex-1 text-gray-400">
+          Ask NodeBench about any company…
+        </span>
+        <kbd className="rounded border border-gray-200 bg-[#f5f4f1] px-1.5 py-[1px] font-mono text-[10px] text-gray-500 dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-gray-400">
+          ⌘K
+        </kbd>
+      </button>
+
+      {/* Watchlist */}
+      <section>
+        <header className="mb-2 flex items-center justify-between">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-gray-400 dark:text-gray-500">
+            Watchlist
+          </span>
+          <button
+            type="button"
+            className="text-[12px] font-medium text-[#d97757] transition hover:underline"
+            onClick={() => navigate("/reports")}
+          >
+            Manage
+          </button>
+        </header>
+        <div className="grid grid-cols-2 gap-2">
+          {WATCHLIST.map((tile) => (
+            <WatchlistCard
+              key={tile.id}
+              tile={tile}
+              onClick={() => navigate(`/reports/${tile.id}/graph?tab=brief`)}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Nudges */}
+      <section>
+        <header className="mb-2 flex items-center justify-between">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-gray-400 dark:text-gray-500">
+            Since you were last here
+          </span>
+          <button
+            type="button"
+            onClick={() => navigate("/?surface=inbox")}
+            className="text-[12px] font-medium text-[#d97757] transition hover:underline"
+          >
+            All {NUDGES.length}
+          </button>
+        </header>
+        <div className="flex flex-col gap-1.5">
+          {NUDGES.map((n) => (
+            <NudgeRow
+              key={n.id}
+              item={n}
+              onClick={() => navigate("/?surface=inbox")}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Recent threads */}
+      <section>
+        <header className="mb-2 flex items-center justify-between">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-gray-400 dark:text-gray-500">
+            Recent threads
+          </span>
+          <button
+            type="button"
+            onClick={() => navigate("/?surface=chat")}
+            className="text-[12px] font-medium text-[#d97757] transition hover:underline"
+          >
+            View all
+          </button>
+        </header>
+        <div className="flex flex-col gap-1.5">
+          {THREADS.map((t) => (
+            <ThreadRow
+              key={t.id}
+              item={t}
+              onClick={() => openChat(t.title)}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function WatchlistCard({
+  tile,
+  onClick,
+}: {
+  tile: WatchlistTile;
+  onClick: () => void;
+}) {
+  const trendColor =
+    tile.trend === "up" ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col items-start gap-1.5 rounded-[14px] border border-gray-200 bg-white p-3 text-left transition active:scale-[0.98] dark:border-white/[0.08] dark:bg-white/[0.02]"
+    >
+      <div className="flex w-full items-center gap-2">
+        <span
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] text-[11px] font-semibold text-white"
+          style={{ background: tile.avatarGradient }}
+          aria-hidden
+        >
+          {tile.initials}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[13px] font-semibold">
+          {tile.name}
+        </span>
+        <span className="shrink-0 font-mono text-[10px] text-gray-400 dark:text-gray-500">
+          {tile.ticker}
+        </span>
+      </div>
+      <div className="flex items-baseline gap-1.5">
+        <strong className="text-[15px] font-semibold tracking-tight">{tile.value}</strong>
+        <span className={`text-[11px] font-medium ${trendColor}`}>{tile.delta}</span>
+      </div>
+      <div className="truncate text-[11px] text-gray-500 dark:text-gray-400">
+        {tile.meta}
+      </div>
+    </button>
+  );
+}
+
+function NudgeRow({
+  item,
+  onClick,
+}: {
+  item: NudgeItem;
+  onClick: () => void;
+}) {
+  const kindBg = {
+    source: "bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300",
+    claim: "bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-300",
+    entity: "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300",
+  }[item.kind];
+  const IconCmp = item.icon;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-start gap-2.5 rounded-[12px] border border-gray-200 bg-white px-3 py-2.5 text-left transition active:scale-[0.99] dark:border-white/[0.08] dark:bg-white/[0.02]"
+    >
+      <span
+        className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${kindBg}`}
+      >
+        <IconCmp size={13} />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-[13px] font-medium leading-tight">
+          {item.title}
+        </span>
+        <span className="mt-0.5 flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400">
+          {item.meta.map((m, i) => (
+            <span key={i} className="truncate">
+              {i > 0 && <span className="mx-1 text-gray-300 dark:text-gray-600">·</span>}
+              {m}
+            </span>
+          ))}
+        </span>
+      </span>
+      <ChevronRight size={14} className="mt-1 shrink-0 text-gray-300 dark:text-gray-600" />
+    </button>
+  );
+}
+
+function ThreadRow({
+  item,
+  onClick,
+}: {
+  item: ThreadItem;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-2.5 rounded-[12px] border border-gray-200 bg-white px-3 py-2.5 text-left transition active:scale-[0.99] dark:border-white/[0.08] dark:bg-white/[0.02]"
+    >
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#d97757]/10 text-[#d97757]">
+        <MessageSquare size={13} />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-[13px] font-medium">{item.title}</span>
+        <span className="mt-0.5 text-[11px] text-gray-500 dark:text-gray-400">
+          {item.meta}
+        </span>
+      </span>
+      <ChevronRight size={14} className="shrink-0 text-gray-300 dark:text-gray-600" />
+    </button>
+  );
+}
+
+export default MobileHomeSurface;

--- a/test-results.json
+++ b/test-results.json
@@ -93,12 +93,12 @@
                       "workerIndex": 0,
                       "parallelIndex": 0,
                       "status": "passed",
-                      "duration": 1208,
+                      "duration": 5687,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-04-22T23:28:08.010Z",
+                      "startTime": "2026-04-24T02:37:57.803Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -127,12 +127,12 @@
                       "workerIndex": 0,
                       "parallelIndex": 0,
                       "status": "passed",
-                      "duration": 1440,
+                      "duration": 3263,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-04-22T23:28:09.431Z",
+                      "startTime": "2026-04-24T02:38:03.845Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -161,12 +161,12 @@
                       "workerIndex": 0,
                       "parallelIndex": 0,
                       "status": "passed",
-                      "duration": 954,
+                      "duration": 3260,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-04-22T23:28:10.883Z",
+                      "startTime": "2026-04-24T02:38:07.123Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -195,12 +195,12 @@
                       "workerIndex": 0,
                       "parallelIndex": 0,
                       "status": "passed",
-                      "duration": 971,
+                      "duration": 2564,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-04-22T23:28:11.854Z",
+                      "startTime": "2026-04-24T02:38:10.397Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -229,12 +229,12 @@
                       "workerIndex": 0,
                       "parallelIndex": 0,
                       "status": "passed",
-                      "duration": 1020,
+                      "duration": 3384,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-04-22T23:28:12.838Z",
+                      "startTime": "2026-04-24T02:38:12.977Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -245,6 +245,108 @@
               "id": "365489eee4d4394f3125-4a58ced9be452d71c0e5",
               "file": "live-smoke.spec.ts",
               "line": 81,
+              "column": 3
+            },
+            {
+              "title": "/reports/:slug/graph mounts ReportDetailWorkspace",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 45000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 2552,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-04-24T02:38:16.374Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "365489eee4d4394f3125-55b6b40e5d9dfe1fa2dd",
+              "file": "live-smoke.spec.ts",
+              "line": 89,
+              "column": 3
+            },
+            {
+              "title": "/?surface=reports shows Brief|Explore|Chat action row on cards",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 45000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 2864,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-04-24T02:38:18.939Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "365489eee4d4394f3125-cf86999d708d60eda15c",
+              "file": "live-smoke.spec.ts",
+              "line": 104,
+              "column": 3
+            },
+            {
+              "title": "/workspace/w/:id mounts UniversalWorkspacePage chromelessly",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 45000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 1640,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-04-24T02:38:21.814Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "365489eee4d4394f3125-826bca1075271f107242",
+              "file": "live-smoke.spec.ts",
+              "line": 125,
               "column": 3
             },
             {
@@ -263,12 +365,12 @@
                       "workerIndex": 0,
                       "parallelIndex": 0,
                       "status": "passed",
-                      "duration": 3703,
+                      "duration": 3993,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-04-22T23:28:13.871Z",
+                      "startTime": "2026-04-24T02:38:23.465Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -278,7 +380,7 @@
               ],
               "id": "365489eee4d4394f3125-4ab23ad804eb80cbd614",
               "file": "live-smoke.spec.ts",
-              "line": 89,
+              "line": 142,
               "column": 3
             }
           ]
@@ -288,9 +390,9 @@
   ],
   "errors": [],
   "stats": {
-    "startTime": "2026-04-22T23:28:07.131Z",
-    "duration": 10654.287,
-    "expected": 6,
+    "startTime": "2026-04-24T02:37:56.519Z",
+    "duration": 31127.048,
+    "expected": 9,
     "skipped": 0,
     "unexpected": 0,
     "flaky": 0


### PR DESCRIPTION
Closes the highest-visibility mobile design parity gap from the NodeBench Mobile UI Kit.

## Shipped
- `src/features/home/views/MobileHomeSurface.tsx` — matches `docs/design/.../ui_kits/nodebench-mobile/MobileHome.jsx` shape + DISCO fixture
- Sections: header, greeting, tap-to-chat search, 2x2 watchlist, nudges feed, recent threads
- Wired nav: tap-to-chat → FastAgentPanel, watchlist tile → `/reports/{id}/graph?tab=brief`, nudges → Inbox, threads → prefilled chat
- `HomeLanding` renders mobile surface first, desktop shell below with `hidden md:flex`

## Deferred (each a PR)
- MobileChat (answer-first, entity pills, sources, SO WHAT callout)
- MobileBrief / MobileSources / MobileNotebook (report sub-tabs)
- MobileInbox (filter tabs + threaded feed)
- MobileMe (profile + workspaces)

## Verification
- `npx tsc --noEmit` clean
- Preview deploy now works (fixed by PR #22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)