### PR TITLE
feat(web-kit): add Daily Pulse card to nodebench-web UI kit

### DIFF
--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/App.jsx
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/App.jsx
@@ -46,7 +46,12 @@ function App() {
         onToggleTheme={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
       />
       <div className="nb-shell">
-        {surface === 'home' && <window.NBComposer onSubmit={handleStart} />}
+        {surface === 'home' && (
+          <>
+            <window.NBComposer onSubmit={handleStart} />
+            <window.NBDailyPulse onOpen={handleStart} />
+          </>
+        )}
 
         {surface === 'chat' && thread && (
           <window.NBAnswerPacket

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/DailyPulse.jsx
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/DailyPulse.jsx
@@ -1,0 +1,121 @@
+// Daily Pulse — the home-surface "return at the right moment" card.
+// Sits below the composer and surfaces today's strongest signals with their
+// source counts. The entire card is clickable — tapping/clicking starts a
+// Deep-dive run with the pulse's stored prompt. Freshness is rendered as a
+// relative timestamp pill next to the kicker.
+//
+// Mirrors the live implementation at
+// src/features/home/views/HomeLanding.tsx `showPulseCard` block.
+
+const PULSE_SEED = {
+  prompt: "Give me today's sharpest signals across my watchlist — rank by what's likely to move a decision in the next 7 days.",
+  title: "Today's strongest signals",
+  summary:
+    "Four watchlist entities moved overnight. Disco's churn is bending down, Mercor posted 7 new eng roles in 24h, Relay Legal's Series D memo leaked, and LexNode quietly extended their runway.",
+  updatedAt: Date.now() - 42 * 60 * 1000, // 42 minutes ago
+  items: [
+    {
+      id: "p1",
+      title: "DISCO — SOC 2 Type II GA in EU",
+      summary:
+        "Addresses the regulatory risk flagged in your Nov 14 run. Your prior 'needs_review' stance likely flips. Material.",
+      sourceCount: 3,
+    },
+    {
+      id: "p2",
+      title: "Mercor — 7 new eng roles in 24h",
+      summary:
+        "Consistent with the Series B prep hypothesis. 3 new stealth hires on LinkedIn reinforce it.",
+      sourceCount: 5,
+    },
+    {
+      id: "p3",
+      title: "Relay Legal — Series D memo surfaced",
+      summary:
+        "Direct head-to-head claims against Disco on Am Law 200 renewals. Contradicts last week's Competitive card.",
+      sourceCount: 4,
+    },
+    {
+      id: "p4",
+      title: "LexNode — runway extended to Q1 2027",
+      summary:
+        "Bridge from existing investors + aggressive mid-market pricing change. Watch for spillover into Disco's GRR.",
+      sourceCount: 2,
+    },
+  ],
+};
+
+function formatPulseFreshness(updatedAt) {
+  if (!updatedAt) return "just now";
+  const delta = Math.max(0, Date.now() - updatedAt);
+  const minutes = Math.round(delta / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `updated ${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `updated ${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `updated ${days}d ago`;
+}
+
+function DailyPulse({ onOpen, seed }) {
+  const { Clock } = window.NBIcon;
+  const pulse = seed ?? PULSE_SEED;
+  const items = (pulse.items || []).slice(0, 5);
+
+  function open() {
+    if (typeof onOpen === "function") {
+      onOpen(pulse.prompt, "deep");
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="pulse-card"
+      onClick={open}
+      className="nb-reveal nb-pulse-card"
+    >
+      <div className="nb-pulse-head">
+        <div>
+          <div className="nb-pulse-kicker">
+            <span className="nb-pulse-dot" aria-hidden="true" />
+            Daily Pulse
+          </div>
+          <h2 className="nb-pulse-title">{pulse.title}</h2>
+        </div>
+        <span className="nb-pulse-freshness">
+          <Clock width={14} height={14} />
+          {formatPulseFreshness(pulse.updatedAt)}
+        </span>
+      </div>
+
+      {pulse.summary ? <p className="nb-pulse-summary">{pulse.summary}</p> : null}
+
+      <div className="nb-pulse-items">
+        {items.map((item, index) => (
+          <div
+            key={item.id ?? `${item.title}-${index}`}
+            className="nb-pulse-item"
+          >
+            <div className="nb-pulse-item-body">
+              <div className="nb-pulse-item-title">{item.title}</div>
+              <p className="nb-pulse-item-summary">{item.summary}</p>
+            </div>
+            <span className="nb-pulse-item-sources">
+              {item.sourceCount} source{item.sourceCount === 1 ? "" : "s"}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="nb-pulse-cta">
+        Open full brief in Chat
+        <span aria-hidden="true" className="nb-pulse-cta-arrow">↗</span>
+      </div>
+    </button>
+  );
+}
+
+window.NBDailyPulse = DailyPulse;
+window.NBDailyPulseSeed = PULSE_SEED;
+window.formatPulseFreshness = formatPulseFreshness;

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/index.html
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NodeBench AI · UI Kit</title>
   <link rel="icon" type="image/svg+xml" href="../../assets/logo-mark.svg">
-  <link rel="stylesheet" href="nodebench.css?v=4">
+  <link rel="stylesheet" href="nodebench.css?v=5">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body class="nb-app">
@@ -19,6 +19,7 @@
   <script type="text/babel" src="tweaks-panel.jsx"></script>
   <script type="text/babel" src="TopNav.jsx"></script>
   <script type="text/babel" src="Composer.jsx"></script>
+  <script type="text/babel" src="DailyPulse.jsx"></script>
   <script type="text/babel" src="AnswerPacket.jsx"></script>
   <script type="text/babel" src="ReportCard.jsx"></script>
   <script type="text/babel" src="NudgeList.jsx"></script>

--- a/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/nodebench.css
+++ b/docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/nodebench.css
@@ -1468,3 +1468,155 @@ html[data-theme="dark"] .nb-chat-composer { background: rgba(13,16,20,.88); }
   color: var(--text-muted);
   margin: 0 2px;
 }
+
+/* === Daily Pulse (home surface) ============================================ */
+/* A single-tap card that opens a Deep-dive run with today's curated prompt.
+   Sits directly below the composer on the home surface. Mirrors
+   src/features/home/views/HomeLanding.tsx showPulseCard block. */
+.nb-pulse-card {
+  display: block;
+  width: 100%;
+  margin: 28px 0 0;
+  padding: 22px 22px 20px;
+  border-radius: 28px;
+  border: 1px solid var(--border-subtle);
+  background:
+    radial-gradient(circle at top left, rgba(217, 119, 87, 0.16), transparent 34%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 245, 241, 0.98));
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 180ms var(--ease-out-expo),
+              box-shadow 180ms var(--ease-out-expo),
+              transform 180ms var(--ease-out-expo);
+}
+html[data-theme="dark"] .nb-pulse-card {
+  background:
+    radial-gradient(circle at top left, rgba(217, 119, 87, 0.20), transparent 28%),
+    linear-gradient(180deg, rgba(23, 28, 34, 0.96), rgba(18, 22, 27, 0.98));
+  border-color: rgba(255, 255, 255, 0.12);
+}
+.nb-pulse-card:hover {
+  border-color: var(--accent-primary-border);
+  box-shadow: 0 24px 60px rgba(217, 119, 87, 0.14);
+}
+.nb-pulse-card:focus-visible {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary-tint);
+}
+.nb-pulse-card:active { transform: translateY(1px) scale(0.997); }
+
+.nb-pulse-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+.nb-pulse-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+.nb-pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary-tint);
+}
+.nb-pulse-title {
+  margin: 6px 0 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  line-height: 1.25;
+}
+.nb-pulse-freshness {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+html[data-theme="dark"] .nb-pulse-freshness {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: var(--text-secondary);
+}
+
+.nb-pulse-summary {
+  margin: 14px 0 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.nb-pulse-items {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 18px;
+}
+.nb-pulse-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in oklab, var(--border-subtle) 80%, transparent);
+  background: rgba(255, 255, 255, 0.7);
+}
+html[data-theme="dark"] .nb-pulse-item {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+.nb-pulse-item-body { min-width: 0; flex: 1; }
+.nb-pulse-item-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+.nb-pulse-item-summary {
+  margin: 4px 0 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+.nb-pulse-item-sources {
+  flex: none;
+  align-self: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.nb-pulse-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent-primary);
+}
+.nb-pulse-cta-arrow { font-size: 14px; line-height: 1; transform: translateY(-1px); }


### PR DESCRIPTION
## Summary
Ports the home-surface pulse card from the live app into the \`nodebench-web\` design kit. Sits below the composer and mirrors [HomeLanding.tsx](src/features/home/views/HomeLanding.tsx) \`showPulseCard\` block one-for-one.

## What's new in the kit
- [\`DailyPulse.jsx\`](docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/DailyPulse.jsx) — registered on \`window.NBDailyPulse\`, seeded with DISCO/Mercor/Relay/LexNode scenario fixtures.
- [\`App.jsx\`](docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/App.jsx) — home surface now renders Composer + DailyPulse in order.
- [\`nodebench.css\`](docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/nodebench.css) — adds \`.nb-pulse-*\` tokens (radial glow, freshness pill, item rows, CTA). Light + dark parity. Cache bumped to \`?v=5\`.
- [\`index.html\`](docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/index.html) — loads DailyPulse between Composer and AnswerPacket.

## Test plan
- [x] Kit loads at \`docs/.../nodebench-web/index.html\` (visible in preview)
- [x] Clicking the card calls \`onOpen(prompt, "deep")\` → routes to Chat surface
- [x] Light + dark theme both render correctly
- [ ] (Optional) Regenerate kit thumbnail screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)