### PR TITLE
test(e2e): add Tier B regression spec for PR #77 Me anchor nav

### DIFF
--- a/tests/e2e/pr77-me-anchor-nav.spec.ts
+++ b/tests/e2e/pr77-me-anchor-nav.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Tier B regression spec for PR #77 — me kit-aligned section anchors + jump nav.
+ *
+ * Defaults to production www.nodebenchai.com.  Override with BASE_URL env to
+ * point at a preview deployment or localhost dev server.  Mirrors the
+ * BASE_URL convention from tests/e2e/live-smoke.spec.ts so this spec can be
+ * folded into the live-smoke run when desired.
+ *
+ * What this guards against:
+ *   - The 7 kit-aligned section anchors disappearing from MeHome
+ *   - The jump-nav pill row regressing label or order (kit voice)
+ *   - The me cockpit case routing back to ExactMeSurface (which has no
+ *     anchor IDs and no jump nav — the regression that PR #73's cockpit
+ *     fix corrected)
+ */
+
+import { test, expect } from "@playwright/test";
+
+const BASE_URL =
+  process.env.BASE_URL?.replace(/\/$/, "") ?? "https://www.nodebenchai.com";
+
+test("PR #77: /?surface=me has 7 kit-aligned anchor IDs + jump nav", async ({ page }) => {
+  await page.goto(`${BASE_URL}/?surface=me`, { waitUntil: "networkidle", timeout: 30_000 });
+  await page.waitForTimeout(3000);
+
+  const result = await page.evaluate(() => {
+    const anchors = [
+      "me-notebook",
+      "me-profile",
+      "me-files",
+      "me-plan",
+      "me-saved-context",
+      "me-connectors",
+      "me-privacy",
+    ];
+    return {
+      hasJumpNav: !!document.querySelector('nav[aria-label="Jump to section"]'),
+      navLabels: Array.from(document.querySelectorAll('nav[aria-label="Jump to section"] a')).map((a) =>
+        (a.textContent ?? "").trim(),
+      ),
+      anchorsFound: anchors.filter((id) => !!document.getElementById(id)),
+    };
+  });
+
+  console.log("PR77 Me anchor nav:", JSON.stringify(result, null, 2));
+
+  expect(result.hasJumpNav).toBe(true);
+  expect(result.navLabels).toEqual([
+    "Notebook",
+    "Profile",
+    "Files",
+    "Plan",
+    "Data & memory",
+    "Integrations",
+    "Privacy",
+  ]);
+  expect(result.anchorsFound).toEqual([
+    "me-notebook",
+    "me-profile",
+    "me-files",
+    "me-plan",
+    "me-saved-context",
+    "me-connectors",
+    "me-privacy",
+  ]);
+});


### PR DESCRIPTION
## Summary

Locks in the kit-aligned section anchors + jump nav landed in [PR #77](https://github.com/HomenShum/nodebench-ai/pull/77) (commit `6c344384`) as a durable Playwright regression spec.

Defaults to production `www.nodebenchai.com`; override with `BASE_URL` env to point at a preview deployment or localhost dev (matches `tests/e2e/live-smoke.spec.ts` convention).

## Guards against

- 7 anchor IDs disappearing from MeHome (`me-notebook`, `me-profile`, `me-files`, `me-plan`, `me-saved-context`, `me-connectors`, `me-privacy`)
- Jump nav pill row regressing label or order (kit voice)
- Me cockpit case routing back to `ExactMeSurface` (the static-fixture regression that PR #73's cockpit fix corrected)

## Test plan

- [x] `npx playwright test tests/e2e/pr77-me-anchor-nav.spec.ts` against production — 1 passed in 4.8s
- [x] BASE_URL override pattern matches existing live-smoke.spec.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)