### PR TITLE
Document event intelligence serving model

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ NodeBench is a research and reporting product built around five user-facing
 surfaces:
 
 - `Home` = start quickly
-- `Chat` = do the work
 - `Reports` = reusable memory
-- `Nudges` = return at the right moment
+- `Chat` = do the work
+- `Inbox` = captures, nudges, alerts, automations, and unassigned review
 - `Me` = operator context and control
+
+Deep research opens in the separate Workspace surface at `nodebench.workspace`;
+it is not a sixth tab in the operating app.
 
 The core idea is simple:
 
@@ -31,7 +34,8 @@ They need a system that can:
 
 ## What Shipped
 
-- five-surface web app across `Home`, `Chat`, `Reports`, `Nudges`, and `Me`
+- five-surface web app across `Home`, `Reports`, `Chat`, `Inbox`, and `Me`
+- separate deep-work Workspace shell at `nodebench.workspace`
 - typed search and reporting pipeline
 - live SSE streaming with saved runtime state
 - Convex-backed product state for sessions, reports, entities, nudges, files,
@@ -50,9 +54,9 @@ They need a system that can:
 USER SURFACES
 -------------
 Home      -> start quickly
-Chat      -> answer, sources, trace, follow-ups
 Reports   -> reusable report memory
-Nudges    -> return loop
+Chat      -> answer, sources, trace, follow-ups
+Inbox     -> captures, nudges, automations, alerts, unassigned items
 Me        -> operator context, permissions, controls
 
 BACKEND
@@ -81,10 +85,82 @@ question
 DISTRIBUTION
 ------------
 nodebenchai.com
+nodebench.workspace
 nodebench-mcp
 nodebench-mcp-power
 nodebench-mcp-admin
 ```
+
+## Event Intelligence Serving Model
+
+Event serving extends the same budgeted search route used by the main app and
+MCP runtime. NodeBench treats search as a memory-building operation with a
+budget. For events, NodeBench checks the event corpus and workspace memory
+before live search, then persists useful results as entities, claims, sources,
+and workspace context.
+
+The event flow is:
+
+```text
+Before event
+  -> build event corpus
+
+During event
+  -> capture messy notes instantly
+
+After event
+  -> turn captures into report, cards, follow-ups, and reusable memory
+```
+
+The product model is:
+
+```text
+Event corpus + live capture + post-event intelligence workspace
+```
+
+Event corpus and capture data stay separated:
+
+- `Shared event corpus` = public event info, speakers, sponsors, company pages,
+  sessions, and public source cache.
+- `Private captures` = what a user personally heard, wrote, recorded, or
+  photographed.
+- `Team/org memory` = shared only inside the fund, company, or workspace.
+- `Event aggregate insights` = opt-in or anonymized only.
+
+During the event, most captures should hit the event corpus first and avoid paid
+search:
+
+```text
+voice memo / text / screenshot
+  -> captureRouter
+  -> active event corpus
+  -> entity and claim extraction
+  -> active event session attachment
+  -> budget policy
+  -> ack + next action
+```
+
+Example mobile ack:
+
+```text
+Saved to Ship Demo Day session
+Detected 1 person | 1 company | 2 claims | 1 follow-up
+Using event corpus | 0 paid calls
+```
+
+After the event, the report opens in `nodebench.workspace`:
+
+```text
+Brief      -> post-event memo
+Cards      -> people, companies, products, themes
+Notebook   -> raw notes, transcripts, screenshot OCR, cleaned notes
+Sources    -> field notes, public evidence, verification status
+Chat       -> follow-up questions and deeper refreshes
+Map        -> graph view later
+```
+
+The canonical spec lives in
+[EVENT_INTELLIGENCE_SERVING_MODEL.md](./docs/architecture/EVENT_INTELLIGENCE_SERVING_MODEL.md).
 
 ## Why This Design
 
@@ -137,18 +213,22 @@ The intended product behavior is:
 Home
   -> start quickly
 
+Reports
+  -> turn that artifact into reusable memory
+
 Chat
   -> do the work
   -> create the first useful artifact
 
-Reports
-  -> turn that artifact into reusable memory
-
-Nudges
-  -> bring the user back when something important changes
+Inbox
+  -> triage captures, nudges, automations, alerts, and unassigned items
 
 Me
   -> improve how the next run is handled
+
+Workspace
+  -> open deep Brief / Cards / Notebook / Sources / Chat / Map work
+  -> lives at nodebench.workspace, not in the operating tab bar
 
 Next Home or Chat run
   -> starts with more context than before
@@ -182,11 +262,13 @@ input
 What each page contributes:
 
 - `Home` starts the run with the least friction possible
-- `Chat` creates the answer, sources, trace, entities, and next actions
 - `Reports` turns those into a durable report the user can reopen, refresh, and
   reuse
-- `Nudges` watches that report or entity and decides when it matters again
+- `Chat` creates the answer, sources, trace, entities, and next actions
+- `Inbox` collects nudges, captures, automations, alerts, and unassigned items
 - `Me` stores the operator context that improves the next answer
+- `Workspace` owns recursive cards, notebook editing, source verification, and
+  long-lived intelligence memory
 
 ## Current Legacy Infrastructure
 
@@ -222,7 +304,7 @@ ship one clear compounding workflow
 
 Main tasks still to finish:
 
-- [ ] make `Home -> Chat -> Reports -> Nudges -> Me` behave like one continuous
+- [ ] make `Home -> Reports -> Chat -> Inbox -> Me` behave like one continuous
       workflow instead of five adjacent surfaces
 - [ ] turn harness v1 into the clearer v2 shape described in
       [HARNESS_V2_PROPOSAL](docs/architecture/HARNESS_V2_PROPOSAL.md)
@@ -236,7 +318,7 @@ Main tasks still to finish:
 - [ ] add anticipatory prep behavior so the system can prepare the user before
       important interactions, not only answer after the fact
 - [ ] make saved reports behave like reusable memory, not storage
-- [ ] make `Nudges` a real return loop with at least one working daily trigger
+- [ ] keep `Nudges` as an Inbox section with at least one working daily trigger
 - [ ] make `Me` clearly improve future runs by exposing what context is being
       used and why
 - [ ] finish the `nodebench-mcp` v3 cut-and-split plan so default runtime,
@@ -414,7 +496,7 @@ nodebench-ai/
 ├── LICENSE                     ← MIT
 │
 ├── src/                        ← React frontend (Vite)
-│   ├── features/               ← feature-first, 30 folders (Home · Chat · Reports · Nudges · Me · entities · agents · …)
+│   ├── features/               ← feature-first, 30 folders (Home · Reports · Chat · Inbox · Me · Workspace · entities · agents · …)
 │   │   └── <feature>/          ← views · components · hooks · lib · __tests__ (colocated)
 │   ├── shared/                 ← shared UI primitives, hooks, utils
 │   ├── lib/                    ← registry, analytics, error reporting

--- a/convex/domains/search/fusion/README.md
+++ b/convex/domains/search/fusion/README.md
@@ -4,11 +4,14 @@ Multi-source search with parallel execution, RRF fusion, and LLM reranking.
 
 ## Overview
 
-The Search Fusion module provides a unified interface for searching across multiple sources:
-- **LinkUp** - External web search
-- **SEC EDGAR** - SEC filings
-- **RAG** - Internal vector + keyword search
-- **Documents** - Direct document search
+The Search Fusion module provides a unified interface for budgeted search across
+internal memory, free public providers, paid fallback providers, and structured
+public sources:
+
+- **RAG / Documents** - internal memory and source cache first
+- **Brave / Serper / Tavily** - free-first public web search
+- **Linkup** - paid fallback only when explicitly allowed
+- **SEC EDGAR / YouTube / arXiv / News** - structured public sources
 
 ## Architecture
 
@@ -25,17 +28,23 @@ The Search Fusion module provides a unified interface for searching across multi
 └─────────────────────────────────────────────────────────────────┘
     │         │         │         │         │         │         │
 ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐
-│LinkUp │ │  SEC  │ │  RAG  │ │ Docs  │ │YouTube│ │ arXiv │ │ News  │
+│ RAG   │ │ Docs  │ │Brave  │ │Serper │ │Tavily │ │  SEC  │ │Linkup*│
 └───────┘ └───────┘ └───────┘ └───────┘ └───────┘ └───────┘ └───────┘
 ```
