### PR TITLE
Align Home web surface with web kit

### DIFF
--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -13,6 +13,7 @@ import {
 } from '../types/theme';
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
+const THEME_STORAGE_VERSION = 'web-kit-light-v1';
 
 function hexToHslTriplet(hex: string): string {
   const normalized = hex.replace('#', '');
@@ -93,7 +94,15 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     if (typeof window === 'undefined') return DEFAULT_THEME;
     try {
       const saved = localStorage.getItem('nodebench-theme');
-      if (saved) return { ...DEFAULT_THEME, ...JSON.parse(saved) };
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        const next = { ...DEFAULT_THEME, ...parsed };
+        const savedVersion = localStorage.getItem('nodebench-theme-version');
+        if (savedVersion !== THEME_STORAGE_VERSION && next.mode === 'system') {
+          return { ...next, mode: DEFAULT_THEME.mode };
+        }
+        return next;
+      }
 
       // NOTE(coworker): Legacy support — some tests/older builds persisted a plain
       // `theme=dark|light` key without the full ThemePreferences payload.
@@ -200,6 +209,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
     // Persist to localStorage
     localStorage.setItem('nodebench-theme', JSON.stringify(theme));
+    localStorage.setItem('nodebench-theme-version', THEME_STORAGE_VERSION);
     localStorage.setItem('theme', resolvedMode); // Legacy support
   }, [theme, resolvedMode]);
 

