### PR TITLE
fix(home): Memory Pulse counts only user-created saved reports (HONEST_SCORES)

### DIFF
--- a/src/features/home/views/HomeLanding.tsx
+++ b/src/features/home/views/HomeLanding.tsx
@@ -588,7 +588,10 @@ export function HomeLanding() {
           HONEST_SCORES: only renders when the user has >= 3 entities; metrics
           are computed from the existing listEntities query (no fake numbers).
         */}
-        <MemoryPulse reportsCreated={visibleReports.length} className="mt-6 sm:mt-8" />
+        {/* HONEST_SCORES: count only user-created saved reports.  visibleReports
+            mixes in system-intelligence cards everyone sees, which would
+            show "3 reports created" to a brand-new user with zero chats. */}
+        <MemoryPulse reportsCreated={savedReports?.length ?? 0} className="mt-6 sm:mt-8" />
 
         {/*
           Welcome fallback — shown only when there's nothing else to anchor the


### PR DESCRIPTION
## Summary

Refines [PR #76](https://github.com/HomenShum/nodebench-ai/pull/76)'s MemoryPulse data source from `visibleReports.length` to `savedReports?.length ?? 0` so the band only counts user-created saved reports.

## Diagnosis

A Playwright probe against production showed a brand-new anonymous session rendering "3 reports created" despite zero chats.  Root cause: `visibleReports = [savedReports, ...projectedSystemReports]`, and the system-intelligence layer ships 3 cards everyone sees by default.  The hero count was honest about `visibleReports.length` but misleading about user-created reports — fails `agentic_reliability` HONEST_SCORES.

## Behavior after this fix

| User state | Band |
|---|---|
| Brand-new (savedReports = []) | Hidden (component short-circuits when reportsCreated <= 0) |
| N saved reports | Shows N (honest count) |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/features/home/` — 6/6 pass
- [x] `npm run build` clean
- [ ] Production verify post-merge: bundle hash advances + new users see no band, returning users see honest count

🤖 Generated with [Claude Code](https://claude.com/claude-code)