### PR TITLE
feat(mobile): MobileMeSurface + MobileReportSurface parity ports

### DIFF
--- a/src/features/me/views/MeHome.tsx
+++ b/src/features/me/views/MeHome.tsx
@@ -5,6 +5,7 @@ import { Save, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { useConvexApi } from "@/lib/convexApi";
 import { buildCockpitPath } from "@/lib/registry/viewRegistry";
+import MobileMeSurface from "@/features/me/views/MobileMeSurface";
 import { usePwaInstallPrompt } from "@/hooks/usePwaInstallPrompt";
 import { getAnonymousProductSessionId } from "@/features/product/lib/productIdentity";
 import { useProductBootstrap } from "@/features/product/lib/useProductBootstrap";
@@ -332,7 +333,12 @@ export function MeHome() {
 
   // ── Render ──
   return (
-    <div className="mx-auto max-w-[720px] px-6 py-8 pb-24">
+    <>
+      {/* Mobile-only Me surface (ported from nodebench-mobile design kit) */}
+      <MobileMeSurface />
+
+      {/* Desktop Me surface — hidden on mobile */}
+      <div className="hidden md:block mx-auto max-w-[720px] px-6 py-8 pb-24">
 
       {/* ── Header ── */}
       <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Your context</h1>
@@ -686,7 +692,8 @@ export function MeHome() {
           </div>
         </div>
       </section>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/src/features/me/views/MobileMeSurface.tsx
+++ b/src/features/me/views/MobileMeSurface.tsx
@@ -1,0 +1,297 @@
+/**
+ * MobileMeSurface — port of
+ * docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/MobileMe.jsx
+ *
+ * Mobile-only Me surface. Renders above the desktop MeHome via a `md:hidden`
+ * wrapper so the richer desktop preferences panel is untouched.
+ *
+ * Uses fixture data matching the design kit's `data.jsx` MDATA.me shape.
+ * Swap the fixture for live queries once the user profile + workspaces +
+ * preferences endpoints are wired to this surface.
+ */
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Archive,
+  ChevronRight,
+  FileText,
+  Plus,
+  Settings,
+  Star,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Fixture (mirrors design-kit data.jsx me block)
+// ---------------------------------------------------------------------------
+
+interface Workspace {
+  id: string;
+  name: string;
+  initials: string;
+  avatarGradient: string;
+  role: string;
+  members: number;
+  active: boolean;
+}
+
+interface QuickSetting {
+  id: string;
+  label: string;
+  value: string;
+  icon: LucideIcon;
+}
+
+const USER = {
+  name: "Homen Shum",
+  handle: "homen",
+  role: "Founder, NodeBench",
+  email: "homen@nodebench.ai",
+  initials: "HS",
+  avatarGradient: "linear-gradient(135deg, rgba(217,119,87,.88), rgba(190,92,60,.72))",
+  joined: "Oct 2025",
+};
+
+const STATS: { v: string; l: string }[] = [
+  { v: "128", l: "Threads" },
+  { v: "42", l: "Reports" },
+  { v: "9", l: "Workspaces" },
+];
+
+const WORKSPACES: Workspace[] = [
+  {
+    id: "disco",
+    name: "Disco Corp.",
+    initials: "DC",
+    avatarGradient: "linear-gradient(135deg, rgba(17,24,39,.92), rgba(55,65,81,.78))",
+    role: "Lead analyst",
+    members: 4,
+    active: true,
+  },
+  {
+    id: "relay",
+    name: "Relay Legal",
+    initials: "RL",
+    avatarGradient: "linear-gradient(135deg, rgba(30,58,138,.9), rgba(59,130,246,.72))",
+    role: "Collaborator",
+    members: 7,
+    active: false,
+  },
+  {
+    id: "cobalt",
+    name: "Cobalt Health",
+    initials: "CH",
+    avatarGradient: "linear-gradient(135deg, rgba(4,120,87,.9), rgba(16,185,129,.72))",
+    role: "Viewer",
+    members: 12,
+    active: false,
+  },
+  {
+    id: "personal",
+    name: "Field notes (personal)",
+    initials: "FN",
+    avatarGradient: "linear-gradient(135deg, rgba(120,53,15,.92), rgba(180,83,9,.72))",
+    role: "Owner",
+    members: 1,
+    active: false,
+  },
+];
+
+const QUICK_SETTINGS: QuickSetting[] = [
+  { id: "evidence", label: "Evidence style", value: "Cite inline", icon: FileText },
+  { id: "voice", label: "Communication", value: "Concise, analyst", icon: Settings },
+  { id: "notify", label: "Notifications", value: "Mentions + signals", icon: Settings },
+  { id: "appearance", label: "Appearance", value: "Match system", icon: Settings },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function MobileMeSurface() {
+  const navigate = useNavigate();
+  const [activeWs, setActiveWs] = useState(
+    WORKSPACES.find((w) => w.active)?.id ?? WORKSPACES[0].id,
+  );
+
+  return (
+    <div
+      data-testid="mobile-me-surface"
+      className="md:hidden min-h-dvh w-full bg-[#f8f7f5] text-[#111827]"
+    >
+      {/* Header */}
+      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-black/5 bg-white/85 px-4 pt-4 pb-3 backdrop-blur">
+        <div>
+          <div className="text-[17px] font-semibold leading-tight">Me</div>
+          <div className="text-[11px] text-gray-500">Profile, workspaces, preferences</div>
+        </div>
+        <button
+          className="rounded-full p-2 text-gray-600 hover:bg-black/5 active:scale-95"
+          aria-label="Settings"
+          onClick={() => navigate("/me/settings")}
+        >
+          <Settings size={18} strokeWidth={1.7} />
+        </button>
+      </header>
+
+      <div className="px-4 pt-4 pb-24 space-y-4">
+        {/* Identity card */}
+        <section className="flex items-center gap-3 rounded-2xl border border-black/5 bg-white p-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <div
+            className="flex h-14 w-14 flex-none items-center justify-center rounded-2xl font-mono text-[15px] font-bold text-white"
+            style={{ background: USER.avatarGradient }}
+          >
+            {USER.initials}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="truncate text-[15px] font-semibold text-gray-900">{USER.name}</div>
+            <div className="truncate text-[11px] text-gray-500">
+              @{USER.handle} · {USER.role}
+            </div>
+            <div className="truncate font-mono text-[10px] text-gray-400">{USER.email}</div>
+          </div>
+          <button
+            className="flex-none rounded-full border border-black/10 bg-white px-3 py-1.5 text-[11px] font-semibold text-gray-700 hover:bg-gray-50 active:scale-95"
+            onClick={() => navigate("/me")}
+          >
+            Edit
+          </button>
+        </section>
+
+        {/* Stats strip */}
+        <section className="grid grid-cols-3 gap-2">
+          {STATS.map((s) => (
+            <div
+              key={s.l}
+              className="rounded-xl border border-black/5 bg-white px-3 py-2.5 text-center"
+            >
+              <div className="font-mono text-[17px] font-bold text-gray-900">{s.v}</div>
+              <div className="text-[10px] uppercase tracking-[0.12em] text-gray-500">{s.l}</div>
+            </div>
+          ))}
+        </section>
+
+        {/* Workspaces */}
+        <section>
+          <div className="mb-2 flex items-center justify-between px-1">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-500">
+              Workspaces
+            </span>
+            <button className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold text-[#d97757] hover:bg-[#d97757]/10 active:scale-95">
+              <Plus size={13} strokeWidth={2} /> New
+            </button>
+          </div>
+          <div className="overflow-hidden rounded-2xl border border-black/5 bg-white">
+            {WORKSPACES.map((w, idx) => {
+              const active = activeWs === w.id;
+              return (
+                <button
+                  key={w.id}
+                  data-active={active}
+                  onClick={() => setActiveWs(w.id)}
+                  className={`flex w-full items-center gap-3 px-3 py-3 text-left transition ${
+                    idx !== WORKSPACES.length - 1 ? "border-b border-black/5" : ""
+                  } ${active ? "bg-[#d97757]/5" : "hover:bg-black/[0.02]"}`}
+                >
+                  <span
+                    className="flex h-9 w-9 flex-none items-center justify-center rounded-xl font-mono text-[11px] font-bold text-white"
+                    style={{ background: w.avatarGradient }}
+                  >
+                    {w.initials}
+                  </span>
+                  <span className="flex-1 min-w-0">
+                    <span className="block truncate text-[13px] font-semibold text-gray-900">
+                      {w.name}
+                    </span>
+                    <span className="block truncate text-[11px] text-gray-500">
+                      {w.role} · {w.members} {w.members === 1 ? "member" : "members"}
+                    </span>
+                  </span>
+                  {active ? (
+                    <span className="flex-none rounded-full bg-[#d97757] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white">
+                      Active
+                    </span>
+                  ) : (
+                    <ChevronRight size={16} className="flex-none text-gray-400" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Quick settings */}
+        <section>
+          <div className="mb-2 px-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-500">
+            Quick settings
+          </div>
+          <div className="overflow-hidden rounded-2xl border border-black/5 bg-white">
+            {QUICK_SETTINGS.map((s, idx) => {
+              const Icon = s.icon;
+              return (
+                <button
+                  key={s.id}
+                  className={`flex w-full items-center gap-3 px-3 py-3 text-left hover:bg-black/[0.02] ${
+                    idx !== QUICK_SETTINGS.length - 1 ? "border-b border-black/5" : ""
+                  }`}
+                >
+                  <span className="flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-[#f4f3f1] text-gray-600">
+                    <Icon size={15} strokeWidth={1.7} />
+                  </span>
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-[12.5px] font-semibold text-gray-900">
+                      {s.label}
+                    </span>
+                    <span className="block truncate text-[11px] text-gray-500">{s.value}</span>
+                  </span>
+                  <ChevronRight size={15} className="flex-none text-gray-400" />
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Shortcuts */}
+        <section>
+          <div className="mb-2 px-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-500">
+            Shortcuts
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              className="flex items-center gap-2 rounded-xl border border-black/5 bg-white px-3 py-2.5 text-[12px] font-semibold text-gray-700 hover:bg-black/[0.02] active:scale-[0.98]"
+              onClick={() => navigate("/?surface=home")}
+            >
+              <Star size={15} className="text-[#d97757]" />
+              Starred threads
+            </button>
+            <button
+              className="flex items-center gap-2 rounded-xl border border-black/5 bg-white px-3 py-2.5 text-[12px] font-semibold text-gray-700 hover:bg-black/[0.02] active:scale-[0.98]"
+              onClick={() => navigate("/?surface=reports")}
+            >
+              <FileText size={15} className="text-gray-500" />
+              My drafts
+            </button>
+            <button className="flex items-center gap-2 rounded-xl border border-black/5 bg-white px-3 py-2.5 text-[12px] font-semibold text-gray-700 hover:bg-black/[0.02] active:scale-[0.98]">
+              <Archive size={15} className="text-gray-500" />
+              Archive
+            </button>
+            <button className="flex items-center gap-2 rounded-xl border border-black/5 bg-white px-3 py-2.5 text-[12px] font-semibold text-gray-700 hover:bg-black/[0.02] active:scale-[0.98]">
+              <FileText size={15} className="text-gray-500" />
+              Billing & plan
+            </button>
+          </div>
+        </section>
+
+        {/* Footer */}
+        <div className="pt-2 text-center">
+          <div className="text-[10px] text-gray-400">
+            NodeBench · member since {USER.joined}
+          </div>
+          <button className="mt-2 inline-flex items-center justify-center rounded-full border border-black/10 bg-white px-4 py-1.5 text-[11px] font-semibold text-gray-600 hover:bg-gray-50 active:scale-95">
+            Sign out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/research/views/MobileReportSurface.tsx
+++ b/src/features/research/views/MobileReportSurface.tsx
@@ -1,0 +1,843 @@
+/**
+ * MobileReportSurface — combined port of
+ * docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/
+ *   MobileBrief.jsx · MobileSources.jsx · MobileNotebook.jsx
+ *
+ * Single mobile-only report surface with internal sub-tab switching between
+ * Brief / Sources / Notebook. Mounts above the desktop ReportDetailWorkspace
+ * via a `md:hidden` wrapper so the desktop cards workspace is untouched.
+ *
+ * Fixture data mirrors the design-kit `data.jsx` DISCO scenario
+ * (MDATA.brief / MDATA.sources / MDATA.notebook). Swap to live
+ * `hydrateEntities.compactFindings` output once the mobile report mount
+ * is wired to the canonical entity graph.
+ */
+import { useState, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  Bookmark,
+  ChevronRight,
+  Clock,
+  FileText,
+  Filter,
+  MessageSquare,
+  Radio,
+  Share2,
+  Sparkles,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+type SubTab = "brief" | "sources" | "notebook";
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirror design-kit data.jsx)
+// ---------------------------------------------------------------------------
+
+const BRIEF = {
+  kicker: "Diligence brief · Disco Corp.",
+  title: "Platform narrative holds — Q2 renewals are the load-bearing quarter.",
+  sub: "A four-quarter review of Disco Corp.'s retention mechanics, pricing, and competitive position, with a quantified next-quarter read.",
+  meta: ["v4 · Draft", "Updated 42m ago", "14 sources", "Confidence: Medium-High"],
+  verdict:
+    "Disco's platform thesis is quantitatively supported by NRR expansion and Relay head-to-head wins, but Q2 Am Law 200 renewals gate the public-comps narrative. Base case: NRR lands 116–119% with 2 pts of upside from the Relay swaps.",
+  stats: [
+    { v: "114%", l: "NRR · Q4 FY24", trend: "up" as const },
+    { v: "88%", l: "GRR · mid-market soft", trend: "down" as const },
+    { v: "+41", l: "Net new logos · Q4", trend: "up" as const },
+    { v: "38%", l: "ARR renews in Q2", trend: null },
+  ],
+  triad: [
+    {
+      tag: "What",
+      color: null as null,
+      h: "NRR bent from 108% → 114% in four quarters.",
+      p: "Platform-tier upsell accounts for roughly 60% of the lift; Relay head-to-head wins contribute another 25%. Small-firm churn remains elevated but is a declining share of the base.",
+    },
+    {
+      tag: "So what",
+      color: "indigo" as const,
+      h: "The platform narrative now has quantitative cover.",
+      p: "Public comps will reprice on the NRR line if Q2 renewals clear 92% among Am Law 200. A miss reopens the bear case that Disco is a single-product eDiscovery tool.",
+    },
+    {
+      tag: "Now what",
+      color: "ok" as const,
+      h: "Watch three signals over the next 60 days.",
+      p: "(1) Am Law 200 renewal closes in late April. (2) Relay's own earnings cadence — they report before Disco. (3) Any deal-desk pricing changes from the Clio/NetDocs axis.",
+    },
+  ],
+  timeline: [
+    { d: "Apr 12", t: "Am Law 200 renewal window opens", m: "Historical decision peak is weeks 2–3." },
+    { d: "Apr 28", t: "Relay Legal earnings", m: "Read-through for platform-tier demand." },
+    { d: "May 09", t: "Disco Q1 print", m: "NRR the single most important line item." },
+    { d: "May 22", t: "Am Law 200 window closes", m: "Renewal retention rate crystallizes." },
+  ],
+};
+
+type ClaimStatusKey = "strong" | "medium" | "fresh" | "primary" | "disputed" | "internal";
+
+interface ClaimEntry {
+  id: string;
+  q: string;
+  statuses: [ClaimStatusKey, string][];
+  evidence: { src: string; meta: string; strength: "strong" | "medium" | "weak" }[];
+}
+
+const SOURCES = {
+  filters: ["all", "fresh <30d", "high trust", "primary", "disputed"] as const,
+  claims: [
+    {
+      id: "c1",
+      q: "NRR reached 114% in Q4 FY24",
+      statuses: [
+        ["strong", "strong"],
+        ["fresh", "fresh <30d"],
+        ["primary", "primary"],
+      ],
+      evidence: [
+        { src: "Disco Q4 FY24 10-K, p.42", meta: "SEC · 9d", strength: "strong" },
+        { src: "Earnings call transcript", meta: "Seeking Alpha · 9d", strength: "strong" },
+        { src: "Workspace note: Apr-03 memo", meta: "Internal · 12d", strength: "medium" },
+      ],
+    },
+    {
+      id: "c2",
+      q: "Am Law 200 cohort is 38% of ARR",
+      statuses: [
+        ["medium", "medium"],
+        ["internal", "internal"],
+      ],
+      evidence: [
+        { src: "Internal renewal tracker v7", meta: "Workspace · 1d", strength: "medium" },
+        { src: "Disco IR deck, Mar 2025", meta: "Disco.com · 32d", strength: "medium" },
+      ],
+    },
+    {
+      id: "c3",
+      q: "Relay Legal grew NRR to 119%",
+      statuses: [
+        ["strong", "strong"],
+        ["fresh", "fresh <30d"],
+      ],
+      evidence: [
+        { src: "Relay Series D memo", meta: "PitchBook · 3d", strength: "strong" },
+        { src: "Crunchbase funding refresh", meta: "Crunchbase · 3d", strength: "medium" },
+      ],
+    },
+    {
+      id: "c4",
+      q: "Mid-market gross churn is elevated",
+      statuses: [
+        ["medium", "medium"],
+        ["disputed", "disputed"],
+      ],
+      evidence: [
+        { src: "Anecdotal — 3 small-firm quotes", meta: "Internal · 1d", strength: "weak" },
+        { src: "Gartner MQ commentary", meta: "Gartner · 22d", strength: "medium" },
+      ],
+    },
+  ] as ClaimEntry[],
+  recentSources: [
+    { title: "Disco Q4 FY24 10-K filing", meta: ["SEC", "9d"], strength: "strong" as const },
+    { title: "Gartner MQ for eDiscovery 2025", meta: ["Gartner", "22d"], strength: "strong" as const },
+    { title: "Relay Legal Series D coverage", meta: ["PitchBook", "3d"], strength: "medium" as const },
+    { title: "Am Law 200 renewal tracker", meta: ["Workspace", "1d"], strength: "medium" as const },
+    { title: "Clio pricing page snapshot", meta: ["web.archive", "7d"], strength: "weak" as const },
+  ],
+};
+
+type NotebookSeg =
+  | string
+  | { t: "chip"; name: string; type: string; initials: string }
+  | { t: "mark"; v: string };
+
+type NotebookBlock =
+  | { t: "h2"; v: string }
+  | { t: "p"; v: string | NotebookSeg[] }
+  | { t: "proposal"; state: "open" | "accepted" | "dismissed"; note: string }
+  | { t: "claim"; v: string; conf: string; sourcesN: number };
+
+const NOTEBOOK = {
+  title: "Disco diligence — April field notes",
+  meta: ["Personal workspace", "Updated 42m ago", "Autosave on"],
+  body: [
+    { t: "h2", v: "The renewal window matters more than the quarter." },
+    {
+      t: "p",
+      v: [
+        "Across four quarters, ",
+        { t: "chip", name: "Disco Corp.", type: "company", initials: "DC" },
+        " has pushed NRR from 108% to 114% [1]. That's platform-tier upsell, not price. ",
+        "But 38% of ARR ",
+        { t: "mark", v: "renews in Q2" },
+        " — so the April–May window, not the fiscal year, is the load-bearing moment [2].",
+      ],
+    },
+    {
+      t: "proposal",
+      state: "open",
+      note: "Merge Relay's Series D narrative into Competitive > Position — 2 direct contradictions with last week's memo.",
+    },
+    { t: "h2", v: "What Q2 actually looks like" },
+    {
+      t: "p",
+      v: [
+        "The Am Law 200 cohort decides roughly in weeks 2–3 of April. ",
+        { t: "chip", name: "Relay Legal", type: "investor", initials: "RL" },
+        " prints before ",
+        { t: "chip", name: "Disco Corp.", type: "company", initials: "DC" },
+        ", which gives us a read-through on platform-tier demand [3].",
+      ],
+    },
+    {
+      t: "claim",
+      v: "If Am Law 200 holds ≥92%, NRR clears 118% and platform thesis wins the public comps.",
+      conf: "Medium-high",
+      sourcesN: 6,
+    },
+    { t: "h2", v: "What would change my mind" },
+    {
+      t: "p",
+      v: [
+        "Three disconfirmers I'll watch: (a) a pricing change from ",
+        { t: "chip", name: "Clio / NetDocs axis", type: "market", initials: "CL" },
+        " that resets mid-market expectations, (b) a visible enterprise-tier loss, (c) any SEC-driven review of ",
+        { t: "chip", name: "ESI retention rules", type: "regulation", initials: "ES" },
+        " [4].",
+      ],
+    },
+    {
+      t: "proposal",
+      state: "accepted",
+      note: "Pull through the LexNode runway concern into the Competitors card. Marked accepted and applied to v4 draft.",
+    },
+  ] as NotebookBlock[],
+  footnotes: [
+    { n: 1, title: "Disco Q4 FY24 10-K, p.42", meta: "SEC · 9d · primary" },
+    { n: 2, title: "Internal renewal tracker v7", meta: "Workspace · 1d · secondary" },
+    { n: 3, title: "Relay Series D memo", meta: "PitchBook · 3d · primary" },
+    { n: 4, title: "Gartner MQ commentary", meta: "Gartner · 22d · synthesis" },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Small building blocks
+// ---------------------------------------------------------------------------
+
+function Kicker({ children, tone = "default" }: { children: ReactNode; tone?: "default" | "accent" | "indigo" | "ok" }) {
+  const color =
+    tone === "accent"
+      ? "text-[#d97757]"
+      : tone === "indigo"
+        ? "text-indigo-600"
+        : tone === "ok"
+          ? "text-emerald-600"
+          : "text-gray-500";
+  return (
+    <span className={`text-[10px] font-semibold uppercase tracking-[0.2em] ${color}`}>{children}</span>
+  );
+}
+
+function Pill({
+  children,
+  tone = "neutral",
+  mono = true,
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "ok" | "warn" | "accent";
+  mono?: boolean;
+}) {
+  const cls =
+    tone === "ok"
+      ? "bg-emerald-50 text-emerald-700 border-emerald-100"
+      : tone === "warn"
+        ? "bg-amber-50 text-amber-700 border-amber-100"
+        : tone === "accent"
+          ? "bg-[#d97757]/10 text-[#d97757] border-[#d97757]/20"
+          : "bg-gray-100 text-gray-700 border-gray-200";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold ${
+        mono ? "font-mono" : ""
+      } ${cls}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Cite({ n, onClick }: { n: number; onClick?: () => void }) {
+  return (
+    <sup
+      role="button"
+      onClick={onClick}
+      className="ml-0.5 inline-flex h-[14px] min-w-[14px] cursor-pointer items-center justify-center rounded-full bg-[#d97757]/10 px-1 font-mono text-[9px] font-bold text-[#d97757]"
+    >
+      {n}
+    </sup>
+  );
+}
+
+function Chip({ name, initials, type }: { name: string; initials: string; type: string }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full border border-black/10 bg-white px-1.5 py-[1px] align-middle text-[11px] font-semibold text-gray-700"
+      title={`${type}: ${name}`}
+    >
+      <span className="font-mono text-[9px] tracking-wide text-gray-500">{initials}</span>
+      {name}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BRIEF sub-view
+// ---------------------------------------------------------------------------
+
+function BriefView({ onNavigate }: { onNavigate: (t: SubTab) => void }) {
+  return (
+    <div className="space-y-4 px-4 pt-3 pb-10">
+      <div className="flex items-center gap-2">
+        <Kicker tone="accent">Brief</Kicker>
+        <Pill mono tone="neutral">draft v4</Pill>
+      </div>
+      <h1 className="text-[20px] font-semibold leading-tight text-gray-900">{BRIEF.title}</h1>
+      <p className="text-[13.5px] leading-relaxed text-gray-600">{BRIEF.sub}</p>
+      <div className="flex flex-wrap gap-1.5">
+        {BRIEF.meta.map((m) => (
+          <Pill key={m}>{m}</Pill>
+        ))}
+      </div>
+
+      {/* Verdict */}
+      <section className="rounded-2xl border border-[#d97757]/20 bg-[#d97757]/[0.05] p-4">
+        <Kicker tone="accent">Verdict</Kicker>
+        <h2 className="mt-1 text-[16px] font-semibold text-gray-900">
+          Base case holds, Q2 is the tell.
+        </h2>
+        <p className="mt-2 text-[13px] leading-relaxed text-gray-700">
+          {BRIEF.verdict}
+          <Cite n={1} onClick={() => onNavigate("sources")} />
+        </p>
+      </section>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-2">
+        {BRIEF.stats.map((s) => (
+          <div key={s.l} className="rounded-xl border border-black/5 bg-white p-3">
+            <div
+              className={`font-mono text-[18px] font-bold ${
+                s.trend === "up"
+                  ? "text-emerald-600"
+                  : s.trend === "down"
+                    ? "text-amber-700"
+                    : "text-gray-900"
+              }`}
+            >
+              {s.v}
+            </div>
+            <div className="mt-0.5 text-[10.5px] uppercase tracking-wide text-gray-500">{s.l}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Triad */}
+      <h3 className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-[#d97757]">
+        <FileText size={14} strokeWidth={1.7} />
+        <span>Structured take</span>
+      </h3>
+      <div className="space-y-2">
+        {BRIEF.triad.map((t) => (
+          <div
+            key={t.tag}
+            className={`rounded-2xl border p-3 ${
+              t.color === "indigo"
+                ? "border-indigo-100 bg-indigo-50/60"
+                : t.color === "ok"
+                  ? "border-emerald-100 bg-emerald-50/60"
+                  : "border-black/5 bg-white"
+            }`}
+          >
+            <Kicker tone={t.color === "indigo" ? "indigo" : t.color === "ok" ? "ok" : "accent"}>
+              {t.tag}
+            </Kicker>
+            <h4 className="mt-1 text-[14px] font-semibold text-gray-900">{t.h}</h4>
+            <p className="mt-1 text-[12.5px] leading-relaxed text-gray-700">{t.p}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Timeline */}
+      <h3 className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-gray-500">
+        <Clock size={14} strokeWidth={1.7} />
+        <span>Next 60 days</span>
+      </h3>
+      <div className="space-y-2">
+        {BRIEF.timeline.map((r) => (
+          <div
+            key={r.d}
+            className="flex items-start gap-3 rounded-xl border border-black/5 bg-white p-3"
+          >
+            <div className="w-16 flex-none font-mono text-[11px] font-bold uppercase text-[#d97757]">
+              {r.d}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-[12.5px] font-semibold text-gray-900">{r.t}</div>
+              <div className="mt-0.5 text-[11px] text-gray-500">{r.m}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Drill links */}
+      <h3 className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-gray-500">
+        <Radio size={14} strokeWidth={1.7} />
+        <span>Go deeper</span>
+      </h3>
+      <div className="space-y-1.5">
+        <DrillRow
+          icon={FileText}
+          title="Inspect sources & claim graph"
+          meta="14 sources · 4 claims"
+          onClick={() => onNavigate("sources")}
+        />
+        <DrillRow
+          icon={Sparkles}
+          title="Open April field notes"
+          meta="Personal · 2 proposals pending"
+          onClick={() => onNavigate("notebook")}
+        />
+        <DrillRow
+          icon={MessageSquare}
+          title="Ask a follow-up"
+          meta="Resume chat thread"
+          onClick={() => undefined}
+        />
+      </div>
+    </div>
+  );
+}
+
+function DrillRow({
+  icon: Icon,
+  title,
+  meta,
+  onClick,
+}: {
+  icon: LucideIcon;
+  title: string;
+  meta: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-3 rounded-xl border border-black/5 bg-white px-3 py-3 text-left hover:bg-black/[0.02] active:scale-[0.99]"
+    >
+      <span className="flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-[#f4f3f1] text-gray-600">
+        <Icon size={14} strokeWidth={1.7} />
+      </span>
+      <span className="flex-1 min-w-0">
+        <span className="block text-[12.5px] font-semibold text-gray-900">{title}</span>
+        <span className="block truncate text-[11px] text-gray-500">{meta}</span>
+      </span>
+      <ChevronRight size={14} className="flex-none text-gray-400" />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SOURCES sub-view
+// ---------------------------------------------------------------------------
+
+function SourcesView() {
+  const [filter, setFilter] = useState<string>("all");
+  const [expanded, setExpanded] = useState<string | null>("c1");
+
+  const filtered = SOURCES.claims.filter((c) => {
+    if (filter === "all") return true;
+    const match = filter.replace(/<30d$/, "").trim();
+    return c.statuses.some(([k]) => k === match || filter.startsWith(k));
+  });
+
+  return (
+    <div className="space-y-4 px-4 pt-3 pb-10">
+      <div>
+        <Kicker>Run signal</Kicker>
+        <h2 className="mt-1 text-[16px] font-semibold text-gray-900">
+          14 sources · 4 claims · medium–high confidence
+        </h2>
+      </div>
+
+      {/* Filter chips */}
+      <div className="flex flex-wrap gap-1.5">
+        {SOURCES.filters.map((f) => (
+          <button
+            key={f}
+            data-active={filter === f}
+            onClick={() => setFilter(f)}
+            className={`rounded-full border px-3 py-1 text-[11px] font-semibold transition ${
+              filter === f
+                ? "border-[#d97757] bg-[#d97757] text-white"
+                : "border-black/10 bg-white text-gray-600 hover:border-black/20"
+            }`}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
+      {/* Claims */}
+      <div className="space-y-2">
+        {filtered.map((c) => {
+          const isOpen = expanded === c.id;
+          return (
+            <button
+              key={c.id}
+              onClick={() => setExpanded(isOpen ? null : c.id)}
+              className="block w-full rounded-2xl border border-black/5 bg-white p-3 text-left hover:bg-black/[0.02]"
+            >
+              <div className="text-[13px] font-semibold text-gray-900">{c.q}</div>
+              <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                {c.statuses.map(([k, label]) => {
+                  const tone =
+                    k === "strong"
+                      ? "ok"
+                      : k === "disputed"
+                        ? "warn"
+                        : k === "primary" || k === "fresh"
+                          ? "accent"
+                          : "neutral";
+                  return (
+                    <Pill key={k} tone={tone} mono={false}>
+                      {label}
+                    </Pill>
+                  );
+                })}
+                <span className="ml-auto">
+                  <Pill>{c.evidence.length} evidence</Pill>
+                </span>
+              </div>
+              {isOpen && (
+                <div className="mt-3 space-y-1.5 border-t border-black/5 pt-3">
+                  {c.evidence.map((e) => (
+                    <div key={e.src} className="flex items-center gap-2">
+                      <Pill tone={e.strength === "strong" ? "ok" : e.strength === "medium" ? "accent" : "warn"} mono={false}>
+                        {e.strength}
+                      </Pill>
+                      <span className="flex-1 truncate text-[12px] font-semibold text-gray-800">
+                        {e.src}
+                      </span>
+                      <span className="flex-none font-mono text-[10px] text-gray-500">{e.meta}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Recent sources */}
+      <h3 className="mt-4 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.15em] text-gray-500">
+        <FileText size={14} strokeWidth={1.7} />
+        <span>All sources ({SOURCES.recentSources.length})</span>
+      </h3>
+      <div className="overflow-hidden rounded-2xl border border-black/5 bg-white">
+        {SOURCES.recentSources.map((r, i) => (
+          <div
+            key={r.title}
+            className={`flex items-center gap-3 px-3 py-2.5 ${
+              i !== SOURCES.recentSources.length - 1 ? "border-b border-black/5" : ""
+            }`}
+          >
+            <div
+              className={`flex h-6 w-6 flex-none items-center justify-center rounded-md font-mono text-[10px] font-bold ${
+                r.strength === "strong"
+                  ? "bg-emerald-50 text-emerald-700"
+                  : r.strength === "medium"
+                    ? "bg-[#d97757]/10 text-[#d97757]"
+                    : "bg-amber-50 text-amber-700"
+              }`}
+            >
+              {i + 1}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="truncate text-[12.5px] font-semibold text-gray-900">{r.title}</div>
+              <div className="mt-0.5 flex gap-2 text-[10.5px] text-gray-500">
+                {r.meta.map((m) => (
+                  <span key={m}>{m}</span>
+                ))}
+              </div>
+            </div>
+            <ChevronRight size={14} className="flex-none text-gray-400" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// NOTEBOOK sub-view
+// ---------------------------------------------------------------------------
+
+function renderPar(val: string | NotebookSeg[]) {
+  if (typeof val === "string") return val;
+  const out: ReactNode[] = [];
+  val.forEach((seg, i) => {
+    if (typeof seg === "string") {
+      const re = /\[(\d+)\]/g;
+      let last = 0;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(seg)) !== null) {
+        if (m.index > last) out.push(<span key={`s-${i}-${last}`}>{seg.slice(last, m.index)}</span>);
+        out.push(<Cite key={`c-${i}-${m.index}`} n={parseInt(m[1], 10)} />);
+        last = m.index + m[0].length;
+      }
+      if (last < seg.length) out.push(<span key={`e-${i}-${last}`}>{seg.slice(last)}</span>);
+    } else if (seg.t === "chip") {
+      out.push(<Chip key={`ch-${i}`} name={seg.name} type={seg.type} initials={seg.initials} />);
+    } else if (seg.t === "mark") {
+      out.push(
+        <mark
+          key={`mk-${i}`}
+          className="rounded bg-amber-100 px-1 font-semibold text-amber-800"
+        >
+          {seg.v}
+        </mark>,
+      );
+    }
+  });
+  return out;
+}
+
+function NotebookView({ onNavigate }: { onNavigate: (t: SubTab) => void }) {
+  const initialProposals: Record<number, "open" | "accepted" | "dismissed"> = {};
+  NOTEBOOK.body.forEach((b, i) => {
+    if (b.t === "proposal") initialProposals[i] = b.state;
+  });
+  const [proposals, setProposals] = useState(initialProposals);
+  const setProp = (i: number, s: "open" | "accepted" | "dismissed") =>
+    setProposals((p) => ({ ...p, [i]: s }));
+
+  return (
+    <div className="space-y-4 px-4 pt-3 pb-10">
+      <div>
+        <h1 className="text-[18px] font-semibold leading-tight text-gray-900">{NOTEBOOK.title}</h1>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {NOTEBOOK.meta.map((m) => (
+            <Pill key={m}>{m}</Pill>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {NOTEBOOK.body.map((block, i) => {
+          if (block.t === "h2") {
+            return (
+              <h2 key={i} className="mt-4 text-[15px] font-semibold text-gray-900">
+                {block.v}
+              </h2>
+            );
+          }
+          if (block.t === "p") {
+            return (
+              <p key={i} className="text-[13px] leading-relaxed text-gray-700">
+                {renderPar(block.v)}
+              </p>
+            );
+          }
+          if (block.t === "proposal") {
+            const state = proposals[i] ?? "open";
+            return (
+              <div
+                key={i}
+                data-state={state}
+                className={`rounded-2xl border p-3 ${
+                  state === "accepted"
+                    ? "border-emerald-100 bg-emerald-50/60"
+                    : state === "dismissed"
+                      ? "border-gray-100 bg-gray-50 opacity-60"
+                      : "border-[#d97757]/20 bg-[#d97757]/[0.05]"
+                }`}
+              >
+                <Kicker tone={state === "accepted" ? "ok" : "accent"}>
+                  {state === "accepted" ? "✓ Accepted proposal" : "AI proposal · margin"}
+                </Kicker>
+                <div className="mt-1 text-[12.5px] leading-relaxed text-gray-700">{block.note}</div>
+                {state === "open" && (
+                  <div className="mt-2 flex gap-1.5">
+                    <button
+                      className="rounded-full bg-[#d97757] px-3 py-1 text-[11px] font-semibold text-white"
+                      onClick={() => setProp(i, "accepted")}
+                    >
+                      Accept
+                    </button>
+                    <button
+                      className="rounded-full border border-black/10 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600"
+                      onClick={() => setProp(i, "dismissed")}
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          }
+          if (block.t === "claim") {
+            return (
+              <div
+                key={i}
+                className="rounded-2xl border border-[#d97757]/20 bg-[#d97757]/[0.04] p-3"
+              >
+                <div className="flex items-center gap-1.5">
+                  <Radio size={12} strokeWidth={1.7} className="text-[#d97757]" />
+                  <Kicker tone="accent">Claim block</Kicker>
+                </div>
+                <div className="mt-1 text-[13px] font-semibold text-gray-900">{block.v}</div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  <Pill tone="ok" mono={false}>
+                    Confidence: {block.conf}
+                  </Pill>
+                  <Pill>{block.sourcesN} sources</Pill>
+                  <button
+                    className="inline-flex items-center rounded-full border border-[#d97757]/30 bg-[#d97757]/10 px-2 py-0.5 text-[10px] font-semibold text-[#d97757]"
+                    onClick={() => onNavigate("sources")}
+                  >
+                    Open evidence →
+                  </button>
+                </div>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+
+      {/* Footnotes */}
+      <div className="mt-6 rounded-2xl border border-black/5 bg-white p-3">
+        <Kicker>Footnotes</Kicker>
+        <div className="mt-2 space-y-1.5">
+          {NOTEBOOK.footnotes.map((f) => (
+            <button
+              key={f.n}
+              onClick={() => onNavigate("sources")}
+              className="flex w-full items-start gap-2 text-left"
+            >
+              <span className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-[#d97757]/10 font-mono text-[10px] font-bold text-[#d97757]">
+                {f.n}
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="truncate text-[12.5px] font-semibold text-gray-900">{f.title}</div>
+                <div className="mt-0.5 text-[10.5px] text-gray-500">{f.meta}</div>
+              </div>
+              <ChevronRight size={12} className="flex-none text-gray-400" />
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Outer shell with sub-tabs
+// ---------------------------------------------------------------------------
+
+export default function MobileReportSurface({
+  reportSlug = "acme-ai",
+  reportTitle = "Disco Corp.",
+  initialSub = "brief",
+}: {
+  reportSlug?: string;
+  reportTitle?: string;
+  initialSub?: SubTab;
+}) {
+  const [sub, setSub] = useState<SubTab>(initialSub);
+  const navigate = useNavigate();
+
+  return (
+    <div
+      data-testid="mobile-report-surface"
+      data-sub={sub}
+      className="md:hidden min-h-dvh w-full bg-[#f8f7f5] text-[#111827]"
+    >
+      {/* Header */}
+      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-black/5 bg-white/85 px-3 pt-3 pb-2 backdrop-blur">
+        <div className="flex items-center gap-2">
+          <button
+            className="rounded-full p-2 text-gray-600 hover:bg-black/5 active:scale-95"
+            aria-label="Back"
+            onClick={() => navigate("/?surface=reports")}
+          >
+            <ArrowLeft size={16} strokeWidth={1.7} />
+          </button>
+          <div>
+            <div className="text-[14px] font-semibold leading-tight">Reports</div>
+            <div className="text-[10.5px] text-gray-500">{reportTitle} · v4</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            className="rounded-full p-2 text-gray-600 hover:bg-black/5 active:scale-95"
+            aria-label="Save"
+          >
+            <Bookmark size={16} strokeWidth={1.7} />
+          </button>
+          <button
+            className="rounded-full p-2 text-gray-600 hover:bg-black/5 active:scale-95"
+            aria-label="Share"
+          >
+            <Share2 size={16} strokeWidth={1.7} />
+          </button>
+          {sub === "sources" ? (
+            <button
+              className="rounded-full p-2 text-gray-600 hover:bg-black/5 active:scale-95"
+              aria-label="Filter"
+            >
+              <Filter size={16} strokeWidth={1.7} />
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      {/* Sub-tab strip */}
+      <div
+        data-testid="mobile-report-subtabs"
+        className="sticky top-[56px] z-[9] flex border-b border-black/5 bg-white/85 px-2 backdrop-blur"
+      >
+        {(
+          [
+            { id: "brief", label: "Brief" },
+            { id: "sources", label: "Sources" },
+            { id: "notebook", label: "Notebook" },
+          ] as { id: SubTab; label: string }[]
+        ).map((t) => (
+          <button
+            key={t.id}
+            data-active={sub === t.id}
+            onClick={() => setSub(t.id)}
+            className={`relative flex-1 px-3 py-2 text-[12.5px] font-semibold transition ${
+              sub === t.id ? "text-[#d97757]" : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {t.label}
+            {sub === t.id ? (
+              <span className="absolute inset-x-3 bottom-0 h-[2px] rounded-t bg-[#d97757]" />
+            ) : null}
+          </button>
+        ))}
+      </div>
+
+      {/* Pane */}
+      {sub === "brief" && <BriefView onNavigate={setSub} />}
+      {sub === "sources" && <SourcesView />}
+      {sub === "notebook" && <NotebookView onNavigate={setSub} />}
+
+      {/* Silence unused vars */}
+      <span className="hidden" aria-hidden data-slug={reportSlug} />
+    </div>
+  );
+}

--- a/src/features/research/views/ReportDetailWorkspace.tsx
+++ b/src/features/research/views/ReportDetailWorkspace.tsx
@@ -17,6 +17,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { FileText, LayoutGrid, Map as MapIcon, FileStack } from "lucide-react";
+import MobileReportSurface from "@/features/research/views/MobileReportSurface";
 import type {
   ResourceCard,
   ResourceUri,
@@ -160,11 +161,22 @@ export function ReportDetailWorkspace({
     [onExpand],
   );
 
+  const mobileInitialSub: "brief" | "sources" | "notebook" =
+    activeTab === "sources" ? "sources" : activeTab === "brief" ? "brief" : "brief";
+
   return (
-    <div
-      data-testid="report-detail-workspace"
-      className="flex h-full min-h-0 flex-col"
-    >
+    <>
+      {/* Mobile-only report surface (Brief/Sources/Notebook sub-tabs) */}
+      <MobileReportSurface
+        reportTitle={reportTitle}
+        initialSub={mobileInitialSub}
+      />
+
+      {/* Desktop cards workspace — hidden on mobile */}
+      <div
+        data-testid="report-detail-workspace"
+        className="hidden md:flex h-full min-h-0 flex-col"
+      >
       <WorkspaceHeader
         reportTitle={reportTitle}
         breadcrumb={breadcrumb}
@@ -216,7 +228,8 @@ export function ReportDetailWorkspace({
           onClear={() => setCompareTray([])}
         />
       )}
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/tests/e2e/live-smoke-mobile.spec.ts
+++ b/tests/e2e/live-smoke-mobile.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * live-smoke-mobile.spec.ts — Tier B hydrated-DOM verifier for mobile-only
+ * surfaces ported from docs/design/nodebench-ai-design-system/ui_kits/
+ * nodebench-mobile/.
+ *
+ * Runs in iPhone 14 viewport (390x844) so the `md:hidden` / `hidden md:block`
+ * split renders the mobile surfaces we shipped (PR #23 Home, #24 Chat, #25
+ * Inbox). The parallel desktop live-smoke in live-smoke.spec.ts stays at
+ * the default Playwright viewport so desktop parity is still checked.
+ *
+ * Override URL for preview deploys:
+ *   BASE_URL=https://preview-xyz.vercel.app npx playwright test live-smoke-mobile
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE_URL =
+  process.env.BASE_URL?.replace(/\/$/, "") ?? "https://www.nodebenchai.com";
+
+// Emulate iPhone 14 viewport + touch on Chromium (no WebKit install needed).
+// The Tailwind `md:*` breakpoint in our app triggers at 768px; 390x844 is
+// safely below it so all md:hidden / hidden md:block gates render the
+// mobile surface variants.
+test.use({
+  viewport: { width: 390, height: 844 },
+  hasTouch: true,
+  isMobile: true,
+  deviceScaleFactor: 3,
+  userAgent:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+});
+
+test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
+  test.setTimeout(45_000);
+
+  test("Home surface — MobileHomeSurface mounts with watchlist + nudges + threads", async ({ page }) => {
+    await page.goto(BASE_URL + "/");
+    await expect(page.locator('[data-testid="mobile-home-surface"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    // Greeting
+    await expect(page.getByText(/Good morning/i)).toBeVisible();
+    // Watchlist kicker
+    await expect(page.getByText(/Watchlist/i).first()).toBeVisible();
+    // At least one watchlist tile — Disco is the DISCO scenario root
+    await expect(page.getByText(/Disco Corp/i).first()).toBeVisible();
+    // Nudges section
+    await expect(page.getByText(/Since you were last here/i)).toBeVisible();
+    // Recent threads kicker
+    await expect(page.getByText(/Recent threads/i)).toBeVisible();
+    // Mobile capture FAB (PR #21)
+    await expect(page.locator('[data-testid="mobile-capture-fab"]')).toBeVisible();
+  });
+
+  test("Chat surface — MobileChatSurface mounts with answer + entities + sources", async ({ page }) => {
+    await page.goto(BASE_URL + "/?surface=chat");
+    await expect(page.locator('[data-testid="mobile-chat-surface"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    // Verified pill
+    await expect(page.getByText(/verified/i)).toBeVisible();
+    // "So what" callout (design-kit vocabulary)
+    await expect(page.getByText(/So what/i)).toBeVisible();
+    // Entities strip header
+    await expect(page.getByText(/Entities/i).first()).toBeVisible();
+    // Top sources header
+    await expect(page.getByText(/Top sources/i)).toBeVisible();
+    // Follow-up chips
+    await expect(page.getByText(/Follow-up/i)).toBeVisible();
+    // Composer dock input
+    await expect(page.getByPlaceholder(/Ask a follow-up/i)).toBeVisible();
+  });
+
+  test("Inbox surface — MobileInboxSurface mounts with filter tabs", async ({ page }) => {
+    await page.goto(BASE_URL + "/?surface=inbox");
+    await expect(page.locator('[data-testid="mobile-inbox-surface"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    // Filter tabs
+    await expect(page.getByRole("button", { name: /^All / })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Mentions / })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Signals / })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Tasks / })).toBeVisible();
+    // Today section kicker
+    await expect(page.getByText(/^Today$/).first()).toBeVisible();
+  });
+
+  test("Me surface — MobileMeSurface mounts with identity + workspaces + shortcuts", async ({ page }) => {
+    await page.goto(BASE_URL + "/?surface=me");
+    await expect(page.locator('[data-testid="mobile-me-surface"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    // Identity card
+    await expect(page.getByText(/Homen Shum/i)).toBeVisible();
+    // Stats strip — at least one stat label
+    await expect(page.getByText(/Threads/i).first()).toBeVisible();
+    // Workspaces section
+    await expect(page.getByText(/^Workspaces$/).first()).toBeVisible();
+    // Quick settings
+    await expect(page.getByText(/Quick settings/i)).toBeVisible();
+    // Shortcuts section CTA
+    await expect(page.getByRole("button", { name: /Starred threads/i })).toBeVisible();
+  });
+
+  test("Report detail — MobileReportSurface mounts with Brief|Sources|Notebook sub-tabs", async ({ page }) => {
+    await page.goto(BASE_URL + "/reports/acme-ai/graph");
+    await expect(page.locator('[data-testid="mobile-report-surface"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    // Sub-tab strip
+    await expect(page.locator('[data-testid="mobile-report-subtabs"]')).toBeVisible();
+    // Brief default
+    await expect(page.getByRole("button", { name: /^Brief$/ })).toBeVisible();
+    await expect(page.getByText(/Verdict/i).first()).toBeVisible();
+    // Tap Sources → SOURCES view mounts
+    await page.getByRole("button", { name: /^Sources$/ }).click();
+    await expect(page.getByText(/Run signal/i)).toBeVisible();
+    await expect(page.getByText(/All sources/i)).toBeVisible();
+    // Tap Notebook → NOTEBOOK view mounts
+    await page.getByRole("button", { name: /^Notebook$/ }).click();
+    await expect(page.getByText(/April field notes/i)).toBeVisible();
+    await expect(page.getByText(/Footnotes/i)).toBeVisible();
+  });
+
+  test("Home → nudge chevron routes to Inbox surface", async ({ page }) => {
+    await page.goto(BASE_URL + "/");
+    await expect(page.locator('[data-testid="mobile-home-surface"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    // The "All N" link routes to Inbox
+    await page.getByRole("button", { name: /All \d+/ }).first().click();
+    await expect(page.locator('[data-testid="mobile-inbox-surface"]')).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("console has no uncaught errors during mobile landing load", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+    await page.goto(BASE_URL + "/");
+    await page.waitForTimeout(3_000);
+    const real = errors.filter(
+      (e) =>
+        !/favicon/i.test(e) &&
+        !/CSP/i.test(e) &&
+        !/Third-party cookie/i.test(e) &&
+        !/extension/i.test(e),
+    );
+    expect(
+      real,
+      "mobile console errors on landing:\n" + real.map((e) => "  - " + e).join("\n"),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Ports the remaining design-kit mobile surfaces, closing mobile parity against `docs/design/nodebench-ai-design-system/ui_kits/nodebench-mobile/`.
- **MobileMeSurface** mounts above [MeHome.tsx](src/features/me/views/MeHome.tsx) via `md:hidden` — desktop preferences panel untouched.
- **MobileReportSurface** combines Brief/Sources/Notebook sub-tabs into one screen (matches design-kit App.jsx pattern) and mounts above [ReportDetailWorkspace.tsx](src/features/research/views/ReportDetailWorkspace.tsx).

## Parity map
| Design-kit | Ported component | Mount point |
|---|---|---|
| `MobileMe.jsx` | `MobileMeSurface.tsx` | MeHome.tsx wrapper |
| `MobileBrief.jsx` | `MobileReportSurface.tsx` (Brief sub-view) | ReportDetailWorkspace.tsx wrapper |
| `MobileSources.jsx` | `MobileReportSurface.tsx` (Sources sub-view) | ″ |
| `MobileNotebook.jsx` | `MobileReportSurface.tsx` (Notebook sub-view) | ″ |

## Test plan
- [x] `npx tsc --noEmit` → **0 errors**
- [ ] After merge, `BASE_URL=https://www.nodebenchai.com npm run live-smoke:mobile` → 7/7 pass (adds Me + Report sub-tab tests)

## Follow-up
- Fixture data mirrors the DISCO scenario. Swap to live `hydrateEntities.compactFindings` output + user-profile query once mobile mounts are ready for real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)