### PR TITLE
Fix MCP preset CLI parity

### DIFF
--- a/packages/mcp-local/src/index.ts
+++ b/packages/mcp-local/src/index.ts
@@ -33,7 +33,7 @@ import { startOperatingDashboardServer, getOperatingDashboardUrl, stopOperatingD
 import { startEngineServer, getEngineUrl } from "./engine/server.js";
 import { getAnalyticsDb, closeAnalyticsDb, clearOldRecords } from "./analytics/index.js";
 import { AnalyticsTracker } from "./analytics/toolTracker.js";
-import { generateSmartPreset, formatPresetRecommendation, listPresets } from "./analytics/index.js";
+import { generateSmartPreset, formatPresetRecommendation } from "./analytics/index.js";
 import { getProjectUsageSummary, exportUsageStats, formatStatsDisplay } from "./analytics/index.js";
 import { TOOLSET_MAP, TOOL_TO_TOOLSET, loadToolsets, ALL_DOMAIN_KEYS, TOOLSET_LOADERS } from "./toolsetRegistry.js";
 import { initObservability, startWatchdog, stopWatchdog } from "./tools/observabilityTools.js";
@@ -164,6 +164,24 @@ const PRESET_DESCRIPTIONS: Record<string, string> = {
   full:        "Everything — all domains for maximum coverage",
 };
 
+function listRuntimePresets(): Array<{ name: string; toolsets: string[]; toolCount: number; description: string }> {
+  return Object.entries(PRESETS).map(([name, toolsets]) => {
+    const toolNames = new Set<string>();
+    for (const toolset of new Set(toolsets)) {
+      for (const tool of TOOLSET_MAP[toolset] ?? []) {
+        toolNames.add(tool.name);
+      }
+    }
+
+    return {
+      name,
+      toolsets,
+      toolCount: toolNames.size,
+      description: PRESET_DESCRIPTIONS[name] ?? "",
+    };
+  });
+}
+
 function isWorkflowFacadePreset(presetName: string): boolean {
   return presetName === "default" || presetName === "starter" || presetName === "v3";
 }
@@ -273,8 +291,7 @@ function isWorkflowFacadePreset(presetName: string): boolean {
 // Handle --list-presets
 if (listPresetsFlag) {
   await loadToolsets(ALL_DOMAIN_KEYS);
-  const presets = listPresets(TOOLSET_MAP);
-  console.log(JSON.stringify(presets, null, 2));
+  console.log(JSON.stringify(listRuntimePresets(), null, 2));
   process.exit(0);
 }
 

--- a/public/agent-setup.txt
+++ b/public/agent-setup.txt
@@ -17,6 +17,9 @@ Local terminal:
   npx nodebench-mcp --list-presets
   npx nodebench-mcp --preset power
 
+Power preset in Claude Code:
+  claude mcp add nodebench-power -- npx -y nodebench-mcp --preset power
+
 Cloud sync:
   npx nodebench-mcp --cloud
 

--- a/src/features/controlPlane/views/DevelopersPage.tsx
+++ b/src/features/controlPlane/views/DevelopersPage.tsx
@@ -254,9 +254,9 @@ function McpParitySurface({ stagger }: { stagger: (delay: string) => CSSProperti
           <TerminalLine lead="|" tone="ok">loaded default tools - investigate, report, track, nodebench.research_run</TerminalLine>
           <div className="my-3 h-px bg-white/[0.06]" />
           <TerminalLine>
-            <span className="text-[#8c97f0]">homen@mac</span>
+            <span className="text-[#8c97f0]">agent</span>
             <span className="text-[#d97757]"> &gt; </span>
-            <span>npx nodebench-mcp investigate --entity "DISCO" --lane answer</span>
+            <span>nodebench.research_run({"{"} objective: "Fast debrief on DISCO", subjects: [{"{"} type: "company", name: "DISCO" {"}"}] {"}"})</span>
           </TerminalLine>
           <TerminalLine lead=">" tone="accent">plan - resolve entity, search, synthesize, verify</TerminalLine>
           <TerminalLine lead=">" tone="ok">24 sources captured - answer packet streaming</TerminalLine>
@@ -277,7 +277,8 @@ function McpParitySurface({ stagger }: { stagger: (delay: string) => CSSProperti
           </TerminalLine>
           <div className="overflow-hidden rounded-md border border-white/[0.06]">
             {[
-              ["core", "fast lane - investigate, compare, report, track"],
+              ["default", "research bridge, workflow facade, discovery"],
+              ["core", "flywheel, verification, recon, packets"],
               ["power", "founder, recon, packet workflows"],
               ["admin", "profiling, dashboards, eval, observability"],
               ["full", "maximum coverage across domains"],
@@ -294,15 +295,15 @@ function McpParitySurface({ stagger }: { stagger: (delay: string) => CSSProperti
           <TerminalLine>
             <span className="text-[#8c97f0]">homen@mac</span>
             <span className="text-[#d97757]"> &gt; </span>
-            <span>npx nodebench-mcp-power discover_tools --query "visual QA"</span>
+            <span>claude mcp add nodebench-power -- npx -y nodebench-mcp --preset power</span>
+          </TerminalLine>
+          <TerminalLine lead=">" tone="ok">registered with extended founder/research toolsets</TerminalLine>
+          <TerminalLine>
+            <span className="text-[#8c97f0]">agent</span>
+            <span className="text-[#d97757]"> &gt; </span>
+            <span>discover_tools({"{"} query: "visual QA", limit: 3 {"}"})</span>
           </TerminalLine>
           <TerminalLine lead=">" tone="ok">matches - dogfood.visual_qa, ui_ux_dive.inspect_surface, ui_ux_dive.motion_trace</TerminalLine>
-          <TerminalLine>
-            <span className="text-[#8c97f0]">homen@mac</span>
-            <span className="text-[#d97757]"> &gt; </span>
-            <span>npx nodebench-mcp-power load_toolset --domain ui_ux_dive</span>
-          </TerminalLine>
-          <TerminalLine lead=">" tone="warn">missing GEMINI_API_KEY - set env var before synthesis</TerminalLine>
         </TerminalWindow>
       </div>
 


### PR DESCRIPTION
## Summary
- make nodebench-mcp --list-presets report the actual runtime PRESETS table, including default, power, admin, and full
- remove unsupported pseudo CLI binaries/subcommands from the developer page terminal examples
- add the Claude Code power-preset registration command to agent-setup.txt

## Verification
- npx tsc --noEmit
- npm --prefix packages/mcp-local run build
- node packages/mcp-local/dist/index.js --list-presets 2>\
- npm run build

Note: npm --prefix packages/mcp-local test timed out on two existing local-file tests in tools.test.ts in this fresh worktree; all unrelated suites in that command passed.