### PR TITLE
fix(vercel): extract buildCommand to scripts/vercel-build.sh (425>256 char limit)

### DIFF
--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Vercel build entry — invoked from vercel.json `buildCommand`.
+#
+# Why this script exists:
+#   The previous inline `buildCommand` in vercel.json grew past Vercel's
+#   256-char API limit, which made every deploy fail at config validation
+#   (no build logs produced — Vercel rejects the config before invoking
+#   any build steps).  Extracting to a script keeps `vercel.json` short
+#   and makes the build logic editable + reviewable.
+#
+# Behavior:
+#   Production env:
+#     - require CONVEX_DEPLOY_KEY (fail-fast with actionable message)
+#     - run `npx convex deploy --cmd 'npm run build'` so the Convex
+#       backend ships in lockstep with the frontend bundle
+#   Preview env (PR previews):
+#     - skip `convex deploy` (don't touch shared Convex from a PR branch)
+#     - warn if VITE_CONVEX_URL is missing (frontend will fall back to
+#       baked-in default)
+#     - run plain `npm run build`
+
+set -euo pipefail
+
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+  if [ -z "${CONVEX_DEPLOY_KEY:-}" ]; then
+    echo "::error::Missing CONVEX_DEPLOY_KEY in production env. Add it at Vercel → Settings → Environment Variables → Production."
+    exit 1
+  fi
+  exec npx convex deploy --cmd "npm run build"
+fi
+
+if [ -z "${VITE_CONVEX_URL:-}" ]; then
+  echo "::warning::VITE_CONVEX_URL not set in preview env — frontend will use baked-in default."
+fi
+exec npm run build

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "if [ \"$VERCEL_ENV\" = \"production\" ]; then if [ -z \"$CONVEX_DEPLOY_KEY\" ]; then echo '::error::Missing CONVEX_DEPLOY_KEY in production env. Add it at Vercel → Settings → Environment Variables → Production.'; exit 1; fi; npx convex deploy --cmd 'npm run build'; else if [ -z \"$VITE_CONVEX_URL\" ]; then echo '::warning::VITE_CONVEX_URL not set in preview env — frontend will use baked-in default.'; fi; npm run build; fi",
+  "buildCommand": "bash scripts/vercel-build.sh",
   "functions": {
     "api/search.js": {
       "maxDuration": 60


### PR DESCRIPTION
## Root cause

Every Vercel deploy (production + preview) had been failing silently for 4+ hours with no build logs.  `vercel.json` `buildCommand` was an inline bash conditional that grew to **425 characters** — Vercel's API rejects buildCommand >256 chars, so deploys fail at config validation before any build step runs.

Symptoms:
- PR #73 production deploy (commit d51915ab) — failed
- 15 most recent deploys — `● Error` status, zero duration, no logs
- `vercel logs` returns "waiting for new logs" (none ever produced)
- www.nodebenchai.com still serves the OLD bundle (`index-QZSCvZV1.js`)

## Fix

Extract the inline bash to `scripts/vercel-build.sh`. `vercel.json` buildCommand becomes `bash scripts/vercel-build.sh` (28 chars).  Behavior unchanged — production still requires `CONVEX_DEPLOY_KEY`, preview still warns on missing `VITE_CONVEX_URL`.

## Test plan

- [x] `bash -n scripts/vercel-build.sh` — syntax OK
- [x] `vercel.json` buildCommand length 425 → 28
- [ ] Vercel deploy succeeds (verifies the 256-char issue was the blocker)
- [ ] www.nodebenchai.com bundle hash changes from `index-QZSCvZV1.js` to a new hash
- [ ] Live DOM verification: kit-aligned Home renders ("ENTITY INTELLIGENCE" + "What are we researching today?")

🤖 Generated with [Claude Code](https://claude.com/claude-code)