--- a/src/features/home/views/HomeLanding.tsx
+++ b/src/features/home/views/HomeLanding.tsx
@@ -22,7 +22,11 @@ import {
 import { ReportCardSkeleton } from "@/components/skeletons";
 import { ProductThumbnail } from "@/features/product/components/ProductThumbnail";
 import { ProductSourceIdentity } from "@/features/product/components/ProductSourceIdentity";
-import { ProductIntakeComposer, type ProductComposerMode } from "@/features/product/components/ProductIntakeComposer";
+import {
+  ProductIntakeComposer,
+  type ProductComposerMode,
+  type ProductResearchLane,
+} from "@/features/product/components/ProductIntakeComposer";
 import { IntakeDetectedSources } from "@/features/product/components/IntakeDetectedSources";
 import { ComposerRoutingPreview } from "@/features/product/components/ComposerRoutingPreview";
 import { useProductBootstrap } from "@/features/product/lib/useProductBootstrap";
@@ -42,6 +46,14 @@ const WEB_KIT_PROMPT_CARDS = [
   { icon: FileText, prompt: SUGGESTED_PROMPTS[1] },
   { icon: Eye, prompt: SUGGESTED_PROMPTS[2] },
 ] as const;
+
+const WEB_KIT_RESEARCH_LANES = [
+  { id: "answer", label: "Answer", note: "fast - default" },
+  { id: "deep", label: "Deep dive", note: "multi-agent - 3-5 min" },
+  { id: "admin", label: "Admin", note: "nodebench-mcp-admin" },
+] as const satisfies readonly ProductResearchLane[];
+
+type WebKitResearchLaneId = (typeof WEB_KIT_RESEARCH_LANES)[number]["id"];
 
 const STARTER_REPORTS = [
   {
@@ -204,6 +216,7 @@ export function HomeLanding() {
   const [pendingFiles, setPendingFiles] = useState<ProductDraftFile[]>(() => draft?.files ?? []);
   const [uploadingFiles, setUploadingFiles] = useState(false);
   const [composerMode, setComposerMode] = useState<ProductComposerMode>("ask");
+  const [researchLane, setResearchLane] = useState<WebKitResearchLaneId>("answer");
   const [savingCapture, setSavingCapture] = useState(false);
   const [pulsePreview, setPulsePreview] = useState<any | null>(null);
   const [recentSearches] = useState(() => getRecentSearches());
@@ -373,8 +386,8 @@ export function HomeLanding() {
       buildCockpitPath({
         surfaceId: "workspace",
         extra: shouldPersistDraftQueryInUrl(resolvedQuery)
-          ? { q: resolvedQuery, lens: resolvedLens }
-          : { lens: resolvedLens, draft: "1" },
+          ? { q: resolvedQuery, lens: resolvedLens, lane: researchLane }
+          : { lens: resolvedLens, lane: researchLane, draft: "1" },
       }),
     );
   };
@@ -446,10 +459,10 @@ export function HomeLanding() {
         {/* "NEW RUN" pill removed — the composer below IS the CTA.
             Perplexity / Claude / ChatGPT all omit this label. If
             removing an element loses no function, remove it. */}
-        <div className="mb-3 text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--accent-primary)]">
+        <div className="mb-3 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-500 dark:text-gray-400">
           ENTITY INTELLIGENCE
         </div>
-        <h1 className="text-[1.75rem] font-semibold leading-[1.1] tracking-[-0.01em] text-gray-900 dark:text-gray-100 md:text-[2rem]">
+        <h1 className="text-[1.75rem] font-semibold leading-[1.1] tracking-[-0.01em] text-gray-900 dark:text-gray-100 md:text-[2.25rem]">
           What are we researching today?
         </h1>
         <p className="mx-auto mt-2 max-w-[460px] text-[15px] leading-6 text-gray-500 dark:text-gray-400">
@@ -471,18 +484,22 @@ export function HomeLanding() {
             files={pendingFiles}
             lens={lens}
             onLensChange={setLens}
+            researchLanes={WEB_KIT_RESEARCH_LANES}
+            selectedResearchLane={researchLane}
+            onResearchLaneChange={(laneId) => setResearchLane(laneId as WebKitResearchLaneId)}
             operatorContextLabel={operatorContextLabel}
             operatorContextHint={operatorContextHint}
             uploadingFiles={uploadingFiles}
-            placeholder="Paste a LinkedIn URL, drop a pitch deck, or describe the company."
+            placeholder="Ask anything - a company, a market, a question..."
             helperText="Accepts URLs, PDFs, docs, and notes."
             submitLabel="Start run"
             showOperatorContextChip={false}
             showOperatorContextHint={false}
+            showLensSelector={false}
             autoFocus
             mode={composerMode}
             onModeChange={setComposerMode}
-            showCaptureModes
+            showCaptureModes={false}
             onSaveCapture={handleSaveCapture}
             captureSavePending={savingCapture}
           />
@@ -633,7 +650,7 @@ export function HomeLanding() {
               </p>
             ) : null}
             <div className="mt-4 grid gap-3">
-              {pulsePreview.items.slice(0, 5).map((item: any, index: number) => (
+              {pulsePreview.items.slice(0, 3).map((item: any, index: number) => (
                 <div
                   key={item.id ?? `${item.title}-${index}`}
                   className="rounded-2xl border border-gray-200/80 bg-white/70 px-4 py-3 dark:border-white/[0.08] dark:bg-white/[0.03]"

--- a/src/features/product/components/ProductIntakeComposer.tsx
+++ b/src/features/product/components/ProductIntakeComposer.tsx
@@ -9,6 +9,12 @@ import { useVoiceRecording } from "@/hooks/useVoiceRecording";
 
 export type ProductComposerMode = "ask" | "note" | "task";
 
+export type ProductResearchLane = {
+  id: string;
+  label: string;
+  note: string;
+};
+
 type ProductIntakeComposerProps = {
   value: string;
   onChange: (value: string) => void;
@@ -41,6 +47,9 @@ type ProductIntakeComposerProps = {
   captureSavePending?: boolean;
   compact?: boolean;
   chatUtilityLabel?: string | null;
+  researchLanes?: readonly ProductResearchLane[];
+  selectedResearchLane?: string;
+  onResearchLaneChange?: (laneId: string) => void;
 };
 
 export function ProductIntakeComposer({
@@ -75,6 +84,9 @@ export function ProductIntakeComposer({
   captureSavePending = false,
   compact = false,
   chatUtilityLabel = "M+1",
+  researchLanes,
+  selectedResearchLane,
+  onResearchLaneChange,
 }: ProductIntakeComposerProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -89,6 +101,10 @@ export function ProductIntakeComposer({
   const isCaptureMode = mode !== "ask";
   const isCompactChatVariant = isChatVariant && compact;
   const showIntegratedCaptureModes = showCaptureModes && Boolean(onModeChange && onSaveCapture);
+  const showResearchLaneControls =
+    !isChatVariant &&
+    !isCaptureMode &&
+    Boolean(researchLanes?.length && selectedResearchLane && onResearchLaneChange);
 
   const {
     isRecording,
@@ -136,6 +152,12 @@ export function ProductIntakeComposer({
     if (mode === "task") return "Capture a task, follow-up, or reminder...";
     return placeholder;
   }, [mode, placeholder]);
+  const textareaAriaLabel =
+    mode === "ask"
+      ? showResearchLaneControls
+        ? "Ask anything - a company, a market, or a question"
+        : "Paste notes, links, or your ask"
+      : `Write your ${mode}`;
 
   const primaryLabel = useMemo(() => {
     if (mode === "note") return captureSavePending ? "Saving..." : "Save note";
@@ -433,7 +455,7 @@ export function ProductIntakeComposer({
               ref={textareaRef}
               id="product-intake-query"
               name="productIntakeQuery"
-              aria-label={mode === "ask" ? "Paste notes, links, or your ask" : `Write your ${mode}`}
+              aria-label={textareaAriaLabel}
               value={value}
               onChange={(event) => onChange(event.target.value)}
               onKeyDown={handleKeyDown}
@@ -454,7 +476,7 @@ export function ProductIntakeComposer({
             ref={textareaRef}
             id="product-intake-query"
             name="productIntakeQuery"
-            aria-label={mode === "ask" ? "Paste notes, links, or your ask" : `Write your ${mode}`}
+            aria-label={textareaAriaLabel}
             value={value}
             onChange={(event) => onChange(event.target.value)}
             onKeyDown={handleKeyDown}
@@ -489,27 +511,60 @@ export function ProductIntakeComposer({
                 : "hidden"
               : "flex text-gray-500 dark:text-gray-300"
           }`}>
-            <Sparkles className={`mt-0.5 shrink-0 text-[var(--accent-primary)] ${isChatVariant ? "h-3.5 w-3.5" : "h-4 w-4"}`} />
-            <div className="min-w-0">
-              <div className="leading-5">
-                {attachmentLabel}
-                {!isChatVariant && !isCaptureMode && dragActive ? " Drop files to attach them." : null}
-                {!isChatVariant && !isCaptureMode && !dragActive ? " Drag files or attach them below." : null}
+            {showResearchLaneControls ? (
+              <div
+                role="tablist"
+                aria-label="Research lane"
+                className="flex min-w-0 flex-wrap items-center gap-2"
+              >
+                {researchLanes!.map((lane) => {
+                  const active = selectedResearchLane === lane.id;
+                  return (
+                    <button
+                      key={lane.id}
+                      type="button"
+                      role="tab"
+                      aria-selected={active}
+                      data-testid="home-research-lane"
+                      data-state={active ? "active" : "inactive"}
+                      onClick={() => onResearchLaneChange?.(lane.id)}
+                      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-all duration-fast ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]/35 ${
+                        active
+                          ? "border-[var(--accent-primary)]/25 bg-[var(--accent-primary)]/10 text-[#ad5f45] shadow-sm dark:text-[#ffd7ca]"
+                          : "border-gray-200 bg-white/75 text-gray-500 hover:border-gray-300 hover:text-gray-800 dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-gray-400 dark:hover:border-white/[0.14] dark:hover:text-gray-100"
+                      }`}
+                    >
+                      <span>{lane.label}</span>
+                      <span className="font-mono text-[10px] opacity-70">&middot; {lane.note}</span>
+                    </button>
+                  );
+                })}
               </div>
-              {voiceActive ? (
-                <div className="mt-1 text-[11px] font-medium text-[var(--accent-primary)]">
-                {voicePending
-                    ? "Starting voice memo..."
-                    : "Recording voice memo... "}
-                  {!voicePending ? `${Math.floor(duration / 60)}:${`${duration % 60}`.padStart(2, "0")}` : null}
+            ) : (
+              <>
+                <Sparkles className={`mt-0.5 shrink-0 text-[var(--accent-primary)] ${isChatVariant ? "h-3.5 w-3.5" : "h-4 w-4"}`} />
+                <div className="min-w-0">
+                  <div className="leading-5">
+                    {attachmentLabel}
+                    {!isChatVariant && !isCaptureMode && dragActive ? " Drop files to attach them." : null}
+                    {!isChatVariant && !isCaptureMode && !dragActive ? " Drag files or attach them below." : null}
+                  </div>
+                  {voiceActive ? (
+                    <div className="mt-1 text-[11px] font-medium text-[var(--accent-primary)]">
+                    {voicePending
+                        ? "Starting voice memo..."
+                        : "Recording voice memo... "}
+                      {!voicePending ? `${Math.floor(duration / 60)}:${`${duration % 60}`.padStart(2, "0")}` : null}
+                    </div>
+                  ) : null}
                 </div>
-              ) : null}
-              {isRecording ? (
-                <div className="sr-only" aria-live="polite">
-                  Recording voice memo... {Math.floor(duration / 60)}:{`${duration % 60}`.padStart(2, "0")}
-                </div>
-              ) : null}
-            </div>
+              </>
+            )}
+            {isRecording ? (
+              <div className="sr-only" aria-live="polite">
+                Recording voice memo... {Math.floor(duration / 60)}:{`${duration % 60}`.padStart(2, "0")}
+              </div>
+            ) : null}
           </div>
           <div className={`flex items-center ${isChatVariant ? "gap-1.5" : "gap-2"}`}>
             {!isCaptureMode ? (

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -168,7 +168,7 @@ export interface ThemePreferences {
 }
 
 export const DEFAULT_THEME: ThemePreferences = {
-  mode: 'system',
+  mode: 'light',
   accentColor: 'terracotta',
   density: 'comfortable',
   fontFamily: 'Manrope Studio',

--- a/tests/e2e/full-ui-dogfood.spec.ts
+++ b/tests/e2e/full-ui-dogfood.spec.ts
@@ -350,7 +350,9 @@ test.describe("Full UI Dogfood", () => {
       activeRoute = "/?surface=home";
       await navigateWithinApp(page, "/?surface=home");
       const homeQuery = "What does Ditto AI do and what matters most right now?";
-      const homeInput = page.getByRole("textbox", { name: "Paste notes, links, or your ask" }).first();
+      const homeInput = page
+        .getByRole("textbox", { name: /Ask anything - a company, a market, or a question|Paste notes, links, or your ask/ })
+        .first();
       await expect(homeInput).toBeVisible({ timeout: 20_000 });
       await homeInput.fill(homeQuery);
       await page.getByRole("button", { name: /^start run$/i }).first().click();


### PR DESCRIPTION
## Summary
- Aligns the production Home surface with the uploaded nodebench-web kit: light default, answer-first composer, research lane chips, and web-kit prompt cards.
- Removes Home-only Ask/Note/Task and lens controls from the desktop composer while keeping attachments, screenshots, and voice capture actions available.
- Migrates old system-theme visitors to the new light web-kit default without overriding explicit dark-mode users.

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run src/features/home/views/HomeLanding.test.ts
- npm run build
- agent-browser verified local Home at http://127.0.0.1:5178/?surface=home&v=web-parity-local