### PR TITLE
feat(parity): round 3 — full kit→prod 1:1 sweep

### DIFF
--- a/docs/design/SCENARIO_COVERAGE.md
+++ b/docs/design/SCENARIO_COVERAGE.md
@@ -26,7 +26,7 @@ Inferred intent:
   capture_field_note / ask_question / append_to_report / create_followup / expand_entity
 
 Target:
-  current report / active event / inbox item / unassigned buffer
+  current report / active_event_session / inbox item / unassigned buffer
 
 Expected structured output:
   entities / claims / edges / follow-ups / evidence
@@ -48,7 +48,7 @@ Scenario:
 
 Expected:
   Intent: capture_field_note
-  Target: active event report
+  Target: active_event_session
   Entities: Alex, Orbital Labs, voice agent eval infra, healthcare
   Claims: Orbital Labs builds voice-agent eval infra;
           looking for healthcare design partners

--- a/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
+++ b/src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx
@@ -26,6 +26,7 @@ import { MemoryStatusHeader, type PlanItem } from './MemoryStatusHeader';
 import { ContextBar, type ContextConstraint } from './ContextBar';
 import { SwarmQuickActions } from './SwarmQuickActions';
 import { QuickCommandChips } from './QuickCommandChips';
+import { QuotePopover } from '@/features/chat/components/QuotePopover';
 
 // Tab-gated / conditional components — lazy-loaded on first use
 import type { DisclosureEvent } from './FastAgentPanel.DisclosureTrace';
@@ -3263,6 +3264,27 @@ export const FastAgentPanel = memo(function FastAgentPanel({
                       estimatedItemHeight={150}
                     />
                   </MessageHandlersProvider>
+
+                  {/* Quote popover — appears on text selection inside assistant messages.
+                      Ports the nb-quote-pop behavior from docs/design/.../ChatThread.jsx:321-333. */}
+                  <QuotePopover
+                    containerRef={scrollContainerRef}
+                    onQuote={(text) => {
+                      const quoted = '> ' + text.replace(/\n/g, '\n> ') + '\n\n';
+                      setInput((prev) => quoted + (prev ?? ''));
+                      setTimeout(() => {
+                        const el = document.querySelector<HTMLTextAreaElement>('[placeholder="Message..."]');
+                        el?.focus();
+                      }, 20);
+                    }}
+                    onAskAbout={(text) => {
+                      setInput(`What about this: "${text}"?`);
+                      setTimeout(() => {
+                        const el = document.querySelector<HTMLTextAreaElement>('[placeholder="Message..."]');
+                        el?.focus();
+                      }, 20);
+                    }}
+                  />
 
                   {/* Queued Indicator */}
                   {(streamingThread as any)?.runStatus === 'queued' && (

--- a/src/features/chat/components/QuotePopover.tsx
+++ b/src/features/chat/components/QuotePopover.tsx
@@ -1,0 +1,266 @@
+// src/features/chat/components/QuotePopover.tsx
+//
+// QuotePopover — a floating selection-action popover for assistant messages.
+//
+// Ports the behavior of docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/
+// ChatThread.jsx lines 321-333 (the `nb-quote-pop` floating menu) to the production
+// FastAgentPanel / ChatHome surface.
+//
+// When the user selects text inside the mount container, a small glass card
+// appears near the selection with two pills:
+//   - "Quote to composer"  → prepends `> ${selection}\n\n` to the composer input
+//   - "Ask about this"     → fills composer with `About "${selection}" — can you explain more?`
+//
+// The popover closes on:
+//   - Selection cleared (mousedown outside the popover)
+//   - Scroll inside the container
+//   - Escape key
+//
+// Pattern: Floating menu on selection (see web kit ChatThread.jsx handleQuote).
+// Prior art:
+//   - ChatGPT / Perplexity quote-on-select popovers
+//   - Medium highlight-and-share toolbar
+//
+// See also: .claude/rules/reexamine_a11y.md (aria-label on icon buttons),
+//           .claude/rules/reexamine_keyboard.md (Escape to close, focus ring).
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export interface QuotePopoverSelection {
+  /** The selected text, trimmed. */
+  text: string;
+  /** Viewport-relative x coordinate (center of selection). */
+  x: number;
+  /** Viewport-relative y coordinate (top of selection). */
+  y: number;
+}
+
+export interface QuotePopoverProps {
+  /**
+   * The scrollable container whose selection events we listen to. The popover
+   * only opens when the selection anchor is inside this container.
+   */
+  containerRef: React.RefObject<HTMLElement | null>;
+  /**
+   * Called when the user clicks "Quote to composer". Receives the raw selected
+   * text (the consumer is responsible for formatting, e.g. prepending `> `).
+   */
+  onQuote: (text: string) => void;
+  /**
+   * Called when the user clicks "Ask about this". Receives the raw selected
+   * text (the consumer is responsible for wording the prompt).
+   */
+  onAskAbout: (text: string) => void;
+  /**
+   * Minimum selection length before the popover appears. Defaults to 3.
+   * Matches the kit's `text.length < 3` guard in ChatThread.jsx:161.
+   */
+  minLength?: number;
+  /**
+   * When true, disables the popover entirely (e.g. on mobile where the native
+   * text-selection UI is more useful).
+   */
+  disabled?: boolean;
+}
+
+/**
+ * Returns true if `node` is a descendant of `container` (handles text nodes).
+ */
+function isInsideContainer(node: Node | null, container: HTMLElement | null): boolean {
+  if (!node || !container) return false;
+  let current: Node | null = node.nodeType === Node.TEXT_NODE ? node.parentNode : node;
+  while (current) {
+    if (current === container) return true;
+    current = current.parentNode;
+  }
+  return false;
+}
+
+export function QuotePopover({
+  containerRef,
+  onQuote,
+  onAskAbout,
+  minLength = 3,
+  disabled = false,
+}: QuotePopoverProps): React.ReactElement | null {
+  const [selection, setSelection] = useState<QuotePopoverSelection | null>(null);
+  const popRef = useRef<HTMLDivElement | null>(null);
+
+  const close = useCallback(() => setSelection(null), []);
+
+  // Capture a selection when it's inside the mount container.
+  const captureSelection = useCallback(() => {
+    if (disabled) return;
+    const sel = typeof window !== 'undefined' ? window.getSelection() : null;
+    const text = sel ? sel.toString().trim() : '';
+    if (!text || text.length < minLength || !sel || sel.rangeCount === 0) {
+      setSelection(null);
+      return;
+    }
+    const container = containerRef.current;
+    if (!container) {
+      setSelection(null);
+      return;
+    }
+    const range = sel.getRangeAt(0);
+    // Require the selection to be inside the container (don't trigger on
+    // selections in e.g. the composer or other surfaces).
+    if (!isInsideContainer(range.startContainer, container) || !isInsideContainer(range.endContainer, container)) {
+      setSelection(null);
+      return;
+    }
+    const rect = range.getBoundingClientRect();
+    if (!rect || (rect.width === 0 && rect.height === 0)) {
+      setSelection(null);
+      return;
+    }
+    setSelection({
+      text,
+      x: rect.left + rect.width / 2,
+      y: rect.top,
+    });
+  }, [containerRef, disabled, minLength]);
+
+  // Listen for selection end on the container.
+  useEffect(() => {
+    if (disabled) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const onEnd = () => {
+      // Defer so window.getSelection() reflects the final selection state.
+      setTimeout(captureSelection, 0);
+    };
+    container.addEventListener('mouseup', onEnd);
+    container.addEventListener('touchend', onEnd);
+    return () => {
+      container.removeEventListener('mouseup', onEnd);
+      container.removeEventListener('touchend', onEnd);
+    };
+  }, [captureSelection, containerRef, disabled]);
+
+  // Close on outside mousedown, container scroll, or Escape.
+  useEffect(() => {
+    if (!selection) return;
+    const onDocMouseDown = (ev: MouseEvent) => {
+      if (popRef.current && ev.target instanceof Node && popRef.current.contains(ev.target)) {
+        return; // click was inside the popover — keep it open
+      }
+      close();
+    };
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') close();
+    };
+    const container = containerRef.current;
+    window.addEventListener('mousedown', onDocMouseDown);
+    window.addEventListener('keydown', onKey);
+    container?.addEventListener('scroll', close);
+    window.addEventListener('scroll', close, true);
+    return () => {
+      window.removeEventListener('mousedown', onDocMouseDown);
+      window.removeEventListener('keydown', onKey);
+      container?.removeEventListener('scroll', close);
+      window.removeEventListener('scroll', close, true);
+    };
+  }, [close, containerRef, selection]);
+
+  const clearNativeSelection = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      window.getSelection()?.removeAllRanges();
+    }
+  }, []);
+
+  const handleQuote = useCallback(() => {
+    if (!selection) return;
+    onQuote(selection.text);
+    setSelection(null);
+    clearNativeSelection();
+  }, [clearNativeSelection, onQuote, selection]);
+
+  const handleAskAbout = useCallback(() => {
+    if (!selection) return;
+    onAskAbout(selection.text);
+    setSelection(null);
+    clearNativeSelection();
+  }, [clearNativeSelection, onAskAbout, selection]);
+
+  // Clamp the popover to the viewport so it doesn't overflow.
+  const style = useMemo<React.CSSProperties | undefined>(() => {
+    if (!selection) return undefined;
+    // Position above the selection, centered, with a small gap. The popover
+    // uses `translate(-50%, -100%)` so the coordinates are the anchor point.
+    const gap = 8;
+    const top = Math.max(8, selection.y - gap);
+    const left = Math.max(80, Math.min(selection.x, (typeof window !== 'undefined' ? window.innerWidth : 1024) - 80));
+    return {
+      position: 'fixed',
+      top,
+      left,
+      transform: 'translate(-50%, -100%)',
+      zIndex: 60,
+    };
+  }, [selection]);
+
+  if (!selection) return null;
+
+  return (
+    <div
+      ref={popRef}
+      role="menu"
+      aria-label="Quote actions"
+      style={style}
+      // Stop the mousedown from propagating to our window-level close handler.
+      onMouseDown={(e) => e.stopPropagation()}
+      className={[
+        'flex items-center gap-1',
+        'rounded-full border border-white/[0.08]',
+        'bg-[#1a1a1a]/95 backdrop-blur-md',
+        'shadow-[0_8px_24px_rgba(0,0,0,0.45)]',
+        'px-1 py-1',
+        'animate-in fade-in zoom-in-95 duration-150 motion-reduce:animate-none',
+      ].join(' ')}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={handleQuote}
+        aria-label="Quote selection to composer"
+        className={[
+          'inline-flex items-center gap-1.5',
+          'px-2.5 py-1 rounded-full',
+          'text-[11px] font-medium text-white/90',
+          'hover:bg-white/[0.08] active:bg-white/[0.12]',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]/60',
+          'transition-colors',
+        ].join(' ')}
+      >
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
+          <polyline points="9 17 4 12 9 7" />
+          <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
+        </svg>
+        Quote
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={handleAskAbout}
+        aria-label="Ask about selection"
+        className={[
+          'inline-flex items-center gap-1.5',
+          'px-2.5 py-1 rounded-full',
+          'text-[11px] font-medium text-white/90',
+          'hover:bg-white/[0.08] active:bg-white/[0.12]',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]/60',
+          'transition-colors',
+        ].join(' ')}
+      >
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" aria-hidden="true">
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+        </svg>
+        Ask about this
+      </button>
+    </div>
+  );
+}
+
+export default QuotePopover;

