### PR TITLE
feat(parity): port nodebench-workspace Map.jsx SVG constellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ NodeBench is a research and reporting product built around five user-facing
 surfaces:
 
 - `Home` = start quickly
-- `Chat` = do the work
 - `Reports` = reusable memory
-- `Nudges` = return at the right moment
+- `Chat` = do the work
+- `Inbox` = captures, nudges, alerts, automations, and unassigned review
 - `Me` = operator context and control
+
+Deep research opens in the separate Workspace surface at `nodebench.workspace`;
+it is not a sixth tab in the operating app.
 
 The core idea is simple:
 
@@ -31,7 +34,8 @@ They need a system that can:
 
 ## What Shipped
 
-- five-surface web app across `Home`, `Chat`, `Reports`, `Nudges`, and `Me`
+- five-surface web app across `Home`, `Reports`, `Chat`, `Inbox`, and `Me`
+- separate deep-work Workspace shell at `nodebench.workspace`
 - typed search and reporting pipeline
 - live SSE streaming with saved runtime state
 - Convex-backed product state for sessions, reports, entities, nudges, files,
@@ -50,9 +54,9 @@ They need a system that can:
 USER SURFACES
 -------------
 Home      -> start quickly
-Chat      -> answer, sources, trace, follow-ups
 Reports   -> reusable report memory
-Nudges    -> return loop
+Chat      -> answer, sources, trace, follow-ups
+Inbox     -> captures, nudges, automations, alerts, unassigned items
 Me        -> operator context, permissions, controls
 
 BACKEND
@@ -81,10 +85,82 @@ question
 DISTRIBUTION
 ------------
 nodebenchai.com
+nodebench.workspace
 nodebench-mcp
 nodebench-mcp-power
 nodebench-mcp-admin
 ```
+
+## Event Intelligence Serving Model
+
+Event serving extends the same budgeted search route used by the main app and
+MCP runtime. NodeBench treats search as a memory-building operation with a
+budget. For events, NodeBench checks the event corpus and workspace memory
+before live search, then persists useful results as entities, claims, sources,
+and workspace context.
+
+The event flow is:
+
+```text
+Before event
+  -> build event corpus
+
+During event
+  -> capture messy notes instantly
+
+After event
+  -> turn captures into report, cards, follow-ups, and reusable memory
+```
+
+The product model is:
+
+```text
+Event corpus + live capture + post-event intelligence workspace
+```
+
+Event corpus and capture data stay separated:
+
+- `Shared event corpus` = public event info, speakers, sponsors, company pages,
+  sessions, and public source cache.
+- `Private captures` = what a user personally heard, wrote, recorded, or
+  photographed.
+- `Team/org memory` = shared only inside the fund, company, or workspace.
+- `Event aggregate insights` = opt-in or anonymized only.
+
+During the event, most captures should hit the event corpus first and avoid paid
+search:
+
+```text
+voice memo / text / screenshot
+  -> captureRouter
+  -> active event corpus
+  -> entity and claim extraction
+  -> active event session attachment
+  -> budget policy
+  -> ack + next action
+```
+
+Example mobile ack:
+
+```text
+Saved to Ship Demo Day session
+Detected 1 person | 1 company | 2 claims | 1 follow-up
+Using event corpus | 0 paid calls
+```
+
+After the event, the report opens in `nodebench.workspace`:
+
+```text
+Brief      -> post-event memo
+Cards      -> people, companies, products, themes
+Notebook   -> raw notes, transcripts, screenshot OCR, cleaned notes
+Sources    -> field notes, public evidence, verification status
+Chat       -> follow-up questions and deeper refreshes
+Map        -> graph view later
+```
+
+The canonical spec lives in
+[EVENT_INTELLIGENCE_SERVING_MODEL.md](./docs/architecture/EVENT_INTELLIGENCE_SERVING_MODEL.md).
 
 ## Why This Design
 
@@ -137,18 +213,22 @@ The intended product behavior is:
 Home
   -> start quickly
 
+Reports
+  -> turn that artifact into reusable memory
+
 Chat
   -> do the work
   -> create the first useful artifact
 
-Reports
-  -> turn that artifact into reusable memory
-
-Nudges
-  -> bring the user back when something important changes
+Inbox
+  -> triage captures, nudges, automations, alerts, and unassigned items
 
 Me
   -> improve how the next run is handled
+
+Workspace
+  -> open deep Brief / Cards / Notebook / Sources / Chat / Map work
+  -> lives at nodebench.workspace, not in the operating tab bar
 
 Next Home or Chat run
   -> starts with more context than before
@@ -182,11 +262,13 @@ input
 What each page contributes:
 
 - `Home` starts the run with the least friction possible
-- `Chat` creates the answer, sources, trace, entities, and next actions
 - `Reports` turns those into a durable report the user can reopen, refresh, and
   reuse
-- `Nudges` watches that report or entity and decides when it matters again
+- `Chat` creates the answer, sources, trace, entities, and next actions
+- `Inbox` collects nudges, captures, automations, alerts, and unassigned items
 - `Me` stores the operator context that improves the next answer
+- `Workspace` owns recursive cards, notebook editing, source verification, and
+  long-lived intelligence memory
 
 ## Current Legacy Infrastructure
 
@@ -222,7 +304,7 @@ ship one clear compounding workflow
 
 Main tasks still to finish:
 
-- [ ] make `Home -> Chat -> Reports -> Nudges -> Me` behave like one continuous
+- [ ] make `Home -> Reports -> Chat -> Inbox -> Me` behave like one continuous
       workflow instead of five adjacent surfaces
 - [ ] turn harness v1 into the clearer v2 shape described in
       [HARNESS_V2_PROPOSAL](docs/architecture/HARNESS_V2_PROPOSAL.md)
@@ -236,7 +318,7 @@ Main tasks still to finish:
 - [ ] add anticipatory prep behavior so the system can prepare the user before
       important interactions, not only answer after the fact
 - [ ] make saved reports behave like reusable memory, not storage
-- [ ] make `Nudges` a real return loop with at least one working daily trigger
+- [ ] keep `Nudges` as an Inbox section with at least one working daily trigger
 - [ ] make `Me` clearly improve future runs by exposing what context is being
       used and why
 - [ ] finish the `nodebench-mcp` v3 cut-and-split plan so default runtime,
@@ -414,7 +496,7 @@ nodebench-ai/
 ├── LICENSE                     ← MIT
 │
 ├── src/                        ← React frontend (Vite)
-│   ├── features/               ← feature-first, 30 folders (Home · Chat · Reports · Nudges · Me · entities · agents · …)
+│   ├── features/               ← feature-first, 30 folders (Home · Reports · Chat · Inbox · Me · Workspace · entities · agents · …)
 │   │   └── <feature>/          ← views · components · hooks · lib · __tests__ (colocated)
 │   ├── shared/                 ← shared UI primitives, hooks, utils
 │   ├── lib/                    ← registry, analytics, error reporting

--- a/convex/domains/search/fusion/README.md
+++ b/convex/domains/search/fusion/README.md
@@ -4,11 +4,14 @@ Multi-source search with parallel execution, RRF fusion, and LLM reranking.
 
 ## Overview
 
-The Search Fusion module provides a unified interface for searching across multiple sources:
-- **LinkUp** - External web search
-- **SEC EDGAR** - SEC filings
-- **RAG** - Internal vector + keyword search
-- **Documents** - Direct document search
+The Search Fusion module provides a unified interface for budgeted search across
+internal memory, free public providers, paid fallback providers, and structured
+public sources:
+
+- **RAG / Documents** - internal memory and source cache first
+- **Brave / Serper / Tavily** - free-first public web search
+- **Linkup** - paid fallback only when explicitly allowed
+- **SEC EDGAR / YouTube / arXiv / News** - structured public sources
 
 ## Architecture
 
@@ -25,17 +28,23 @@ The Search Fusion module provides a unified interface for searching across multi
 └─────────────────────────────────────────────────────────────────┘
     │         │         │         │         │         │         │
 ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼───┐
-│LinkUp │ │  SEC  │ │  RAG  │ │ Docs  │ │YouTube│ │ arXiv │ │ News  │
+│ RAG   │ │ Docs  │ │Brave  │ │Serper │ │Tavily │ │  SEC  │ │Linkup*│
 └───────┘ └───────┘ └───────┘ └───────┘ └───────┘ └───────┘ └───────┘
 ```
+
+`Linkup*` means paid fallback only when `allowPaidSearch` or the deployment
+policy explicitly allows it.
 
 ## Search Modes
 
 | Mode | Sources | Fusion | Reranking | Cache TTL | Use Case |
 |------|---------|--------|-----------|-----------|----------|
-| `fast` | LinkUp only | None | No | 5 min | Quick answers |
-| `balanced` | LinkUp, RAG, Documents, News | RRF | No | 15 min | General research |
-| `comprehensive` | All 7 sources | RRF | Yes (LLM) | 15 min | Deep research |
+| `fast` | RAG, Documents, Brave, Serper, Tavily | RRF where needed | No | 5 min | Quick answers |
+| `balanced` | RAG, Documents, Brave, Serper, Tavily | RRF | No | 15 min | General research |
+| `comprehensive` | RAG, Documents, structured public sources, Brave, Serper, Tavily | RRF | Yes (LLM) | 15 min | Deep research |
+
+Paid providers are not part of the default source set. They are appended only
+when `allowPaidSearch` is true.
 
 ## Usage
 
@@ -129,10 +138,10 @@ The module logs:
 Example log output:
 ```
 [SearchOrchestrator] Starting balanced search: "AAPL earnings"
-[SearchOrchestrator] Sources: linkup, rag, documents
-[LinkupAdapter] Search completed in 450ms, 10 results
+[SearchOrchestrator] Sources: rag, documents, brave, serper, tavily
 [RagAdapter] Search completed in 120ms, 8 results
 [DocumentAdapter] Search completed in 80ms, 5 results
+[BraveAdapter] Search completed in 450ms, 10 results
 [SearchOrchestrator] Collected 23 results from 3 sources
 [SearchOrchestrator] Search completed in 520ms (reranked: false)
 ```
@@ -144,7 +153,7 @@ Example log output:
 1. **Add More Search Adapters** ✅
    - [x] YouTube adapter (`adapters/youtubeAdapter.ts`) - YouTube Data API v3
    - [x] arXiv adapter (`adapters/arxivAdapter.ts`) - Academic papers via Atom API
