### PR TITLE
Complete four-surface design parity

### DIFF
--- a/docs/design/PRODUCT_SURFACES.md
+++ b/docs/design/PRODUCT_SURFACES.md
@@ -93,6 +93,23 @@ All four surfaces share:
 - dry operator copy
 - same visual tokens
 
+## Parity Completion Contract
+
+Each design-kit folder has a production responsibility and a concrete route or
+package target.
+
+| Kit | Production target | Parity requirement |
+| --- | --- | --- |
+| `nodebench-web` | `nodebenchai.com` | Five-tab operating app, report grid, chat, inbox, Me, web notebook handoff |
+| `nodebench-mobile` | responsive `nodebenchai.com` | capture-first five-tab UI, mobile Home/Chat/Inbox/Reports/Me surfaces |
+| `nodebench-workspace` | `workspace.nodebenchai.com` | separate deep-work shell with Brief, Cards, Notebook, Sources, Chat, Map |
+| `nodebench-mcp` | `nodebench-mcp` package plus `/developers` | terminal-style instructions, MCP primitives, CLI command map, saved report/workspace handoff |
+
+The MCP lane is parity-complete only when `nodebench.research_run` and
+`nodebench.expand_resource` are exposed by the default MCP package, documented
+on the web install surface, and listed in `agent-setup.txt` for external
+agents.
+
 ## Connection Graph
 
 ```text

--- a/packages/mcp-local/GETTING_STARTED.md
+++ b/packages/mcp-local/GETTING_STARTED.md
@@ -29,6 +29,8 @@ npx nodebench-mcp --preset cursor
 | `ask_context` | Query against saved session memory and knowledge base. |
 | `discover_tools` | Find the next toolset or deeper tool lane when the default workflow is not enough. |
 | `load_toolset` | Expand the session with a specific toolset only when the workflow needs it. |
+| `nodebench.research_run` | Start a NodeBench research run from any MCP client and return run/workspace links. |
+| `nodebench.expand_resource` | Expand a `nodebench://` URI into cards, evidence refs, and next-hop URIs. |
 
 ## First Prompts to Try
 
@@ -37,6 +39,8 @@ npx nodebench-mcp --preset cursor
 3. `report topic="AI agent infrastructure" decision="Which framework to use?"` -- decision memo
 4. `search "MCP server best practices 2026"` -- web + knowledge search
 5. `track entity="Anthropic" action="add"` -- start watching for changes
+6. `nodebench.research_run objective="prep for DISCO call" subjects=[{type:"company",name:"DISCO"}]` -- create a saved run
+7. `nodebench.expand_resource uri="nodebench://org/disco"` -- inspect reusable cards
 
 ## Need More?
 

--- a/packages/mcp-local/package.json
+++ b/packages/mcp-local/package.json
@@ -2,7 +2,7 @@
   "name": "nodebench-mcp",
   "version": "3.2.0",
   "mcpName": "io.github.homenshum/nodebench",