--- a/src/features/me/views/MobileMeSurface.tsx
+++ b/src/features/me/views/MobileMeSurface.tsx
@@ -235,8 +235,8 @@ export default function MobileMeSurface() {
                     idx !== QUICK_SETTINGS.length - 1 ? "border-b border-black/5" : ""
                   }`}
                 >
-                  <span className="flex h-8 w-8 flex-none items-center justify-center rounded-lg bg-[#f4f3f1] text-gray-600">
-                    <Icon size={15} strokeWidth={1.7} />
+                  <span className="flex h-8 w-8 flex-none items-center justify-center text-[#475569]">
+                    <Icon size={17} strokeWidth={1.7} />
                   </span>
                   <span className="flex-1 min-w-0">
                     <span className="block text-[12.5px] font-semibold text-gray-900">

--- a/src/features/notebook/components/RichNotebookEditor.tsx
+++ b/src/features/notebook/components/RichNotebookEditor.tsx
@@ -1,4 +1,20 @@
-import { useMemo, type ReactNode } from "react";
+/**
+ * RichNotebookEditor — TipTap-based notebook surface with kit parity.
+ *
+ * Features (1:1 parity with docs/design/nodebench-ai-design-system/ui_kits/
+ * nodebench-workspace/Notebook.jsx):
+ *   1. Slash command menu (type `/`, 8 items, arrow/enter/esc).
+ *   2. AI proposals (accept/dismiss inline via nb_proposal node).
+ *   3. Save-state indicator (green dot "Saved" / warn dot "Saving…",
+ *      900ms debounce matching kit markEdit).
+ *   4. Claim block with expand/collapse + evidence list (nb_claim node).
+ *
+ * The component stays backwards-compatible: existing callers that only
+ * pass { initialContent, storageKey, ... } still mount without a
+ * proposals[] or claims[] array. When those arrays are provided, they
+ * are seeded into the editor document on first mount.
+ */
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import {
@@ -14,6 +30,16 @@ import {
 import type { LucideIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { NbProposal, type ProposalAttrs } from "../extensions/nbProposal";
+import { NbClaim, type ClaimAttrs } from "../extensions/nbClaim";
+import { createSlashCommandExtension } from "../extensions/slashCommand";
+import { createSlashRenderer } from "../extensions/slashMenuRenderer";
+import "../styles/notebook.css";
+
+export type NotebookProposal = Omit<ProposalAttrs, "state"> & {
+  state?: ProposalAttrs["state"];
+};
+export type NotebookClaim = ClaimAttrs;
 
 type RichNotebookEditorProps = {
   initialContent: string;
@@ -23,6 +49,14 @@ type RichNotebookEditorProps = {
   editorClassName?: string;
   footer?: ReactNode;
   onChange?: (html: string) => void;
+  /** Optional AI proposals seeded at mount; rendered as nb_proposal nodes. */
+  proposals?: NotebookProposal[];
+  /** Optional claim blocks seeded at mount; rendered as nb_claim nodes. */
+  claims?: NotebookClaim[];
+  /** Debounce for "saved" → "saving" transition (default 900ms, matches kit). */
+  saveDebounceMs?: number;
+  /** Show the save-state indicator pill (default true). */
+  showSaveState?: boolean;
 };
 
 type ToolbarButton = {
@@ -52,6 +86,44 @@ function writeStoredNotebook(storageKey: string | undefined, html: string) {
   }
 }
 
+function buildSeedHtml(
+  initial: string,
+  proposals?: NotebookProposal[],
+  claims?: NotebookClaim[],
+) {
+  let html = initial;
+  if (proposals?.length) {
+    const rendered = proposals
+      .map((p) => {
+        const attrs = {
+          ...p,
+          state: p.state ?? "pending",
+        } satisfies ProposalAttrs;
+        return `<div data-type="nb-proposal" data-id="${encodeHtml(attrs.id)}" data-label="${encodeHtml(attrs.label)}" data-note="${encodeHtml(attrs.note)}" data-original-text="${encodeHtml(attrs.originalText)}" data-proposed-text="${encodeHtml(attrs.proposedText)}" data-state="${attrs.state}"></div>`;
+      })
+      .join("");
+    html += rendered;
+  }
+  if (claims?.length) {
+    const rendered = claims
+      .map((c) => {
+        const encoded = encodeHtml(JSON.stringify(c));
+        return `<div data-type="nb-claim" data-claim="${encoded}"></div>`;
+      })
+      .join("");
+    html += rendered;
+  }
+  return html;
+}
+
+function encodeHtml(s: string) {
+  return String(s)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
 export function RichNotebookEditor({
   initialContent,
   storageKey,
@@ -60,14 +132,32 @@ export function RichNotebookEditor({
   editorClassName,
   footer,
   onChange,
+  proposals,
+  claims,
+  saveDebounceMs = 900,
+  showSaveState = true,
 }: RichNotebookEditorProps) {
   const content = useMemo(
-    () => readStoredNotebook(storageKey, initialContent),
-    [initialContent, storageKey],
+    () => buildSeedHtml(readStoredNotebook(storageKey, initialContent), proposals, claims),
+    // Only seed once; subsequent proposals/claims updates should flow via the
+    // editor's own API to avoid resetting user edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const [saveState, setSaveState] = useState<"saved" | "saving">("saved");
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const slashExtension = useMemo(
+    () =>
+      createSlashCommandExtension({
+        render: createSlashRenderer,
+      }),
+    [],
   );
 
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [StarterKit, NbProposal, NbClaim, slashExtension],
     content,
     editorProps: {
       attributes: {
@@ -82,8 +172,19 @@ export function RichNotebookEditor({
       const html = activeEditor.getHTML();
       writeStoredNotebook(storageKey, html);
       onChange?.(html);
+      setSaveState("saving");
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        setSaveState("saved");
+      }, Math.max(120, saveDebounceMs));
     },
   });
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
 
   const buttons: ToolbarButton[] = editor
     ? [
@@ -170,6 +271,30 @@ export function RichNotebookEditor({
             </button>
           );
         })}
+        {showSaveState ? (
+          <div
+            className="nb-save-state ml-auto"
+            role="status"
+            aria-live="polite"
+            data-testid={`${testId}-save-state`}
+          >
+            <span
+              className="nb-save-dot"
+              style={{
+                background:
+                  saveState === "saved"
+                    ? "var(--success, #059669)"
+                    : "var(--warn, #b45309)",
+                boxShadow:
+                  saveState === "saved"
+                    ? "0 0 0 2px rgba(4,120,87,0.16)"
+                    : "0 0 0 2px rgba(180,83,9,0.16)",
+              }}
+              aria-hidden="true"
+            />
+            <span>{saveState === "saved" ? "Saved" : "Saving…"}</span>
+          </div>
+        ) : null}
       </div>
       <div className="border-l-2 border-[#d97757] pl-5">
         {editor ? (

--- a/src/features/notebook/extensions/nbClaim.tsx
+++ b/src/features/notebook/extensions/nbClaim.tsx
@@ -1,0 +1,133 @@
+/**
+ * nb_claim — claim block with expand/collapse + evidence list.
+ *
+ * Kit parity: Notebook.jsx lines 195-228, notebook.css .nb-claim*.
+ */
+import { useState } from "react";
+import {
+  Node,
+  mergeAttributes,
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+} from "@tiptap/react";
+import { Target, CheckCircle2, AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
+
+export type ClaimEvidence = {
+  n: number;
+  label: string;
+  kind: "support" | "conflict";
+};
+
+export type ClaimAttrs = {
+  statement: string;
+  support: number;
+  conflict: number;
+  evidence: ClaimEvidence[];
+  open: boolean;
+};
+
+function ClaimNodeView(props: {
+  node: { attrs: ClaimAttrs };
+  updateAttributes: (attrs: Partial<ClaimAttrs>) => void;
+}) {
+  const { statement, support, conflict, evidence, open: initialOpen } =
+    props.node.attrs;
+  const [localOpen, setLocalOpen] = useState<boolean>(initialOpen !== false);
+
+  const toggle = () => {
+    const next = !localOpen;
+    setLocalOpen(next);
+    props.updateAttributes({ open: next });
+  };
+
+  return (
+    <NodeViewWrapper as="div" className="nb-claim" data-type="nb-claim">
+      <div
+        className="nb-claim-head"
+        onClick={toggle}
+        role="button"
+        tabIndex={0}
+        aria-expanded={localOpen}
+        aria-controls="nb-claim-evidence"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        style={{ cursor: "pointer" }}
+      >
+        <Target className="h-3 w-3" aria-hidden="true" />
+        <span
+          className="kicker"
+          style={{ color: "var(--accent-ink, #ad5f45)" }}
+        >
+          Claim
+        </span>
+        <span className="nb-claim-status">
+          <span className="pill pill-ok" style={{ fontSize: 10 }}>
+            <CheckCircle2 className="inline h-2.5 w-2.5 mr-1" aria-hidden="true" />
+            {support} support
+          </span>
+          <span className="pill pill-warn" style={{ fontSize: 10 }}>
+            <AlertTriangle className="inline h-2.5 w-2.5 mr-1" aria-hidden="true" />
+            {conflict} conflict
+          </span>
+        </span>
+        <span style={{ marginLeft: 8, fontSize: 10.5 }}>
+          {localOpen ? (
+            <ChevronDown className="h-3 w-3 inline" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="h-3 w-3 inline" aria-hidden="true" />
+          )}
+        </span>
+      </div>
+      <div className="nb-claim-body">{statement}</div>
+      {localOpen && evidence.length > 0 && (
+        <div className="nb-claim-evidence" id="nb-claim-evidence">
+          {evidence.map((ev, i) => (
+            <div
+              key={`${ev.n}-${i}`}
+              className="nb-claim-ev"
+              data-kind={ev.kind}
+            >
+              <span className="cite" style={{ pointerEvents: "none" }}>
+                {ev.n}
+              </span>
+              <span>{ev.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+export const NbClaim = Node.create({
+  name: "nbClaim",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: false,
+  addAttributes() {
+    return {
+      statement: { default: "" },
+      support: { default: 0 },
+      conflict: { default: 0 },
+      evidence: { default: [] as ClaimEvidence[] },
+      open: { default: true },
+    };
+  },
+  parseHTML() {
+    return [{ tag: 'div[data-type="nb-claim"]' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-type": "nb-claim" }),
+    ];
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(ClaimNodeView);
+  },
+});

--- a/src/features/notebook/extensions/nbProposal.tsx
+++ b/src/features/notebook/extensions/nbProposal.tsx
@@ -1,0 +1,127 @@
+/**
+ * nb_proposal — inline AI proposal with accept/dismiss.
+ *
+ * Kit parity: Notebook.jsx lines 126-152 & 230-250 (inline replacement with strikethrough),
+ * lines 327-345 (ProposalCard).
+ *
+ * Rendered as a block-level node containing both the original text (superseded
+ * when accepted) and the proposed replacement, plus an aside card with actions.
+ */
+import {
+  Node,
+  mergeAttributes,
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+} from "@tiptap/react";
+import { Sparkles } from "lucide-react";
+
+type ProposalState = "pending" | "accepted" | "dismissed";
+
+export type ProposalAttrs = {
+  id: string;
+  label: string;
+  note: string;
+  originalText: string;
+  proposedText: string;
+  state: ProposalState;
+};
+
+function ProposalNodeView(props: {
+  node: { attrs: ProposalAttrs };
+  updateAttributes: (attrs: Partial<ProposalAttrs>) => void;
+}) {
+  const { id, label, note, originalText, proposedText, state } = props.node.attrs;
+
+  if (state === "dismissed") {
+    return <NodeViewWrapper style={{ display: "none" }} />;
+  }
+
+  const accepted = state === "accepted";
+
+  return (
+    <NodeViewWrapper
+      as="div"
+      className="nb-proposal-line"
+      data-accepted={accepted ? "true" : "false"}
+      data-proposal-id={id}
+    >
+      <p className="nb-p">
+        {accepted ? (
+          <span className="nb-proposal-ink">{proposedText}</span>
+        ) : (
+          <>
+            <span className="nb-strike">{originalText}</span>{" "}
+            <span className="nb-proposal-hl">{proposedText}</span>
+          </>
+        )}
+      </p>
+      <aside
+        className="nb-proposal-card"
+        data-state={accepted ? "accepted" : "pending"}
+      >
+        <div className="nb-proposal-head">
+          <Sparkles className="h-3 w-3" aria-hidden="true" />
+          <span
+            className="kicker"
+            style={{
+              color: accepted ? "var(--success, #059669)" : "var(--accent-ink, #ad5f45)",
+            }}
+          >
+            {accepted ? "applied" : label}
+          </span>
+        </div>
+        <div className="nb-proposal-note">{note}</div>
+        {!accepted && (
+          <div className="nb-proposal-actions">
+            <button
+              type="button"
+              className="nb-proposal-btn nb-proposal-btn--accept"
+              aria-label={`Accept proposal: ${label}`}
+              onClick={() => props.updateAttributes({ state: "accepted" })}
+            >
+              Accept
+            </button>
+            <button
+              type="button"
+              className="nb-proposal-btn"
+              aria-label={`Dismiss proposal: ${label}`}
+              onClick={() => props.updateAttributes({ state: "dismissed" })}
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+      </aside>
+    </NodeViewWrapper>
+  );
+}
+
+export const NbProposal = Node.create({
+  name: "nbProposal",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: false,
+  addAttributes() {
+    return {
+      id: { default: "" },
+      label: { default: "AI proposal" },
+      note: { default: "" },
+      originalText: { default: "" },
+      proposedText: { default: "" },
+      state: { default: "pending" },
+    };
+  },
+  parseHTML() {
+    return [{ tag: 'div[data-type="nb-proposal"]' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-type": "nb-proposal" }),
+    ];
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(ProposalNodeView);
+  },
+});

--- a/src/features/notebook/extensions/slashCommand.ts
+++ b/src/features/notebook/extensions/slashCommand.ts
@@ -1,0 +1,181 @@
+/**
+ * Slash Command Extension for RichNotebookEditor.
+ *
+ * Pattern: TipTap Suggestion plugin triggering on `/`.
+ * Kit parity: docs/design/nodebench-ai-design-system/ui_kits/nodebench-workspace/Notebook.jsx
+ *   - 8 items: Heading, Claim block, Embed card, Citation, Ask a question,
+ *     Continue writing, Rewrite w/ sources, Draft email
+ *   - Arrow/Enter/Escape keyboard navigation
+ *   - Filtered by typed query
+ *
+ * Prior art:
+ *   - TipTap Suggestion utility — https://tiptap.dev/docs/editor/api/utilities/suggestion
+ *   - NovelAI, Notion slash menus
+ */
+import { Extension } from "@tiptap/core";
+import type { Editor, Range } from "@tiptap/core";
+import Suggestion from "@tiptap/suggestion";
+import type { SuggestionOptions } from "@tiptap/suggestion";
+
+export type SlashItem = {
+  key: string;
+  label: string;
+  hint: string;
+  accent?: boolean;
+  command: (args: { editor: Editor; range: Range }) => void;
+};
+
+export const SLASH_ITEMS: SlashItem[] = [
+  {
+    key: "h2",
+    label: "Heading",
+    hint: "h2",
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .setNode("heading", { level: 2 })
+        .run();
+    },
+  },
+  {
+    key: "claim",
+    label: "Claim block",
+    hint: "claim",
+    accent: true,
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent({
+          type: "nbClaim",
+          attrs: {
+            statement: "New claim — edit me.",
+            support: 0,
+            conflict: 0,
+            evidence: [],
+            open: true,
+          },
+        })
+        .run();
+    },
+  },
+  {
+    key: "card",
+    label: "Embed card",
+    hint: "card",
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent(
+          '<blockquote><p><strong>Embedded card</strong> — live-linked artifact.</p></blockquote>',
+        )
+        .run();
+    },
+  },
+  {
+    key: "cite",
+    label: "Citation",
+    hint: "cite",
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent('<sup class="nb-cite">[cite]</sup>')
+        .run();
+    },
+  },
+  {
+    key: "ask",
+    label: "Ask a question",
+    hint: "ask",
+    accent: true,
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent("<p><em>Ask: </em></p>")
+        .run();
+    },
+  },
+  {
+    key: "cont",
+    label: "Continue writing",
+    hint: "cont",
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).run();
+    },
+  },
+  {
+    key: "rew",
+    label: "Rewrite w/ sources",
+    hint: "rew",
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).run();
+    },
+  },
+  {
+    key: "email",
+    label: "Draft email",
+    hint: "email",
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent(
+          "<p><strong>Subject:</strong> </p><p>Hi,</p><p></p><p>Best,</p>",
+        )
+        .run();
+    },
+  },
+];
+
+export type SlashRendererHandle = {
+  onStart: (props: unknown) => void;
+  onUpdate: (props: unknown) => void;
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+  onExit: () => void;
+};
+
+export type CreateSlashExtensionOptions = {
+  render: () => SlashRendererHandle;
+};
+
+export function createSlashCommandExtension(
+  options: CreateSlashExtensionOptions,
+) {
+  return Extension.create({
+    name: "slashCommand",
+    addProseMirrorPlugins() {
+      const suggestion: Omit<SuggestionOptions<SlashItem>, "editor"> = {
+        char: "/",
+        startOfLine: false,
+        allowSpaces: false,
+        command: ({ editor, range, props }) => {
+          props.command({ editor, range });
+        },
+        items: ({ query }) => {
+          const q = query.toLowerCase();
+          if (!q) return SLASH_ITEMS;
+          return SLASH_ITEMS.filter((it) =>
+            it.label.toLowerCase().includes(q),
+          );
+        },
+        render: options.render,
+      };
+      return [
+        Suggestion({
+          editor: this.editor,
+          ...suggestion,
+        }),
+      ];
+    },
+  });
+}

--- a/src/features/notebook/extensions/slashMenuRenderer.tsx
+++ b/src/features/notebook/extensions/slashMenuRenderer.tsx
@@ -1,0 +1,175 @@
+/**
+ * Slash Menu Renderer — floating React menu for the slash command extension.
+ *
+ * Kit parity: see Notebook.jsx lines 347-373 for SlashMenu component; notebook.css
+ * .nb-slash, .nb-slash-item, .is-active, .nb-slash-icon etc.
+ */
+import { createRoot, type Root } from "react-dom/client";
+import { useEffect, useImperativeHandle, useState, forwardRef } from "react";
+import { Hash, Sparkles, Layers, BookOpen } from "lucide-react";
+import type { SlashItem, SlashRendererHandle } from "./slashCommand";
+
+type SlashMenuProps = {
+  items: SlashItem[];
+  command: (item: SlashItem) => void;
+};
+
+export type SlashMenuRef = {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+};
+
+function iconFor(item: SlashItem) {
+  if (item.key === "h2") return Hash;
+  if (item.key === "card") return Layers;
+  if (item.key === "cite") return BookOpen;
+  return Sparkles;
+}
+
+export const SlashMenu = forwardRef<SlashMenuRef, SlashMenuProps>(
+  ({ items, command }, ref) => {
+    const [active, setActive] = useState(0);
+
+    useEffect(() => {
+      setActive(0);
+    }, [items]);
+
+    useImperativeHandle(ref, () => ({
+      onKeyDown: (event: KeyboardEvent) => {
+        if (event.key === "ArrowUp") {
+          setActive((prev) => (prev + items.length - 1) % Math.max(items.length, 1));
+          return true;
+        }
+        if (event.key === "ArrowDown") {
+          setActive((prev) => (prev + 1) % Math.max(items.length, 1));
+          return true;
+        }
+        if (event.key === "Enter") {
+          const item = items[active];
+          if (item) {
+            command(item);
+            return true;
+          }
+        }
+        if (event.key === "Escape") {
+          return true;
+        }
+        return false;
+      },
+    }));
+
+    if (items.length === 0) {
+      return (
+        <div className="nb-slash" role="listbox" aria-label="Slash commands">
+          <div className="nb-slash-head">
+            <Sparkles className="h-3 w-3" aria-hidden="true" />
+            <span className="text-xs text-gray-500">No matches</span>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="nb-slash" role="listbox" aria-label="Slash commands">
+        <div className="nb-slash-head">
+          <Sparkles className="h-3 w-3" aria-hidden="true" />
+          <span className="text-[11px] text-gray-500 font-mono">
+            type to filter…
+          </span>
+          <span className="ml-auto text-[10px] text-gray-400 font-mono">
+            up/down · enter · esc
+          </span>
+        </div>
+        {items.map((item, idx) => {
+          const Icon = iconFor(item);
+          const isActive = idx === active;
+          return (
+            <div
+              key={item.key}
+              role="option"
+              aria-selected={isActive}
+              className={`nb-slash-item ${isActive ? "is-active" : ""}`}
+              onMouseEnter={() => setActive(idx)}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                command(item);
+              }}
+            >
+              <span className={`nb-slash-icon ${item.accent ? "is-accent" : ""}`}>
+                <Icon className="h-3 w-3" aria-hidden="true" />
+              </span>
+              <span>{item.label}</span>
+              <span className="nb-slash-key">{item.hint}</span>
+            </div>
+          );
+        })}
+      </div>
+    );
+  },
+);
+SlashMenu.displayName = "SlashMenu";
+
+type ClientRect = { left: number; top: number; bottom: number };
+
+type SuggestionProps = {
+  editor: unknown;
+  range: unknown;
+  query: string;
+  text: string;
+  items: SlashItem[];
+  command: (item: SlashItem) => void;
+  decorationNode: Element | null;
+  clientRect?: (() => ClientRect | null) | null;
+};
+
+export function createSlashRenderer(): SlashRendererHandle {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+  let refApi: { current: SlashMenuRef | null } = { current: null };
+
+  const mount = (props: SuggestionProps) => {
+    if (!container) {
+      container = document.createElement("div");
+      container.style.position = "absolute";
+      container.style.zIndex = "9999";
+      container.style.pointerEvents = "auto";
+      document.body.appendChild(container);
+      root = createRoot(container);
+    }
+    const setRef = (r: SlashMenuRef | null) => {
+      refApi.current = r;
+    };
+    root?.render(
+      <SlashMenu ref={setRef} items={props.items} command={props.command} />,
+    );
+    position(props);
+  };
+
+  const position = (props: SuggestionProps) => {
+    if (!container) return;
+    const rect = props.clientRect?.();
+    if (!rect) return;
+    container.style.left = `${rect.left}px`;
+    container.style.top = `${rect.bottom + 6}px`;
+  };
+
+  const destroy = () => {
+    root?.unmount();
+    root = null;
+    container?.remove();
+    container = null;
+    refApi.current = null;
+  };
+
+  return {
+    onStart: (props) => mount(props as SuggestionProps),
+    onUpdate: (props) => mount(props as SuggestionProps),
+    onKeyDown: ({ event }) => {
+      if (event.key === "Escape") {
+        destroy();
+        return true;
+      }
+      return refApi.current?.onKeyDown(event) ?? false;
+    },
+    onExit: () => destroy(),
+  };
+}

--- a/src/features/notebook/styles/notebook.css
+++ b/src/features/notebook/styles/notebook.css
@@ -1,0 +1,282 @@
+/*
+ * NodeBench Notebook styles — ported from the golden-truth kit
+ * (docs/design/nodebench-ai-design-system/ui_kits/nodebench-workspace/notebook.css).
+ *
+ * Only the classes actually used by RichNotebookEditor + the nb_proposal /
+ * nb_claim / slash menu extensions. Color tokens fall back to sensible defaults
+ * so the notebook renders even outside the full kit theme.
+ */
+
+/* ---------- Save-state pill ---------- */
+.nb-save-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted, #6b7280);
+  padding: 4px 10px 4px 8px;
+  border-radius: 999px;
+  background: var(--bg-muted, rgba(15, 23, 42, 0.04));
+  border: 1px solid var(--border-subtle, rgba(15, 23, 42, 0.08));
+}
+.nb-save-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--success, #059669);
+  box-shadow: 0 0 0 2px rgba(4, 120, 87, 0.16);
+}
+
+/* ---------- Proposal card ---------- */
+.nb-proposal-line {
+  position: relative;
+  margin: 14px 0;
+  padding-right: 200px;
+  transition: background 220ms cubic-bezier(0.19, 1, 0.22, 1);
+}
+.nb-proposal-line[data-accepted="true"] {
+  background: linear-gradient(90deg, rgba(4, 120, 87, 0.04), transparent 60%);
+  border-radius: 8px;
+  padding: 6px 200px 6px 10px;
+  margin-left: -10px;
+}
+.nb-proposal-hl {
+  background: linear-gradient(180deg, transparent 60%, rgba(217, 119, 87, 0.18) 60%);
+  padding: 0 2px;
+}
+.nb-proposal-ink {
+  color: var(--success, #059669);
+  background: rgba(4, 120, 87, 0.08);
+  padding: 0 4px;
+  border-radius: 3px;
+}
+.nb-strike {
+  text-decoration: line-through;
+  color: var(--text-faint, #94a3b8);
+}
+.nb-proposal-card {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 180px;
+  padding: 10px 12px;
+  background: var(--bg-surface, #fffdf8);
+  border: 1px solid var(--accent-border, rgba(217, 119, 87, 0.35));
+  border-left: 3px solid var(--accent, #d97757);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+}
+.nb-proposal-card[data-state="accepted"] {
+  border-color: rgba(4, 120, 87, 0.2);
+  border-left-color: var(--success, #059669);
+  background: rgba(4, 120, 87, 0.04);
+}
+.nb-proposal-head {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 4px;
+  color: var(--accent, #d97757);
+}
+.nb-proposal-note {
+  font-size: 11.5px;
+  color: var(--text-secondary, #334155);
+  line-height: 1.5;
+}
+.nb-proposal-card[data-state="accepted"] .nb-proposal-note {
+  color: var(--success, #059669);
+}
+.nb-proposal-actions {
+  display: flex;
+  gap: 4px;
+  margin-top: 8px;
+}
+.nb-proposal-btn {
+  padding: 3px 8px;
+  border-radius: 5px;
+  border: 1px solid var(--border-subtle, rgba(15, 23, 42, 0.08));
+  background: var(--bg-surface, #fffdf8);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary, #334155);
+  cursor: pointer;
+  font-family: inherit;
+}
+.nb-proposal-btn:hover {
+  background: var(--bg-muted, rgba(15, 23, 42, 0.04));
+}
+.nb-proposal-btn--accept {
+  background: var(--accent, #d97757);
+  color: #fffaf8;
+  border-color: var(--accent-border, rgba(217, 119, 87, 0.35));
+}
+.nb-proposal-btn--accept:hover {
+  background: var(--accent-hover, #c25f3f);
+}
+.nb-proposal-btn:focus-visible {
+  outline: 2px solid var(--accent, #d97757);
+  outline-offset: 2px;
+}
+
+/* ---------- Claim block ---------- */
+.nb-claim {
+  margin: 18px 0;
+  padding: 14px 16px;
+  background: linear-gradient(180deg, #fffdf8, #fffbf1);
+  border: 1px solid var(--accent-border, rgba(217, 119, 87, 0.35));
+  border-radius: 8px;
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+}
+.nb-claim-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  color: var(--accent, #d97757);
+}
+.nb-claim-status {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+}
+.nb-claim-body {
+  font-family: var(--font-serif, ui-serif, Georgia, serif);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.45;
+  color: var(--text-primary, #0f172a);
+  margin-bottom: 10px;
+}
+.nb-claim-evidence {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.nb-claim-ev {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  border-radius: 5px;
+  font-size: 12.5px;
+  background: rgba(255, 255, 255, 0.5);
+}
+.nb-claim-ev[data-kind="conflict"] {
+  background: rgba(180, 83, 9, 0.06);
+}
+.nb-claim-ev .cite {
+  display: inline-flex;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 4px;
+  background: rgba(217, 119, 87, 0.12);
+  color: var(--accent-ink, #ad5f45);
+  border: 1px solid rgba(217, 119, 87, 0.24);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ---------- Slash menu ---------- */
+.nb-slash {
+  width: 300px;
+  background: var(--bg-surface, #ffffff);
+  border: 1px solid var(--border-default, rgba(15, 23, 42, 0.12));
+  border-radius: 8px;
+  box-shadow:
+    0 8px 24px rgba(15, 23, 42, 0.16),
+    0 2px 6px rgba(15, 23, 42, 0.08);
+  padding: 8px;
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+}
+.nb-slash-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 8px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--border-subtle, rgba(15, 23, 42, 0.08));
+}
+.nb-slash-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--text-primary, #0f172a);
+}
+.nb-slash-item:hover {
+  background: var(--bg-muted, rgba(15, 23, 42, 0.04));
+}
+.nb-slash-item.is-active {
+  background: var(--accent-tint, rgba(217, 119, 87, 0.12));
+  color: var(--accent-ink, #ad5f45);
+  font-weight: 600;
+}
+.nb-slash-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  background: var(--bg-muted, rgba(15, 23, 42, 0.04));
+  color: var(--text-muted, #6b7280);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.nb-slash-icon.is-accent {
+  background: var(--accent-tint, rgba(217, 119, 87, 0.12));
+  color: var(--accent, #d97757);
+}
+.nb-slash-key {
+  margin-left: auto;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  color: var(--text-faint, #94a3b8);
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--bg-muted, rgba(15, 23, 42, 0.04));
+}
+
+/* ---------- Pills (reused by claim status badges) ---------- */
+.nb-claim .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle, rgba(15, 23, 42, 0.08));
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-weight: 600;
+  font-size: 10.5px;
+}
+.nb-claim .pill-ok {
+  background: rgba(4, 120, 87, 0.08);
+  color: var(--success, #059669);
+  border-color: rgba(4, 120, 87, 0.2);
+}
+.nb-claim .pill-warn {
+  background: rgba(180, 83, 9, 0.08);
+  color: var(--warn, #b45309);
+  border-color: rgba(180, 83, 9, 0.2);
+}
+.nb-claim .kicker {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .nb-proposal-line,
+  .nb-proposal-card {
+    transition: none !important;
+  }
+}

--- a/src/features/reports/components/ReportThumbnail.tsx
+++ b/src/features/reports/components/ReportThumbnail.tsx
@@ -1,0 +1,257 @@
+// ReportThumbnail — inline SVG preview thumbs ported 1:1 from the NodeBench web kit.
+// Kit source: docs/design/nodebench-ai-design-system/ui_kits/nodebench-web/ReportCard.jsx (lines 6-121)
+//
+// Renders a tiny inline SVG "dashboard" that signals the report's shape at a glance.
+// Six kinds: diligence (KV pairs + risk card), bars (bar chart), table (rows+status),
+// line (trend line), memo (document/brief), matrix (scatter/competitor map).
+
+import { type CSSProperties, type ReactNode } from "react";
+
+export type ReportThumbnailKind =
+  | "diligence"
+  | "bars"
+  | "table"
+  | "line"
+  | "memo"
+  | "matrix";
+
+const THUMBNAILS: Record<ReportThumbnailKind, ReactNode> = {
+  // DISCO — diligence debrief: kv pairs + risk bar
+  diligence: (
+    <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" className="h-full w-full">
+      <defs>
+        <linearGradient id="nb-thumb-dgrad" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#FFF3EC" />
+          <stop offset="1" stopColor="#FBE5D6" />
+        </linearGradient>
+      </defs>
+      <rect width="320" height="180" fill="url(#nb-thumb-dgrad)" />
+      {/* Header mini */}
+      <rect x="20" y="18" width="90" height="8" rx="2" fill="#AD5F45" opacity=".9" />
+      <rect x="20" y="30" width="140" height="5" rx="2" fill="#AD5F45" opacity=".35" />
+      {/* KV pairs left */}
+      {[0, 1, 2, 3].map((i) => (
+        <g key={i} transform={`translate(20, ${54 + i * 20})`}>
+          <rect width="50" height="5" rx="2" fill="#6B7280" opacity=".5" />
+          <rect x="60" width="80" height="6" rx="2" fill="#111827" opacity=".7" />
+        </g>
+      ))}
+      {/* Risk card right */}
+      <rect x="190" y="54" width="110" height="100" rx="8" fill="#fff" stroke="#E5D1C0" />
+      <rect x="202" y="66" width="44" height="5" rx="2" fill="#B45309" opacity=".8" />
+      <rect x="202" y="78" width="85" height="7" rx="2" fill="#111827" opacity=".72" />
+      <rect x="202" y="92" width="85" height="5" rx="2" fill="#6B7280" opacity=".45" />
+      <rect x="202" y="102" width="85" height="5" rx="2" fill="#6B7280" opacity=".45" />
+      <rect x="202" y="112" width="60" height="5" rx="2" fill="#6B7280" opacity=".45" />
+      <rect x="202" y="130" width="76" height="10" rx="5" fill="#D97757" opacity=".85" />
+    </svg>
+  ),
+
+  // Mercor — hiring velocity: bar chart of roles
+  bars: (
+    <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" className="h-full w-full">
+      <rect width="320" height="180" fill="#F3F4F6" />
+      <rect x="20" y="18" width="120" height="8" rx="2" fill="#111827" opacity=".82" />
+      <rect x="20" y="30" width="180" height="5" rx="2" fill="#6B7280" opacity=".5" />
+      {/* Axes */}
+      <line x1="30" y1="150" x2="300" y2="150" stroke="#D1D5DB" />
+      {[18, 32, 28, 44, 38, 56, 48].map((h, i) => (
+        <rect
+          key={i}
+          x={40 + i * 38}
+          y={150 - h * 1.6}
+          width="24"
+          height={h * 1.6}
+          rx="3"
+          fill={i === 5 ? "#D97757" : "#5E6AD2"}
+          opacity={i === 5 ? 1 : 0.55}
+        />
+      ))}
+      {/* Legend */}
+      <circle cx="30" cy="165" r="3" fill="#5E6AD2" opacity=".55" />
+      <rect x="38" y="162" width="38" height="5" rx="2" fill="#6B7280" opacity=".5" />
+      <circle cx="90" cy="165" r="3" fill="#D97757" />
+      <rect x="98" y="162" width="30" height="5" rx="2" fill="#6B7280" opacity=".5" />
+    </svg>
+  ),
+
+  // Cognition — benchmark postmortem: table-ish
+  table: (
+    <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" className="h-full w-full">
+      <rect width="320" height="180" fill="#FAFAFA" />
+      <rect x="20" y="18" width="110" height="8" rx="2" fill="#111827" opacity=".82" />
+      <rect x="140" y="18" width="42" height="10" rx="5" fill="#B45309" opacity=".15" stroke="#B45309" strokeOpacity=".3" />
+      <rect x="146" y="21" width="30" height="4" rx="2" fill="#B45309" opacity=".8" />
+      {/* table header */}
+      <rect x="20" y="48" width="280" height="16" rx="3" fill="#E5E7EB" />
+      {[20, 105, 175, 235].map((x, i) => (
+        <rect key={i} x={x + 6} y="54" width={i === 0 ? 40 : 40} height="4" rx="2" fill="#374151" opacity=".75" />
+      ))}
+      {/* table rows */}
+      {[0, 1, 2, 3, 4].map((r) => (
+        <g key={r} transform={`translate(0, ${68 + r * 18})`}>
+          <rect x="20" y="0" width="280" height="16" rx="3" fill={r % 2 ? "#F3F4F6" : "#fff"} stroke="#E5E7EB" />
+          <rect x="26" y="6" width="72" height="4" rx="2" fill="#111827" opacity=".7" />
+          <rect x="111" y="6" width="56" height="4" rx="2" fill="#6B7280" opacity=".55" />
+          <rect x="181" y="6" width="48" height="4" rx="2" fill="#6B7280" opacity=".55" />
+          <rect
+            x="241"
+            y="4"
+            width="24"
+            height="8"
+            rx="4"
+            fill={r < 2 ? "#047857" : r === 2 ? "#B45309" : "#9CA3AF"}
+            opacity={r < 2 ? 0.85 : r === 2 ? 0.75 : 0.45}
+          />
+        </g>
+      ))}
+    </svg>
+  ),
+
+  // Turing — contract spend YoY: line chart
+  line: (
+    <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" className="h-full w-full">
+      <rect width="320" height="180" fill="#FFFDF7" />
+      <rect x="20" y="18" width="140" height="8" rx="2" fill="#111827" opacity=".82" />
+      <rect x="20" y="30" width="60" height="5" rx="2" fill="#047857" opacity=".75" />
+      <line x1="30" y1="150" x2="300" y2="150" stroke="#E5E7EB" />
+      <line x1="30" y1="110" x2="300" y2="110" stroke="#E5E7EB" strokeDasharray="2 3" />
+      <line x1="30" y1="70" x2="300" y2="70" stroke="#E5E7EB" strokeDasharray="2 3" />
+      <path
+        d="M 30 138 L 75 128 L 120 118 L 165 102 L 210 84 L 255 62 L 300 48"
+        fill="none"
+        stroke="#D97757"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M 30 138 L 75 128 L 120 118 L 165 102 L 210 84 L 255 62 L 300 48 L 300 150 L 30 150 Z"
+        fill="#D97757"
+        opacity=".12"
+      />
+      {[30, 75, 120, 165, 210, 255, 300].map((x, i) => (
+        <circle key={i} cx={x} cy={[138, 128, 118, 102, 84, 62, 48][i]} r="3" fill="#D97757" />
+      ))}
+    </svg>
+  ),
+
+  // generic competitor matrix
+  matrix: (
+    <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" className="h-full w-full">
+      <rect width="320" height="180" fill="#F3F4F6" />
+      <rect x="20" y="18" width="110" height="8" rx="2" fill="#111827" opacity=".82" />
+      <rect x="20" y="50" width="280" height="112" rx="6" fill="#fff" stroke="#E5E7EB" />
+      <line x1="20" y1="106" x2="300" y2="106" stroke="#E5E7EB" strokeDasharray="2 3" />
+      <line x1="160" y1="50" x2="160" y2="162" stroke="#E5E7EB" strokeDasharray="2 3" />
+      <circle cx="105" cy="80" r="10" fill="#5E6AD2" opacity=".75" />
+      <circle cx="215" cy="70" r="14" fill="#D97757" />
+      <circle cx="240" cy="128" r="8" fill="#9CA3AF" opacity=".7" />
+      <circle cx="80" cy="140" r="6" fill="#9CA3AF" opacity=".5" />
+      <circle cx="180" cy="110" r="7" fill="#047857" opacity=".7" />
+    </svg>
+  ),
+
+  // brief / memo
+  memo: (
+    <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" className="h-full w-full">
+      <rect width="320" height="180" fill="#FBF8F2" />
+      <rect x="20" y="18" width="80" height="8" rx="2" fill="#111827" opacity=".82" />
+      <rect x="20" y="30" width="140" height="5" rx="2" fill="#AD5F45" opacity=".6" />
+      {Array.from({ length: 9 }).map((_, i) => (
+        <rect
+          key={i}
+          x="20"
+          y={52 + i * 12}
+          width={i % 3 === 2 ? 180 : 280}
+          height="5"
+          rx="2"
+          fill="#6B7280"
+          opacity={i % 4 === 0 ? 0.7 : 0.35}
+        />
+      ))}
+    </svg>
+  ),
+};
+
+export interface ReportThumbnailProps {
+  kind: ReportThumbnailKind;
+  className?: string;
+  style?: CSSProperties;
+  /** Accessible label for screen readers; default "Report preview". */
+  ariaLabel?: string;
+}
+
+/**
+ * ReportThumbnail — renders one of 6 inline SVG preview thumbs.
+ * The SVG uses preserveAspectRatio="xMidYMid slice" and fills its wrapper,
+ * so the caller controls the aspect ratio via className (e.g. "aspect-[16/10]").
+ */
+export function ReportThumbnail({
+  kind,
+  className,
+  style,
+  ariaLabel = "Report preview",
+}: ReportThumbnailProps) {
+  const thumb = THUMBNAILS[kind] ?? THUMBNAILS.memo;
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      className={className}
+      style={{ overflow: "hidden", ...style }}
+    >
+      {thumb}
+    </div>
+  );
+}
+
+/**
+ * Heuristic kind picker from entity fields.
+ *
+ * Priority:
+ * 1. Explicit latestReportType values ("diligence", "bars", "table", "line", "memo", "matrix") pass through.
+ * 2. latestReportType keyword match (benchmark/postmortem → table, trend/spend → line, etc.).
+ * 3. entityType (company/organization → diligence, person → memo, market → matrix, metric → bars).
+ * 4. Fallback → "memo".
+ */
+export function pickReportThumbnailKind(input: {
+  entityType?: string;
+  latestReportType?: string;
+  slug?: string;
+}): ReportThumbnailKind {
+  const reportType = (input.latestReportType ?? "").toLowerCase().trim();
+  const entityType = (input.entityType ?? "").toLowerCase().trim();
+
+  // 1. Direct match on kind name
+  if (
+    reportType === "diligence" ||
+    reportType === "bars" ||
+    reportType === "table" ||
+    reportType === "line" ||
+    reportType === "memo" ||
+    reportType === "matrix"
+  ) {
+    return reportType as ReportThumbnailKind;
+  }
+
+  // 2. Keyword heuristics on report type
+  if (reportType) {
+    if (/(diligence|disco|risk|debrief)/.test(reportType)) return "diligence";
+    if (/(benchmark|postmortem|compare|scorecard|table)/.test(reportType)) return "table";
+    if (/(trend|spend|growth|yoy|timeline|line)/.test(reportType)) return "line";
+    if (/(hiring|velocity|metric|bar|count)/.test(reportType)) return "bars";
+    if (/(competitor|matrix|positioning|landscape|map)/.test(reportType)) return "matrix";
+    if (/(memo|brief|framework|policy|summary|note)/.test(reportType)) return "memo";
+  }
+
+  // 3. Entity-type fallback
+  if (/(company|organization|startup|business)/.test(entityType)) return "diligence";
+  if (/(competitor|market|segment|industry)/.test(entityType)) return "matrix";
+  if (/(metric|kpi|benchmark)/.test(entityType)) return "bars";
+  if (/(trend|signal|timeline)/.test(entityType)) return "line";
+  if (/(person|contact|founder|people)/.test(entityType)) return "memo";
+
+  return "memo";
+}
+
+export default ReportThumbnail;

--- a/src/features/reports/views/ReportsHome.tsx
+++ b/src/features/reports/views/ReportsHome.tsx
@@ -7,6 +7,10 @@ import { trackEvent } from "@/lib/analytics";
 import { useConvexApi } from "@/lib/convexApi";
 import { cn } from "@/lib/utils";
 import { ProductThumbnail } from "@/features/product/components/ProductThumbnail";
+import {
+  ReportThumbnail,
+  pickReportThumbnailKind,
+} from "@/features/reports/components/ReportThumbnail";
 import { ProductFileAssetPicker, type ProductFileAsset } from "@/features/product/components/ProductFileAssetPicker";
 import { buildEntityShareUrl } from "@/features/entities/lib/entityExport";
 import { ReportShareSheet, type ReportVisibility } from "@/features/reports/components/ReportShareSheet";
@@ -259,18 +263,30 @@ function ReportCard({
               </span>
             ) : null}
           </div>
-          <ProductThumbnail
-            className="aspect-[16/10]"
-            title={card.name}
-            summary={card.summary}
-            type={card.entityType}
-            imageUrl={card.thumbnailUrl}
-            imageUrls={card.thumbnailUrls}
-            sourceUrls={card.sourceUrls}
-            sourceLabels={card.sourceLabels}
-            tone={getEntityThumbnailTone(card.entityType, index)}
-            compact
-          />
+          {card.thumbnailUrl || (card.thumbnailUrls && card.thumbnailUrls.length > 0) ? (
+            <ProductThumbnail
+              className="aspect-[16/10]"
+              title={card.name}
+              summary={card.summary}
+              type={card.entityType}
+              imageUrl={card.thumbnailUrl}
+              imageUrls={card.thumbnailUrls}
+              sourceUrls={card.sourceUrls}
+              sourceLabels={card.sourceLabels}
+              tone={getEntityThumbnailTone(card.entityType, index)}
+              compact
+            />
+          ) : (
+            <ReportThumbnail
+              kind={pickReportThumbnailKind({
+                entityType: card.entityType,
+                latestReportType: card.latestReportType,
+                slug: card.slug,
+              })}
+              className="aspect-[16/10] w-full"
+              ariaLabel={`${card.name} report preview`}
+            />
+          )}
         </div>
 
         {/* Content */}
@@ -331,7 +347,7 @@ function ReportCard({
         </div>
       </button>
 
-      {/* Action row — Brief | Graph | Chat. Sits under the main card so the
+      {/* Action row — Brief | Explore | Chat. Sits under the main card so the
           article's primary click still flows through onClick (Brief). */}
       <div
         data-testid="report-card-actions"

--- a/src/features/research/components/CardInspector.tsx
+++ b/src/features/research/components/CardInspector.tsx
@@ -1,0 +1,314 @@
+/**
+ * CardInspector — right-side inspector pane for expanded card detail.
+ *
+ * Pattern: Workspace shell right-inspector (contextual detail + drill action)
+ * Prior art:
+ *   - docs/design/nodebench-ai-design-system/ui_kits/nodebench-workspace/Report.jsx
+ *     (CardInspector @ line 318; `ws-inspector-*` classes from workspace.css)
+ *
+ * Ported to production React + Tailwind. The kit uses `window.WS_DATA.entities[id]`
+ * fixtures; prod receives a `ResourceCard` directly (chips + keyFacts + evidenceRefs
+ * + nextHops) with an onDrill callback that promotes the card to root.
+ *
+ * Visual contract (matches kit):
+ *   - 360px fixed width column on lg+
+ *   - Rounded 16px (kit uses 20px; we honor the glass-card DNA of 16px/xl in prod)
+ *   - Sticky inspector header with close button
+ *   - Dark glass surface: border-white/[0.06] bg-white/[0.02]
+ *   - Kicker (uppercase tracked) + title + subtitle
+ *   - Metrics grid fallback to keyFacts when metrics are not modeled
+ *   - Actions block: Promote to root (drill) + Pin + Watch
+ *
+ * Accessibility:
+ *   - aria-label on close button
+ *   - role="complementary" on the aside so screen readers know it's auxiliary
+ *   - Primary action button has focus-visible ring
+ */
+
+import { useMemo } from "react";
+import { X, Network, Bell, Layers } from "lucide-react";
+import type {
+  ResourceCard,
+  ResourceUri,
+} from "../../../../shared/research/resourceCards";
+
+export interface CardInspectorProps {
+  card: ResourceCard | null;
+  onDrill: (uri: ResourceUri) => void;
+  onClose: () => void;
+}
+
+export function CardInspector({ card, onDrill, onClose }: CardInspectorProps) {
+  // Memoize derived kicker + confidence so we don't recompute on every keypress
+  // in the surrounding surface.
+  const derived = useMemo(() => {
+    if (!card) return null;
+    const kicker = kickerForCardKind(card.kind);
+    const confidencePct = Math.round(
+      Math.max(0, Math.min(1, card.confidence)) * 100,
+    );
+    return { kicker, confidencePct };
+  }, [card]);
+
+  if (!card || !derived) {
+    return (
+      <aside
+        role="complementary"
+        aria-label="Card inspector"
+        data-testid="card-inspector-empty"
+        className="hidden lg:flex h-full w-[360px] shrink-0 flex-col rounded-2xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-md"
+      >
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+          <div className="text-[11px] uppercase tracking-[0.2em] text-white/40">
+            Inspector
+          </div>
+          <div className="text-sm text-white/60">
+            Select a card to inspect
+          </div>
+          <div className="max-w-[220px] text-[11px] leading-relaxed text-white/35">
+            Click any card in the columns to the left to see its evidence,
+            relations, and drill actions here.
+          </div>
+        </div>
+      </aside>
+    );
+  }
+
+  const { kicker, confidencePct } = derived;
+
+  return (
+    <aside
+      role="complementary"
+      aria-label={`Inspector for ${card.title}`}
+      data-testid="card-inspector"
+      className="hidden lg:flex h-full w-[360px] shrink-0 flex-col overflow-hidden rounded-2xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-md"
+    >
+      {/* Sticky header — ws-inspector-header parity */}
+      <header className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-white/[0.06] bg-white/[0.02] px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-[10.5px] uppercase tracking-[0.2em] text-white/45">
+            {kicker}
+          </div>
+          <h3 className="mt-1 truncate text-[15px] font-semibold text-white">
+            {card.title}
+          </h3>
+          {card.subtitle && (
+            <div className="mt-0.5 truncate text-[11.5px] text-white/55">
+              {card.subtitle}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close inspector"
+          title="Close inspector"
+          className="shrink-0 rounded-md p-1 text-white/60 transition hover:bg-white/[0.06] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]/70"
+        >
+          <X size={14} aria-hidden="true" />
+        </button>
+      </header>
+
+      {/* Body — scrollable */}
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        {/* Chips row (if any) */}
+        {card.chips && card.chips.length > 0 && (
+          <section className="mb-4 flex flex-wrap gap-1.5">
+            {card.chips.map((chip, i) => (
+              <span
+                key={`${chip.label}-${i}`}
+                className={chipClass(chip.tone)}
+              >
+                {chip.label}
+              </span>
+            ))}
+          </section>
+        )}
+
+        {/* At-a-glance: key facts grid (metrics fallback) */}
+        {card.keyFacts && card.keyFacts.length > 0 && (
+          <section className="mb-4">
+            <h4 className="mb-2 text-[10.5px] uppercase tracking-[0.18em] text-white/45">
+              At a glance
+            </h4>
+            <ul className="grid grid-cols-1 gap-1.5">
+              {card.keyFacts.slice(0, 6).map((fact, i) => (
+                <li
+                  key={i}
+                  className="rounded-md border border-white/[0.04] bg-white/[0.015] px-2.5 py-1.5 font-mono text-[11.5px] leading-snug text-white/75"
+                >
+                  {fact}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Summary */}
+        <section className="mb-4">
+          <h4 className="mb-2 text-[10.5px] uppercase tracking-[0.18em] text-white/45">
+            Summary
+          </h4>
+          <p className="text-[12.5px] leading-[1.55] text-white/75">
+            {card.summary || "No summary available for this card."}
+          </p>
+        </section>
+
+        {/* Confidence meter (HONEST_SCORES: renders the actual card.confidence) */}
+        <section className="mb-4">
+          <h4 className="mb-2 text-[10.5px] uppercase tracking-[0.18em] text-white/45">
+            Confidence
+          </h4>
+          <div className="flex items-center gap-2">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-white/[0.06]">
+              <div
+                className="h-full rounded-full bg-[#d97757]"
+                style={{ width: `${confidencePct}%` }}
+                aria-hidden="true"
+              />
+            </div>
+            <span className="font-mono text-[11px] tabular-nums text-white/60">
+              {confidencePct}%
+            </span>
+          </div>
+        </section>
+
+        {/* Evidence refs */}
+        {card.evidenceRefs && card.evidenceRefs.length > 0 && (
+          <section className="mb-4">
+            <h4 className="mb-2 text-[10.5px] uppercase tracking-[0.18em] text-white/45">
+              Evidence ({card.evidenceRefs.length})
+            </h4>
+            <ul className="flex flex-col gap-1">
+              {card.evidenceRefs.slice(0, 6).map((uri, i) => (
+                <li
+                  key={uri}
+                  className="truncate rounded-md border border-white/[0.04] bg-white/[0.015] px-2 py-1 font-mono text-[10.5px] text-white/55"
+                  title={uri}
+                >
+                  <span className="mr-1.5 text-white/40">[{i + 1}]</span>
+                  {formatUriShort(uri)}
+                </li>
+              ))}
+              {card.evidenceRefs.length > 6 && (
+                <li className="px-2 text-[10.5px] text-white/40">
+                  +{card.evidenceRefs.length - 6} more
+                </li>
+              )}
+            </ul>
+          </section>
+        )}
+
+        {/* Relations / next hops */}
+        {card.nextHops && card.nextHops.length > 0 && (
+          <section className="mb-4">
+            <h4 className="mb-2 text-[10.5px] uppercase tracking-[0.18em] text-white/45">
+              Relations ({card.nextHops.length})
+            </h4>
+            <div className="flex flex-wrap gap-1.5">
+              {card.nextHops.slice(0, 8).map((uri) => (
+                <button
+                  key={uri}
+                  type="button"
+                  onClick={() => onDrill(uri)}
+                  title={`Drill into ${uri}`}
+                  className="rounded-md border border-white/[0.06] bg-white/[0.02] px-2 py-1 font-mono text-[10.5px] text-white/70 transition hover:border-[#d97757]/40 hover:bg-[#d97757]/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]/70"
+                >
+                  {formatUriShort(uri)}
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Actions */}
+        <section>
+          <h4 className="mb-2 text-[10.5px] uppercase tracking-[0.18em] text-white/45">
+            Actions
+          </h4>
+          <div className="flex flex-col gap-1.5">
+            <button
+              type="button"
+              onClick={() => onDrill(card.uri)}
+              data-testid="card-inspector-promote"
+              className="flex items-center gap-2 rounded-md border border-[#d97757]/40 bg-[#d97757]/10 px-3 py-2 text-left text-[12px] font-medium text-white transition hover:bg-[#d97757]/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]/70"
+            >
+              <Network size={13} aria-hidden="true" />
+              <span className="truncate">Promote to root</span>
+            </button>
+            <button
+              type="button"
+              disabled
+              title="Watch for changes (coming soon)"
+              className="flex items-center gap-2 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-left text-[12px] text-white/50"
+            >
+              <Bell size={13} aria-hidden="true" />
+              <span>Watch for changes</span>
+            </button>
+            <button
+              type="button"
+              disabled
+              title="Pin to notebook (coming soon)"
+              className="flex items-center gap-2 rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-left text-[12px] text-white/50"
+            >
+              <Layers size={13} aria-hidden="true" />
+              <span>Pin to notebook</span>
+            </button>
+          </div>
+        </section>
+      </div>
+    </aside>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function kickerForCardKind(kind: ResourceCard["kind"]): string {
+  switch (kind) {
+    case "org_summary":
+      return "organization";
+    case "person_summary":
+      return "person";
+    case "product_summary":
+      return "product";
+    case "event_summary":
+      return "event";
+    case "topic_summary":
+      return "topic";
+    case "signal_summary":
+      return "signal";
+    case "evidence_ref":
+      return "evidence";
+    default:
+      return "card";
+  }
+}
+
+function chipClass(tone: "default" | "accent" | "warn" | "positive" | undefined): string {
+  const base =
+    "inline-flex items-center rounded-full border px-2 py-0.5 text-[10.5px] font-medium tracking-tight";
+  switch (tone) {
+    case "accent":
+      return `${base} border-[#d97757]/40 bg-[#d97757]/10 text-[#f4a57a]`;
+    case "warn":
+      return `${base} border-amber-500/40 bg-amber-500/10 text-amber-200`;
+    case "positive":
+      return `${base} border-emerald-500/40 bg-emerald-500/10 text-emerald-200`;
+    default:
+      return `${base} border-white/[0.08] bg-white/[0.03] text-white/70`;
+  }
+}
+
+/**
+ * Trim `nodebench://kind/long-id-string` to a short display label.
+ * Never throws — degrades gracefully on malformed input.
+ */
+function formatUriShort(uri: ResourceUri): string {
+  const afterScheme = uri.replace(/^nodebench:\/\//, "");
+  if (afterScheme.length <= 48) return afterScheme;
+  return `${afterScheme.slice(0, 45)}…`;
+}
+
+export default CardInspector;

--- a/src/features/research/views/MobileReportSurface.tsx
+++ b/src/features/research/views/MobileReportSurface.tsx
@@ -353,9 +353,9 @@ function BriefView({ onNavigate }: { onNavigate: (t: SubTab) => void }) {
             key={t.tag}
             className={`rounded-2xl border p-3 ${
               t.color === "indigo"
-                ? "border-indigo-100 bg-indigo-50/60"
+                ? "border-[rgba(94,106,210,0.18)] bg-[rgba(94,106,210,0.08)]"
                 : t.color === "ok"
-                  ? "border-emerald-100 bg-emerald-50/60"
+                  ? "border-[rgba(4,120,87,0.18)] bg-[rgba(4,120,87,0.08)]"
                   : "border-black/5 bg-white"
             }`}
           >

--- a/src/features/research/views/ReportDetailWorkspace.tsx
+++ b/src/features/research/views/ReportDetailWorkspace.tsx
@@ -18,6 +18,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { FileText, LayoutGrid, Map as MapIcon, FileStack } from "lucide-react";
 import MobileReportSurface from "@/features/research/views/MobileReportSurface";
+import { CardInspector } from "@/features/research/components/CardInspector";
 import type {
   ResourceCard,
   ResourceUri,
@@ -73,6 +74,9 @@ export function ReportDetailWorkspace({
   ]);
   const [pinnedUris, setPinnedUris] = useState<ResourceUri[]>([]);
   const [compareTray, setCompareTray] = useState<ResourceUri[]>([]);
+  const [inspectedCardUri, setInspectedCardUri] = useState<ResourceUri | null>(
+    null,
+  );
   const [loadingUri, setLoadingUri] = useState<ResourceUri | null>(null);
   const [errorForUri, setErrorForUri] = useState<
     { uri: ResourceUri; message: string } | null
@@ -198,18 +202,37 @@ export function ReportDetailWorkspace({
           <BriefTab cards={columns[0]?.cards ?? []} />
         )}
         {activeTab === "cards" && (
-          <CardsTab
-            columns={columns}
-            loadingUri={loadingUri}
-            errorForUri={errorForUri}
-            pinnedUris={pinnedUris}
-            compareTray={compareTray}
-            onExpand={handleExpand}
-            onPromote={handlePromote}
-            onTogglePin={togglePinned}
-            onToggleCompare={toggleCompare}
-            onOpenInChat={onOpenInChat}
-          />
+          <div className="flex flex-1 min-h-0 gap-3 overflow-hidden">
+            <div className="flex min-w-0 flex-1 overflow-hidden">
+              <CardsTab
+                columns={columns}
+                loadingUri={loadingUri}
+                errorForUri={errorForUri}
+                pinnedUris={pinnedUris}
+                compareTray={compareTray}
+                inspectedCardUri={inspectedCardUri}
+                onExpand={handleExpand}
+                onPromote={handlePromote}
+                onInspect={setInspectedCardUri}
+                onTogglePin={togglePinned}
+                onToggleCompare={toggleCompare}
+                onOpenInChat={onOpenInChat}
+              />
+            </div>
+            <div className="hidden lg:flex shrink-0 py-3 pr-3">
+              <CardInspector
+                card={findCardByUri(columns, inspectedCardUri)}
+                onDrill={(uri) => {
+                  // Promote-to-root from inspector mirrors kit drill semantics.
+                  const target = findCardByUri(columns, uri);
+                  const label = target?.title ?? uri;
+                  handlePromote(uri, label);
+                  setInspectedCardUri(null);
+                }}
+                onClose={() => setInspectedCardUri(null)}
+              />
+            </div>
+          </div>
         )}
         {activeTab === "map" && (
           <MapTab
@@ -398,8 +421,10 @@ function CardsTab({
   errorForUri,
   pinnedUris,
   compareTray,
+  inspectedCardUri,
   onExpand,
   onPromote,
+  onInspect,
   onTogglePin,
   onToggleCompare,
   onOpenInChat,
@@ -409,8 +434,10 @@ function CardsTab({
   errorForUri: { uri: ResourceUri; message: string } | null;
   pinnedUris: ReadonlyArray<ResourceUri>;
   compareTray: ReadonlyArray<ResourceUri>;
+  inspectedCardUri: ResourceUri | null;
   onExpand: (uri: ResourceUri, label: string) => void;
   onPromote: (uri: ResourceUri, label: string) => void;
+  onInspect: (uri: ResourceUri | null) => void;
   onTogglePin: (uri: ResourceUri) => void;
   onToggleCompare: (uri: ResourceUri) => void;
   onOpenInChat?: (uri: ResourceUri) => void;
@@ -426,8 +453,10 @@ function CardsTab({
           errorForUri={errorForUri}
           pinnedUris={pinnedUris}
           compareTray={compareTray}
+          inspectedCardUri={inspectedCardUri}
           onExpand={onExpand}
           onPromote={onPromote}
+          onInspect={onInspect}
           onTogglePin={onTogglePin}
           onToggleCompare={onToggleCompare}
           onOpenInChat={onOpenInChat}
@@ -449,8 +478,10 @@ function CardColumn({
   errorForUri,
   pinnedUris,
   compareTray,
+  inspectedCardUri,
   onExpand,
   onPromote,
+  onInspect,
   onTogglePin,
   onToggleCompare,
   onOpenInChat,
@@ -461,8 +492,10 @@ function CardColumn({
   errorForUri: { uri: ResourceUri; message: string } | null;
   pinnedUris: ReadonlyArray<ResourceUri>;
   compareTray: ReadonlyArray<ResourceUri>;
+  inspectedCardUri: ResourceUri | null;
   onExpand: (uri: ResourceUri, label: string) => void;
   onPromote: (uri: ResourceUri, label: string) => void;
+  onInspect: (uri: ResourceUri | null) => void;
   onTogglePin: (uri: ResourceUri) => void;
   onToggleCompare: (uri: ResourceUri) => void;
   onOpenInChat?: (uri: ResourceUri) => void;
@@ -479,11 +512,13 @@ function CardColumn({
           pinned={pinnedUris.includes(card.uri)}
           inCompare={compareTray.includes(card.uri)}
           isLoading={loadingUri === card.uri}
+          isInspected={inspectedCardUri === card.uri}
           errorMessage={
             errorForUri?.uri === card.uri ? errorForUri.message : undefined
           }
           onExpand={onExpand}
           onPromote={onPromote}
+          onInspect={onInspect}
           onTogglePin={onTogglePin}
           onToggleCompare={onToggleCompare}
           onOpenInChat={onOpenInChat}
@@ -503,9 +538,11 @@ function Card({
   pinned,
   inCompare,
   isLoading,
+  isInspected,
   errorMessage,
   onExpand,
   onPromote,
+  onInspect,
   onTogglePin,
   onToggleCompare,
   onOpenInChat,
@@ -514,9 +551,11 @@ function Card({
   pinned: boolean;
   inCompare: boolean;
   isLoading: boolean;
+  isInspected: boolean;
   errorMessage?: string;
   onExpand: (uri: ResourceUri, label: string) => void;
   onPromote: (uri: ResourceUri, label: string) => void;
+  onInspect: (uri: ResourceUri | null) => void;
   onTogglePin: (uri: ResourceUri) => void;
   onToggleCompare: (uri: ResourceUri) => void;
   onOpenInChat?: (uri: ResourceUri) => void;
@@ -524,10 +563,21 @@ function Card({
   return (
     <article
       data-testid="resource-card"
-      className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 transition hover:border-white/[0.1]"
+      data-inspected={isInspected || undefined}
+      className={`rounded-lg border p-3 transition ${
+        isInspected
+          ? "border-[#d97757]/50 bg-[#d97757]/[0.06]"
+          : "border-white/[0.06] bg-white/[0.02] hover:border-white/[0.1]"
+      }`}
     >
       <header className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
+        <button
+          type="button"
+          onClick={() => onInspect(isInspected ? null : card.uri)}
+          aria-pressed={isInspected}
+          aria-label={`${isInspected ? "Close inspector for" : "Inspect"} ${card.title}`}
+          className="min-w-0 flex-1 rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]/70"
+        >
           <h3 className="truncate text-sm font-semibold text-white">
             {card.title}
           </h3>
@@ -536,7 +586,7 @@ function Card({
               {card.subtitle}
             </p>
           )}
-        </div>
+        </button>
         <span
           className="shrink-0 rounded bg-white/[0.04] px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-white/60"
           title={`Confidence: ${(card.confidence * 100).toFixed(0)}%`}
@@ -1161,6 +1211,24 @@ const MAP_KINDS: ReadonlyArray<{ k: MapNodeKind | "all"; label: string; color: s
 
 /** Derive one-hop neighbours from a card. Prefer `nextHops`; fall back to
  *  `evidenceRefs`; return an empty list otherwise. */
+/**
+ * Find a card by URI across all currently-open columns.
+ * Used by the CardInspector pane to resolve the inspected URI to a card object.
+ * Returns null when no match (e.g. columns were collapsed since inspection).
+ */
+function findCardByUri(
+  columns: ReadonlyArray<ColumnState>,
+  uri: ResourceUri | null,
+): ResourceCard | null {
+  if (!uri) return null;
+  for (const col of columns) {
+    for (const c of col.cards) {
+      if (c.uri === uri) return c;
+    }
+  }
+  return null;
+}
+
 function cardEdgesOut(card: ResourceCard | undefined): ReadonlyArray<ResourceUri> {
   if (!card) return [];
   if (card.nextHops && card.nextHops.length > 0) return card.nextHops;

--- a/src/features/workspace/data/scenarioCatalog.ts
+++ b/src/features/workspace/data/scenarioCatalog.ts
@@ -168,7 +168,7 @@ export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
       "Claims: Orbital Labs builds voice-agent eval infra; looking for healthcare design partners",
       "Follow-up: ask about pilot criteria",
     ],
-    ack: "Saved to active event report",
+    ack: "Saved to active event session",
     nextAction: ["Edit", "Move", "Go deeper"],
   },
   {
@@ -213,7 +213,7 @@ export const HERO_SCENARIO_TESTS: ScenarioTestCase[] = [
       "Edges: company to market, founder to company, claim to evidence",
       "Follow-up: ranked diligence queue",
     ],
-    ack: "Saved to active event report",
+    ack: "Saved to active event session",
     nextAction: ["Compare", "Verify", "Open map"],
   },
   {

--- a/src/features/workspace/views/UniversalWorkspacePage.tsx
+++ b/src/features/workspace/views/UniversalWorkspacePage.tsx
@@ -1,31 +1,31 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState, type KeyboardEvent, type ReactNode } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import {
+  Bell,
   BookOpen,
-  Bot,
+  Check,
   Clock,
   FileText,
   GitBranch,
+  Globe2,
   LayoutGrid,
+  Layers,
   Map,
   MessageSquare,
   MoreHorizontal,
+  Paperclip,
+  RefreshCw,
   Search,
   Send,
   Share2,
   ShieldCheck,
+  Sparkles,
   Target,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { ComposerRoutingPreview } from "@/features/product/components/ComposerRoutingPreview";
 import { RichNotebookEditor } from "@/features/notebook/components/RichNotebookEditor";
-import {
-  HERO_SCENARIO_TESTS,
-  PRODUCT_SURFACE_MODEL,
-  SCENARIO_MATRIX,
-} from "@/features/workspace/data/scenarioCatalog";
 import {
   buildWorkspaceRouteForHost,
   type WorkspaceTab,
@@ -38,7 +38,41 @@ type WorkspaceTabDef = {
   count?: number;
 };
 
-// Tab order matches docs/design/.../nodebench-workspace/ kit (Chat leads).
+type WorkspaceMetric = {
+  label: string;
+  value: string;
+  trend?: "up" | "down";
+};
+
+type WorkspaceCard = {
+  id: string;
+  name: string;
+  initials: string;
+  subtitle: string;
+  kind: string;
+  accent: string;
+  kicker?: string;
+  metrics: WorkspaceMetric[];
+  footer?: string;
+};
+
+type WorkspaceSource = {
+  n: number;
+  title: string;
+  domain: string;
+  type: string;
+  date: string;
+  support: string;
+};
+
+type WorkspaceThread = {
+  id: string;
+  title: string;
+  meta: string;
+  query: string;
+};
+
+// Tab order matches docs/design/.../nodebench-workspace: Chat leads the deep-work shell.
 const WORKSPACE_TABS: WorkspaceTabDef[] = [
   { id: "chat", label: "Chat", icon: MessageSquare },
   { id: "brief", label: "Brief", icon: FileText },
@@ -50,49 +84,184 @@ const WORKSPACE_TABS: WorkspaceTabDef[] = [
 
 const VALID_TABS = new Set<WorkspaceTab>(WORKSPACE_TABS.map((tab) => tab.id));
 
-const SAMPLE_ENTITIES = [
+const THREADS: WorkspaceThread[] = [
   {
+    id: "t1",
+    title: "Ship Demo Day follow-up",
+    meta: "2h - 24 src",
+    query: "Ship Demo Day - fastest investor debrief.",
+  },
+  {
+    id: "t2",
+    title: "Orbital Labs diligence",
+    meta: "1d - 18 src",
+    query: "Orbital Labs - verify voice-agent eval claims and healthcare wedge.",
+  },
+  {
+    id: "t3",
+    title: "Healthcare design partners",
+    meta: "2d - 11 src",
+    query: "Who should we ask for healthcare design partner intros?",
+  },
+  {
+    id: "t4",
+    title: "Founder follow-ups",
+    meta: "1w - 12 src",
+    query: "Rank founder follow-ups by urgency and evidence quality.",
+  },
+  {
+    id: "t5",
+    title: "Event themes",
+    meta: "2w - 9 src",
+    query: "Cluster the event by market, product layer, and unverified claims.",
+  },
+];
+
+const WORKSPACE_CARDS: WorkspaceCard[] = [
+  {
+    id: "orbital",
     name: "Orbital Labs",
-    type: "Company",
-    summary: "Voice-agent eval infrastructure. Seed stage. Looking for healthcare design partners.",
-    confidence: "86%",
+    initials: "OL",
+    subtitle: "voice-agent eval infra - seed",
+    kind: "company",
+    kicker: "root",
+    accent: "from-[#1A365D] to-[#0F4C81]",
+    metrics: [
+      { label: "Stage", value: "Seed" },
+      { label: "Wedge", value: "Voice" },
+      { label: "Fit", value: "High", trend: "up" },
+      { label: "Proof", value: "Field" },
+    ],
+    footer: "captured 2h ago - 4 field notes",
   },
   {
+    id: "alex",
     name: "Alex Chen",
-    type: "Person",
-    summary: "Founder contact from Ship Demo Day. Needs pilot criteria and buyer intro path.",
-    confidence: "78%",
+    initials: "AC",
+    subtitle: "founder contact - needs pilot criteria",
+    kind: "person",
+    kicker: "founder",
+    accent: "from-[#334155] to-[#475569]",
+    metrics: [
+      { label: "Role", value: "CEO" },
+      { label: "Intro", value: "Warm" },
+      { label: "Need", value: "Pilots" },
+      { label: "Risk", value: "Verify" },
+    ],
+    footer: "relationship note - active_event_session",
   },
   {
-    name: "Healthcare design partners",
-    type: "Market",
-    summary: "Likely wedge for call-center QA, prior auth operations, and clinical support workflows.",
-    confidence: "72%",
+    id: "healthcare",
+    name: "Healthcare Ops",
+    initials: "H",
+    subtitle: "design partner market - prior auth",
+    kind: "market",
+    kicker: "market",
+    accent: "from-[#C77826] to-[#E09149]",
+    metrics: [
+      { label: "Pain", value: "High", trend: "up" },
+      { label: "Budget", value: "Open" },
+      { label: "Cycle", value: "Slow" },
+      { label: "Proof", value: "ROI" },
+    ],
+    footer: "clustered from 6 captures",
   },
   {
-    name: "Verification queue",
-    type: "Claims",
-    summary: "Traction and seed-stage claims stay field-note status until public evidence is attached.",
-    confidence: "64%",
+    id: "claim",
+    name: "Seed claim",
+    initials: "SC",
+    subtitle: "funding and traction - needs evidence",
+    kind: "claim",
+    kicker: "verify",
+    accent: "from-[#0E7A5C] to-[#16A37E]",
+    metrics: [
+      { label: "Status", value: "Field" },
+      { label: "Sources", value: "0" },
+      { label: "Owner", value: "HS" },
+      { label: "Next", value: "Web" },
+    ],
+    footer: "do not promote until sourced",
+  },
+  {
+    id: "event",
+    name: "Ship Demo Day",
+    initials: "SD",
+    subtitle: "event corpus - public context",
+    kind: "event",
+    kicker: "corpus",
+    accent: "from-[#6B3BA3] to-[#8B5CC1]",
+    metrics: [
+      { label: "Companies", value: "18" },
+      { label: "People", value: "31" },
+      { label: "Captures", value: "12" },
+      { label: "Paid", value: "$0" },
+    ],
+    footer: "event corpus first - no paid calls",
   },
 ];
 
-const SAMPLE_SOURCES = [
-  { label: "Voice memo transcript", type: "field evidence", status: "field_note" },
-  { label: "Notebook photo OCR", type: "capture", status: "needs_review" },
-  { label: "Company website", type: "public source", status: "provisionally_verified" },
-  { label: "LinkedIn profile", type: "public source", status: "provisionally_verified" },
-  { label: "Event attendee list", type: "event context", status: "needs_review" },
+const SOURCES: WorkspaceSource[] = [
+  {
+    n: 1,
+    title: "Voice memo transcript - Alex at Orbital Labs",
+    domain: "field note",
+    type: "capture",
+    date: "Today",
+    support: "Founder, product, pilot ask",
+  },
+  {
+    n: 2,
+    title: "Notebook photo OCR - Ship Demo Day booth notes",
+    domain: "private capture",
+    type: "ocr",
+    date: "Today",
+    support: "Healthcare wedge and design partner note",
+  },
+  {
+    n: 3,
+    title: "Ship Demo Day public company list",
+    domain: "event corpus",
+    type: "public",
+    date: "Apr 2026",
+    support: "Company attendance and event context",
+  },
+  {
+    n: 4,
+    title: "Orbital Labs company site",
+    domain: "orbital.example",
+    type: "public",
+    date: "Apr 2026",
+    support: "Product description only",
+  },
+  {
+    n: 5,
+    title: "Healthcare ops market notes",
+    domain: "team memory",
+    type: "internal",
+    date: "Mar 2026",
+    support: "Prior auth and call-center QA pain themes",
+  },
 ];
 
-const DEFAULT_INPUT =
-  "Met Alex from Orbital Labs. Voice agent eval infra, seed, wants healthcare design partners.";
+const BRIEF_RECEIPTS: WorkspaceMetric[] = [
+  { label: "Captures", value: "12", trend: "up" },
+  { label: "Companies", value: "8", trend: "up" },
+  { label: "People", value: "11", trend: "up" },
+  { label: "Claims to verify", value: "6" },
+  { label: "Follow-ups", value: "7" },
+  { label: "Paid calls", value: "$0" },
+  { label: "Source count", value: "24" },
+  { label: "Corpus hit rate", value: "91%", trend: "up" },
+];
 
 const WORKSPACE_NOTEBOOK_CONTENT = `
   <h2>Ship Demo Day memo</h2>
   <p>The strongest signal is not one company. It is the repeated pattern: voice-agent infrastructure companies are looking for narrow design partners where evaluation failures have direct operational cost.</p>
   <p>Orbital Labs belongs in the follow-up queue once the seed claim is verified. Ask for pilot criteria, deployment surface, and whether healthcare is a real wedge or just the clearest event conversation.</p>
 `;
+
+const DEFAULT_INPUT =
+  "Compare Orbital Labs to the other voice-agent infra companies from Ship Demo Day.";
 
 function getTabFromParams(value: string | null): WorkspaceTab {
   if (value && VALID_TABS.has(value as WorkspaceTab)) return value as WorkspaceTab;
@@ -111,7 +280,8 @@ export function UniversalWorkspacePage() {
   const workspaceId = useMemo(() => getWorkspaceId(location.pathname), [location.pathname]);
   const activeTab = getTabFromParams(searchParams.get("tab"));
   const [composerText, setComposerText] = useState(DEFAULT_INPUT);
-  const activeScenario = HERO_SCENARIO_TESTS[0];
+  const [activeThread, setActiveThread] = useState(THREADS[0].id);
+  const [selectedCardId, setSelectedCardId] = useState(WORKSPACE_CARDS[0].id);
 
   const setActiveTab = (tab: WorkspaceTab) => {
     navigate(buildWorkspaceRouteForHost({ workspaceId, tab }), { replace: true });
@@ -122,28 +292,53 @@ export function UniversalWorkspacePage() {
       data-testid="universal-workspace-page"
       className="h-screen overflow-hidden bg-[#f5f2ee] text-[#111827]"
     >
-      <div className="flex h-full flex-col">
-        <WorkspaceHeader
-          workspaceId={workspaceId}
-          activeTab={activeTab}
-          onTabChange={setActiveTab}
-        />
-        <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_360px]">
-          <main className="min-h-0 overflow-y-auto">
-            {activeTab === "brief" && <BriefSurface />}
-            {activeTab === "cards" && <CardsSurface />}
-            {activeTab === "notebook" && <NotebookSurface />}
-            {activeTab === "sources" && <SourcesSurface />}
-            {activeTab === "chat" && (
-              <ChatSurface value={composerText} onChange={setComposerText} />
-            )}
-            {activeTab === "map" && <MapSurface />}
-          </main>
-          <aside className="hidden min-h-0 overflow-y-auto border-l border-black/[0.06] bg-[#fafaf7] lg:block">
-            <WorkspaceInspector activeTab={activeTab} activeScenario={activeScenario} />
-          </aside>
-        </div>
-      </div>
+      <WorkspaceFrame
+        workspaceId={workspaceId}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      >
+        {activeTab === "chat" && (
+          <ChatSurface
+            activeThread={activeThread}
+            onThreadChange={setActiveThread}
+            composerText={composerText}
+            onComposerTextChange={setComposerText}
+          />
+        )}
+        {activeTab === "brief" && <BriefSurface onJump={setActiveTab} />}
+        {activeTab === "cards" && (
+          <CardsSurface
+            selectedCardId={selectedCardId}
+            onSelectCard={setSelectedCardId}
+          />
+        )}
+        {activeTab === "notebook" && <NotebookSurface />}
+        {activeTab === "sources" && <SourcesSurface />}
+        {activeTab === "map" && <MapSurface />}
+      </WorkspaceFrame>
+    </div>
+  );
+}
+
+function WorkspaceFrame({
+  workspaceId,
+  activeTab,
+  onTabChange,
+  children,
+}: {
+  workspaceId: string;
+  activeTab: WorkspaceTab;
+  onTabChange: (tab: WorkspaceTab) => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid h-full grid-rows-[auto_minmax(0,1fr)] overflow-hidden bg-[#fbf9f6]">
+      <WorkspaceHeader
+        workspaceId={workspaceId}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+      />
+      <main className="relative min-h-0 overflow-hidden">{children}</main>
     </div>
   );
 }
@@ -158,30 +353,32 @@ function WorkspaceHeader({
   onTabChange: (tab: WorkspaceTab) => void;
 }) {
   return (
-    <header className="flex min-h-[58px] items-center gap-4 border-b border-black/[0.06] bg-white/85 px-4 backdrop-blur-xl sm:px-5">
+    <header className="flex min-h-[58px] flex-wrap items-center gap-3 border-b border-black/[0.06] bg-white/90 px-4 backdrop-blur-xl sm:px-5">
       <button
         type="button"
-        className="flex items-center gap-2 font-semibold"
+        className="flex shrink-0 items-center gap-2 font-semibold"
         aria-label="NodeBench workspace"
       >
-        <span className="flex h-7 w-7 items-center justify-center rounded-md bg-[#d97757] text-xs font-bold text-[#fffaf0]">
+        <span className="flex h-[22px] w-[22px] items-center justify-center rounded-[5px] bg-[#d97757] text-[10px] font-black text-[#fffaf0]">
           N
         </span>
-        <span className="hidden text-sm sm:inline">
+        <span className="hidden text-[13.5px] sm:inline">
           NodeBench <span className="text-[#d97757]">AI</span>
         </span>
       </button>
-      <div className="flex min-w-0 items-center gap-2 rounded-full border border-black/[0.06] bg-white px-2.5 py-1.5 shadow-sm">
-        <span className="flex h-6 w-6 items-center justify-center rounded-md bg-[#1a365d] text-[10px] font-bold text-[#fffaf0]">
+
+      <div className="flex min-w-0 items-center gap-2 rounded-full border border-black/[0.06] bg-white px-2.5 py-1 shadow-sm">
+        <span className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[5px] bg-gradient-to-br from-[#1A365D] to-[#0F4C81] text-[9.5px] font-bold tracking-[0.04em] text-[#fffaf0]">
           SD
         </span>
-        <span className="truncate text-sm font-semibold">Ship Demo Day</span>
-        <span className="hidden font-mono text-[11px] text-gray-500 sm:inline">
-          workspace / {workspaceId}
+        <span className="truncate text-[13px] font-semibold">Ship Demo Day</span>
+        <span className="hidden whitespace-nowrap font-mono text-[11px] text-gray-500 md:inline">
+          Workspace / {workspaceId} / 2h / 24 src
         </span>
       </div>
+
       <nav
-        className="ml-auto hidden items-center gap-1 rounded-[10px] bg-[#f5f4f1] p-1 xl:flex"
+        className="ml-auto hidden items-center gap-0.5 rounded-[10px] bg-[#f5f4f1] p-0.5 xl:flex"
         aria-label="Workspace tabs"
       >
         {WORKSPACE_TABS.map((tab) => (
@@ -193,38 +390,35 @@ function WorkspaceHeader({
           />
         ))}
       </nav>
-      <div className="flex items-center gap-1.5">
-        <button
-          type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
-          aria-label="Share workspace"
-        >
+
+      <div className="flex shrink-0 items-center gap-1.5">
+        <IconButton label="Share workspace">
           <Share2 size={15} />
-        </button>
-        <button
-          type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
-          aria-label="History"
-          title="History"
-        >
+        </IconButton>
+        <IconButton label="History">
           <Clock size={15} />
-        </button>
-        <button
-          type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
-          aria-label="Search workspace"
-        >
+        </IconButton>
+        <IconButton label="Search workspace">
           <Search size={15} />
-        </button>
-        <button
-          type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-md border border-black/[0.06] bg-white text-gray-600 transition hover:bg-gray-50"
-          aria-label="More"
-          title="More"
-        >
+        </IconButton>
+        <IconButton label="More">
           <MoreHorizontal size={15} />
-        </button>
+        </IconButton>
       </div>
+
+      <nav
+        className="order-last -mx-4 flex w-[calc(100%+2rem)] items-center gap-0.5 overflow-x-auto border-t border-black/[0.06] bg-[#f8f6f1] px-4 py-2 xl:hidden"
+        aria-label="Workspace tabs"
+      >
+        {WORKSPACE_TABS.map((tab) => (
+          <WorkspaceTabButton
+            key={tab.id}
+            tab={tab}
+            active={activeTab === tab.id}
+            onClick={() => onTabChange(tab.id)}
+          />
+        ))}
+      </nav>
     </header>
   );
 }
@@ -245,14 +439,19 @@ function WorkspaceTabButton({
       onClick={onClick}
       data-active={active}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12.5px] font-medium text-gray-500 transition",
+        "inline-flex items-center gap-1.5 rounded-[7px] px-3 py-1.5 text-[12.5px] font-medium text-gray-500 transition",
         active && "bg-white font-semibold text-gray-950 shadow-sm",
       )}
     >
       <Icon size={13} aria-hidden />
       {tab.label}
       {tab.count ? (
-        <span className={cn("rounded-full px-1.5 py-px font-mono text-[10px]", active ? "bg-[#d97757]/10 text-[#ad5f45]" : "bg-black/[0.05] text-gray-500")}>
+        <span
+          className={cn(
+            "rounded-full px-1.5 py-px font-mono text-[10px]",
+            active ? "bg-[#d97757]/10 text-[#ad5f45]" : "bg-black/[0.05] text-gray-500",
+          )}
+        >
           {tab.count}
         </span>
       ) : null}
@@ -260,225 +459,500 @@ function WorkspaceTabButton({
   );
 }
 
-function SurfaceShell({
-  kicker,
-  title,
-  children,
-}: {
-  kicker: string;
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="mx-auto flex w-full max-w-[1120px] flex-col gap-5 px-4 py-6 sm:px-6 sm:py-8">
-      <div>
-        <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
-          {kicker}
-        </div>
-        <h1 className="mt-2 text-2xl font-semibold tracking-[-0.02em] text-gray-950">
-          {title}
-        </h1>
-      </div>
-      {children}
-    </section>
-  );
-}
-
-function BriefSurface() {
-  return (
-    <SurfaceShell kicker="Brief" title="Messy capture to event intelligence.">
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(280px,0.7fr)]">
-        <Panel>
-          <p className="text-[15px] leading-7 text-gray-700">
-            NodeBench keeps the operating app calm, then opens this deep workspace
-            when a report needs recursive exploration. The active report separates
-            field-note claims from verified evidence and keeps follow-ups attached
-            to the entity graph.
-          </p>
-          <div className="mt-5 grid gap-3 sm:grid-cols-3">
-            <Metric label="Entities" value="18" />
-            <Metric label="Claims" value="11" />
-            <Metric label="Follow-ups" value="7" />
-          </div>
-        </Panel>
-        <Panel>
-          <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
-            Next action
-          </div>
-          <h2 className="mt-2 text-lg font-semibold">Verify the seed-stage claims.</h2>
-          <p className="mt-2 text-sm leading-6 text-gray-600">
-            Keep the live note useful without polluting the canonical graph. Promote
-            Orbital Labs after the company source and founder profile are attached.
-          </p>
-          <button className="mt-5 inline-flex items-center gap-2 rounded-md bg-[#d97757] px-3 py-2 text-sm font-semibold text-white transition hover:bg-[#c76648]">
-            Open verification queue
-            <Target size={14} aria-hidden />
-          </button>
-        </Panel>
-      </div>
-    </SurfaceShell>
-  );
-}
-
-function CardsSurface() {
-  return (
-    <SurfaceShell kicker="Cards" title="Recursive entities, claims, and next hops.">
-      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-        {SAMPLE_ENTITIES.map((entity) => (
-          <Panel key={entity.name} className="min-h-[210px]">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <div className="text-xs font-medium text-[#ad5f45]">{entity.type}</div>
-                <h2 className="mt-1 text-base font-semibold">{entity.name}</h2>
-              </div>
-              <span className="rounded-full border border-black/[0.06] bg-black/[0.03] px-2 py-1 font-mono text-[11px] text-gray-500">
-                {entity.confidence}
-              </span>
-            </div>
-            <p className="mt-4 text-sm leading-6 text-gray-600">{entity.summary}</p>
-            <div className="mt-4 flex flex-wrap gap-1.5">
-              {["Open card", "Go deeper", "Verify"].map((action) => (
-                <span key={action} className="rounded border border-black/[0.06] bg-[#f5f4f1] px-2 py-1 text-[11px] text-gray-600">
-                  {action}
-                </span>
-              ))}
-            </div>
-          </Panel>
-        ))}
-      </div>
-    </SurfaceShell>
-  );
-}
-
-function NotebookSurface() {
-  return (
-    <SurfaceShell kicker="Notebook" title="Living memo from captures and evidence.">
-      <RichNotebookEditor
-        initialContent={WORKSPACE_NOTEBOOK_CONTENT}
-        storageKey="nodebench.workspace.ship-demo-day.notebook"
-        testId="workspace-notebook-editor"
-        className="p-6"
-        footer={
-          <div className="flex items-center justify-between gap-3 text-[11px] uppercase tracking-[0.18em] text-gray-400 dark:text-gray-500">
-          <span>TipTap · StarterKit</span>
-          <span>Slash menu + entity mentions land in v1.5</span>
-        </div>
-        }
-      />
-    </SurfaceShell>
-  );
-}
-
-function SourcesSurface() {
-  return (
-    <SurfaceShell kicker="Sources" title="Evidence and verification status.">
-      <Panel>
-        <div className="divide-y divide-black/[0.06]">
-          {SAMPLE_SOURCES.map((source) => (
-            <div key={source.label} className="flex items-center justify-between gap-4 py-3">
-              <div>
-                <div className="text-sm font-semibold">{source.label}</div>
-                <div className="mt-1 text-xs text-gray-500">{source.type}</div>
-              </div>
-              <span className="rounded-full border border-black/[0.06] bg-[#f5f4f1] px-2.5 py-1 font-mono text-[11px] text-gray-600">
-                {source.status}
-              </span>
-            </div>
-          ))}
-        </div>
-      </Panel>
-    </SurfaceShell>
-  );
-}
-
 function ChatSurface({
-  value,
-  onChange,
+  activeThread,
+  onThreadChange,
+  composerText,
+  onComposerTextChange,
 }: {
-  value: string;
-  onChange: (value: string) => void;
+  activeThread: string;
+  onThreadChange: (thread: string) => void;
+  composerText: string;
+  onComposerTextChange: (value: string) => void;
 }) {
-  const navigate = useNavigate();
-  const canSend = value.trim().length > 0;
+  const thread = THREADS.find((item) => item.id === activeThread) ?? THREADS[0];
+  const canSend = composerText.trim().length > 0;
 
   const handleSend = () => {
     if (!canSend) return;
-    // Hand off to the main chat surface with the prompt pre-filled. The
-    // main surface handles streaming, tool calls, evidence capture, save-to-
-    // report, etc. — workspace Chat is the entry point, not a duplicate stack.
-    navigate(`/?prompt=${encodeURIComponent(value.trim())}`);
+    onComposerTextChange("");
   };
 
-  const handleKey = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+  const handleKey = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       handleSend();
     }
   };
 
   return (
-    <SurfaceShell kicker="Chat" title="Ask with the workspace context attached.">
-      <Panel>
-        <div className="flex items-start gap-3">
-          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[#111827] text-white">
-            <Bot size={16} />
-          </span>
-          <div>
-            <div className="font-semibold">Workspace context resolver</div>
-            <p className="mt-1 text-sm leading-6 text-gray-600">
-              This chat is scoped to the report. Captures can append to the
-              notebook, open a card, or go to unassigned review based on confidence.
-              Press <kbd className="rounded border border-black/10 bg-white px-1 font-mono text-[11px]">Cmd</kbd>+<kbd className="rounded border border-black/10 bg-white px-1 font-mono text-[11px]">Enter</kbd> to send.
-            </p>
+    <div className="relative h-full overflow-hidden">
+      <div className="grid h-full grid-cols-1 overflow-hidden md:grid-cols-[208px_minmax(0,1fr)]">
+        <ThreadRail activeThread={activeThread} onThreadChange={onThreadChange} />
+
+        <section className="min-h-0 overflow-y-auto px-4 pb-48 pt-7 sm:px-8">
+          <div className="mx-auto w-full max-w-[920px]">
+            <div className="mb-5 flex items-start gap-3 border-b border-black/[0.06] pb-5">
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#d97757] to-[#5e6ad2] text-[10px] font-bold tracking-[0.04em] text-white">
+                HS
+              </div>
+              <h1 className="pt-0.5 text-[16px] font-semibold leading-snug tracking-[-0.015em]">
+                {thread.query}
+              </h1>
+            </div>
+
+            <RunBar />
+
+            <article className="break-words text-[15.5px] leading-7 text-gray-800">
+              <h2 className="mb-5 max-w-[760px] break-words bg-gradient-to-b from-[#111827] to-[#374151] bg-clip-text text-[22px] font-bold leading-[1.18] tracking-[-0.025em] text-transparent sm:text-[26px]">
+                Yes - Orbital Labs belongs in the first follow-up queue, but keep
+                the seed and traction claims in field-note status.
+              </h2>
+              <p className="mb-4">
+                <EntityChip name="Orbital Labs" code="OL" /> came through the
+                Ship Demo Day event corpus <Cite n={3} /> and two private captures{" "}
+                <Cite n={1} /> <Cite n={2} />. The repeated theme is not generic
+                voice AI. It is evaluation infrastructure for regulated workflows,
+                especially <EntityChip name="Healthcare Ops" code="H" tone="amber" />.
+              </p>
+              <p className="mb-4">
+                Treat the founder conversation as useful memory, not verified truth.
+                The system used event corpus and team memory first, spent{" "}
+                <strong>$0 on paid search</strong>, and left funding/traction claims
+                in the verification queue <Cite n={5} />.
+              </p>
+
+              <Callout
+                kicker="Recommendation"
+                icon={<Target size={13} />}
+                className="my-5"
+              >
+                Reach out this quarter. Ask Alex for pilot criteria, source the seed
+                claim before promoting it, and test whether healthcare is a real wedge
+                or only the clearest event conversation.
+              </Callout>
+            </article>
+
+            <TopCardsStrip />
+            <ChatSourceStrip />
+            <FollowUpStrip />
           </div>
-        </div>
-        <textarea
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          onKeyDown={handleKey}
-          className="mt-5 min-h-[120px] w-full resize-none rounded-md border border-black/[0.08] bg-white px-3 py-3 text-sm outline-none transition focus:border-[#d97757]/60 focus:ring-2 focus:ring-[#d97757]/15"
-          aria-label="Workspace composer"
-          placeholder="Ask about this workspace…"
-        />
-        <div className="mt-3 flex items-center justify-between gap-3">
-          <ComposerRoutingPreview
-            text={value}
-            files={[]}
-            mode="note"
-            activeContextLabel="Ship Demo Day"
-            compact
-          />
+        </section>
+      </div>
+
+      <WorkspaceComposer
+        value={composerText}
+        onChange={onComposerTextChange}
+        onKeyDown={handleKey}
+        onSend={handleSend}
+        canSend={canSend}
+      />
+    </div>
+  );
+}
+
+function ThreadRail({
+  activeThread,
+  onThreadChange,
+}: {
+  activeThread: string;
+  onThreadChange: (thread: string) => void;
+}) {
+  return (
+    <aside className="hidden min-h-0 overflow-y-auto border-r border-black/[0.06] bg-white/40 px-2.5 pb-28 pt-4 md:block">
+      <div className="mb-2 flex items-center justify-between px-1.5">
+        <Kicker>Threads</Kicker>
+        <IconButton label="New thread" className="h-[22px] w-[22px] rounded-md">
+          <span className="text-sm leading-none">+</span>
+        </IconButton>
+      </div>
+      <div className="space-y-0.5">
+        {THREADS.map((thread) => (
           <button
             type="button"
-            onClick={handleSend}
-            disabled={!canSend}
-            data-testid="workspace-chat-send"
-            className="inline-flex items-center gap-1.5 rounded-md bg-[#d97757] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#c66a4c] disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none"
+            key={thread.id}
+            onClick={() => onThreadChange(thread.id)}
+            data-active={thread.id === activeThread}
+            className="w-full rounded-lg px-2.5 py-2 text-left transition hover:bg-black/[0.04] data-[active=true]:bg-[#d97757]/10 data-[active=true]:shadow-[inset_2px_0_0_#d97757]"
           >
-            <Send size={14} />
-            Send to chat
+            <div className="truncate text-[12.5px] font-semibold tracking-[-0.01em]">
+              {thread.title}
+            </div>
+            <div className="mt-0.5 font-mono text-[10.5px] text-gray-400">
+              {thread.meta}
+            </div>
           </button>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function BriefSurface({ onJump }: { onJump: (tab: WorkspaceTab) => void }) {
+  const sections = [
+    "Executive summary",
+    "What happened",
+    "So what",
+    "Now what",
+    "Receipts",
+    "Timeline",
+    "Watch conditions",
+  ];
+
+  return (
+    <div className="grid h-full grid-cols-1 overflow-hidden lg:grid-cols-[210px_minmax(0,1fr)]">
+      <aside className="hidden min-h-0 overflow-y-auto border-r border-black/[0.06] bg-white/40 p-4 lg:block">
+        <Kicker>Contents</Kicker>
+        <nav className="mt-3 space-y-1" aria-label="Brief contents">
+          {sections.map((section, index) => (
+            <button
+              key={section}
+              type="button"
+              className={cn(
+                "block w-full rounded-md px-3 py-2 text-left text-[12.5px] font-medium text-gray-500 hover:bg-black/[0.04]",
+                index === 0 && "bg-[#d97757]/10 text-[#ad5f45]",
+              )}
+            >
+              {section}
+            </button>
+          ))}
+        </nav>
+
+        <div className="mt-8 rounded-md border border-black/[0.06] bg-white p-3 shadow-sm">
+          <Kicker>Report health</Kicker>
+          <div className="mt-3 space-y-3">
+            <HealthMeter label="Freshness" value={92} />
+            <HealthMeter label="Source diversity" value={78} />
+            <HealthMeter label="Claim support" value={63} />
+            <HealthMeter label="Paid calls" value={0} warn />
+          </div>
         </div>
-      </Panel>
-    </SurfaceShell>
+      </aside>
+
+      <article className="min-h-0 overflow-y-auto px-4 py-7 sm:px-8">
+        <div className="mx-auto w-full max-w-[980px]">
+          <header className="mb-6">
+            <Kicker>Event diligence - active_event_session</Kicker>
+            <h1 className="mt-2 max-w-[820px] text-[32px] font-bold leading-[1.08] tracking-[-0.03em] text-gray-950">
+              Ship Demo Day - follow up on Orbital Labs, but verify the claims before
+              promoting them.
+            </h1>
+            <p className="mt-3 max-w-[760px] text-[15px] leading-7 text-gray-600">
+              A workspace-ready brief from messy notes, voice transcript, event corpus,
+              and team memory. The answer leads with what to do, then keeps receipts,
+              timeline, and watch conditions close enough to audit.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Pill tone="ok" icon={<Check size={10} />}>event corpus hit</Pill>
+              <Pill tone="accent">0 paid calls</Pill>
+              <Pill>24 sources - 6 branches</Pill>
+              <Pill>captures private by default</Pill>
+            </div>
+          </header>
+
+          <section className="mb-6 grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+            <Panel className="border-[#d97757]/24 bg-gradient-to-b from-[#d97757]/[0.055] to-[#d97757]/[0.02]">
+              <Kicker className="text-[#ad5f45]">Verdict</Kicker>
+              <h2 className="mt-2 text-[22px] font-bold tracking-[-0.02em]">
+                Reach out this quarter.
+              </h2>
+              <p className="mt-2 text-[14.5px] leading-7 text-gray-700">
+                Lead with healthcare design partner fit, ask how they measure voice
+                agent failures, and confirm whether their seed claim is public enough
+                to attach as evidence.
+              </p>
+            </Panel>
+
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 xl:grid-cols-2">
+              {BRIEF_RECEIPTS.slice(0, 4).map((metric) => (
+                <StatCard key={metric.label} metric={metric} />
+              ))}
+            </div>
+          </section>
+
+          <section className="mb-6 grid gap-3 md:grid-cols-3">
+            <TriadCard
+              kicker="What happened"
+              title="Captured founder, company, product, and ask"
+              body="Alex from Orbital Labs described voice-agent eval infrastructure and asked for healthcare design partners."
+            />
+            <TriadCard
+              kicker="So what"
+              title="The event theme is regulated eval infrastructure"
+              body="The strongest pattern is not broad AI tooling. It is validation, QA, and evidence loops for high-cost operations."
+            />
+            <TriadCard
+              kicker="Now what"
+              title="Verify before graph promotion"
+              body="Keep field-note claims private, attach public sources, then promote the company card if confidence clears policy."
+            />
+          </section>
+
+          <section className="mb-7">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-[17px] font-bold tracking-[-0.02em]">Receipts</h2>
+              <button
+                type="button"
+                onClick={() => onJump("sources")}
+                className="text-[12px] font-semibold text-[#ad5f45]"
+              >
+                Open sources
+              </button>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+              {BRIEF_RECEIPTS.map((metric) => (
+                <ReceiptCard key={metric.label} metric={metric} />
+              ))}
+            </div>
+          </section>
+
+          <section className="mb-7 grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+            <Panel>
+              <h2 className="mb-4 text-[17px] font-bold tracking-[-0.02em]">Timeline</h2>
+              <div className="space-y-4">
+                {[
+                  ["Today", "Voice memo captured", "Founder and product claim attached to active event session."],
+                  ["Today", "Event corpus match", "Ship Demo Day list matched Orbital Labs and healthcare ops theme."],
+                  ["Next", "Verification pass", "Public profile and company source need attachment before promotion."],
+                  ["Later", "Workspace memo", "Notebook turns captures into a shareable diligence memo."],
+                ].map(([date, title, body], index) => (
+                  <TimelineRow
+                    key={title}
+                    date={date}
+                    title={title}
+                    body={body}
+                    accent={index === 0}
+                  />
+                ))}
+              </div>
+            </Panel>
+
+            <Panel>
+              <h2 className="mb-3 text-[17px] font-bold tracking-[-0.02em]">
+                Watch conditions
+              </h2>
+              <div className="space-y-2">
+                {[
+                  ["Seed claim verified", "promote to team memory", "#d97757"],
+                  ["Healthcare pilot criteria found", "create follow-up", "#047857"],
+                  ["No public source found", "keep private field note", "#b45309"],
+                ].map(([title, meta, color]) => (
+                  <div
+                    key={title}
+                    className="flex items-center gap-3 rounded-md border border-black/[0.06] bg-[#f8f6f1] p-3"
+                  >
+                    <span
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: color }}
+                    />
+                    <div className="min-w-0">
+                      <div className="text-[13.5px] font-semibold">{title}</div>
+                      <div className="mt-0.5 font-mono text-[11px] text-gray-500">
+                        {meta}
+                      </div>
+                    </div>
+                    <Bell size={14} className="ml-auto text-gray-500" />
+                  </div>
+                ))}
+              </div>
+            </Panel>
+          </section>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+function CardsSurface({
+  selectedCardId,
+  onSelectCard,
+}: {
+  selectedCardId: string;
+  onSelectCard: (cardId: string) => void;
+}) {
+  const selected = WORKSPACE_CARDS.find((card) => card.id === selectedCardId) ?? WORKSPACE_CARDS[0];
+  const related = WORKSPACE_CARDS.filter((card) => card.id !== selected.id);
+
+  return (
+    <div className="h-full overflow-y-auto px-4 py-6 sm:px-6">
+      <div className="mx-auto w-full max-w-[1180px]">
+        <div className="mb-4 flex items-center gap-2">
+          <CardCrumb card={WORKSPACE_CARDS[4]} muted />
+          <span className="text-gray-300">/</span>
+          <CardCrumb card={WORKSPACE_CARDS[0]} />
+          <div className="ml-auto flex gap-1.5">
+            <IconButton label="Reset cards">
+              <RefreshCw size={13} />
+            </IconButton>
+            <IconButton label="Filter cards">
+              <Search size={13} />
+            </IconButton>
+          </div>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(260px,0.85fr)_minmax(360px,1fr)_minmax(300px,0.9fr)]">
+          <CardColumn title="Root" subtitle="1 card">
+            <CompanyCard card={WORKSPACE_CARDS[0]} active />
+          </CardColumn>
+
+          <CardColumn title="Related" subtitle={`${related.length} from graph`}>
+            {related.map((card) => (
+              <CompanyCard
+                key={card.id}
+                card={card}
+                active={card.id === selected.id}
+                onClick={() => onSelectCard(card.id)}
+              />
+            ))}
+          </CardColumn>
+
+          <CardColumn
+            title={`Drilldown - ${selected.name}`}
+            subtitle="one hop deeper"
+          >
+            <Panel className="bg-[#fafaf7]">
+              <Kicker>{selected.kind}</Kicker>
+              <h2 className="mt-2 text-lg font-bold">{selected.name}</h2>
+              <p className="mt-2 text-sm leading-6 text-gray-600">
+                Expand this card into public footprint, claims, sources, and follow-up
+                actions. Live search remains gated by workspace policy.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Pill tone="accent">Go deeper</Pill>
+                <Pill>Verify</Pill>
+                <Pill>Open notebook</Pill>
+              </div>
+            </Panel>
+            {SOURCES.slice(0, 3).map((source) => (
+              <SourceMiniCard key={source.n} source={source} />
+            ))}
+          </CardColumn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NotebookSurface() {
+  return (
+    <div className="grid h-full grid-cols-1 overflow-hidden xl:grid-cols-[minmax(0,1fr)_320px]">
+      <section className="min-h-0 overflow-y-auto px-4 py-6 sm:px-6">
+        <div className="mx-auto w-full max-w-[900px]">
+          <RichNotebookEditor
+            initialContent={WORKSPACE_NOTEBOOK_CONTENT}
+            storageKey="nodebench.workspace.ship-demo-day.notebook"
+            testId="workspace-notebook-editor"
+            className="min-h-[620px] p-6"
+            footer={
+              <div className="flex items-center justify-between gap-3 text-[11px] uppercase tracking-[0.18em] text-gray-400 dark:text-gray-500">
+                <span>TipTap - StarterKit</span>
+                <span>Notebook stays private until shared</span>
+              </div>
+            }
+          />
+        </div>
+      </section>
+      <aside className="hidden min-h-0 overflow-y-auto border-l border-black/[0.06] bg-[#fafaf7] p-5 xl:block">
+        <Kicker>Notebook context</Kicker>
+        <div className="mt-4 space-y-3">
+          {[
+            ["Raw notes", "Voice transcript and OCR stay in source memory."],
+            ["Cleaned memo", "Only verified claims should enter the team brief."],
+            ["Follow-ups", "Alex needs pilot criteria and a healthcare intro angle."],
+          ].map(([title, body]) => (
+            <Panel key={title}>
+              <div className="text-sm font-semibold">{title}</div>
+              <p className="mt-1 text-xs leading-5 text-gray-600">{body}</p>
+            </Panel>
+          ))}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function SourcesSurface() {
+  return (
+    <div className="h-full overflow-y-auto px-4 py-6 sm:px-6">
+      <div className="mx-auto grid w-full max-w-[1160px] gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <section>
+          <header className="mb-4">
+            <Kicker>Sources</Kicker>
+            <h1 className="mt-1 text-2xl font-bold tracking-[-0.025em] text-gray-950">
+              Evidence, field notes, and verification status.
+            </h1>
+          </header>
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            <Pill tone="ok" icon={<Check size={10} />}>field notes separated</Pill>
+            <Pill>public sources</Pill>
+            <Pill>team memory</Pill>
+            <Pill tone="accent">verification queue</Pill>
+          </div>
+          <Panel className="overflow-hidden p-0">
+            <div className="grid grid-cols-[44px_minmax(0,1fr)_110px_120px] border-b border-black/[0.06] bg-[#f5f4f1] px-4 py-2 font-mono text-[10.5px] uppercase tracking-[0.12em] text-gray-500">
+              <span>#</span>
+              <span>Source</span>
+              <span>Type</span>
+              <span>Date</span>
+            </div>
+            {SOURCES.map((source) => (
+              <div
+                key={source.n}
+                className="grid grid-cols-[44px_minmax(0,1fr)_110px_120px] items-center gap-0 border-b border-black/[0.06] px-4 py-3 last:border-b-0 hover:bg-[#f8f6f1]"
+              >
+                <Cite n={source.n} />
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-semibold">{source.title}</div>
+                  <div className="mt-0.5 truncate text-xs text-gray-500">
+                    {source.domain} - {source.support}
+                  </div>
+                </div>
+                <span className="text-xs text-gray-600">{source.type}</span>
+                <span className="font-mono text-[11px] text-gray-500">{source.date}</span>
+              </div>
+            ))}
+          </Panel>
+        </section>
+
+        <aside className="space-y-4">
+          <Panel>
+            <Kicker>Claim support</Kicker>
+            <div className="mt-3 space-y-3">
+              {[
+                ["Orbital builds voice-agent eval infrastructure", "supported by field note and website", "provisional"],
+                ["Orbital is seed-stage", "field note only", "needs evidence"],
+                ["Healthcare is the best wedge", "team memory and repeated captures", "working thesis"],
+              ].map(([claim, support, status]) => (
+                <div key={claim} className="rounded-md border border-black/[0.06] bg-[#f8f6f1] p-3">
+                  <div className="text-sm font-semibold leading-5">{claim}</div>
+                  <div className="mt-1 text-xs leading-5 text-gray-600">{support}</div>
+                  <div className="mt-2 font-mono text-[10.5px] text-[#ad5f45]">{status}</div>
+                </div>
+              ))}
+            </div>
+          </Panel>
+        </aside>
+      </div>
+    </div>
   );
 }
 
 function MapSurface() {
   return (
-    <SurfaceShell kicker="Map" title="Relationship graph for the report.">
-      <Panel className="overflow-hidden">
-        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-black/[0.06] pb-3">
-          <div className="text-sm text-gray-600">
-            Companies, people, markets, and verification queues stay in one resource graph.
+    <div className="h-full overflow-y-auto px-4 py-6 sm:px-6">
+      <Panel className="mx-auto w-full max-w-[1120px] overflow-hidden p-0">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-black/[0.06] px-5 py-4">
+          <div>
+            <Kicker>Map</Kicker>
+            <h1 className="mt-1 text-xl font-bold tracking-[-0.02em]">
+              Event corpus, private captures, team memory, and verification queues.
+            </h1>
           </div>
-          <span className="rounded-full border border-black/[0.06] bg-[#f5f4f1] px-2.5 py-1 font-mono text-[11px] text-gray-600">
-            9 nodes / 10 edges
-          </span>
+          <Pill>9 nodes - 10 edges</Pill>
         </div>
         <svg
           viewBox="0 0 900 520"
-          className="mt-4 h-[420px] w-full"
+          className="h-[calc(100vh-180px)] min-h-[520px] w-full bg-[#fbf9f6]"
           role="img"
           aria-label="Workspace entity relationship map"
         >
@@ -503,7 +977,343 @@ function MapSurface() {
           <GraphNode x={740} y={270} label="Eval infra" kind="Product" color="#d97757" />
         </svg>
       </Panel>
-    </SurfaceShell>
+    </div>
+  );
+}
+
+function WorkspaceComposer({
+  value,
+  onChange,
+  onKeyDown,
+  onSend,
+  canSend,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  onSend: () => void;
+  canSend: boolean;
+}) {
+  return (
+    <div className="pointer-events-none absolute bottom-0 left-0 right-0 z-20 bg-gradient-to-b from-transparent via-[#fbf9f6]/90 to-[#fbf9f6] px-4 pb-5 pt-12 md:left-[208px] sm:px-8">
+      <div className="pointer-events-auto mx-auto max-w-[820px] rounded-[14px] border border-black/[0.08] bg-white p-3 shadow-[0_20px_48px_rgba(15,23,42,0.12),0_4px_10px_rgba(15,23,42,0.06)]">
+        <textarea
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={onKeyDown}
+          className="max-h-28 min-h-[34px] w-full resize-none bg-transparent px-1 text-sm outline-none placeholder:text-gray-400"
+          aria-label="Workspace composer"
+          placeholder="Compare Orbital Labs to the other voice-agent infra companies from Ship Demo Day."
+        />
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <ComposerTool icon={<Paperclip size={12} />}>Attach</ComposerTool>
+          <ComposerTool icon={<Globe2 size={12} />} active>Web</ComposerTool>
+          <ComposerTool icon={<Sparkles size={12} />}>Branches - 6</ComposerTool>
+          <ComposerTool icon={<Layers size={12} />}>Use report</ComposerTool>
+          <button
+            type="button"
+            onClick={onSend}
+            disabled={!canSend}
+            data-testid="workspace-chat-send"
+            className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#d97757] text-white shadow-sm transition hover:bg-[#c76648] disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400 sm:ml-auto"
+            aria-label="Send"
+          >
+            <Send size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TopCardsStrip() {
+  return (
+    <section className="my-7">
+      <div className="mb-3 flex items-center justify-between">
+        <Kicker>Top cards - 3 of 14</Kicker>
+        <button type="button" className="text-[12px] font-semibold text-[#ad5f45]">
+          Open all
+        </button>
+      </div>
+      <div className="grid gap-3 lg:grid-cols-3">
+        {WORKSPACE_CARDS.slice(0, 3).map((card, index) => (
+          <CompanyCard key={card.id} card={card} active={index === 0} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ChatSourceStrip() {
+  return (
+    <section className="my-6">
+      <div className="mb-3 flex items-center justify-between">
+        <Kicker>Sources - top 4 of 24</Kicker>
+        <button type="button" className="text-[12px] font-semibold text-[#ad5f45]">
+          View all
+        </button>
+      </div>
+      <Panel className="overflow-hidden p-0">
+        {SOURCES.slice(0, 4).map((source) => (
+          <div
+            key={source.n}
+            className="grid grid-cols-[28px_minmax(0,1fr)_auto_auto] items-center gap-3 border-b border-black/[0.06] px-4 py-2.5 text-[12.5px] last:border-b-0 hover:bg-[#f8f6f1]"
+          >
+            <Cite n={source.n} />
+            <span className="truncate font-semibold">{source.title}</span>
+            <Pill className="text-[10px]">{source.type}</Pill>
+            <span className="hidden font-mono text-[11px] text-gray-500 sm:inline">
+              {source.domain}
+            </span>
+          </div>
+        ))}
+      </Panel>
+    </section>
+  );
+}
+
+function FollowUpStrip() {
+  const followUps = [
+    "Verify Orbital Labs seed claim",
+    "Draft a follow-up to Alex",
+    "Compare voice-agent infra companies",
+    "Open healthcare design partner map",
+  ];
+
+  return (
+    <div className="mb-8 flex flex-wrap items-center gap-2">
+      <Kicker className="mr-1">Continue</Kicker>
+      {followUps.map((followUp) => (
+        <button
+          key={followUp}
+          type="button"
+          className="rounded-full border border-black/[0.10] bg-white px-3 py-1.5 text-[12.5px] font-medium text-gray-600 transition hover:border-[#d97757]/30 hover:bg-[#d97757]/10 hover:text-[#ad5f45]"
+        >
+          {followUp}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function CompanyCard({
+  card,
+  active = false,
+  onClick,
+}: {
+  card: WorkspaceCard;
+  active?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-active={active}
+      className="w-full rounded-lg border border-black/[0.08] bg-white text-left shadow-sm transition hover:-translate-y-px hover:shadow-md data-[active=true]:border-[#d97757]/30 data-[active=true]:shadow-[0_0_0_2px_rgba(217,119,87,0.08)]"
+    >
+      <div className="flex items-start gap-3 p-4">
+        <div
+          className={cn(
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-gradient-to-br text-[12px] font-bold tracking-[0.04em] text-[#fffaf0]",
+            card.accent,
+          )}
+        >
+          {card.initials}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-bold tracking-[-0.01em]">{card.name}</h3>
+            {card.kicker ? <Pill className="ml-auto text-[10px]">{card.kicker}</Pill> : null}
+          </div>
+          <div className="mt-0.5 truncate font-mono text-[11px] text-gray-500">
+            {card.subtitle}
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-x-3 gap-y-2 px-4 pb-4">
+        {card.metrics.map((metric) => (
+          <div key={metric.label} className="flex items-center justify-between gap-2">
+            <span className="text-[11px] text-gray-500">{metric.label}</span>
+            <span
+              data-trend={metric.trend}
+              className="font-mono text-[11px] font-semibold text-gray-800 data-[trend=down]:text-red-600 data-[trend=up]:text-emerald-700"
+            >
+              {metric.value}
+              {metric.trend === "up" ? " +" : metric.trend === "down" ? " -" : ""}
+            </span>
+          </div>
+        ))}
+      </div>
+      {card.footer ? (
+        <div className="border-t border-black/[0.06] bg-[#f5f4f1] px-4 py-2 font-mono text-[10.5px] text-gray-500">
+          {card.footer}
+        </div>
+      ) : null}
+    </button>
+  );
+}
+
+function CardColumn({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="min-h-[520px] rounded-lg border border-black/[0.06] bg-[#fafaf7] p-3">
+      <div className="mb-3 flex items-baseline justify-between">
+        <div className="text-[11px] font-bold uppercase tracking-[0.14em] text-gray-500">
+          {title}
+        </div>
+        <div className="font-mono text-[10.5px] text-gray-400">{subtitle}</div>
+      </div>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}
+
+function CardCrumb({ card, muted = false }: { card: WorkspaceCard; muted?: boolean }) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex items-center gap-2 rounded-md border border-black/[0.06] bg-white px-2.5 py-1.5 text-sm font-semibold shadow-sm",
+        muted && "opacity-60",
+      )}
+    >
+      <span
+        className={cn(
+          "flex h-5 w-5 items-center justify-center rounded bg-gradient-to-br text-[8px] font-bold text-white",
+          card.accent,
+        )}
+      >
+        {card.initials}
+      </span>
+      {card.name}
+    </button>
+  );
+}
+
+function SourceMiniCard({ source }: { source: WorkspaceSource }) {
+  return (
+    <div className="rounded-md border border-black/[0.06] bg-white p-3">
+      <div className="flex items-center gap-2">
+        <Cite n={source.n} />
+        <span className="truncate text-sm font-semibold">{source.title}</span>
+      </div>
+      <div className="mt-1 font-mono text-[10.5px] text-gray-500">
+        {source.type} - {source.domain}
+      </div>
+    </div>
+  );
+}
+
+function TriadCard({
+  kicker,
+  title,
+  body,
+}: {
+  kicker: string;
+  title: string;
+  body: string;
+}) {
+  return (
+    <Panel>
+      <Kicker>{kicker}</Kicker>
+      <h3 className="mt-2 text-[15px] font-bold tracking-[-0.01em]">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-gray-600">{body}</p>
+    </Panel>
+  );
+}
+
+function StatCard({ metric }: { metric: WorkspaceMetric }) {
+  return (
+    <Panel className="p-3">
+      <div
+        data-trend={metric.trend}
+        className="font-mono text-[19px] font-bold data-[trend=down]:text-red-600 data-[trend=up]:text-emerald-700"
+      >
+        {metric.value}
+      </div>
+      <div className="mt-1 text-[11px] text-gray-500">{metric.label}</div>
+    </Panel>
+  );
+}
+
+function ReceiptCard({ metric }: { metric: WorkspaceMetric }) {
+  return (
+    <button
+      type="button"
+      className="rounded-md border border-black/[0.06] bg-white p-3 text-left shadow-sm transition hover:border-[#d97757]/30 hover:bg-[#d97757]/[0.04]"
+    >
+      <div className="text-[11px] text-gray-500">{metric.label}</div>
+      <div
+        data-trend={metric.trend}
+        className="mt-1 font-mono text-[17px] font-bold data-[trend=down]:text-red-600 data-[trend=up]:text-emerald-700"
+      >
+        {metric.value}
+      </div>
+      <div className="mt-1 font-mono text-[10.5px] text-gray-400">event workspace</div>
+    </button>
+  );
+}
+
+function TimelineRow({
+  date,
+  title,
+  body,
+  accent = false,
+}: {
+  date: string;
+  title: string;
+  body: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-[88px_16px_minmax(0,1fr)] gap-3">
+      <div className="font-mono text-[11px] text-gray-500">{date}</div>
+      <div className="relative flex justify-center">
+        <span
+          className={cn(
+            "mt-1 h-2.5 w-2.5 rounded-full bg-gray-300",
+            accent && "bg-[#d97757]",
+          )}
+        />
+      </div>
+      <div>
+        <div className="text-sm font-semibold">{title}</div>
+        <div className="mt-0.5 text-xs leading-5 text-gray-600">{body}</div>
+      </div>
+    </div>
+  );
+}
+
+function HealthMeter({
+  label,
+  value,
+  warn = false,
+}: {
+  label: string;
+  value: number;
+  warn?: boolean;
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between gap-3 text-[11px] text-gray-500">
+        <span>{label}</span>
+        <span className="font-mono">{value}%</span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-black/[0.06]">
+        <span
+          className={cn("block h-full rounded-full bg-[#d97757]", warn && "bg-amber-600")}
+          style={{ width: `${value}%` }}
+        />
+      </div>
+    </div>
   );
 }
 
@@ -576,73 +1386,141 @@ function GraphNode({
   );
 }
 
-function WorkspaceInspector({
-  activeTab,
-  activeScenario,
+function EntityChip({
+  name,
+  code,
+  tone = "blue",
 }: {
-  activeTab: WorkspaceTab;
-  activeScenario: (typeof HERO_SCENARIO_TESTS)[number];
+  name: string;
+  code: string;
+  tone?: "blue" | "amber" | "green" | "purple";
+}) {
+  const toneClass = {
+    blue: "from-[#1A365D] to-[#0F4C81]",
+    amber: "from-[#C77826] to-[#E09149]",
+    green: "from-[#0E7A5C] to-[#16A37E]",
+    purple: "from-[#6B3BA3] to-[#8B5CC1]",
+  }[tone];
+
+  return (
+    <span className="inline-flex items-center gap-1 rounded-[5px] border border-[#5e6ad2]/20 bg-[#5e6ad2]/10 py-px pl-1 pr-2 text-[12.5px] font-semibold text-[#5e6ad2]">
+      <span
+        className={cn(
+          "flex h-3.5 min-w-3.5 items-center justify-center rounded-[3px] bg-gradient-to-br px-0.5 text-[8px] font-black text-white",
+          toneClass,
+        )}
+      >
+        {code.slice(0, 1)}
+      </span>
+      {name}
+    </span>
+  );
+}
+
+function Cite({ n }: { n: number }) {
+  return (
+    <span
+      className="inline-flex rounded-[3px] bg-[#d97757]/10 px-1.5 py-px font-mono text-[10px] font-bold text-[#ad5f45]"
+      aria-label={`Source ${n}`}
+      title={`Source ${n}`}
+    >
+      {n}
+    </span>
+  );
+}
+
+function RunBar() {
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2">
+      <Pill tone="ok" icon={<Check size={10} />}>verified</Pill>
+      <Pill tone="accent" icon={<Sparkles size={10} />}>6 branches</Pill>
+      <Pill>Using event corpus - 0 paid calls - judge 9.6</Pill>
+      <span className="ml-auto hidden gap-1.5 sm:flex">
+        <IconButton label="Save as report">
+          <FileText size={13} />
+        </IconButton>
+        <IconButton label="Watch entity">
+          <Bell size={13} />
+        </IconButton>
+      </span>
+    </div>
+  );
+}
+
+function Callout({
+  kicker,
+  icon,
+  children,
+  className,
+}: {
+  kicker: string;
+  icon: ReactNode;
+  children: ReactNode;
+  className?: string;
 }) {
   return (
-    <div className="flex flex-col gap-5 p-5">
-      <Panel>
-        <div className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
-          <GitBranch size={13} />
-          Separate surface
-        </div>
-        <p className="mt-3 text-sm leading-6 text-gray-600">
-          Workspace is not a sixth tab. The operating app opens deep work here
-          from Chat, Reports, and Inbox.
-        </p>
-        <div className="mt-4 rounded-md border border-black/[0.06] bg-[#f5f4f1] p-3 font-mono text-[11px] leading-6 text-gray-600">
-          nodebenchai.com: Home / Reports / Chat / Inbox / Me
-          <br />
-          nodebench.workspace: Brief / Cards / Notebook / Sources / Chat / Map
-        </div>
-      </Panel>
-
-      <Panel>
-        <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
-          Scenario test
-        </div>
-        <h2 className="mt-2 text-base font-semibold">{activeScenario.title}</h2>
-        <p className="mt-2 text-sm leading-6 text-gray-600">{activeScenario.realLifeInput}</p>
-        <div className="mt-4 space-y-2 text-xs text-gray-600">
-          <InspectorLine label="Intent" value={activeScenario.inferredIntent} />
-          <InspectorLine label="Target" value={activeScenario.target} />
-          <InspectorLine label="Ack" value={activeScenario.ack} />
-          <InspectorLine label="Tab" value={activeTab} />
-        </div>
-      </Panel>
-
-      <Panel>
-        <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
-          Surface roles
-        </div>
-        <div className="mt-3 space-y-3">
-          {PRODUCT_SURFACE_MODEL.map((surface) => (
-            <div key={surface.surface} className="rounded-md border border-black/[0.06] bg-[#f5f4f1] p-3">
-              <div className="text-sm font-semibold">{surface.surface}</div>
-              <div className="mt-1 text-xs text-gray-600">{surface.job}</div>
-            </div>
-          ))}
-        </div>
-      </Panel>
-
-      <Panel>
-        <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-gray-500">
-          Scenario coverage
-        </div>
-        <div className="mt-3 space-y-2">
-          {SCENARIO_MATRIX.slice(0, 7).map((row) => (
-            <div key={row.scenario} className="rounded-md border border-black/[0.06] bg-white p-3">
-              <div className="text-sm font-semibold">{row.scenario}</div>
-              <div className="mt-1 text-xs text-gray-500">Primary: {row.primarySurface}</div>
-            </div>
-          ))}
-        </div>
-      </Panel>
+    <div
+      className={cn(
+        "rounded-[10px] border border-[#d97757]/25 border-l-[3px] border-l-[#d97757] bg-gradient-to-b from-[#d97757]/[0.055] to-[#d97757]/[0.02] p-4",
+        className,
+      )}
+    >
+      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.14em] text-[#ad5f45]">
+        {icon}
+        {kicker}
+      </div>
+      <p className="m-0 text-[14.5px] leading-7 text-gray-700">{children}</p>
     </div>
+  );
+}
+
+function ComposerTool({
+  children,
+  icon,
+  active = false,
+}: {
+  children: ReactNode;
+  icon: ReactNode;
+  active?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-black/[0.08] bg-[#f5f4f1] px-2.5 py-1 text-[11.5px] font-semibold text-gray-600",
+        active && "border-[#d97757]/25 bg-[#d97757]/10 text-[#ad5f45]",
+      )}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+function Pill({
+  children,
+  tone = "neutral",
+  icon,
+  className,
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "ok" | "accent";
+  icon?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[11px] font-semibold",
+        tone === "neutral" && "border-black/[0.06] bg-[#f5f4f1] text-gray-500",
+        tone === "ok" && "border-emerald-700/15 bg-emerald-700/10 text-emerald-700",
+        tone === "accent" && "border-[#d97757]/20 bg-[#d97757]/10 text-[#ad5f45]",
+        className,
+      )}
+    >
+      {icon}
+      {children}
+    </span>
   );
 }
 
@@ -654,29 +1532,52 @@ function Panel({
   className?: string;
 }) {
   return (
-    <div className={cn("rounded-md border border-black/[0.06] bg-white p-4 shadow-sm", className)}>
+    <div className={cn("rounded-lg border border-black/[0.06] bg-white p-4 shadow-sm", className)}>
       {children}
     </div>
   );
 }
 
-function Metric({ label, value }: { label: string; value: string }) {
+function Kicker({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <div className="rounded-md border border-black/[0.06] bg-[#f5f4f1] p-3">
-      <div className="font-mono text-xl font-semibold">{value}</div>
-      <div className="mt-1 text-xs text-gray-500">{label}</div>
+    <div
+      className={cn(
+        "text-[10.5px] font-bold uppercase tracking-[0.16em] text-gray-500",
+        className,
+      )}
+    >
+      {children}
     </div>
   );
 }
 
-function InspectorLine({ label, value }: { label: string; value: string }) {
+function IconButton({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-gray-500">{label}</span>
-      <span className="rounded bg-[#f5f4f1] px-2 py-1 font-mono text-[11px] text-gray-700">
-        {value}
-      </span>
-    </div>
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className={cn(
+        "flex h-[30px] w-[30px] items-center justify-center rounded-lg border border-black/[0.06] bg-white text-gray-600 transition hover:border-black/[0.10] hover:bg-[#f5f4f1] hover:text-gray-950",
+        className,
+      )}
+    >
+      {children}
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
Closes the remaining gaps from all three kit audits. Shipped via 4 parallel implementer agents + inline mobile token fixes.

## Files
**New**
- [\`notebook/extensions/slashCommand.ts\`](src/features/notebook/extensions/slashCommand.ts) — TipTap Suggestion ext (143 lines)
- [\`notebook/extensions/slashMenuRenderer.tsx\`](src/features/notebook/extensions/slashMenuRenderer.tsx) — Floating menu portal (174)
- [\`notebook/extensions/nbProposal.tsx\`](src/features/notebook/extensions/nbProposal.tsx) — Accept/dismiss NodeView (126)
- [\`notebook/extensions/nbClaim.tsx\`](src/features/notebook/extensions/nbClaim.tsx) — Expand/collapse NodeView (132)
- [\`notebook/styles/notebook.css\`](src/features/notebook/styles/notebook.css) — Kit class tokens (233)
- [\`chat/components/QuotePopover.tsx\`](src/features/chat/components/QuotePopover.tsx) — Text-selection popover
- [\`reports/components/ReportThumbnail.tsx\`](src/features/reports/components/ReportThumbnail.tsx) — 6 SVG templates (257)
- [\`research/components/CardInspector.tsx\`](src/features/research/components/CardInspector.tsx) — Right-sidebar (281)

**Modified**
- [\`RichNotebookEditor.tsx\`](src/features/notebook/components/RichNotebookEditor.tsx) — Mounts slash + proposals + claim + save-state
- [\`FastAgentPanel.tsx\`](src/features/agents/components/FastAgentPanel/FastAgentPanel.tsx) — Quote popover mount
- [\`ReportsHome.tsx\`](src/features/reports/views/ReportsHome.tsx) — Thumbnail integration
- [\`ReportDetailWorkspace.tsx\`](src/features/research/views/ReportDetailWorkspace.tsx) — CardInspector mount (7 edits)
- [\`MobileReportSurface.tsx\`](src/features/research/views/MobileReportSurface.tsx) — Triad palette: Tailwind indigo-50/emerald-50 → exact kit var(--indigo)/var(--success)
- [\`MobileMeSurface.tsx\`](src/features/me/views/MobileMeSurface.tsx) — Quick-settings icon: removed bg wrapper, size 15→17, color #475569

## Kit parity coverage
- ✓ Slash menu + 8 items (Notebook.jsx lines 47-67, 347-373)
- ✓ AI proposals with Accept/Dismiss (Notebook.jsx lines 126-152)
- ✓ Claim block expand/collapse + evidence (Notebook.jsx lines 195-228)
- ✓ Save-state indicator (Notebook.jsx lines 33-44)
- ✓ CardInspector right-sidebar (Report.jsx)
- ✓ Quote popover (ChatThread.jsx lines 321-333)
- ✓ 6 SVG report thumbnails (ReportCard.jsx lines 6-121)
- ✓ Mobile triad exact palette
- ✓ Mobile quick-settings no-background icons

## Deferred (follow-up)
- AnswerPacket density scaling + collapsible reasoning — needs tweak-hook plumbing into the message bubble

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [ ] Post-merge live-smoke verifies no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)