+
+`Linkup*` means paid fallback only when `allowPaidSearch` or the deployment
+policy explicitly allows it.
 
 ## Search Modes
 
 | Mode | Sources | Fusion | Reranking | Cache TTL | Use Case |
 |------|---------|--------|-----------|-----------|----------|
-| `fast` | LinkUp only | None | No | 5 min | Quick answers |
-| `balanced` | LinkUp, RAG, Documents, News | RRF | No | 15 min | General research |
-| `comprehensive` | All 7 sources | RRF | Yes (LLM) | 15 min | Deep research |
+| `fast` | RAG, Documents, Brave, Serper, Tavily | RRF where needed | No | 5 min | Quick answers |
+| `balanced` | RAG, Documents, Brave, Serper, Tavily | RRF | No | 15 min | General research |
+| `comprehensive` | RAG, Documents, structured public sources, Brave, Serper, Tavily | RRF | Yes (LLM) | 15 min | Deep research |
+
+Paid providers are not part of the default source set. They are appended only
+when `allowPaidSearch` is true.
 
 ## Usage
 
@@ -129,10 +138,10 @@ The module logs:
 Example log output:
 ```
 [SearchOrchestrator] Starting balanced search: "AAPL earnings"
-[SearchOrchestrator] Sources: linkup, rag, documents
-[LinkupAdapter] Search completed in 450ms, 10 results
+[SearchOrchestrator] Sources: rag, documents, brave, serper, tavily
 [RagAdapter] Search completed in 120ms, 8 results
 [DocumentAdapter] Search completed in 80ms, 5 results
+[BraveAdapter] Search completed in 450ms, 10 results
 [SearchOrchestrator] Collected 23 results from 3 sources
 [SearchOrchestrator] Search completed in 520ms (reranked: false)
 ```
@@ -144,7 +153,7 @@ Example log output:
 1. **Add More Search Adapters** ✅
    - [x] YouTube adapter (`adapters/youtubeAdapter.ts`) - YouTube Data API v3
    - [x] arXiv adapter (`adapters/arxivAdapter.ts`) - Academic papers via Atom API
-   - [x] News adapter (`adapters/newsAdapter.ts`) - NewsAPI with LinkUp fallback
+   - [x] News adapter (`adapters/newsAdapter.ts`) - NewsAPI, with paid fallback gated by search policy
 
 2. **Observability Persistence** ✅
    - [x] Store `searchRun` records with per-tool latency/errors + fused IDs
@@ -218,7 +227,13 @@ Example log output:
 
 ### Pipeline Order (Cost-Optimized)
 