-   - [x] News adapter (`adapters/newsAdapter.ts`) - NewsAPI with LinkUp fallback
+   - [x] News adapter (`adapters/newsAdapter.ts`) - NewsAPI, with paid fallback gated by search policy
 
 2. **Observability Persistence** ✅
    - [x] Store `searchRun` records with per-tool latency/errors + fused IDs
@@ -218,7 +227,13 @@ Example log output:
 
 ### Pipeline Order (Cost-Optimized)
 
-The search pipeline is ordered to minimize LLM costs:
+The search pipeline is ordered to minimize provider and LLM costs:
+
+1. Cache and internal memory first.
+2. Structured public sources when requested.
+3. Free public web providers in quota order.
+4. Paid fallback only when explicitly allowed.
+5. LLM reranking only after cheaper pruning and only for comprehensive runs.
 
 ```
 expandQuery → retrieval → boost → RRF → dedup → rerank (top-K) → recency
@@ -278,10 +293,10 @@ Structured logging at pipeline completion:
   query: 'machine learning research papers',
   queryType: 'research',
   expansionApplied: true,
-  sourcesQueried: ['linkup', 'sec', 'rag', 'documents', 'youtube', 'arxiv', 'news'],
+  sourcesQueried: ['rag', 'documents', 'sec', 'brave', 'serper', 'tavily'],
   perSourceMetrics: [
-    { source: 'linkup', timeMs: 3225, resultCount: 10 },
-    { source: 'youtube', timeMs: 359, resultCount: 10 },
+    { source: 'rag', timeMs: 80, resultCount: 8 },
+    { source: 'brave', timeMs: 359, resultCount: 10 },
     // ...
   ],
   totalBeforeFusion: 32,
@@ -353,7 +368,7 @@ When disabled, `fusionSearch` and `quickSearch` will throw:
 |------|-------------|
 | `adapters/youtubeAdapter.ts` | YouTube Data API v3 adapter |
 | `adapters/arxivAdapter.ts` | arXiv Atom API adapter |
-| `adapters/newsAdapter.ts` | NewsAPI with LinkUp fallback |
+| `adapters/newsAdapter.ts` | NewsAPI adapter with paid fallback gated by policy |
 | `observability.ts` | Search run persistence and analytics |
 | `rateLimiter.ts` | Rate limiting and concurrency control |
 | `cache.ts` | TTL-based result caching |
@@ -363,7 +378,7 @@ When disabled, `fusionSearch` and `quickSearch` will throw:
 ### Changelog
 
 **Features:**
-- Multi-source search fusion with 7 adapters (LinkUp, SEC, RAG, Documents, YouTube, arXiv, News)
+- Multi-source search fusion with cache/internal first, free public web, structured public sources, and gated paid fallback
 - RRF (Reciprocal Rank Fusion) for result combination
 - LLM reranking for comprehensive mode
 - Versioned payload contract (`FusionSearchPayload` v1)

--- a/docs/architecture/EVENT_INTELLIGENCE_SERVING_MODEL.md
+++ b/docs/architecture/EVENT_INTELLIGENCE_SERVING_MODEL.md
@@ -1,0 +1,197 @@
+# Event Intelligence Serving Model
+
+NodeBench event serving is the event-specific version of the shared search
+gateway:
+
+```text
+Capture at event
+-> use event corpus first
+-> extract entities and claims
+-> attach to active event session
+-> spend only when deeper diligence is justified
+```
+
+The product should feel like one agent capability, not a provider picker.
+Search is a memory-building operation with a budget: every useful result should
+become reusable source memory, entity memory, claim memory, or workspace memory.
+
+## Serving Model
+
+NodeBench serves three event moments:
+
+| Moment | Job | Default cost posture |
+| --- | --- | --- |
+| Before event | Build the event corpus from public event material and prior memory | Batch once, cache aggressively |
+| During event | Capture messy notes, voice, screenshots, and follow-ups | Event corpus first, no paid search |
+| After event | Convert captures into reports, cards, sources, notebook, and follow-ups | Workspace run, paid only by policy |
+
+The event product is:
+
+```text
+Event corpus + live capture + post-event intelligence workspace
+```
+
+It is not a generic people-search scrape and not a raw note-taking tool.
+
+## Memory Layers
+
+Keep these layers separate:
+
+| Layer | Meaning | Sharing default |
+| --- | --- | --- |
+| Shared event corpus | Public event page, speakers, sponsors, companies, sessions, public sources | Shared for the event |
+| Private captures | Notes, voice memos, screenshots, conversations, follow-ups | Private by default |
+| Team or org memory | Fund/company/team reports, watchlists, relationship context | Tenant-scoped |
+| Event aggregate insights | Trends across attendees or teams | Opt-in or anonymized only |
+
+This separation lets NodeBench serve many attendees without burning live search
+on every capture or leaking private field notes.
+
+## Before The Event
+
+Build an `EventCorpus` from:
+
+- event page, such as Luma, conference site, or demo day page
+- agenda and session pages
+- speaker, sponsor, and company lists
+- known attendees only when available and permitted
+- public company and person profiles
+- prior NodeBench reports and team memory
+- cached source documents and entity cards
+
+The resulting corpus should contain:
+
+```text
+Event
+|-- Companies
+|-- People
+|-- Products
+|-- Sponsors
+|-- Sessions
+|-- Topics
+|-- Public sources
+`-- Prior internal memory
+```
+
+## During The Event
+
+The composer stays mode-free:
+
+```text
+Ask, capture, paste, upload, or record...
+```
+
+Runtime flow:
+
+```text
+voice memo / text / screenshot
+-> captureRouter
+-> scenario classifier
+-> active event corpus
+-> entity and claim extraction
+-> active event session attachment
+-> budget policy
+-> optional live search
+-> ack + next action
+```
+
+Most event captures should not run paid search. They should attach to the active
+event session, extract entities and field-note claims, then queue enrichment
+only when the user asks for deeper diligence.
+
+Example ack:
+
+```text
+Saved to Ship Demo Day
+Detected 1 person | 1 company | 2 claims | 1 follow-up
+Using event corpus | 0 paid calls
+```
+
+## After The Event
+
+The event report opens in `nodebench.workspace` as durable intelligence:
+
+```text
+Event Workspace
+|-- Brief      who you met, strongest companies, repeated themes, next actions
+|-- Cards      company, person, product, and theme cards
+|-- Notebook   raw notes, cleaned notes, transcripts, screenshot OCR
+|-- Sources    field notes, public evidence, confidence, verification status
+|-- Chat       follow-up questions and deeper refreshes
+`-- Map        graph view, later default
+```
+
+Event capture can start in mobile or web. Serious synthesis happens in
+Workspace.
+
+## Budget Policy
+
+Default policy table:
+
+| Scenario | Policy |
+| --- | --- |
+| At-event note capture | Event corpus first, no paid search, persist private capture |
+| Open person card | Event corpus plus cached public profile, no paid search unless user asks |
+| Open company card | Event corpus plus prior memory plus source cache |
+| Is this company worth following up with? | Allow free refresh, maybe queue a workspace run |
+| Investment-grade diligence | Admin or fund approval required for paid/deep search |
+| Anonymous event guest | Public event corpus only, strict quota, no paid search |
+| Internal member | Tenant memory first, paid only by workspace policy |
+| Admin or research lead | Can approve deep refreshes |
+
+User-facing status must be product-level:
+
+```text
+Using event corpus
+Using team memory
+Checking public sources
+Deep refresh queued
+Paid refresh requires approval
+Saved to Ship Demo Day
+```
+
+Do not expose provider names such as Brave, Serper, Tavily, or Linkup in normal
+product copy.
+
+## Shared Contracts
+
+The first implementation slice adds shared TypeScript contracts in
+`shared/eventIntelligence.ts`:
+
+- `EventCorpus`
+- `EventSession`
+- `EventCapture`
+- `EventWorkspace`
+- `EventSearchPolicy`
+- `EventServingStatus`
+
+It also adds deterministic helpers:
+
+- `getDefaultEventSearchPolicy(actorType, scenario)`
+- `buildEventServingStatus(policy, cacheState)`
+- `formatEventCaptureAck(result)`
+
+These contracts are intentionally not Convex tables yet. They define the product
+contract before the storage implementation.
+
+## Surface Mapping
+
+| Surface | Event responsibility |
+| --- | --- |
+| Home | Active event snapshot and recent signals |
+| Chat | Universal ask/capture composer |
+| Reports | Event reports as reusable memory |
+| Inbox | Captures, unassigned notes, needs confirmation, nudges, alerts |
+| Me | Evidence mode, search budget, event capture privacy, integrations |
+| Workspace | Brief, Cards, Notebook, Sources, Chat, Map |
+| MCP/CLI | Batch import, event corpus build, scheduled refreshes |
+
+## Acceptance Criteria
+
+- Event captures route to `active_event_session` when event context is detected.
+- At-event captures default to no paid search.
+- Investment-grade diligence requires approval before paid/deep search.
+- Status copy uses product-level labels and hides provider names.
+- Event reports open as Workspace workspaces, not as a sixth app tab.
+- Private captures remain private unless team sharing or anonymized aggregation
+  is explicitly chosen.

--- a/docs/design/PRODUCT_SURFACES.md
+++ b/docs/design/PRODUCT_SURFACES.md
@@ -20,7 +20,7 @@ nodebenchai.com                  (the operating app: five tabs)
 |-- Inbox                        captures, nudges, unassigned, automations, alerts
 `-- Me                           preferences, context, files, credits
 