-  "description": "Turn messy input into a sourced report. 13 default tools: 7 workflow + 4 bidirectional sync + discover_tools + load_toolset. Push company context from Claude Code into NodeBench AI and pull it back.",
+  "description": "Turn messy input into a sourced report. 15 default tools: workflow, bidirectional sync, canonical NodeBench research bridge, discover_tools, and load_toolset.",
   "type": "module",
   "bin": {
     "nodebench-mcp": "dist/index.js"

--- a/packages/mcp-local/src/__tests__/nodebenchResearchTools.test.ts
+++ b/packages/mcp-local/src/__tests__/nodebenchResearchTools.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { TOOLSET_LOADERS } from "../toolsetRegistry.js";
+
+describe("nodebench_research toolset", () => {
+  it("exposes the canonical NodeBench research bridge tools", async () => {
+    const tools = await TOOLSET_LOADERS.nodebench_research();
+    const names = tools.map((tool) => tool.name).sort();
+
+    expect(names).toEqual([
+      "nodebench.expand_resource",
+      "nodebench.research_run",
+    ]);
+  });
+});

--- a/packages/mcp-local/src/index.ts
+++ b/packages/mcp-local/src/index.ts
@@ -91,17 +91,18 @@ async function openOptionalSqlite(dbPath: string, options?: Record<string, unkno
 
 export { TOOLSET_MAP };
 
-// Starter/default: v3 core workflow facade only. Discovery/meta/dynamic tools are added separately.
-const STARTER_TOOLSETS = ["core_workflow"];
+// Starter/default: v3 workflow facade plus the canonical NodeBench API bridge.
+// Discovery/meta/dynamic tools are added separately.
+const STARTER_TOOLSETS = ["core_workflow", "nodebench_research"];
 
 // Core: the original default. ~81 tools across 15 domains.
-const CORE_TOOLSETS = ["verification", "eval", "quality_gate", "learning", "flywheel", "autonomous_delivery", "sync_bridge", "shared_context", "recon", "security", "boilerplate", "skill_update", "context_sandbox", "observability", "execution_trace", "mission_harness", "deep_sim", "founder", "scenario_compiler", "packet_compiler", "entity_temporal"];
+const CORE_TOOLSETS = ["core_workflow", "nodebench_research", "verification", "eval", "quality_gate", "learning", "flywheel", "autonomous_delivery", "sync_bridge", "shared_context", "recon", "security", "boilerplate", "skill_update", "context_sandbox", "observability", "execution_trace", "mission_harness", "deep_sim", "founder", "scenario_compiler", "packet_compiler", "entity_temporal"];
 
 // Power: extended research + founder intelligence without admin/debug-only runtime surfaces.
-const POWER_TOOLSETS = ["core_workflow", "deep_sim", "founder", "recon", "web", "shared_context", "sync_bridge", "session_memory", "entity_lookup", "delta", "site_map"];
+const POWER_TOOLSETS = ["core_workflow", "nodebench_research", "deep_sim", "founder", "recon", "web", "shared_context", "sync_bridge", "session_memory", "entity_lookup", "delta", "site_map"];
 
 // Admin: profiling, debugging, observability, dashboards, and eval harness domains.
-const ADMIN_TOOLSETS = ["core_workflow", "observability", "profiler", "local_dashboard", "benchmark", "longitudinal_benchmark", "dogfood_judge", "execution_trace", "qa_orchestration", "mission_harness", "quality_gate", "eval", "verification"];
+const ADMIN_TOOLSETS = ["core_workflow", "nodebench_research", "observability", "profiler", "local_dashboard", "benchmark", "longitudinal_benchmark", "dogfood_judge", "execution_trace", "qa_orchestration", "mission_harness", "quality_gate", "eval", "verification"];
 
 const PRESETS: Record<string, string[]> = {
   // DEFAULT: v3 core workflow facade. Progressive discovery expands into power/admin domains only when needed.
@@ -140,8 +141,8 @@ const PRESETS: Record<string, string[]> = {
 };
 
 const PRESET_DESCRIPTIONS: Record<string, string> = {
-  default:     "Default v3 surface — 7 workflow tools plus discovery/meta helpers. Fast boot, one artifact-shaped workflow.",
-  starter:     "Default v3 surface — 7 workflow tools plus discovery/meta helpers. Fast boot, one artifact-shaped workflow.",
+  default:     "Default v3 surface — workflow/sync tools plus the canonical NodeBench research bridge and discovery helpers.",
+  starter:     "Default v3 surface — workflow/sync tools plus the canonical NodeBench research bridge and discovery helpers.",
   power:       "Extended workflow preset — founder + recon + web + packets without admin-only runtime surfaces.",
   admin:       "Admin/runtime preset — profiling, observability, dashboards, eval, and debug lanes.",
   core:        "Core AI Flywheel (~81 tools) — verification, eval, quality gates, learning, recon, mission harness",

--- a/packages/mcp-local/src/tools/index.ts
+++ b/packages/mcp-local/src/tools/index.ts
@@ -53,6 +53,7 @@ export { prReportTools } from "./prReportTools.js";
 // ─── Research ───────────────────────────────────────────────────────────────
 export { researchOptimizerTools } from "./researchOptimizerTools.js";
 export { researchWritingTools } from "./researchWritingTools.js";
+export { nodebenchResearchTools } from "./nodebenchResearchTools.js";
 export { rssTools } from "./rssTools.js";
 export { webTools } from "./webTools.js";
 

--- a/packages/mcp-local/src/tools/skillUpdateTools.ts
+++ b/packages/mcp-local/src/tools/skillUpdateTools.ts
@@ -26,7 +26,6 @@ import { createHash } from "node:crypto";
 import { resolve, relative } from "node:path";
 import { getDb, genId } from "../db.js";
 import type { McpTool } from "../types.js";
-import { listExtractedSkillTemplates } from "../../../../server/lib/skillExtractor.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -115,6 +114,60 @@ function findChangedSources(
 }
 
 // ── Tools ───────────────────────────────────────────────────────────
+
+interface ExtractedSkillTemplateRecord {
+  extractedSkillId: string;
+  signature: string;
+  classification: string;
+  lens: string;
+  source: string;
+  sessionId?: string;
+  turnIndex?: number;
+  createdAt: string;
+}
+
+const EXTRACTED_SKILL_FALLBACK_FILE = resolve(
+  process.cwd(),
+  ".tmp",
+  "harness-v2",
+  "extracted_skill_templates.json",
+);
+
+function readExtractedSkillFallback(limit: number): ExtractedSkillTemplateRecord[] {
+  try {
+    const raw = readFileSync(EXTRACTED_SKILL_FALLBACK_FILE, "utf8");
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? (parsed as ExtractedSkillTemplateRecord[]).slice(0, limit)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function listExtractedSkillTemplates(limit = 20): ExtractedSkillTemplateRecord[] {
+  const boundedLimit = Math.max(1, Math.min(limit, 100));
+  try {
+    const db = getDb();
+    return (db.prepare(`
+      SELECT extracted_skill_id, signature, classification, lens, source, session_id, turn_index, created_at
+      FROM extracted_skill_templates
+      ORDER BY updated_at DESC
+      LIMIT ?
+    `).all(boundedLimit) as Array<Record<string, unknown>>).map((row) => ({
+      extractedSkillId: String(row.extracted_skill_id),
+      signature: String(row.signature),
+      classification: String(row.classification),
+      lens: String(row.lens),
+      source: String(row.source),
+      sessionId: typeof row.session_id === "string" ? row.session_id : undefined,
+      turnIndex: typeof row.turn_index === "number" ? row.turn_index : undefined,
+      createdAt: String(row.created_at),
+    }));
+  } catch {
+    return readExtractedSkillFallback(boundedLimit);
+  }
+}
 
 export const skillUpdateTools: McpTool[] = [
   // ═══════════════════════════════════════════════════════════════════

--- a/packages/mcp-local/src/toolsetRegistry.ts
+++ b/packages/mcp-local/src/toolsetRegistry.ts
@@ -27,6 +27,10 @@ export const TOOLSET_LOADERS: Record<string, () => Promise<McpTool[]>> = {
     const { coreWorkflowTools, coreSyncTools } = await import("./tools/coreWorkflowTools.js");
     return [...coreWorkflowTools, ...coreSyncTools];
   },
+  nodebench_research: async () => {
+    const { nodebenchResearchTools } = await import("./tools/nodebenchResearchTools.js");
+    return nodebenchResearchTools;
+  },
   verification: async () => {
     const { verificationTools } = await import("./tools/verificationTools.js");
     return verificationTools;
@@ -381,6 +385,7 @@ const QUIET_CROSS_DOMAIN_DUPLICATES: Record<string, string> = {
 
 const SYNTHETIC_PHASE_BY_DOMAIN: Partial<Record<string, ToolRegistryEntry["phase"]>> = {
   core_workflow: "research",
+  nodebench_research: "research",
   shared_context: "utility",
   workspace: "implement",
   profiler: "utility",

--- a/public/agent-setup.txt
+++ b/public/agent-setup.txt
@@ -21,6 +21,10 @@ Cloud sync:
 Verify:
   discover_tools({ query: "founder", limit: 3 })
 
+Canonical NodeBench tools:
+  nodebench.research_run({ objective: "prep for DISCO call", subjects: [{ type: "company", name: "DISCO" }] })
+  nodebench.expand_resource({ uri: "nodebench://org/disco" })
+
 Build founder profile:
   founder_deep_context_gather({ packetType: "weekly_reset" })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { EvidenceProvider } from "@/features/research/contexts/EvidenceContext";
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
 import { ViewSkeleton } from "@/components/skeletons/ViewSkeleton";
 import { useWebMcpProvider } from "./hooks/useWebMcpProvider";
+import { getReportWorkspaceRouteFromPath } from "@/features/reports/lib/reportNotebookRouting";
 import type { MainView } from "@/lib/registry/viewRegistry";
 import { buildCockpitPathForView } from "@/lib/registry/viewRegistry";
 import { initErrorReporting } from "@/lib/errorReporting";
@@ -251,6 +252,26 @@ function App() {
               className="route-fade-in"
             >
               <ReportNotebookDetail />
+            </div>
+          </Suspense>
+        </ErrorBoundary>
+      </ThemeProvider>
+    );
+  }
+
+  const reportWorkspaceRouteMatch = getReportWorkspaceRouteFromPath(
+    location.pathname,
+  );
+  if (reportWorkspaceRouteMatch) {
+    return (
+      <ThemeProvider>
+        <ErrorBoundary title="Something went wrong">
+          <Suspense fallback={<ViewSkeleton />}>
+            <div
+              key={`report-workspace-${reportWorkspaceRouteMatch.reportId}-${reportWorkspaceRouteMatch.tab}`}
+              className="route-fade-in h-screen"
+            >
+              <ReportDetailPage />
             </div>
           </Suspense>
         </ErrorBoundary>

--- a/src/features/controlPlane/views/DevelopersPage.tsx
+++ b/src/features/controlPlane/views/DevelopersPage.tsx
@@ -3,7 +3,7 @@
  * Houses CAPABILITIES stats, SYSTEM_LAYERS, and TECH_TAGS moved from the old landing shell.
  */
 
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useState, type CSSProperties, type ReactNode } from "react";
 import { useRevealOnMount } from "@/hooks/useRevealOnMount";
 import { ArrowLeft, Check, Copy, Terminal, Monitor, Wind } from "lucide-react";
 import { VIEW_PATH_MAP, type MainView } from "@/lib/registry/viewRegistry";
@@ -94,7 +94,7 @@ function CopyBlock({ code, label }: { code: string; label?: string }) {
 
 const AGENT_ONELINER = "Read https://www.nodebenchai.com/agent-setup.txt and follow all steps.";
 
-function AgentOneLinerBlock({ stagger }: { stagger: (delay: string) => React.CSSProperties }) {
+function AgentOneLinerBlock({ stagger }: { stagger: (delay: string) => CSSProperties }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
@@ -157,6 +157,185 @@ const WINDSURF_CONFIG = `{
   }
 }`;
 
+const MCP_PRIMITIVES = [
+  {
+    name: "nodebench.research_run",
+    job: "Start an evidence-backed run from messy inputs.",
+    output: "plan, streamed checkpoints, answer packet, saved report link",
+  },
+  {
+    name: "nodebench.expand_resource",
+    job: "Expand a nodebench:// URI into the next useful ring.",
+    output: "cards, evidence refs, next-hop URIs, confidence",
+  },
+] as const;
+
+const CLI_COMMANDS = [
+  `nodebench investigate "company"`,
+  `nodebench expand nodebench://org/acme`,
+  `nodebench report nodebench://brief/123`,
+  `nodebench capture --text "Met Alex from Orbital Labs..."`,
+  `nodebench track nodebench://org/acme`,
+] as const;
+
+function TerminalLine({
+  lead = "",
+  children,
+  tone = "muted",
+}: {
+  lead?: string;
+  children: ReactNode;
+  tone?: "muted" | "accent" | "ok" | "warn" | "fail";
+}) {
+  const toneClass =
+    tone === "accent"
+      ? "text-[#d97757]"
+      : tone === "ok"
+        ? "text-emerald-300"
+        : tone === "warn"
+          ? "text-amber-300"
+          : tone === "fail"
+            ? "text-red-300"
+            : "text-slate-400";
+
+  return (
+    <div className="flex gap-3 whitespace-pre-wrap font-mono text-[12px] leading-6">
+      <span className={`w-4 shrink-0 text-right ${toneClass}`}>{lead}</span>
+      <span className="min-w-0 flex-1 text-slate-200">{children}</span>
+    </div>
+  );
+}
+
+function TerminalWindow({
+  label,
+  badge,
+  children,
+}: {
+  label: string;
+  badge: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-white/[0.08] bg-[#0f1115] shadow-lg shadow-black/20">
+      <div className="flex items-center gap-3 border-b border-white/[0.06] bg-[#171b22] px-4 py-3">
+        <div className="flex gap-1.5" aria-hidden="true">
+          <span className="h-2.5 w-2.5 rounded-full bg-[#ff605c]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[#ffbd44]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[#00ca4e]" />
+        </div>
+        <div className="truncate rounded border border-white/[0.06] bg-white/[0.04] px-2 py-1 font-mono text-[11px] text-slate-200">
+          {label}
+        </div>
+        <div className="ml-auto rounded border border-[#d97757]/30 bg-[#d97757]/10 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-[#e59579]">
+          {badge}
+        </div>
+      </div>
+      <div className="space-y-1 bg-[radial-gradient(circle_at_12%_0%,rgba(217,119,87,.08),transparent_44%),radial-gradient(circle_at_100%_100%,rgba(140,151,240,.08),transparent_50%)] p-4">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function McpParitySurface({ stagger }: { stagger: (delay: string) => CSSProperties }) {
+  return (
+    <div style={stagger("0.5s")} className="mt-12">
+      <div className="mb-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
+        MCP run surface
+      </div>
+      <div className="space-y-4">
+        <TerminalWindow label="~/diligence - zsh - 120x32" badge="core lane">
+          <TerminalLine>
+            <span className="text-[#8c97f0]">homen@mac</span>
+            <span className="text-[#d97757]"> &gt; </span>
+            <span>claude mcp add nodebench -- npx -y nodebench-mcp</span>
+          </TerminalLine>
+          <TerminalLine lead="|" tone="ok">registered with Claude Code - nodebench-mcp</TerminalLine>
+          <TerminalLine lead="|" tone="ok">loaded default tools - investigate, report, track, nodebench.research_run</TerminalLine>
+          <div className="my-3 h-px bg-white/[0.06]" />
+          <TerminalLine>
+            <span className="text-[#8c97f0]">homen@mac</span>
+            <span className="text-[#d97757]"> &gt; </span>
+            <span>npx nodebench-mcp investigate --entity "DISCO" --lane answer</span>
+          </TerminalLine>
+          <TerminalLine lead=">" tone="accent">plan - resolve entity, search, synthesize, verify</TerminalLine>
+          <TerminalLine lead=">" tone="ok">24 sources captured - answer packet streaming</TerminalLine>
+          <div className="rounded-md border border-[#d97757]/25 bg-[#d97757]/10 p-3 font-mono text-[12px] leading-6 text-slate-100">
+            <div className="mb-1 text-[10px] font-bold uppercase tracking-[0.18em] text-[#e59579]">
+              Answer packet
+            </div>
+            Worth reaching out. Save the report, verify the funding claim, then open Workspace for cards and sources.
+          </div>
+          <TerminalLine lead=">" tone="ok">verified - 6 branches - 24 sources - saved report URI</TerminalLine>
+        </TerminalWindow>
+
+        <TerminalWindow label="~/diligence - tool loading" badge="power lane">
+          <TerminalLine>
+            <span className="text-[#8c97f0]">homen@mac</span>
+            <span className="text-[#d97757]"> &gt; </span>
+            <span>npx nodebench-mcp --list-presets</span>
+          </TerminalLine>
+          <div className="overflow-hidden rounded-md border border-white/[0.06]">
+            {[
+              ["core", "fast lane - investigate, compare, report, track"],
+              ["power", "founder, recon, packet workflows"],
+              ["admin", "profiling, dashboards, eval, observability"],
+              ["full", "maximum coverage across domains"],
+            ].map(([preset, useCase]) => (
+              <div
+                key={preset}
+                className="grid grid-cols-[92px_minmax(0,1fr)] border-b border-white/[0.04] px-3 py-2 font-mono text-[11px] last:border-b-0"
+              >
+                <span className="text-[#e59579]">{preset}</span>
+                <span className="text-slate-400">{useCase}</span>
+              </div>
+            ))}
+          </div>
+          <TerminalLine>
+            <span className="text-[#8c97f0]">homen@mac</span>
+            <span className="text-[#d97757]"> &gt; </span>
+            <span>npx nodebench-mcp-power discover_tools --query "visual QA"</span>
+          </TerminalLine>
+          <TerminalLine lead=">" tone="ok">matches - dogfood.visual_qa, ui_ux_dive.inspect_surface, ui_ux_dive.motion_trace</TerminalLine>
+          <TerminalLine>
+            <span className="text-[#8c97f0]">homen@mac</span>
+            <span className="text-[#d97757]"> &gt; </span>
+            <span>npx nodebench-mcp-power load_toolset --domain ui_ux_dive</span>
+          </TerminalLine>
+          <TerminalLine lead=">" tone="warn">missing GEMINI_API_KEY - set env var before synthesis</TerminalLine>
+        </TerminalWindow>
+      </div>
+
+      <div className="mt-5 grid gap-3 md:grid-cols-2">
+        <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5">
+          <div className="mb-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
+            Canonical MCP tools
+          </div>
+          <div className="space-y-3">
+            {MCP_PRIMITIVES.map((tool) => (
+              <div key={tool.name} className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+                <div className="font-mono text-[12px] text-[#e59579]">{tool.name}</div>
+                <p className="mt-1 text-[12px] leading-5 text-content-secondary">{tool.job}</p>
+                <p className="mt-1 font-mono text-[11px] text-content-muted">{tool.output}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+        <section className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5">
+          <div className="mb-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
+            CLI command map
+          </div>
+          <div className="space-y-2">
+            {CLI_COMMANDS.map((cmd) => (
+              <CopyBlock key={cmd} code={cmd} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
 interface DevelopersPageProps {
   onNavigate: (view: MainView, path?: string) => void;
 }
@@ -166,7 +345,7 @@ export const DevelopersPage = memo(function DevelopersPage({
 }: DevelopersPageProps) {
   const { ref: revealRef, isVisible, instant } = useRevealOnMount();
 
-  const stagger = (delay: string): React.CSSProperties => ({
+  const stagger = (delay: string): CSSProperties => ({
     opacity: isVisible ? 1 : 0,
     transform: isVisible ? "none" : "translateY(8px)",
     transition: instant ? "none" : "opacity 0.2s ease-out, transform 0.2s ease-out",
@@ -207,8 +386,10 @@ export const DevelopersPage = memo(function DevelopersPage({
         {/* Agent one-liner */}
         <AgentOneLinerBlock stagger={stagger} />
 
+        <McpParitySurface stagger={stagger} />
+
         {/* Capabilities stats */}
-        <div style={stagger("0.2s")} className="mt-10">
+        <div style={stagger("0.55s")} className="mt-10">
           <div className="mb-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
             What&apos;s inside
           </div>
@@ -228,7 +409,7 @@ export const DevelopersPage = memo(function DevelopersPage({
         </div>
 
         {/* System Layers */}
-        <div style={stagger("0.3s")} className="mt-8">
+        <div style={stagger("0.6s")} className="mt-8">
           <div className="mb-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
             System layers
           </div>
@@ -254,7 +435,7 @@ export const DevelopersPage = memo(function DevelopersPage({
         </div>
 
         {/* Tech Tags */}
-        <div style={stagger("0.4s")} className="mt-8">
+        <div style={stagger("0.65s")} className="mt-8">
           <div className="mb-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
             Built with
           </div>
@@ -271,7 +452,7 @@ export const DevelopersPage = memo(function DevelopersPage({
         </div>
 
         {/* ── Install / Integrate ──────────────────────────────── */}
-        <div style={stagger("0.5s")} className="mt-12">
+        <div style={stagger("0.7s")} className="mt-12">
           <div className="mb-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-content-muted">
             Install
           </div>

--- a/src/features/reports/lib/reportNotebookRouting.test.ts
+++ b/src/features/reports/lib/reportNotebookRouting.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { buildReportNotebookPath, getReportNotebookIdFromPath } from "./reportNotebookRouting";
+import {
+  buildReportNotebookPath,
+  getReportNotebookIdFromPath,
+  getReportWorkspaceRouteFromPath,
+} from "./reportNotebookRouting";
 
 describe("reportNotebookRouting", () => {
   it("builds the lightweight web notebook path under Reports", () => {
@@ -12,5 +16,26 @@ describe("reportNotebookRouting", () => {
     expect(getReportNotebookIdFromPath("/reports/orbital-labs/notebook")).toBe("orbital-labs");
     expect(getReportNotebookIdFromPath("/reports/demo%20day/notebook/")).toBe("demo day");
     expect(getReportNotebookIdFromPath("/reports/orbital-labs/graph")).toBeNull();
+  });
+
+  it("parses report workspace routes without stealing the reports index", () => {
+    expect(getReportWorkspaceRouteFromPath("/reports")).toBeNull();
+    expect(getReportWorkspaceRouteFromPath("/reports/orbital-labs")).toEqual({
+      reportId: "orbital-labs",
+      tab: "brief",
+    });
+    expect(getReportWorkspaceRouteFromPath("/reports/orbital-labs/cards")).toEqual({
+      reportId: "orbital-labs",
+      tab: "cards",
+    });
+    expect(getReportWorkspaceRouteFromPath("/reports/orbital-labs/sources")).toEqual({
+      reportId: "orbital-labs",
+      tab: "sources",
+    });
+    expect(getReportWorkspaceRouteFromPath("/reports/orbital-labs/graph")).toEqual({
+      reportId: "orbital-labs",
+      tab: "map",
+    });
+    expect(getReportWorkspaceRouteFromPath("/reports/orbital-labs/notebook")).toBeNull();
   });
 });

--- a/src/features/reports/lib/reportNotebookRouting.ts
+++ b/src/features/reports/lib/reportNotebookRouting.ts
@@ -7,3 +7,32 @@ export function getReportNotebookIdFromPath(pathname: string) {
   const match = pathname.match(/^\/reports\/([^/]+)\/notebook\/?$/);
   return match?.[1] ? decodeURIComponent(match[1]) : null;
 }
+
+export type ReportWorkspaceTab = "brief" | "cards" | "map" | "sources";
+
+export interface ReportWorkspaceRoute {
+  reportId: string;
+  tab: ReportWorkspaceTab;
+}
+
+export function getReportWorkspaceRouteFromPath(
+  pathname: string,
+): ReportWorkspaceRoute | null {
+  const match = pathname.match(
+    /^\/reports\/([^/]+)(?:\/(brief|cards|map|sources|graph))?\/?$/,
+  );
+  if (!match?.[1]) return null;
+
+  const segment = match[2];
+  const tab: ReportWorkspaceTab =
+    segment === "cards" || segment === "sources"
+      ? segment
+      : segment === "map" || segment === "graph"
+        ? "map"
+        : "brief";
+
+  return {
+    reportId: decodeURIComponent(match[1]),
+    tab,
+  };
+}

--- a/src/features/research/views/ReportDetailPage.tsx
+++ b/src/features/research/views/ReportDetailPage.tsx
@@ -12,8 +12,9 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useLocation, useParams, useNavigate } from "react-router-dom";
 import { ReportDetailWorkspace } from "./ReportDetailWorkspace";
+import { getReportWorkspaceRouteFromPath } from "@/features/reports/lib/reportNotebookRouting";
 import type {
   ResourceCard,
   ResourceUri,
@@ -122,8 +123,14 @@ async function fetchExpand(
 }
 
 export function ReportDetailPage() {
-  const { reportId } = useParams<{ reportId?: string }>();
+  const { reportId: routeReportId } = useParams<{ reportId?: string }>();
+  const location = useLocation();
   const navigate = useNavigate();
+  const reportRoute = useMemo(
+    () => getReportWorkspaceRouteFromPath(location.pathname),
+    [location.pathname],
+  );
+  const reportId = routeReportId ?? reportRoute?.reportId;
 
   const [initialCards, setInitialCards] = useState<
     ReadonlyArray<ResourceCard>
@@ -184,7 +191,8 @@ export function ReportDetailPage() {
         rootLabel={rootLabel}
         initialCards={initialCards}
         onExpand={onExpand}
-        onOpenBrief={() => navigate(`/reports/${reportId ?? ""}`)}
+        initialTab={reportRoute?.tab}
+        onOpenBrief={() => navigate(`/reports/${reportId ?? ""}/brief`)}
         onOpenInChat={(uri) => navigate(`/?prompt=${encodeURIComponent(uri)}`)}
       />
     </div>


### PR DESCRIPTION
## What changed
- Completed the four-surface parity contract for web, mobile, workspace, and MCP/CLI.
- Added report workspace route parsing so `/reports/:id`, `/reports/:id/brief`, `/reports/:id/cards`, `/reports/:id/sources`, and `/reports/:id/graph` open the correct report detail surface.
- Exposed canonical NodeBench MCP tools in the default MCP package: `nodebench.research_run` and `nodebench.expand_resource`.
- Added the MCP run surface and CLI command map to the web developer setup page.
- Documented the four-kit parity contract and updated agent setup instructions.

## Validation
- `npx vitest run src/features/reports/lib/reportNotebookRouting.test.ts`
- `npm --prefix packages/mcp-local test`
- `npx tsc --noEmit`
- `npm --prefix packages/mcp-local run build`
- `npm run build`
- `agent-browser` live checks on local app for web, mobile, workspace, and MCP/CLI surfaces