-The search pipeline is ordered to minimize LLM costs:
+The search pipeline is ordered to minimize provider and LLM costs:
+
+1. Cache and internal memory first.
+2. Structured public sources when requested.
+3. Free public web providers in quota order.
+4. Paid fallback only when explicitly allowed.
+5. LLM reranking only after cheaper pruning and only for comprehensive runs.
 
 ```
 expandQuery → retrieval → boost → RRF → dedup → rerank (top-K) → recency
@@ -278,10 +293,10 @@ Structured logging at pipeline completion:
   query: 'machine learning research papers',
   queryType: 'research',
   expansionApplied: true,
-  sourcesQueried: ['linkup', 'sec', 'rag', 'documents', 'youtube', 'arxiv', 'news'],
+  sourcesQueried: ['rag', 'documents', 'sec', 'brave', 'serper', 'tavily'],
   perSourceMetrics: [
-    { source: 'linkup', timeMs: 3225, resultCount: 10 },
-    { source: 'youtube', timeMs: 359, resultCount: 10 },
+    { source: 'rag', timeMs: 80, resultCount: 8 },
+    { source: 'brave', timeMs: 359, resultCount: 10 },
     // ...
   ],
   totalBeforeFusion: 32,
@@ -353,7 +368,7 @@ When disabled, `fusionSearch` and `quickSearch` will throw:
 |------|-------------|
 | `adapters/youtubeAdapter.ts` | YouTube Data API v3 adapter |
 | `adapters/arxivAdapter.ts` | arXiv Atom API adapter |
-| `adapters/newsAdapter.ts` | NewsAPI with LinkUp fallback |
+| `adapters/newsAdapter.ts` | NewsAPI adapter with paid fallback gated by policy |
 | `observability.ts` | Search run persistence and analytics |
 | `rateLimiter.ts` | Rate limiting and concurrency control |
 | `cache.ts` | TTL-based result caching |
@@ -363,7 +378,7 @@ When disabled, `fusionSearch` and `quickSearch` will throw:
 ### Changelog
 
 **Features:**
-- Multi-source search fusion with 7 adapters (LinkUp, SEC, RAG, Documents, YouTube, arXiv, News)
+- Multi-source search fusion with cache/internal first, free public web, structured public sources, and gated paid fallback
 - RRF (Reciprocal Rank Fusion) for result combination
 - LLM reranking for comprehensive mode
 - Versioned payload contract (`FusionSearchPayload` v1)

--- a/docs/architecture/EVENT_INTELLIGENCE_SERVING_MODEL.md
+++ b/docs/architecture/EVENT_INTELLIGENCE_SERVING_MODEL.md
@@ -1,0 +1,197 @@
+# Event Intelligence Serving Model
+
+NodeBench event serving is the event-specific version of the shared search
+gateway:
+
+```text
+Capture at event
+-> use event corpus first
+-> extract entities and claims
+-> attach to active event session
+-> spend only when deeper diligence is justified
+```
+
+The product should feel like one agent capability, not a provider picker.
+Search is a memory-building operation with a budget: every useful result should
+become reusable source memory, entity memory, claim memory, or workspace memory.
+
+## Serving Model
+
+NodeBench serves three event moments:
+
+| Moment | Job | Default cost posture |
+| --- | --- | --- |
+| Before event | Build the event corpus from public event material and prior memory | Batch once, cache aggressively |
+| During event | Capture messy notes, voice, screenshots, and follow-ups | Event corpus first, no paid search |
+| After event | Convert captures into reports, cards, sources, notebook, and follow-ups | Workspace run, paid only by policy |
+
+The event product is:
+
+```text
+Event corpus + live capture + post-event intelligence workspace
+```
+
+It is not a generic people-search scrape and not a raw note-taking tool.
+
+## Memory Layers
+
+Keep these layers separate:
+
+| Layer | Meaning | Sharing default |
+| --- | --- | --- |
+| Shared event corpus | Public event page, speakers, sponsors, companies, sessions, public sources | Shared for the event |
+| Private captures | Notes, voice memos, screenshots, conversations, follow-ups | Private by default |
+| Team or org memory | Fund/company/team reports, watchlists, relationship context | Tenant-scoped |
+| Event aggregate insights | Trends across attendees or teams | Opt-in or anonymized only |
+
+This separation lets NodeBench serve many attendees without burning live search
+on every capture or leaking private field notes.
+
+## Before The Event
+
+Build an `EventCorpus` from:
+
+- event page, such as Luma, conference site, or demo day page
+- agenda and session pages
+- speaker, sponsor, and company lists
+- known attendees only when available and permitted
+- public company and person profiles
+- prior NodeBench reports and team memory
+- cached source documents and entity cards
+
+The resulting corpus should contain:
+
+```text
+Event
+|-- Companies
+|-- People
+|-- Products
+|-- Sponsors
+|-- Sessions
+|-- Topics
+|-- Public sources
+`-- Prior internal memory
+```
+
+## During The Event
+
+The composer stays mode-free:
+
+```text
+Ask, capture, paste, upload, or record...
+```
+
+Runtime flow:
+
+```text
+voice memo / text / screenshot
+-> captureRouter
+-> scenario classifier
+-> active event corpus
+-> entity and claim extraction
+-> active event session attachment
+-> budget policy
+-> optional live search
+-> ack + next action
+```
+
+Most event captures should not run paid search. They should attach to the active
+event session, extract entities and field-note claims, then queue enrichment
+only when the user asks for deeper diligence.
+
+Example ack:
+
+```text
+Saved to Ship Demo Day
+Detected 1 person | 1 company | 2 claims | 1 follow-up
+Using event corpus | 0 paid calls
+```
+
+## After The Event
+
+The event report opens in `nodebench.workspace` as durable intelligence:
+
+```text
+Event Workspace
+|-- Brief      who you met, strongest companies, repeated themes, next actions
+|-- Cards      company, person, product, and theme cards
+|-- Notebook   raw notes, cleaned notes, transcripts, screenshot OCR
+|-- Sources    field notes, public evidence, confidence, verification status
+|-- Chat       follow-up questions and deeper refreshes
+`-- Map        graph view, later default
+```
+
+Event capture can start in mobile or web. Serious synthesis happens in
+Workspace.
+
+## Budget Policy
+
+Default policy table:
+
+| Scenario | Policy |
+| --- | --- |
+| At-event note capture | Event corpus first, no paid search, persist private capture |
+| Open person card | Event corpus plus cached public profile, no paid search unless user asks |
+| Open company card | Event corpus plus prior memory plus source cache |
+| Is this company worth following up with? | Allow free refresh, maybe queue a workspace run |
+| Investment-grade diligence | Admin or fund approval required for paid/deep search |
+| Anonymous event guest | Public event corpus only, strict quota, no paid search |
+| Internal member | Tenant memory first, paid only by workspace policy |
+| Admin or research lead | Can approve deep refreshes |
+
+User-facing status must be product-level:
+
+```text
+Using event corpus
+Using team memory
+Checking public sources
+Deep refresh queued
+Paid refresh requires approval
+Saved to Ship Demo Day
+```
+
+Do not expose provider names such as Brave, Serper, Tavily, or Linkup in normal
+product copy.
+
+## Shared Contracts
+
+The first implementation slice adds shared TypeScript contracts in
+`shared/eventIntelligence.ts`:
+
+- `EventCorpus`
+- `EventSession`
+- `EventCapture`
+- `EventWorkspace`
+- `EventSearchPolicy`
+- `EventServingStatus`
+
+It also adds deterministic helpers:
+
+- `getDefaultEventSearchPolicy(actorType, scenario)`
+- `buildEventServingStatus(policy, cacheState)`
+- `formatEventCaptureAck(result)`
+
+These contracts are intentionally not Convex tables yet. They define the product
+contract before the storage implementation.
+
+## Surface Mapping
+
+| Surface | Event responsibility |
+| --- | --- |
+| Home | Active event snapshot and recent signals |
+| Chat | Universal ask/capture composer |
+| Reports | Event reports as reusable memory |
+| Inbox | Captures, unassigned notes, needs confirmation, nudges, alerts |
+| Me | Evidence mode, search budget, event capture privacy, integrations |
+| Workspace | Brief, Cards, Notebook, Sources, Chat, Map |
+| MCP/CLI | Batch import, event corpus build, scheduled refreshes |
+
+## Acceptance Criteria
+
+- Event captures route to `active_event_session` when event context is detected.
+- At-event captures default to no paid search.
+- Investment-grade diligence requires approval before paid/deep search.
+- Status copy uses product-level labels and hides provider names.
+- Event reports open as Workspace workspaces, not as a sixth app tab.
+- Private captures remain private unless team sharing or anonymized aggregation
+  is explicitly chosen.

--- a/docs/design/PRODUCT_SURFACES.md
+++ b/docs/design/PRODUCT_SURFACES.md
@@ -20,7 +20,7 @@ nodebenchai.com                  (the operating app: five tabs)
 |-- Inbox                        captures, nudges, unassigned, automations, alerts
 `-- Me                           preferences, context, files, credits
 