-workspace.nodebenchai.com        (deep-work surface, separately deployed)
+nodebench.workspace              (deep-work surface, separately deployed)
 `-- Deep workspaces opened from Chat / Reports / Inbox
     |-- Brief                    executive summary
     |-- Cards                    recursive exploration
@@ -39,6 +39,47 @@ workspace.nodebenchai.com        (deep-work surface, separately deployed)
 | CLI / MCP | Agent and developer distribution | Claude/Cursor workflows, automations, batch research, API workflows |
 | Workspace | Deep research and recursive exploration | Report detail, cards, notebook, sources, map, team memory |
 
+## Event Intelligence Serving
+
+Event serving uses the same product split. It is not a new tab.
+
+```text
+Before event
+-> build event corpus
+
+During event
+-> capture messy notes instantly
+
+After event
+-> turn captures into report, cards, follow-ups, and reusable memory
+```
+
+Surface mapping:
+
+| Surface | Event responsibility |
+| --- | --- |
+| Home | Active event snapshot, recent signals, and continue-capture entry |
+| Chat | Universal ask/capture composer with budget-aware ack copy |
+| Reports | Event reports as reusable memory objects |
+| Inbox | Captures, unassigned notes, needs confirmation, nudges, alerts |
+| Me | Evidence mode, search budget, event capture privacy, org settings |
+| Workspace | Brief, Cards, Notebook, Sources, Chat, and Map for post-event work |
+| CLI / MCP | Batch corpus builds, imports, automations, scheduled refreshes |
+
+Event copy should expose product states, not provider names:
+
+```text
+Using event corpus
+Using team memory
+Checking public sources
+Deep refresh queued
+Paid refresh requires approval
+Saved to Ship Demo Day
+```
+
+The detailed contract lives in
+[`EVENT_INTELLIGENCE_SERVING_MODEL.md`](../architecture/EVENT_INTELLIGENCE_SERVING_MODEL.md).
+
 ## Inbox Contents
 
 Inbox is where incoming signals triage before they become reports or
@@ -53,13 +94,13 @@ follow-ups.
 ## Workspace URL Shape
 
 ```text
