### PR TITLE
fix(routing): mobile bare / defaults to Home, not Chat

### DIFF
--- a/src/lib/registry/viewRegistry.test.ts
+++ b/src/lib/registry/viewRegistry.test.ts
@@ -61,7 +61,7 @@ describe("resolvePathToView", () => {
     });
   });
 
-  it("defaults bare mobile root routes to chat", () => {
+  it("defaults bare mobile root routes to Home (5-tab lock)", () => {
     const previousWindow = globalThis.window;
     Object.defineProperty(globalThis, "window", {
       configurable: true,
@@ -73,10 +73,12 @@ describe("resolvePathToView", () => {
     });
 
     try {
+      // Post 5-tab lock: mobile lands on Home (ask surface) which renders
+      // MobileHomeSurface. Previously this defaulted to chat, which
+      // bypassed the canonical mobile Home surface.
       expect(resolvePathToCockpitState("/", "")).toMatchObject({
-        surfaceId: "workspace",
-        view: "chat-home",
-        canonicalPath: "/?surface=chat",
+        surfaceId: "ask",
+        canonicalPath: "/?surface=home",
         isLegacyRedirect: true,
       });
     } finally {

--- a/src/lib/registry/viewRegistry.ts
+++ b/src/lib/registry/viewRegistry.ts
@@ -875,11 +875,11 @@ export function resolvePathToCockpitState(rawPathname: string, rawSearch = ""): 
   const currentPath = `${rawPathname || "/"}${rawSearch || ""}`;
   const activeSurface = requestedSurface ?? null;
   const rootPath = (rawPathname || "/") === "/";
-  const compactRootDefault =
-    typeof window !== "undefined" &&
-    window.matchMedia?.("(max-width: 1279px)")?.matches
-      ? "workspace"
-      : "ask";
+  // 5-tab lock (2026-04-23): Home is the primary tab on every viewport.
+  // Mobile no longer auto-redirects to the Chat surface on bare `/` — the
+  // MobileHomeSurface mounted inside HomeLanding (ask surface) is the
+  // canonical landing, matching the locked Home · Reports · Chat · Inbox · Me IA.
+  const compactRootDefault = "ask";
 
   if (rootPath && !activeSurface) {
     const canonicalPath = buildCockpitPath({ surfaceId: compactRootDefault });


### PR DESCRIPTION
## Summary
- Compact viewport root (`/` at <1280px) now defaults to the **ask** surface (Home) instead of `workspace` (Chat), matching the 5-tab IA lock (Home · Reports · Chat · Inbox · Me).
- Unblocks `MobileHomeSurface` on production mobile so `tests/e2e/live-smoke-mobile.spec.ts` can assert the Home surface is mounted on bare `/`.

## Root cause
`resolvePathToCockpitState` in [src/lib/registry/viewRegistry.ts](src/lib/registry/viewRegistry.ts) carried stale logic that set `compactRootDefault = "workspace"` on mobile viewports, which canonicalized bare `/` to `/?surface=chat`. That was the pre-Home-lock default and bypassed the `MobileHomeSurface` mount in `HomeLanding`.

## Test plan
- [x] `npx vitest run src/lib/registry/viewRegistry.test.ts` → 12/12 tests pass with updated invariant
- [ ] After merge, `BASE_URL=https://www.nodebenchai.com npm run live-smoke:mobile` → 5/5 pass including `MobileHomeSurface mounts`
- [ ] Mobile probe confirms bare `/` now resolves to `/?surface=home` and renders Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)