-workspace.nodebenchai.com        (deep-work surface, separately deployed)
+nodebench.workspace              (deep-work surface, separately deployed)
 `-- Deep workspaces opened from Chat / Reports / Inbox
     |-- Brief                    executive summary
     |-- Cards                    recursive exploration
@@ -39,6 +39,47 @@ workspace.nodebenchai.com        (deep-work surface, separately deployed)
 | CLI / MCP | Agent and developer distribution | Claude/Cursor workflows, automations, batch research, API workflows |
 | Workspace | Deep research and recursive exploration | Report detail, cards, notebook, sources, map, team memory |
 
+## Event Intelligence Serving
+
+Event serving uses the same product split. It is not a new tab.
+
+```text
+Before event
+-> build event corpus
+
+During event
+-> capture messy notes instantly
+
+After event
+-> turn captures into report, cards, follow-ups, and reusable memory
+```
+
+Surface mapping:
+
+| Surface | Event responsibility |
+| --- | --- |
+| Home | Active event snapshot, recent signals, and continue-capture entry |
+| Chat | Universal ask/capture composer with budget-aware ack copy |
+| Reports | Event reports as reusable memory objects |
+| Inbox | Captures, unassigned notes, needs confirmation, nudges, alerts |
+| Me | Evidence mode, search budget, event capture privacy, org settings |
+| Workspace | Brief, Cards, Notebook, Sources, Chat, and Map for post-event work |
+| CLI / MCP | Batch corpus builds, imports, automations, scheduled refreshes |
+
+Event copy should expose product states, not provider names:
+
+```text
+Using event corpus
+Using team memory
+Checking public sources
+Deep refresh queued
+Paid refresh requires approval
+Saved to Ship Demo Day
+```
+
+The detailed contract lives in
+[`EVENT_INTELLIGENCE_SERVING_MODEL.md`](../architecture/EVENT_INTELLIGENCE_SERVING_MODEL.md).
+
 ## Inbox Contents
 
 Inbox is where incoming signals triage before they become reports or
@@ -53,13 +94,13 @@ follow-ups.
 ## Workspace URL Shape
 
 ```text