-workspace.nodebenchai.com/w/{workspaceId}?tab=brief
-workspace.nodebenchai.com/w/{workspaceId}?tab=cards
-workspace.nodebenchai.com/w/{workspaceId}?tab=notebook
-workspace.nodebenchai.com/w/{workspaceId}?tab=sources
-workspace.nodebenchai.com/w/{workspaceId}?tab=chat
-workspace.nodebenchai.com/w/{workspaceId}?tab=map
-workspace.nodebenchai.com/share/{shareId}
+nodebench.workspace/w/{workspaceId}?tab=brief
+nodebench.workspace/w/{workspaceId}?tab=cards
+nodebench.workspace/w/{workspaceId}?tab=notebook
+nodebench.workspace/w/{workspaceId}?tab=sources
+nodebench.workspace/w/{workspaceId}?tab=chat
+nodebench.workspace/w/{workspaceId}?tab=map
+nodebench.workspace/share/{shareId}
 ```
 
 ## Report Entry Mapping

--- a/docs/design/WORKSPACE_DEPLOY.md
+++ b/docs/design/WORKSPACE_DEPLOY.md
@@ -10,8 +10,8 @@ work surface. It is not a sixth tab in the main app.
 - Local route: `/workspace/w/{workspaceId}?tab={tab}`.
 - Workspace-host route: `/w/{workspaceId}?tab={tab}`.
 - Supported tabs: `brief`, `cards`, `notebook`, `sources`, `chat`, `map`.
-- Canonical workspace host: `workspace.nodebenchai.com`.
-- Accepted future alias: `nodebench.workspace`.
+- Canonical workspace host: `nodebench.workspace`.
+- Accepted rollout alias: `workspace.nodebenchai.com`.
 - Accepted rollout alias: `nodebench-workspace.vercel.app`.
 
 `src/App.tsx` checks for the workspace host or `/workspace/*` path before the
@@ -20,10 +20,10 @@ cockpit shell mounts, so Workspace owns its own header and tabs.
 ## URL Mapping
 
 ```text
-nodebenchai.com                  -> Home / Reports / Chat / Inbox / Me
-workspace.nodebenchai.com/w/acme -> Workspace shell
-workspace.nodebenchai.com/share/abc -> Workspace share surface
-localhost:5173/workspace/w/acme  -> Local workspace shell
+nodebenchai.com                 -> Home / Reports / Chat / Inbox / Me
+nodebench.workspace/w/acme      -> Workspace shell
+nodebench.workspace/share/abc   -> Workspace share surface
+localhost:5173/workspace/w/acme -> Local workspace shell
 ```
 
 Report actions use this mapping:
@@ -34,19 +34,47 @@ Report actions use this mapping:
 | Explore | `/w/{workspaceId}?tab=cards` |
 | Chat | `/w/{workspaceId}?tab=chat` |
 
+## Event Workspace Mapping
+
+Event capture starts in mobile or web, but post-event synthesis opens in the
+separate Workspace shell.
+
+```text
+nodebench.workspace/w/ship-demo-day?tab=brief
+nodebench.workspace/w/ship-demo-day?tab=cards
+nodebench.workspace/w/ship-demo-day?tab=notebook
+nodebench.workspace/w/ship-demo-day?tab=sources
+nodebench.workspace/w/ship-demo-day?tab=chat
+nodebench.workspace/w/ship-demo-day?tab=map
+```
+
+Default event tab usage:
+
+| Workspace tab | Event purpose |
+| --- | --- |
+| Brief | Post-event memo with people met, strongest companies, themes, and next actions |
+| Cards | Company, person, product, and theme cards |
+| Notebook | Raw notes, cleaned notes, transcripts, and screenshot OCR |
+| Sources | Field notes, public evidence, confidence, and verification status |
+| Chat | Follow-up questions and deeper refreshes |
+| Map | Graph view later, not the v1 default |
+
+Event report entries should default to `cards` or `notebook` when the user is
+coming from capture review, and to `brief` when the user asks for a memo.
+
 ## Deployment Options
 
 ### Preferred
 
 Deploy the same React bundle with the custom domain
-`workspace.nodebenchai.com`. The bundle routes the bare workspace host directly
+`nodebench.workspace`. The bundle routes the bare workspace host directly
 to the chromeless workspace shell.
 
 ### DNS-Compatible Fallback
 
-If the `nodebench.workspace` domain becomes available later, keep it as an alias
-only. `buildWorkspaceUrl` keeps production links on
-`https://workspace.nodebenchai.com/...`.
+If the `nodebench.workspace` domain is not available during rollout, keep
+`workspace.nodebenchai.com` as an alias. `buildWorkspaceUrl` keeps production
+links on `https://nodebench.workspace/...`.
 
 ## Vercel Rewrites
 
@@ -58,12 +86,12 @@ workspace subdomain keeps clean URLs:
   "rewrites": [
     {
       "source": "/w/:workspaceId",
-      "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
+      "has": [{ "type": "host", "value": "nodebench.workspace" }],
       "destination": "/w/:workspaceId"
     },
     {
       "source": "/share/:shareId",
-      "has": [{ "type": "host", "value": "workspace.nodebenchai.com" }],
+      "has": [{ "type": "host", "value": "nodebench.workspace" }],
       "destination": "/share/:shareId"
     }
   ]

--- a/shared/eventIntelligence.test.ts
+++ b/shared/eventIntelligence.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEventServingStatus,
+  formatEventCaptureAck,
+  getDefaultEventSearchPolicy,
+} from "./eventIntelligence";
+
+describe("eventIntelligence", () => {
+  it("keeps at-event capture on the active event session with no paid search", () => {
+    const policy = getDefaultEventSearchPolicy("member", "at_event_capture");
+
+    expect(policy).toMatchObject({
+      scenario: "at_event_capture",
+      freshness: "cached_ok",
+      maxCostCents: 0,
+      allowPaidSearch: false,
+      requiresApproval: false,
+      persist: true,
+      persistenceScope: "private",
+      preferredOrder: ["event_corpus", "tenant_memory", "source_cache"],
+    });
+  });
+
+  it("requires approval for investment-grade diligence and gates paid search by role", () => {
+    const memberPolicy = getDefaultEventSearchPolicy("member", "investment_grade_diligence");
+    const leadPolicy = getDefaultEventSearchPolicy("research_lead", "investment_grade_diligence");
+
+    expect(memberPolicy).toMatchObject({
+      allowPaidSearch: false,
+      maxCostCents: 0,
+      requiresApproval: true,
+      persistenceScope: "team",
+    });
+    expect(leadPolicy).toMatchObject({
+      allowPaidSearch: true,
+      maxCostCents: 500,
+      requiresApproval: true,
+    });
+  });
+
+  it("returns product-level status copy without provider names", () => {
+    const policy = getDefaultEventSearchPolicy("member", "investment_grade_diligence");
+    const status = buildEventServingStatus(policy, {
+      eventCorpusHit: true,
+      tenantMemoryHit: true,
+    });
+
+    expect(status).toMatchObject({
+      label: "Using event corpus",
+      detail: "No paid search used",
+      paidCallsUsed: 0,
+      persisted: true,
+    });
+    expect(`${status.label} ${status.detail}`).not.toMatch(/Brave|Serper|Tavily|Linkup/i);
+  });
+
+  it("formats event capture ack with active session target and budget status", () => {
+    const policy = getDefaultEventSearchPolicy("event_guest", "at_event_capture");
+    const status = buildEventServingStatus(policy, { eventCorpusHit: true });
+
+    expect(formatEventCaptureAck({
+      targetLabel: "Ship Demo Day session",
+      status: "attached",
+      personCount: 1,
+      companyCount: 1,
+      claimCount: 2,
+      followUpCount: 1,
+      servingStatus: status,
+    })).toBe([
+      "Saved to Ship Demo Day session",
+      "Detected 1 person | 1 company | 2 claims | 1 follow-up",
+      "Using event corpus | No paid search used | 0 paid calls",
+    ].join("\n"));
+  });
+});

--- a/shared/eventIntelligence.ts
+++ b/shared/eventIntelligence.ts
@@ -1,0 +1,262 @@
+export type EventActorType =
+  | "anonymous"
+  | "event_guest"
+  | "member"
+  | "admin"
+  | "research_lead"
+  | "agent";
+
+export type EventScenario =
+  | "at_event_capture"
+  | "person_lookup"
+  | "company_diligence"
+  | "interview_prep"
+  | "customer_discovery"
+  | "market_research"
+  | "investment_grade_diligence"
+  | "agent_runtime";
+
+export type EventFreshness =
+  | "cached_ok"
+  | "recent"
+  | "live_required";
+
+export interface EventCorpus {
+  eventId: string;
+  title: string;
+  publicSourceIds: string[];
+  companyEntityIds: string[];
+  personEntityIds: string[];
+  productEntityIds: string[];
+  topicEntityIds: string[];
+  lastRefreshedAt?: number;
+}
+
+export interface EventSession {
+  eventSessionId: string;
+  eventId?: string;
+  workspaceId?: string;
+  userId: string;
+  title: string;
+  active: boolean;
+  confidence: number;
+  startedAt: number;
+  endedAt?: number;
+}
+
+export interface EventCapture {
+  captureId: string;
+  eventSessionId?: string;
+  kind: "text" | "voice" | "image" | "screenshot" | "file";
+  rawText?: string;
+  transcript?: string;
+  artifactId?: string;
+  extractedEntityIds: string[];
+  extractedClaimIds: string[];
+  confidence: number;
+  status: "captured" | "attached" | "needs_confirmation" | "unassigned";
+  createdAt: number;
+}
+
+export interface EventWorkspace {
+  workspaceId: string;
+  eventSessionId: string;
+  reportId?: string;
+  defaultTabs: Array<"brief" | "cards" | "notebook" | "sources" | "chat" | "map">;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface EventSearchPolicy {
+  actorType: EventActorType;
+  scenario: EventScenario;
+  freshness: EventFreshness;
+  maxCostCents: number;
+  allowPaidSearch: boolean;
+  requiresApproval: boolean;
+  persist: boolean;
+  persistenceScope: "none" | "private" | "team" | "tenant";
+  preferredOrder: Array<
+    | "event_corpus"
+    | "tenant_memory"
+    | "source_cache"
+    | "free_public_search"
+    | "paid_search"
+  >;
+}
+
+export interface EventServingStatus {
+  label: string;
+  detail?: string;
+  paidCallsUsed: number;
+  requiresApproval: boolean;
+  persisted: boolean;
+}
+
+export interface EventServingCacheState {
+  eventCorpusHit?: boolean;
+  tenantMemoryHit?: boolean;
+  sourceCacheHit?: boolean;
+}
+
+export interface EventCaptureAckResult {
+  targetLabel: string;
+  status: EventCapture["status"];
+  personCount?: number;
+  companyCount?: number;
+  claimCount?: number;
+  followUpCount?: number;
+  servingStatus: EventServingStatus;
+}
+
+export function getDefaultEventSearchPolicy(
+  actorType: EventActorType,
+  scenario: EventScenario,
+): EventSearchPolicy {
+  if (scenario === "at_event_capture") {
+    return {
+      actorType,
+      scenario,
+      freshness: "cached_ok",
+      maxCostCents: 0,
+      allowPaidSearch: false,
+      requiresApproval: false,
+      persist: true,
+      persistenceScope: "private",
+      preferredOrder: ["event_corpus", "tenant_memory", "source_cache"],
+    };
+  }
+
+  if (actorType === "anonymous" || actorType === "event_guest") {
+    return {
+      actorType,
+      scenario,
+      freshness: "cached_ok",
+      maxCostCents: 0,
+      allowPaidSearch: false,
+      requiresApproval: false,
+      persist: actorType === "event_guest",
+      persistenceScope: actorType === "event_guest" ? "private" : "none",
+      preferredOrder: ["event_corpus", "source_cache"],
+    };
+  }
+
+  if (scenario === "investment_grade_diligence") {
+    const canApprovePaidSearch = actorType === "admin" || actorType === "research_lead";
+    return {
+      actorType,
+      scenario,
+      freshness: "live_required",
+      maxCostCents: canApprovePaidSearch ? 500 : 0,
+      allowPaidSearch: canApprovePaidSearch,
+      requiresApproval: true,
+      persist: true,
+      persistenceScope: "team",
+      preferredOrder: [
+        "tenant_memory",
+        "event_corpus",
+        "source_cache",
+        "free_public_search",
+        "paid_search",
+      ],
+    };
+  }
+
+  return {
+    actorType,
+    scenario,
+    freshness: "recent",
+    maxCostCents: 25,
+    allowPaidSearch: false,
+    requiresApproval: false,
+    persist: true,
+    persistenceScope: actorType === "agent" ? "team" : "private",
+    preferredOrder: [
+      "tenant_memory",
+      "event_corpus",
+      "source_cache",
+      "free_public_search",
+    ],
+  };
+}
+
+export function buildEventServingStatus(
+  policy: EventSearchPolicy,
+  cacheState: EventServingCacheState = {},
+): EventServingStatus {
+  if (cacheState.eventCorpusHit) {
+    return {
+      label: "Using event corpus",
+      detail: "No paid search used",
+      paidCallsUsed: 0,
+      requiresApproval: false,
+      persisted: policy.persist,
+    };
+  }
+
+  if (cacheState.tenantMemoryHit) {
+    return {
+      label: "Using team memory",
+      detail: "Found reusable context",
+      paidCallsUsed: 0,
+      requiresApproval: false,
+      persisted: policy.persist,
+    };
+  }
+
+  if (cacheState.sourceCacheHit) {
+    return {
+      label: "Using source cache",
+      detail: "No paid search used",
+      paidCallsUsed: 0,
+      requiresApproval: false,
+      persisted: policy.persist,
+    };
+  }
+
+  if (policy.requiresApproval) {
+    return {
+      label: "Deep refresh requires approval",
+      detail: "Live paid search is gated by workspace policy",
+      paidCallsUsed: 0,
+      requiresApproval: true,
+      persisted: policy.persist,
+    };
+  }
+
+  return {
+    label: "Checking public sources",
+    detail: "Free refresh only",
+    paidCallsUsed: 0,
+    requiresApproval: false,
+    persisted: policy.persist,
+  };
+}
+
+export function formatEventCaptureAck(result: EventCaptureAckResult): string {
+  const targetLine = result.status === "attached" || result.status === "captured"
+    ? `Saved to ${result.targetLabel}`
+    : result.status === "needs_confirmation"
+      ? `Needs confirmation for ${result.targetLabel}`
+      : "Saved to unassigned";
+  const detected = [
+    countLabel(result.personCount ?? 0, "person", "people"),
+    countLabel(result.companyCount ?? 0, "company", "companies"),
+    countLabel(result.claimCount ?? 0, "claim", "claims"),
+    countLabel(result.followUpCount ?? 0, "follow-up", "follow-ups"),
+  ].filter(Boolean);
+  const statusDetail = result.servingStatus.detail
+    ? `${result.servingStatus.label} | ${result.servingStatus.detail}`
+    : result.servingStatus.label;
+
+  return [
+    targetLine,
+    detected.length > 0 ? `Detected ${detected.join(" | ")}` : "Detected no structured items",
+    `${statusDetail} | ${result.servingStatus.paidCallsUsed} paid calls`,
+  ].join("\n");
+}
+
+function countLabel(count: number, singular: string, plural: string): string | null {
+  if (count <= 0) return null;
+  return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/src/features/nudges/views/NudgesHome.tsx
+++ b/src/features/nudges/views/NudgesHome.tsx
@@ -194,7 +194,8 @@ function getNudgePriorityClasses(priority: NudgePriority) {
     case "auto":
       return "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/25 dark:bg-emerald-500/12 dark:text-emerald-200";
     case "watch":
-      return "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/25 dark:bg-sky-500/12 dark:text-sky-200";
+      // Kit parity: var(--indigo) = #5E6AD2 for the watch priority pill.
+      return "border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-400/30 dark:bg-indigo-500/12 dark:text-indigo-200";
     default:
       return "border-black/8 bg-black/[0.03] text-content-muted dark:border-white/10 dark:bg-white/[0.03]";
   }

--- a/src/features/product/lib/captureRouter.test.ts
+++ b/src/features/product/lib/captureRouter.test.ts
@@ -3,20 +3,20 @@ import { describe, expect, it } from "vitest";
 import { inferCaptureRoute } from "./captureRouter";
 
 describe("inferCaptureRoute", () => {
-  it("routes demo-day field notes into the active event report", () => {
+  it("routes demo-day field notes into the active event session", () => {
     const route = inferCaptureRoute({
       text: "Met Alex from Orbital Labs. Voice agent eval infra, seed, wants healthcare design partners.",
       mode: "note",
     });
 
     expect(route.intent).toBe("capture_field_note");
-    expect(route.target).toBe("active_event");
+    expect(route.target).toBe("active_event_session");
     expect(route.gate).toBe("auto_route");
     expect(route.entities.map((entity) => entity.name)).toContain("Alex");
     expect(route.entities.map((entity) => entity.name)).toContain("Orbital Labs");
     expect(route.claims.length).toBeGreaterThan(0);
     expect(route.followUps.some((item) => item.text.includes("pilot criteria"))).toBe(true);
-    expect(route.ack).toContain("Saved to active event report");
+    expect(route.ack).toContain("Saved to active event session");
   });
 
   it("keeps uncertain low-signal captures in review", () => {

--- a/src/features/product/lib/captureRouter.ts
+++ b/src/features/product/lib/captureRouter.ts
@@ -13,7 +13,7 @@ export type CaptureIntent =
 
 export type CaptureTarget =
   | "current_report"
-  | "active_event"
+  | "active_event_session"
   | "inbox_item"
   | "unassigned_buffer";
 
@@ -179,7 +179,7 @@ function inferTarget(
     /\b(?:met|talked to|spoke with)\s+[A-Z][A-Za-z.-]*(?:\s+[A-Z][A-Za-z.-]*)?\s+from\s+[A-Z]/i.test(text);
 
   if (EVENT_MARKERS.test(text) || looksLikeEventContext || looksLikeEventCapture) {
-    return "active_event";
+    return "active_event_session";
   }
   if (INBOX_MARKERS.test(text)) return "inbox_item";
   if (intent === "append_to_report" || REPORT_MARKERS.test(text)) {
@@ -206,7 +206,7 @@ function scoreRoute(args: {
   if (args.claims.length > 0) score += 0.12;
   if (args.followUps.length > 0) score += 0.08;
   if (args.target !== "unassigned_buffer") score += 0.08;
-  if (args.target === "active_event" && args.entities.length >= 2) score += 0.04;
+  if (args.target === "active_event_session" && args.entities.length >= 2) score += 0.04;
   if (args.intent === "ask_question" || args.intent === "expand_entity") score += 0.04;
   if (args.text.length > 240) score += 0.04;
   return Math.min(0.96, Number(score.toFixed(2)));
@@ -250,7 +250,7 @@ function extractEntities(
     if (ENTITY_STOPWORDS.has(first)) continue;
     if (COMPANY_SUFFIX.test(phrase)) {
       add(phrase, "company", 0.72);
-    } else if (phrase.split(/\s+/).length <= 2 && target !== "active_event") {
+    } else if (phrase.split(/\s+/).length <= 2 && target !== "active_event_session") {
       add(phrase, "company", 0.58);
     } else if (phrase.split(/\s+/).length <= 2) {
       add(phrase, "person", 0.58);
@@ -315,7 +315,7 @@ function extractFollowUps(
       priority: "high",
     });
   }
-  if (target === "active_event" && entities.some((entity) => entity.type === "person" || entity.type === "company")) {
+  if (target === "active_event_session" && entities.some((entity) => entity.type === "person" || entity.type === "company")) {
     followUps.push({
       text: "Prioritize follow-up queue for this event",
       priority: "medium",
@@ -347,7 +347,7 @@ function extractEvidence(sources: ReadonlyArray<IntakeSource>) {
 
 function labelForTarget(target: CaptureTarget, activeContextLabel?: string | null) {
   if (target === "current_report") return activeContextLabel?.trim() || "current report";
-  if (target === "active_event") return "active event report";
+  if (target === "active_event_session") return "active event session";
   if (target === "inbox_item") return "inbox item";
   return "unassigned capture review";
 }
@@ -377,7 +377,7 @@ function buildNextActions(
   if (needsConfirmation) return ["Confirm target", "Move", "Discard"];
   if (intent === "ask_question" || intent === "expand_entity") return ["Open card", "Go deeper", "Verify"];
   if (intent === "create_followup") return ["Add follow-up", "Open queue", "Draft reply"];
-  if (target === "active_event") return ["Edit", "Move", "Go deeper"];
+  if (target === "active_event_session") return ["Edit", "Move", "Go deeper"];
   return ["Open card", "Attach to report", "Verify"];
 }
 

--- a/src/features/research/views/MobileReportSurface.tsx
+++ b/src/features/research/views/MobileReportSurface.tsx
@@ -600,10 +600,11 @@ function renderPar(val: string | NotebookSeg[]) {
     } else if (seg.t === "chip") {
       out.push(<Chip key={`ch-${i}`} name={seg.name} type={seg.type} initials={seg.initials} />);
     } else if (seg.t === "mark") {
+      // Kit parity: var(--warn) + rgba(180,83,9,0.14) background, not bg-amber-100.
       out.push(
         <mark
           key={`mk-${i}`}
-          className="rounded bg-amber-100 px-1 font-semibold text-amber-800"
+          className="rounded bg-amber-800/15 px-1 font-semibold text-amber-800"
         >
           {seg.v}
         </mark>,

--- a/src/features/research/views/ReportDetailWorkspace.tsx
+++ b/src/features/research/views/ReportDetailWorkspace.tsx
@@ -698,6 +698,22 @@ function BriefTab({ cards }: { cards: ReadonlyArray<ResourceCard> }) {
   );
 }
 
+/**
+ * MapTab — entity-relationship constellation.
+ *
+ * Pattern: Circular 2-ring constellation with center-rooted layout + labeled
+ * edges + kind filter + side panel (Jony-Ive "earned complexity").
+ * Prior art: docs/design/nodebench-ai-design-system/ui_kits/nodebench-workspace/
+ *   (Map.jsx, map.css, data.js) — the golden-truth SVG kit.
+ *
+ * Adaptation notes (kit → prod):
+ *   - Kit uses window.WS_DATA fixture; prod reads ResourceCard[] + rootUri props.
+ *   - Kit relations[id] → prod derives edges from card.nextHops (primary) with
+ *     evidenceRefs fallback.
+ *   - Kit is light-palette; prod is dark-first so we lift the palette tokens
+ *     but dark-mode the canvas/panel chrome.
+ *   - Click = recenter; Shift+click = inspect (selects without recentering).
+ */
 function MapTab({
   cards,
   rootUri,
@@ -705,11 +721,41 @@ function MapTab({
   cards: ReadonlyArray<ResourceCard>;
   rootUri: ResourceUri;
 }) {
-  const graph = useMemo(() => buildSimpleMapGraph(cards, rootUri), [cards, rootUri]);
+  const [currentRootUri, setCurrentRootUri] = useState<ResourceUri>(rootUri);
   const [selectedUri, setSelectedUri] = useState<ResourceUri>(rootUri);
+  const [hoverUri, setHoverUri] = useState<ResourceUri | null>(null);
+  const [kindFilter, setKindFilter] = useState<MapNodeKind | "all">("all");
+
+  const graph = useMemo(
+    () => buildMapGraph(cards, currentRootUri, rootUri),
+    [cards, currentRootUri, rootUri],
+  );
+
+  const resolvedSelectedUri =
+    graph.nodes.find((n) => n.uri === selectedUri)?.uri ?? graph.rootUri;
   const selected =
-    graph.nodes.find((node) => node.uri === selectedUri) ??
-    graph.nodes[0];
+    graph.nodes.find((n) => n.uri === resolvedSelectedUri) ?? graph.nodes[0];
+
+  const recenter = useCallback(
+    (uri: ResourceUri) => {
+      if (!graph.byUri.has(uri)) return;
+      setCurrentRootUri(uri);
+      setSelectedUri(uri);
+    },
+    [graph.byUri],
+  );
+  const selectNode = useCallback(
+    (uri: ResourceUri) => {
+      if (!graph.byUri.has(uri)) return;
+      setSelectedUri(uri);
+    },
+    [graph.byUri],
+  );
+
+  const kindVisible = useCallback(
+    (kind: MapNodeKind) => kindFilter === "all" || kind === kindFilter,
+    [kindFilter],
+  );
 
   if (graph.nodes.length === 0) {
     return (
@@ -719,190 +765,537 @@ function MapTab({
     );
   }
 
+  const W = 900;
+  const H = 620;
+  const CX = W / 2;
+  const CY = H / 2;
+  const R1 = 200;
+  const R2 = 285;
+
   return (
-    <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_300px] overflow-hidden">
-      <section className="min-h-0 overflow-hidden p-4">
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div>
-            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
-              Relationship map
+    <div
+      className="grid min-h-0 flex-1 gap-4 overflow-hidden p-4 lg:grid-cols-[minmax(0,1fr)_340px]"
+      style={{
+        background:
+          "radial-gradient(ellipse at top, rgba(217,119,87,0.04), transparent 60%), transparent",
+      }}
+    >
+      {/* ── Canvas column ── */}
+      <section className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-[14px] border border-white/[0.06] bg-white/[0.02] shadow-[0_1px_2px_rgba(0,0,0,0.25),0_8px_24px_rgba(0,0,0,0.35)]">
+        {/* Toolbar */}
+        <div className="flex min-h-[42px] flex-shrink-0 items-center justify-between gap-4 border-b border-white/[0.06] bg-white/[0.02] px-3.5 py-2.5 backdrop-blur">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <span className="text-[10px] font-bold uppercase tracking-[0.14em] text-white/40">
+              Showing
+            </span>
+            <div className="inline-flex gap-0.5 rounded-[9px] bg-white/[0.04] p-[3px]">
+              {MAP_KINDS.map((k) => {
+                const active = kindFilter === k.k;
+                return (
+                  <button
+                    key={k.k}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => setKindFilter(k.k)}
+                    className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                      active
+                        ? "bg-white/[0.08] text-white shadow-[0_1px_2px_rgba(0,0,0,0.3)]"
+                        : "text-white/55 hover:text-white/85"
+                    }`}
+                  >
+                    <span
+                      className="inline-block h-[7px] w-[7px] flex-shrink-0 rounded-full"
+                      style={{ background: k.color }}
+                    />
+                    {k.label}
+                  </button>
+                );
+              })}
             </div>
-            <p className="mt-1 text-xs text-white/45">
-              Double-click a node from Cards to keep exploring the report graph.
-            </p>
           </div>
-          <div className="flex items-center gap-2 font-mono text-[11px] text-white/45">
-            <span>{graph.nodes.length} nodes</span>
-            <span>{graph.edges.length} edges</span>
+          <div className="flex flex-wrap items-center gap-2 font-mono text-[11px] text-white/50">
+            <span className="rounded border border-white/[0.08] bg-white/[0.03] px-1.5 py-0.5">
+              {graph.nodes.length} nodes
+            </span>
+            <span className="rounded border border-white/[0.08] bg-white/[0.03] px-1.5 py-0.5">
+              {graph.edges.length} edges
+            </span>
+            <button
+              type="button"
+              onClick={() => recenter(rootUri)}
+              title="Recenter on report root"
+              className="inline-flex items-center gap-1 rounded-[7px] border border-white/[0.08] bg-white/[0.04] px-2.5 py-1 text-[11px] font-semibold text-white/70 transition-colors hover:border-[#d97757]/60 hover:bg-[#d97757]/10 hover:text-[#e59579]"
+            >
+              Recenter
+            </button>
           </div>
         </div>
-        <svg
-          viewBox="0 0 900 560"
-          className="h-full max-h-[calc(100vh-190px)] min-h-[420px] w-full rounded-lg border border-white/[0.06] bg-[#0d1117]"
-          role="img"
-          aria-label="Report relationship map"
-        >
-          <defs>
-            <radialGradient id="report-map-glow" cx="50%" cy="50%" r="50%">
-              <stop offset="0%" stopColor="rgba(217,119,87,0.16)" />
-              <stop offset="100%" stopColor="rgba(217,119,87,0)" />
-            </radialGradient>
-            <pattern id="report-map-grid" width="24" height="24" patternUnits="userSpaceOnUse">
-              <path d="M24 0 L0 0 0 24" fill="none" stroke="rgba(255,255,255,0.035)" strokeWidth="1" />
-            </pattern>
-          </defs>
-          <rect width="900" height="560" fill="url(#report-map-grid)" />
-          <circle cx="450" cy="280" r="235" fill="url(#report-map-glow)" />
-          <circle cx="450" cy="280" r="190" fill="none" stroke="rgba(255,255,255,0.07)" strokeDasharray="2 6" />
 
-          {graph.edges.map((edge) => {
-            const from = graph.nodes.find((node) => node.uri === edge.from);
-            const to = graph.nodes.find((node) => node.uri === edge.to);
-            if (!from || !to) return null;
-            const active = selected?.uri === edge.from || selected?.uri === edge.to;
-            return (
-              <line
-                key={`${edge.from}-${edge.to}`}
-                x1={from.x}
-                y1={from.y}
-                x2={to.x}
-                y2={to.y}
-                stroke={active ? "#d97757" : "rgba(255,255,255,0.2)"}
-                strokeWidth={active ? 2.2 : 1.2}
-                strokeLinecap="round"
-              />
-            );
-          })}
+        {/* SVG viewport */}
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          <svg
+            viewBox={`0 0 ${W} ${H}`}
+            preserveAspectRatio="xMidYMid meet"
+            className="block h-full w-full select-none"
+            role="img"
+            aria-label="Report relationship map"
+          >
+            <defs>
+              <radialGradient id="map-glow" cx="50%" cy="50%" r="50%">
+                <stop offset="0%" stopColor="rgba(217,119,87,0.18)" />
+                <stop offset="100%" stopColor="rgba(217,119,87,0)" />
+              </radialGradient>
+              <pattern id="map-grid" width="24" height="24" patternUnits="userSpaceOnUse">
+                <path d="M24 0 L0 0 0 24" fill="none" stroke="rgba(255,255,255,0.035)" strokeWidth="1" />
+              </pattern>
+            </defs>
 
-          {graph.nodes.map((node) => {
-            const active = selected?.uri === node.uri;
-            const radius = node.ring === 0 ? 42 : 31;
-            return (
-              <g
-                key={node.uri}
-                role="button"
-                tabIndex={0}
-                onClick={() => setSelectedUri(node.uri)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    setSelectedUri(node.uri);
-                  }
-                }}
-                className="cursor-pointer outline-none"
-              >
-                <circle
-                  cx={node.x}
-                  cy={node.y}
-                  r={radius + (active ? 7 : 3)}
-                  fill="rgba(255,255,255,0.08)"
-                  stroke={active ? "#d97757" : "rgba(255,255,255,0.1)"}
-                />
-                <circle cx={node.x} cy={node.y} r={radius} fill={mapNodeColor(node.kind)} />
-                <text
-                  x={node.x}
-                  y={node.y + 4}
-                  textAnchor="middle"
-                  fontSize={node.ring === 0 ? 13 : 11}
-                  fontWeight="800"
-                  fill="#fffaf0"
+            {/* Background grid + root glow + ring guides */}
+            <rect width={W} height={H} fill="url(#map-grid)" />
+            <circle cx={CX} cy={CY} r={R1 + 40} fill="url(#map-glow)" />
+            <circle cx={CX} cy={CY} r={R1} fill="none" stroke="rgba(255,255,255,0.06)" strokeDasharray="2 5" strokeWidth="1" />
+            <circle cx={CX} cy={CY} r={R2} fill="none" stroke="rgba(255,255,255,0.04)" strokeDasharray="2 5" strokeWidth="1" />
+
+            {/* Edges */}
+            {graph.edges.map((e, i) => {
+              const a = graph.nodes.find((n) => n.uri === e.from);
+              const b = graph.nodes.find((n) => n.uri === e.to);
+              if (!a || !b) return null;
+              const dim = !kindVisible(a.kind) || !kindVisible(b.kind);
+              const highlight = hoverUri && (hoverUri === e.from || hoverUri === e.to);
+              const mx = (a.x + b.x) / 2;
+              const my = (a.y + b.y) / 2;
+              const c = mapEdgeColor(e.relationKind);
+              return (
+                <g key={`${e.from}-${e.to}-${i}`} opacity={dim ? 0.15 : highlight ? 1 : 0.75}>
+                  <line
+                    x1={a.x}
+                    y1={a.y}
+                    x2={b.x}
+                    y2={b.y}
+                    stroke={c}
+                    strokeWidth={highlight ? 2.2 : e.primary ? 1.6 : 1.1}
+                    strokeLinecap="round"
+                    strokeDasharray={e.primary ? "" : "3 4"}
+                  />
+                  {e.primary && (
+                    <g transform={`translate(${mx}, ${my})`}>
+                      <rect x={-36} y={-8} width={72} height={16} rx={8} fill="#151413" stroke={c} strokeWidth="1" />
+                      <text
+                        x={0}
+                        y={3}
+                        textAnchor="middle"
+                        fontSize="10"
+                        fontWeight="600"
+                        fontFamily="'JetBrains Mono', monospace"
+                        fill={c}
+                      >
+                        {e.label}
+                      </text>
+                    </g>
+                  )}
+                </g>
+              );
+            })}
+
+            {/* Nodes */}
+            {graph.nodes.map((n) => {
+              const isRoot = n.ring === 0;
+              const isSelected = n.uri === resolvedSelectedUri && !isRoot;
+              const isHover = n.uri === hoverUri;
+              const dim = !kindVisible(n.kind);
+              const r = isRoot ? 42 : n.ring === 1 ? 30 : 22;
+              const color = mapNodeColor(n.kind);
+
+              return (
+                <g
+                  key={n.uri}
+                  transform={`translate(${n.x}, ${n.y})`}
+                  style={{
+                    cursor: "pointer",
+                    opacity: dim ? 0.22 : 1,
+                    transition: "opacity 200ms",
+                  }}
+                  onMouseEnter={() => setHoverUri(n.uri)}
+                  onMouseLeave={() => setHoverUri(null)}
+                  onClick={(ev) => (ev.shiftKey ? selectNode(n.uri) : recenter(n.uri))}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(ev) => {
+                    if (ev.key === "Enter" || ev.key === " ") {
+                      ev.preventDefault();
+                      if (ev.shiftKey) selectNode(n.uri);
+                      else recenter(n.uri);
+                    }
+                  }}
+                  aria-label={`${n.title} (${n.kind})`}
                 >
-                  {node.initials}
-                </text>
-                <text x={node.x} y={node.y + radius + 18} textAnchor="middle" fontSize="12" fontWeight="700" fill="#f8fafc">
-                  {shortMapTitle(node.title)}
-                </text>
-                <text x={node.x} y={node.y + radius + 32} textAnchor="middle" fontSize="10" fill="rgba(248,250,252,0.52)">
-                  {node.kind}
-                </text>
-              </g>
-            );
-          })}
-        </svg>
+                  {/* Halo on hover / selected / root */}
+                  {(isHover || isSelected || isRoot) && (
+                    <circle
+                      r={r + 8}
+                      fill="none"
+                      stroke={isRoot ? "#d97757" : color}
+                      strokeWidth={isRoot ? 2.4 : 1.6}
+                      strokeOpacity={0.45}
+                    />
+                  )}
+
+                  <circle r={r} fill={color} />
+                  <circle r={r} fill="none" stroke="rgba(255,255,255,0.85)" strokeWidth="1.5" />
+
+                  {/* Avatar / initials */}
+                  <text
+                    y={4}
+                    textAnchor="middle"
+                    fontSize={isRoot ? 16 : n.ring === 1 ? 12 : 10}
+                    fontWeight="700"
+                    fontFamily="'JetBrains Mono', monospace"
+                    fill="#fffaf0"
+                  >
+                    {n.initials}
+                  </text>
+
+                  {/* Label below */}
+                  <g transform={`translate(0, ${r + 18})`}>
+                    <text
+                      textAnchor="middle"
+                      fontSize={isRoot ? 13 : 11.5}
+                      fontWeight={isRoot ? 700 : 600}
+                      fontFamily="Manrope, Inter, sans-serif"
+                      fill="#f8fafc"
+                    >
+                      {shortMapTitle(n.title)}
+                    </text>
+                    <text
+                      y={14}
+                      textAnchor="middle"
+                      fontSize={9.5}
+                      fontFamily="'JetBrains Mono', monospace"
+                      fill="rgba(248,250,252,0.52)"
+                      letterSpacing="0.05em"
+                    >
+                      {n.kind.toUpperCase()}
+                    </text>
+                  </g>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+
+        {/* Helper strip */}
+        <div className="flex flex-shrink-0 flex-wrap gap-3.5 border-t border-white/[0.06] bg-white/[0.02] px-3.5 py-2 font-mono text-[10.5px] text-white/40">
+          <span>
+            <kbd className="rounded border border-white/[0.08] border-b-2 bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-white/60">
+              Click
+            </kbd>{" "}
+            recenter
+          </span>
+          <span>
+            <kbd className="rounded border border-white/[0.08] border-b-2 bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-white/60">
+              Shift
+            </kbd>
+            +
+            <kbd className="ml-1 rounded border border-white/[0.08] border-b-2 bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-white/60">
+              Click
+            </kbd>{" "}
+            inspect
+          </span>
+          <span>Dashed edges = 2nd-degree relation</span>
+        </div>
       </section>
 
-      <aside className="min-h-0 overflow-y-auto border-l border-white/[0.06] bg-white/[0.02] p-4">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
-          Selected node
-        </div>
+      {/* ── Side panel ── */}
+      <aside className="flex min-h-0 flex-col gap-3.5 overflow-y-auto rounded-[14px] border border-white/[0.06] bg-white/[0.02] p-4 shadow-[0_1px_2px_rgba(0,0,0,0.25),0_8px_24px_rgba(0,0,0,0.35)]">
         {selected ? (
-          <div className="mt-3">
-            <h2 className="text-lg font-semibold text-white">{selected.title}</h2>
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              <span className="rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[11px] text-white/60">
+          <>
+            <header className="flex items-center gap-2.5 border-b border-white/[0.06] pb-3.5">
+              <div
+                className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg font-mono text-[13px] font-bold text-white"
+                style={{ background: mapNodeColor(selected.kind) }}
+              >
+                {selected.initials}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-[15px] font-bold tracking-tight text-white">
+                  {selected.title}
+                </div>
+                <div className="mt-0.5 text-[11.5px] text-white/50">
+                  {selected.kind} · {selected.confidence}% confidence
+                </div>
+              </div>
+              <span className="rounded border border-white/[0.08] bg-white/[0.03] px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-white/55">
                 {selected.kind}
               </span>
-              <span className="rounded border border-[#d97757]/25 bg-[#d97757]/10 px-2 py-1 text-[11px] text-[#e59579]">
-                {selected.confidence}% confidence
-              </span>
-            </div>
-            <p className="mt-4 text-sm leading-6 text-white/60">
-              {selected.summary || "No summary surfaced for this node yet."}
-            </p>
-          </div>
-        ) : null}
+            </header>
+
+            <section className="flex flex-col gap-2">
+              <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-white/40">
+                Summary
+              </div>
+              <p className="text-xs leading-5 text-white/65">
+                {selected.summary || "No summary surfaced for this node yet."}
+              </p>
+            </section>
+
+            <section className="flex flex-col gap-2">
+              <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-white/40">
+                Connected to
+              </div>
+              <div className="flex flex-col gap-1">
+                {graph.neighborsOf(selected.uri).length === 0 ? (
+                  <div className="px-1 py-2.5 text-[11px] italic text-white/40">
+                    No connections recorded yet.
+                  </div>
+                ) : (
+                  graph.neighborsOf(selected.uri).map((n) => (
+                    <button
+                      key={n.uri}
+                      type="button"
+                      onClick={() => recenter(n.uri)}
+                      onMouseEnter={() => setHoverUri(n.uri)}
+                      onMouseLeave={() => setHoverUri(null)}
+                      className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-white/[0.04]"
+                    >
+                      <span
+                        className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-[5px] font-mono text-[9.5px] font-bold text-white"
+                        style={{ background: mapNodeColor(n.kind) }}
+                      >
+                        {n.initials}
+                      </span>
+                      <span className="flex min-w-0 flex-1 flex-col gap-px">
+                        <span className="truncate text-[12.5px] font-semibold text-white">
+                          {n.title}
+                        </span>
+                        <span
+                          className="font-mono text-[10px] font-semibold tracking-wide"
+                          style={{ color: mapEdgeColor(n.relationKind) }}
+                        >
+                          {n.relationLabel}
+                        </span>
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </section>
+          </>
+        ) : (
+          <div className="text-sm text-white/40">Select a node to inspect.</div>
+        )}
       </aside>
     </div>
   );
 }
 
-type SimpleMapNode = {
+// ---------------------------------------------------------------------------
+// Map types + helpers
+// ---------------------------------------------------------------------------
+
+type MapNodeKind =
+  | "company"
+  | "person"
+  | "product"
+  | "event"
+  | "topic"
+  | "source"
+  | "claim"
+  | "regulation"
+  | "investor"
+  | "market";
+
+type MapRelationKind =
+  | "peer"
+  | "investor"
+  | "compete"
+  | "reg"
+  | "person"
+  | "sector";
+
+interface MapNode {
   uri: ResourceUri;
   title: string;
-  kind: string;
+  kind: MapNodeKind;
   summary: string;
   confidence: number;
   initials: string;
   ring: number;
   x: number;
   y: number;
-};
-
-type SimpleMapEdge = {
-  from: ResourceUri;
-  to: ResourceUri;
-};
-
-function buildSimpleMapGraph(cards: ReadonlyArray<ResourceCard>, rootUri: ResourceUri) {
-  const byUri = new Map<ResourceUri, ResourceCard>();
-  for (const card of cards) byUri.set(card.uri, card);
-  const root = byUri.get(rootUri) ?? cards[0];
-  if (!root) return { nodes: [] as SimpleMapNode[], edges: [] as SimpleMapEdge[] };
-
-  const relatedUris =
-    root.nextHops?.length
-      ? root.nextHops
-      : cards.filter((card) => card.uri !== root.uri).slice(0, 8).map((card) => card.uri);
-  const relatedCards = relatedUris.map((uri) => byUri.get(uri) ?? makeSyntheticMapCard(uri)).slice(0, 8);
-  const nodes: SimpleMapNode[] = [toSimpleMapNode(root, 0, 450, 280)];
-  relatedCards.forEach((card, index) => {
-    const angle = (index / Math.max(relatedCards.length, 1)) * Math.PI * 2 - Math.PI / 2;
-    nodes.push(
-      toSimpleMapNode(card, 1, 450 + Math.cos(angle) * 190, 280 + Math.sin(angle) * 190),
-    );
-  });
-  const edges = relatedCards.map((card) => ({ from: root.uri, to: card.uri }));
-  return { nodes, edges };
 }
 
-function toSimpleMapNode(card: ResourceCard, ring: number, x: number, y: number): SimpleMapNode {
+interface MapEdge {
+  from: ResourceUri;
+  to: ResourceUri;
+  label: string;
+  relationKind: MapRelationKind;
+  primary: boolean;
+}
+
+interface MapNeighbor {
+  uri: ResourceUri;
+  title: string;
+  kind: MapNodeKind;
+  initials: string;
+  relationLabel: string;
+  relationKind: MapRelationKind;
+}
+
+interface MapGraph {
+  rootUri: ResourceUri;
+  nodes: ReadonlyArray<MapNode>;
+  edges: ReadonlyArray<MapEdge>;
+  byUri: Map<ResourceUri, ResourceCard>;
+  neighborsOf: (uri: ResourceUri) => ReadonlyArray<MapNeighbor>;
+}
+
+const MAP_KINDS: ReadonlyArray<{ k: MapNodeKind | "all"; label: string; color: string }> = [
+  { k: "all", label: "All", color: "#64748b" },
+  { k: "company", label: "Companies", color: "#0f4c81" },
+  { k: "investor", label: "Investors", color: "#7a50b8" },
+  { k: "person", label: "People", color: "#475569" },
+  { k: "topic", label: "Topics", color: "#c77826" },
+  { k: "regulation", label: "Regulation", color: "#0e7a5c" },
+];
+
+/** Derive one-hop neighbours from a card. Prefer `nextHops`; fall back to
+ *  `evidenceRefs`; return an empty list otherwise. */
+function cardEdgesOut(card: ResourceCard | undefined): ReadonlyArray<ResourceUri> {
+  if (!card) return [];
+  if (card.nextHops && card.nextHops.length > 0) return card.nextHops;
+  if (card.evidenceRefs && card.evidenceRefs.length > 0) return card.evidenceRefs;
+  return [];
+}
+
+function buildMapGraph(
+  cards: ReadonlyArray<ResourceCard>,
+  currentRootUri: ResourceUri,
+  fallbackRootUri: ResourceUri,
+): MapGraph {
+  const byUri = new Map<ResourceUri, ResourceCard>();
+  for (const card of cards) byUri.set(card.uri, card);
+
+  const root = byUri.get(currentRootUri) ?? byUri.get(fallbackRootUri) ?? cards[0];
+  if (!root) {
+    return {
+      rootUri: currentRootUri,
+      nodes: [],
+      edges: [],
+      byUri,
+      neighborsOf: () => [],
+    };
+  }
+
+  // First ring: neighbours of root (capped at 8 for legibility)
+  const neighborUrisRaw = cardEdgesOut(root);
+  const neighborUris =
+    neighborUrisRaw.length > 0
+      ? neighborUrisRaw.slice(0, 8)
+      : // fallback: other cards in the report
+        cards
+          .filter((c) => c.uri !== root.uri)
+          .slice(0, 8)
+          .map((c) => c.uri);
+
+  // Second ring: neighbours-of-neighbours excluding root + first ring (cap 6)
+  const secondRingSet = new Set<ResourceUri>();
+  neighborUris.forEach((nid) => {
+    const nbCard = byUri.get(nid);
+    cardEdgesOut(nbCard).forEach((sid) => {
+      if (sid !== root.uri && !neighborUris.includes(sid)) {
+        secondRingSet.add(sid);
+      }
+    });
+  });
+  const secondRing = Array.from(secondRingSet).slice(0, 6);
+
+  // Canvas constants (match kit)
+  const W = 900;
+  const H = 620;
+  const CX = W / 2;
+  const CY = H / 2;
+  const R1 = 200;
+  const R2 = 285;
+
+  const nodes: MapNode[] = [];
+  nodes.push(toMapNode(root, 0, CX, CY));
+
+  const N1 = neighborUris.length;
+  neighborUris.forEach((uri, i) => {
+    const card = byUri.get(uri) ?? makeSyntheticMapCard(uri);
+    const angle = (i / Math.max(N1, 1)) * Math.PI * 2 - Math.PI / 2;
+    nodes.push(toMapNode(card, 1, CX + Math.cos(angle) * R1, CY + Math.sin(angle) * R1));
+  });
+
+  const N2 = secondRing.length;
+  secondRing.forEach((uri, i) => {
+    const card = byUri.get(uri) ?? makeSyntheticMapCard(uri);
+    const angle = (i / Math.max(N2, 1)) * Math.PI * 2 + Math.PI / Math.max(N2, 1);
+    nodes.push(toMapNode(card, 2, CX + Math.cos(angle) * R2, CY + Math.sin(angle) * R2));
+  });
+
+  const posOf = (uri: ResourceUri) => nodes.find((n) => n.uri === uri);
+
+  const edges: MapEdge[] = [];
+  neighborUris.forEach((nid) => {
+    if (posOf(nid)) {
+      const rel = relationFor(root, byUri.get(nid));
+      edges.push({ from: root.uri, to: nid, label: rel.label, relationKind: rel.kind, primary: true });
+    }
+    const nbCard = byUri.get(nid);
+    cardEdgesOut(nbCard).forEach((sid) => {
+      if (secondRing.includes(sid) && posOf(sid)) {
+        const rel = relationFor(nbCard, byUri.get(sid));
+        edges.push({ from: nid, to: sid, label: rel.label, relationKind: rel.kind, primary: false });
+      }
+    });
+  });
+
+  const neighborsOf = (uri: ResourceUri): ReadonlyArray<MapNeighbor> => {
+    const seen = new Set<ResourceUri>();
+    const out: MapNeighbor[] = [];
+    edges.forEach((e) => {
+      let otherUri: ResourceUri | null = null;
+      if (e.from === uri) otherUri = e.to;
+      else if (e.to === uri) otherUri = e.from;
+      if (!otherUri || seen.has(otherUri)) return;
+      const node = nodes.find((n) => n.uri === otherUri);
+      if (!node) return;
+      seen.add(otherUri);
+      out.push({
+        uri: node.uri,
+        title: node.title,
+        kind: node.kind,
+        initials: node.initials,
+        relationLabel: e.label,
+        relationKind: e.relationKind,
+      });
+    });
+    return out;
+  };
+
+  return { rootUri: root.uri, nodes, edges, byUri, neighborsOf };
+}
+
+function toMapNode(card: ResourceCard, ring: number, x: number, y: number): MapNode {
   return {
     uri: card.uri,
     title: card.title,
     kind: mapNodeKind(card.kind, card.uri),
     summary: card.summary,
     confidence: Math.round(card.confidence * 100),
-    initials: card.title
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((part) => part[0])
-      .join("")
-      .slice(0, 2)
-      .toUpperCase(),
+    initials: initialsFromTitle(card.title),
     ring,
     x,
     y,
   };
+}
+
+function initialsFromTitle(title: string) {
+  const parts = title.split(/\s+/).filter(Boolean);
+  const initials = parts.map((p) => p[0]).join("").slice(0, 2).toUpperCase();
+  return initials || title.slice(0, 2).toUpperCase();
 }
 
 function makeSyntheticMapCard(uri: ResourceUri): ResourceCard {
@@ -910,14 +1303,18 @@ function makeSyntheticMapCard(uri: ResourceUri): ResourceCard {
   return {
     cardId: `synthetic:${uri}`,
     uri,
-    kind: uri.includes("person") ? "person_summary" : uri.includes("topic") ? "topic_summary" : "org_summary",
+    kind: uri.includes("person")
+      ? "person_summary"
+      : uri.includes("topic")
+        ? "topic_summary"
+        : "org_summary",
     title: label.replace(/\b\w/g, (char) => char.toUpperCase()),
     summary: "Related resource surfaced as a next hop.",
     confidence: 0.5,
   };
 }
 
-function mapNodeKind(kind: ResourceCard["kind"], uri: ResourceUri) {
+function mapNodeKind(kind: ResourceCard["kind"], uri: ResourceUri): MapNodeKind {
   if (kind.includes("person") || uri.includes("person")) return "person";
   if (kind.includes("product") || uri.includes("product")) return "product";
   if (kind.includes("event") || uri.includes("event")) return "event";
@@ -927,35 +1324,74 @@ function mapNodeKind(kind: ResourceCard["kind"], uri: ResourceUri) {
   return "company";
 }
 
-function mapNodeColor(kind: string) {
-  if (kind === "company") return "#0f4c81";
-  if (kind === "person") return "#475569";
-  if (kind === "product") return "#7a50b8";
-  if (kind === "event") return "#0e7a5c";
-  if (kind === "topic") return "#c77826";
-  if (kind === "source") return "#64748b";
-  if (kind === "claim") return "#d97757";
-  return "#64748b";
+function mapNodeColor(kind: MapNodeKind) {
+  switch (kind) {
+    case "company":
+      return "#0f4c81";
+    case "investor":
+      return "#7a50b8";
+    case "market":
+      return "#c77826";
+    case "regulation":
+      return "#0e7a5c";
+    case "person":
+      return "#475569";
+    case "product":
+      return "#7a50b8";
+    case "event":
+      return "#0e7a5c";
+    case "topic":
+      return "#c77826";
+    case "source":
+      return "#64748b";
+    case "claim":
+      return "#d97757";
+    default:
+      return "#64748b";
+  }
+}
+
+function mapEdgeColor(kind: MapRelationKind) {
+  switch (kind) {
+    case "investor":
+      return "#a88ad4";
+    case "compete":
+      return "#d97757";
+    case "reg":
+      return "#22b085";
+    case "person":
+      return "#94a3b8";
+    case "sector":
+      return "#e09149";
+    default:
+      return "#b8b2a5";
+  }
+}
+
+/** Heuristic relation label derived from the two endpoint cards' kinds.
+ *  The kit uses a hand-curated RELATION_LABELS map keyed by id pairs; we
+ *  approximate that with a kind-product lookup since prod cards don't carry
+ *  relation labels in the schema yet. */
+function relationFor(
+  from: ResourceCard | undefined,
+  to: ResourceCard | undefined,
+): { label: string; kind: MapRelationKind } {
+  if (!from || !to) return { label: "related", kind: "peer" };
+  const a = mapNodeKind(from.kind, from.uri);
+  const b = mapNodeKind(to.kind, to.uri);
+  const pair = [a, b].sort().join("+");
+  if (pair.includes("regulation")) return { label: "regulated by", kind: "reg" };
+  if (pair.includes("investor")) return { label: "invests in", kind: "investor" };
+  if (pair.includes("market")) return { label: "operates in", kind: "sector" };
+  if (pair.includes("person")) return { label: "affiliated", kind: "person" };
+  if (a === "company" && b === "company") return { label: "competitor", kind: "compete" };
+  if (pair.includes("topic")) return { label: "tagged", kind: "sector" };
+  return { label: "related", kind: "peer" };
 }
 
 function shortMapTitle(title: string) {
   const normalized = title.replace(/\s+/g, " ").trim();
   return normalized.length > 22 ? `${normalized.slice(0, 20).trim()}...` : normalized;
-}
-
-function LegacyMapTab() {
-  return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
-      <span className="rounded bg-white/[0.04] px-2 py-1 text-[10px] uppercase tracking-wide text-white/50">
-        v2
-      </span>
-      <h2 className="text-sm font-semibold text-white">Map view coming in v2</h2>
-      <p className="max-w-md text-xs text-white/50">
-        The canonical entity graph is live in v1 — use the Cards tab to explore.
-        Force-directed mapping ships once the ontology is proven on real dossiers.
-      </p>
-    </div>
-  );
 }
 
 function SourcesTab({ cards }: { cards: ReadonlyArray<ResourceCard> }) {

--- a/src/features/workspace/data/scenarioCatalog.ts
+++ b/src/features/workspace/data/scenarioCatalog.ts
@@ -162,7 +162,7 @@ export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
     realLifeInput:
       "Met Alex from Orbital Labs. Voice agent eval infra, seed, wants healthcare design partners.",
     inferredIntent: "capture_field_note",
-    target: "active_event",
+    target: "active_event_session",
     structuredOutput: [
       "Entities: Alex, Orbital Labs, voice agent eval infra, healthcare",
       "Claims: Orbital Labs builds voice-agent eval infra; looking for healthcare design partners",
@@ -207,7 +207,7 @@ export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
     realLifeInput:
       "Ten startups from Ship Demo Day. Need clusters by market, unverified traction claims, and founder follow-ups.",
     inferredIntent: "expand_entity",
-    target: "active_event",
+    target: "active_event_session",
     structuredOutput: [
       "Entities: startups, markets, founders, traction claims",
       "Edges: company to market, founder to company, claim to evidence",
@@ -232,4 +232,3 @@ export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
     nextAction: ["Open cards", "Edit notebook", "Verify sources"],
   },
 ];
-

--- a/src/features/workspace/views/UniversalWorkspacePage.tsx
+++ b/src/features/workspace/views/UniversalWorkspacePage.tsx
@@ -3,11 +3,13 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import {
   BookOpen,
   Bot,
+  Clock,
   FileText,
   GitBranch,
   LayoutGrid,
   Map,
   MessageSquare,
+  MoreHorizontal,
   Search,
   Send,
   Share2,
@@ -25,7 +27,7 @@ import {
   SCENARIO_MATRIX,
 } from "@/features/workspace/data/scenarioCatalog";
 import {
-  buildLocalWorkspacePath,
+  buildWorkspaceRouteForHost,
   type WorkspaceTab,
 } from "@/features/workspace/lib/workspaceRouting";
 
@@ -36,12 +38,13 @@ type WorkspaceTabDef = {
   count?: number;
 };
 
+// Tab order matches docs/design/.../nodebench-workspace/ kit (Chat leads).
 const WORKSPACE_TABS: WorkspaceTabDef[] = [
+  { id: "chat", label: "Chat", icon: MessageSquare },
   { id: "brief", label: "Brief", icon: FileText },
   { id: "cards", label: "Cards", icon: LayoutGrid, count: 14 },
   { id: "notebook", label: "Notebook", icon: BookOpen },
   { id: "sources", label: "Sources", icon: ShieldCheck, count: 24 },
-  { id: "chat", label: "Chat", icon: MessageSquare },
   { id: "map", label: "Map", icon: Map },
 ];
 
@@ -111,7 +114,7 @@ export function UniversalWorkspacePage() {
   const activeScenario = HERO_SCENARIO_TESTS[0];
 
   const setActiveTab = (tab: WorkspaceTab) => {
-    navigate(buildLocalWorkspacePath({ workspaceId, tab }), { replace: true });
+    navigate(buildWorkspaceRouteForHost({ workspaceId, tab }), { replace: true });
   };
 
   return (
@@ -201,9 +204,25 @@ function WorkspaceHeader({
         <button
           type="button"
           className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
+          aria-label="History"
+          title="History"
+        >
+          <Clock size={15} />
+        </button>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
           aria-label="Search workspace"
         >
           <Search size={15} />
+        </button>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
+          aria-label="More"
+          title="More"
+        >
+          <MoreHorizontal size={15} />
         </button>
       </div>
     </header>
@@ -304,7 +323,7 @@ function BriefSurface() {
 function CardsSurface() {
   return (
     <SurfaceShell kicker="Cards" title="Recursive entities, claims, and next hops.">
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
         {SAMPLE_ENTITIES.map((entity) => (
           <Panel key={entity.name} className="min-h-[210px]">
             <div className="flex items-start justify-between gap-3">
@@ -578,7 +597,7 @@ function WorkspaceInspector({
         <div className="mt-4 rounded-md border border-black/[0.06] bg-[#f5f4f1] p-3 font-mono text-[11px] leading-6 text-gray-600">
           nodebenchai.com: Home / Reports / Chat / Inbox / Me
           <br />
-          workspace.nodebenchai.com: Brief / Cards / Notebook / Sources / Chat / Map
+          nodebench.workspace: Brief / Cards / Notebook / Sources / Chat / Map
         </div>
       </Panel>
 


### PR DESCRIPTION
## Summary
Replaces the legacy SimpleMap/LegacyMapTab stub with a full 1:1 port of [\`Map.jsx\`](docs/design/nodebench-ai-design-system/ui_kits/nodebench-workspace/Map.jsx) into the prod \`MapTab\` inside [\`ReportDetailWorkspace.tsx\`](src/features/research/views/ReportDetailWorkspace.tsx).

## What ships
- 2-ring constellation at R1=200, R2=285 on 900×620 canvas
- Root + one-hop + two-hop nodes (42/30/22px)
- Node/edge colors by kind & relation (kit palette)
- Hover, click-to-recenter, Shift+click inspect
- Kind-filter pill bar
- Side panel with Connected-to list

## Known gaps (schema-bound)
- Edge labels are kind-product heuristics — kit's \`RELATION_LABELS\` needs \`ResourceCard.relations[]\`
- Side-panel metrics grid needs \`ResourceCard.metrics[]\`
- Side-panel actions need \`setTab\` prop drill (tabs are URL-driven on prod)

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [ ] Post-merge live-smoke verifies no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)