-workspace.nodebenchai.com/w/{workspaceId}?tab=brief
-workspace.nodebenchai.com/w/{workspaceId}?tab=cards
-workspace.nodebenchai.com/w/{workspaceId}?tab=notebook
-workspace.nodebenchai.com/w/{workspaceId}?tab=sources
-workspace.nodebenchai.com/w/{workspaceId}?tab=chat
-workspace.nodebenchai.com/w/{workspaceId}?tab=map
-workspace.nodebenchai.com/share/{shareId}
+nodebench.workspace/w/{workspaceId}?tab=brief
+nodebench.workspace/w/{workspaceId}?tab=cards
+nodebench.workspace/w/{workspaceId}?tab=notebook
+nodebench.workspace/w/{workspaceId}?tab=sources
+nodebench.workspace/w/{workspaceId}?tab=chat
+nodebench.workspace/w/{workspaceId}?tab=map
+nodebench.workspace/share/{shareId}
 ```
 
 ## Report Entry Mapping

--- a/docs/design/WORKSPACE_DEPLOY.md
+++ b/docs/design/WORKSPACE_DEPLOY.md
@@ -10,8 +10,8 @@ work surface. It is not a sixth tab in the main app.
 - Local route: `/workspace/w/{workspaceId}?tab={tab}`.
 - Workspace-host route: `/w/{workspaceId}?tab={tab}`.
 - Supported tabs: `brief`, `cards`, `notebook`, `sources`, `chat`, `map`.
-- Canonical workspace host: `workspace.nodebenchai.com`.
-- Accepted future alias: `nodebench.workspace`.
+- Canonical workspace host: `nodebench.workspace`.
+- Accepted rollout alias: `workspace.nodebenchai.com`.
 - Accepted rollout alias: `nodebench-workspace.vercel.app`.
 
 `src/App.tsx` checks for the workspace host or `/workspace/*` path before the
@@ -20,10 +20,10 @@ cockpit shell mounts, so Workspace owns its own header and tabs.
 ## URL Mapping
 
 ```text
-nodebenchai.com                  -> Home / Reports / Chat / Inbox / Me
-workspace.nodebenchai.com/w/acme -> Workspace shell
-workspace.nodebenchai.com/share/abc -> Workspace share surface
-localhost:5173/workspace/w/acme  -> Local workspace shell
+nodebenchai.com                 -> Home / Reports / Chat / Inbox / Me
+nodebench.workspace/w/acme      -> Workspace shell
+nodebench.workspace/share/abc   -> Workspace share surface
+localhost:5173/workspace/w/acme -> Local workspace shell
 ```
 
 Report actions use this mapping:
@@ -34,19 +34,47 @@ Report actions use this mapping:
 | Explore | `/w/{workspaceId}?tab=cards` |
 | Chat | `/w/{workspaceId}?tab=chat` |
 
+## Event Workspace Mapping
+
+Event capture starts in mobile or web, but post-event synthesis opens in the
+separate Workspace shell.
+
+```text
+nodebench.workspace/w/ship-demo-day?tab=brief
+nodebench.workspace/w/ship-demo-day?tab=cards
+nodebench.workspace/w/ship-demo-day?tab=notebook
+nodebench.workspace/w/ship-demo-day?tab=sources
+nodebench.workspace/w/ship-demo-day?tab=chat
+nodebench.workspace/w/ship-demo-day?tab=map
+```
+
+Default event tab usage:
+
+| Workspace tab | Event purpose |
+| --- | --- |
+| Brief | Post-event memo with people met, strongest companies, themes, and next actions |
+| Cards | Company, person, product, and theme cards |
+| Notebook | Raw notes, cleaned notes, transcripts, and screenshot OCR |
+| Sources | Field notes, public evidence, confidence, and verification status |
+| Chat | Follow-up questions and deeper refreshes |
+| Map | Graph view later, not the v1 default |
+
+Event report entries should default to `cards` or `notebook` when the user is
+coming from capture review, and to `brief` when the user asks for a memo.
+
 ## Deployment Options
 
 ### Preferred
 
 Deploy the same React bundle with the custom domain
-`workspace.nodebenchai.com`. The bundle routes the bare workspace host directly
+`nodebench.workspace`. The bundle routes the bare workspace host directly
 to the chromeless workspace shell.
 
 ### DNS-Compatible Fallback
 
-If the `nodebench.workspace` domain becomes available later, keep it as an alias
-only. `buildWorkspaceUrl` keeps production links on
-`https://workspace.nodebenchai.com/...`.
+If the `nodebench.workspace` domain is not available during rollout, keep
+`workspace.nodebenchai.com` as an alias. `buildWorkspaceUrl` keeps production
+links on `https://nodebench.workspace/...`.
 
 ## Vercel Rewrites
 
@@ -58,12 +86,12 @@ workspace subdomain keeps clean URLs:
   "rewrites": [
     {
       "source": "/w/:workspaceId",
-      "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
+      "has": [{ "type": "host", "value": "nodebench.workspace" }],
       "destination": "/w/:workspaceId"
     },
     {
       "source": "/share/:shareId",
-      "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
+      "has": [{ "type": "host", "value": "nodebench.workspace" }],
       "destination": "/share/:shareId"
     }
   ]

--- a/shared/eventIntelligence.test.ts
+++ b/shared/eventIntelligence.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEventServingStatus,
+  formatEventCaptureAck,
+  getDefaultEventSearchPolicy,
+} from "./eventIntelligence";
+
+describe("eventIntelligence", () => {
+  it("keeps at-event capture on the active event session with no paid search", () => {
+    const policy = getDefaultEventSearchPolicy("member", "at_event_capture");
+
+    expect(policy).toMatchObject({
+      scenario: "at_event_capture",
+      freshness: "cached_ok",
+      maxCostCents: 0,
+      allowPaidSearch: false,
+      requiresApproval: false,
+      persist: true,
+      persistenceScope: "private",
+      preferredOrder: ["event_corpus", "tenant_memory", "source_cache"],
+    });
+  });
+
+  it("requires approval for investment-grade diligence and gates paid search by role", () => {
+    const memberPolicy = getDefaultEventSearchPolicy("member", "investment_grade_diligence");
+    const leadPolicy = getDefaultEventSearchPolicy("research_lead", "investment_grade_diligence");
+
+    expect(memberPolicy).toMatchObject({
+      allowPaidSearch: false,
+      maxCostCents: 0,
+      requiresApproval: true,
+      persistenceScope: "team",
+    });
+    expect(leadPolicy).toMatchObject({
+      allowPaidSearch: true,
+      maxCostCents: 500,
+      requiresApproval: true,
+    });
+  });
+
+  it("returns product-level status copy without provider names", () => {
+    const policy = getDefaultEventSearchPolicy("member", "investment_grade_diligence");
+    const status = buildEventServingStatus(policy, {
+      eventCorpusHit: true,
+      tenantMemoryHit: true,
+    });
+
+    expect(status).toMatchObject({
+      label: "Using event corpus",
+      detail: "No paid search used",
+      paidCallsUsed: 0,
+      persisted: true,
+    });
+    expect(`${status.label} ${status.detail}`).not.toMatch(/Brave|Serper|Tavily|Linkup/i);
+  });
+
+  it("formats event capture ack with active session target and budget status", () => {
+    const policy = getDefaultEventSearchPolicy("event_guest", "at_event_capture");
+    const status = buildEventServingStatus(policy, { eventCorpusHit: true });
+
+    expect(formatEventCaptureAck({
+      targetLabel: "Ship Demo Day session",
+      status: "attached",
+      personCount: 1,
+      companyCount: 1,
+      claimCount: 2,
+      followUpCount: 1,
+      servingStatus: status,
+    })).toBe([
+      "Saved to Ship Demo Day session",
+      "Detected 1 person | 1 company | 2 claims | 1 follow-up",
+      "Using event corpus | No paid search used | 0 paid calls",
+    ].join("\n"));
+  });
+});

--- a/shared/eventIntelligence.ts
+++ b/shared/eventIntelligence.ts
@@ -1,0 +1,262 @@
+export type EventActorType =
+  | "anonymous"
+  | "event_guest"
+  | "member"
+  | "admin"
+  | "research_lead"
+  | "agent";
+
+export type EventScenario =
+  | "at_event_capture"
+  | "person_lookup"
+  | "company_diligence"
+  | "interview_prep"
+  | "customer_discovery"
+  | "market_research"
+  | "investment_grade_diligence"
+  | "agent_runtime";
+
+export type EventFreshness =
+  | "cached_ok"
+  | "recent"
+  | "live_required";
+
+export interface EventCorpus {
+  eventId: string;
+  title: string;
+  publicSourceIds: string[];
+  companyEntityIds: string[];
+  personEntityIds: string[];
+  productEntityIds: string[];
+  topicEntityIds: string[];
+  lastRefreshedAt?: number;
+}
+
+export interface EventSession {
+  eventSessionId: string;
+  eventId?: string;
+  workspaceId?: string;
+  userId: string;
+  title: string;
+  active: boolean;
+  confidence: number;
+  startedAt: number;
+  endedAt?: number;
+}
+
+export interface EventCapture {
+  captureId: string;
+  eventSessionId?: string;
+  kind: "text" | "voice" | "image" | "screenshot" | "file";
+  rawText?: string;
+  transcript?: string;
+  artifactId?: string;
+  extractedEntityIds: string[];
+  extractedClaimIds: string[];
+  confidence: number;
+  status: "captured" | "attached" | "needs_confirmation" | "unassigned";
+  createdAt: number;
+}
+
+export interface EventWorkspace {
+  workspaceId: string;
+  eventSessionId: string;
+  reportId?: string;
+  defaultTabs: Array<"brief" | "cards" | "notebook" | "sources" | "chat" | "map">;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface EventSearchPolicy {
+  actorType: EventActorType;
+  scenario: EventScenario;
+  freshness: EventFreshness;
+  maxCostCents: number;
+  allowPaidSearch: boolean;
+  requiresApproval: boolean;
+  persist: boolean;
+  persistenceScope: "none" | "private" | "team" | "tenant";
+  preferredOrder: Array<
+    | "event_corpus"
+    | "tenant_memory"
+    | "source_cache"
+    | "free_public_search"
+    | "paid_search"
+  >;
+}
+
+export interface EventServingStatus {
+  label: string;
+  detail?: string;
+  paidCallsUsed: number;
+  requiresApproval: boolean;
+  persisted: boolean;
+}
+
+export interface EventServingCacheState {
+  eventCorpusHit?: boolean;
+  tenantMemoryHit?: boolean;
+  sourceCacheHit?: boolean;
+}
+
+export interface EventCaptureAckResult {
+  targetLabel: string;
+  status: EventCapture["status"];
+  personCount?: number;
+  companyCount?: number;
+  claimCount?: number;
+  followUpCount?: number;
+  servingStatus: EventServingStatus;
+}
+
+export function getDefaultEventSearchPolicy(
+  actorType: EventActorType,
+  scenario: EventScenario,
+): EventSearchPolicy {
+  if (scenario === "at_event_capture") {
+    return {
+      actorType,
+      scenario,
+      freshness: "cached_ok",
+      maxCostCents: 0,
+      allowPaidSearch: false,
+      requiresApproval: false,
+      persist: true,
+      persistenceScope: "private",
+      preferredOrder: ["event_corpus", "tenant_memory", "source_cache"],
+    };
+  }
+
+  if (actorType === "anonymous" || actorType === "event_guest") {
+    return {
+      actorType,
+      scenario,
+      freshness: "cached_ok",
+      maxCostCents: 0,
+      allowPaidSearch: false,
+      requiresApproval: false,
+      persist: actorType === "event_guest",
+      persistenceScope: actorType === "event_guest" ? "private" : "none",
+      preferredOrder: ["event_corpus", "source_cache"],
+    };
+  }
+
+  if (scenario === "investment_grade_diligence") {
+    const canApprovePaidSearch = actorType === "admin" || actorType === "research_lead";
+    return {
+      actorType,
+      scenario,
+      freshness: "live_required",
+      maxCostCents: canApprovePaidSearch ? 500 : 0,
+      allowPaidSearch: canApprovePaidSearch,
+      requiresApproval: true,
+      persist: true,
+      persistenceScope: "team",
+      preferredOrder: [
+        "tenant_memory",
+        "event_corpus",
+        "source_cache",
+        "free_public_search",
+        "paid_search",
+      ],
+    };
+  }
+
+  return {
+    actorType,
+    scenario,
+    freshness: "recent",
+    maxCostCents: 25,
+    allowPaidSearch: false,
+    requiresApproval: false,
+    persist: true,
+    persistenceScope: actorType === "agent" ? "team" : "private",
+    preferredOrder: [
+      "tenant_memory",
+      "event_corpus",
+      "source_cache",
+      "free_public_search",
+    ],
+  };
+}
+
+export function buildEventServingStatus(
+  policy: EventSearchPolicy,
+  cacheState: EventServingCacheState = {},
+): EventServingStatus {
+  if (cacheState.eventCorpusHit) {
+    return {
+      label: "Using event corpus",
+      detail: "No paid search used",
+      paidCallsUsed: 0,
+      requiresApproval: false,
+      persisted: policy.persist,
+    };
+  }
+
+  if (cacheState.tenantMemoryHit) {
+    return {
+      label: "Using team memory",
+      detail: "Found reusable context",
+      paidCallsUsed: 0,
+      requiresApproval: false,
+      persisted: policy.persist,
+    };
+  }
+
+  if (cacheState.sourceCacheHit) {
+    return {
+      label: "Using source cache",
+      detail: "No paid search used",
+      paidCallsUsed: 0,
+      requiresApproval: false,
+      persisted: policy.persist,
+    };
+  }
+
+  if (policy.requiresApproval) {
+    return {
+      label: "Deep refresh requires approval",
+      detail: "Live paid search is gated by workspace policy",
+      paidCallsUsed: 0,
+      requiresApproval: true,
+      persisted: policy.persist,
+    };
+  }
+
+  return {
+    label: "Checking public sources",
+    detail: "Free refresh only",
+    paidCallsUsed: 0,
+    requiresApproval: false,
+    persisted: policy.persist,
+  };
+}
+
+export function formatEventCaptureAck(result: EventCaptureAckResult): string {
+  const targetLine = result.status === "attached" || result.status === "captured"
+    ? `Saved to ${result.targetLabel}`
+    : result.status === "needs_confirmation"
+      ? `Needs confirmation for ${result.targetLabel}`
+      : "Saved to unassigned";
+  const detected = [
+    countLabel(result.personCount ?? 0, "person", "people"),
+    countLabel(result.companyCount ?? 0, "company", "companies"),
+    countLabel(result.claimCount ?? 0, "claim", "claims"),
+    countLabel(result.followUpCount ?? 0, "follow-up", "follow-ups"),
+  ].filter(Boolean);
+  const statusDetail = result.servingStatus.detail
+    ? `${result.servingStatus.label} | ${result.servingStatus.detail}`
+    : result.servingStatus.label;
+
+  return [
+    targetLine,
+    detected.length > 0 ? `Detected ${detected.join(" | ")}` : "Detected no structured items",
+    `${statusDetail} | ${result.servingStatus.paidCallsUsed} paid calls`,
+  ].join("\n");
+}
+
+function countLabel(count: number, singular: string, plural: string): string | null {
+  if (count <= 0) return null;
+  return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/src/features/product/lib/captureRouter.test.ts
+++ b/src/features/product/lib/captureRouter.test.ts
@@ -3,20 +3,20 @@ import { describe, expect, it } from "vitest";
 import { inferCaptureRoute } from "./captureRouter";
 
 describe("inferCaptureRoute", () => {
-  it("routes demo-day field notes into the active event report", () => {
+  it("routes demo-day field notes into the active event session", () => {
     const route = inferCaptureRoute({
       text: "Met Alex from Orbital Labs. Voice agent eval infra, seed, wants healthcare design partners.",
       mode: "note",
     });
 
     expect(route.intent).toBe("capture_field_note");
-    expect(route.target).toBe("active_event");
+    expect(route.target).toBe("active_event_session");
     expect(route.gate).toBe("auto_route");
     expect(route.entities.map((entity) => entity.name)).toContain("Alex");
     expect(route.entities.map((entity) => entity.name)).toContain("Orbital Labs");
     expect(route.claims.length).toBeGreaterThan(0);
     expect(route.followUps.some((item) => item.text.includes("pilot criteria"))).toBe(true);
-    expect(route.ack).toContain("Saved to active event report");
+    expect(route.ack).toContain("Saved to active event session");
   });
 
   it("keeps uncertain low-signal captures in review", () => {

--- a/src/features/product/lib/captureRouter.ts
+++ b/src/features/product/lib/captureRouter.ts
@@ -13,7 +13,7 @@ export type CaptureIntent =
 
 export type CaptureTarget =
   | "current_report"
-  | "active_event"
+  | "active_event_session"
   | "inbox_item"
   | "unassigned_buffer";
 
@@ -179,7 +179,7 @@ function inferTarget(
     /\b(?:met|talked to|spoke with)\s+[A-Z][A-Za-z.-]*(?:\s+[A-Z][A-Za-z.-]*)?\s+from\s+[A-Z]/i.test(text);
 
   if (EVENT_MARKERS.test(text) || looksLikeEventContext || looksLikeEventCapture) {
-    return "active_event";
+    return "active_event_session";
   }
   if (INBOX_MARKERS.test(text)) return "inbox_item";
   if (intent === "append_to_report" || REPORT_MARKERS.test(text)) {
@@ -206,7 +206,7 @@ function scoreRoute(args: {
   if (args.claims.length > 0) score += 0.12;
   if (args.followUps.length > 0) score += 0.08;
   if (args.target !== "unassigned_buffer") score += 0.08;
-  if (args.target === "active_event" && args.entities.length >= 2) score += 0.04;
+  if (args.target === "active_event_session" && args.entities.length >= 2) score += 0.04;
   if (args.intent === "ask_question" || args.intent === "expand_entity") score += 0.04;
   if (args.text.length > 240) score += 0.04;
   return Math.min(0.96, Number(score.toFixed(2)));
@@ -250,7 +250,7 @@ function extractEntities(
     if (ENTITY_STOPWORDS.has(first)) continue;
     if (COMPANY_SUFFIX.test(phrase)) {
       add(phrase, "company", 0.72);
-    } else if (phrase.split(/\s+/).length <= 2 && target !== "active_event") {
+    } else if (phrase.split(/\s+/).length <= 2 && target !== "active_event_session") {
       add(phrase, "company", 0.58);
     } else if (phrase.split(/\s+/).length <= 2) {
       add(phrase, "person", 0.58);
@@ -315,7 +315,7 @@ function extractFollowUps(
       priority: "high",
     });
   }
-  if (target === "active_event" && entities.some((entity) => entity.type === "person" || entity.type === "company")) {
+  if (target === "active_event_session" && entities.some((entity) => entity.type === "person" || entity.type === "company")) {
     followUps.push({
       text: "Prioritize follow-up queue for this event",
       priority: "medium",
@@ -347,7 +347,7 @@ function extractEvidence(sources: ReadonlyArray<IntakeSource>) {
 
 function labelForTarget(target: CaptureTarget, activeContextLabel?: string | null) {
   if (target === "current_report") return activeContextLabel?.trim() || "current report";
-  if (target === "active_event") return "active event report";
+  if (target === "active_event_session") return "active event session";
   if (target === "inbox_item") return "inbox item";
   return "unassigned capture review";
 }
@@ -377,7 +377,7 @@ function buildNextActions(
   if (needsConfirmation) return ["Confirm target", "Move", "Discard"];
   if (intent === "ask_question" || intent === "expand_entity") return ["Open card", "Go deeper", "Verify"];
   if (intent === "create_followup") return ["Add follow-up", "Open queue", "Draft reply"];
-  if (target === "active_event") return ["Edit", "Move", "Go deeper"];
+  if (target === "active_event_session") return ["Edit", "Move", "Go deeper"];
   return ["Open card", "Attach to report", "Verify"];
 }
 

--- a/src/features/workspace/data/scenarioCatalog.ts
+++ b/src/features/workspace/data/scenarioCatalog.ts
@@ -162,7 +162,7 @@ export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
     realLifeInput:
       "Met Alex from Orbital Labs. Voice agent eval infra, seed, wants healthcare design partners.",
     inferredIntent: "capture_field_note",
-    target: "active_event",
+    target: "active_event_session",
     structuredOutput: [
       "Entities: Alex, Orbital Labs, voice agent eval infra, healthcare",
       "Claims: Orbital Labs builds voice-agent eval infra; looking for healthcare design partners",
@@ -207,7 +207,7 @@ export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
     realLifeInput:
       "Ten startups from Ship Demo Day. Need clusters by market, unverified traction claims, and founder follow-ups.",
     inferredIntent: "expand_entity",
-    target: "active_event",
+    target: "active_event_session",
     structuredOutput: [
       "Entities: startups, markets, founders, traction claims",
       "Edges: company to market, founder to company, claim to evidence",
@@ -232,4 +232,3 @@ export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
     nextAction: ["Open cards", "Edit notebook", "Verify sources"],
   },
 ];
-


### PR DESCRIPTION
## Summary
- Document the Event Intelligence Serving Model in the root README and canonical architecture docs.
- Add shared EventCorpus/EventSession/EventCapture/EventWorkspace/EventSearchPolicy/EventServingStatus contracts plus deterministic policy/status/ack helpers.
- Update product surface, Workspace deploy, and search fusion docs so events use corpus/cache/memory first and Linkup remains gated paid fallback.
- Rename event capture routing target to active_event_session to keep private/team sessions separate from shared EventCorpus.

## Test Plan
- npx tsc --noEmit --pretty false
- npx vitest run shared/eventIntelligence.test.ts src/features/product/lib/captureRouter.test.ts
- npx vitest run server/searchRoute.test.ts

## Notes
- First slice only: docs and shared contracts, no Convex tables or full event UX.
- Slack is draft-first and Notion targets the Product wiki.