### PR TITLE
feat(home): port full kit HomePulse layout to ExactHomeSurface

### DIFF
--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -336,6 +336,325 @@ function ResponsiveSurface({
   );
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+   Home Pulse subsections — ported 1:1 from
+   ui_kits/nodebench-web/{PulseStrip,TodayIntel,ActiveEvent,RecentReports}.jsx
+   Static seed data lives here. Live wiring (when entities/runs exist) replaces
+   it via props in a follow-up — we keep the kit's exact JSX + class names so
+   visual parity is verifiable in raw HTML.
+   ────────────────────────────────────────────────────────────────────────── */
+
+type PulseMetric = {
+  id: string;
+  label: string;
+  value: number;
+  unit: string;
+  trend: string;
+  what: string;
+  hero?: boolean;
+};
+
+const PULSE_METRICS: PulseMetric[] = [
+  { id: "entities",   label: "Entities tracked",     value: 42810,  unit: "",  trend: "+184 today",  what: "A real intelligence graph" },
+  { id: "edges",      label: "Relationships mapped", value: 183204, unit: "",  trend: "+612 today",  what: "How people, companies, products connect" },
+  { id: "reports",    label: "Reports created",      value: 18204,  unit: "",  trend: "+47 today",   what: "Chats become durable work products" },
+  { id: "memory_pct", label: "Served from memory",   value: 71,     unit: "%", trend: "up 4pp / wk", what: "Search not repeated every time", hero: true },
+  { id: "avoided",    label: "Searches avoided",     value: 126000, unit: "",  trend: "this week",   what: "Cost-saving + speed moat" },
+  { id: "refreshed",  label: "Sources refreshed",    value: 9420,   unit: "",  trend: "this week",   what: "Freshness + trust" },
+  { id: "verified",   label: "Claims verified",      value: 2841,   unit: "",  trend: "this week",   what: "Evidence quality" },
+  { id: "avg_time",   label: "Avg sourced answer",   value: 3.4,    unit: "s", trend: "-0.6s / mo",  what: "UX speed" },
+  { id: "followups",  label: "Follow-ups created",   value: 612,    unit: "",  trend: "this week",   what: "Business action, not just research" },
+  { id: "crm",        label: "CRM exports",          value: 184,    unit: "",  trend: "this week",   what: "Workflow completion" },
+];
+
+function fmtNumber(value: number): string {
+  if (value >= 1_000_000) return (value / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+  if (value >= 1_000) return (value / 1_000).toFixed(1).replace(/\.0$/, "") + "k";
+  if (Number.isInteger(value)) return value.toLocaleString();
+  return String(value);
+}
+
+const SPARK_SEEDS: Record<string, number[]> = {
+  memory_pct: [56, 58, 61, 60, 63, 67, 69, 71],
+  entities:   [38, 39, 40, 41, 41, 42, 42, 43],
+  edges:      [160, 165, 170, 173, 176, 178, 181, 183],
+  reports:    [16, 16, 17, 17, 17, 18, 18, 18],
+};
+
+function PulseSparkline({ id }: { id: string }) {
+  const data = SPARK_SEEDS[id] ?? [10, 12, 11, 14, 13, 16, 15, 18];
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const w = 100;
+  const h = 28;
+  const points = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * w;
+    const y = h - ((v - min) / range) * (h - 4) - 2;
+    return [x, y] as const;
+  });
+  const path = points.map((p, i) => (i === 0 ? `M${p[0]},${p[1]}` : `L${p[0]},${p[1]}`)).join(" ");
+  const area = `${path} L${w},${h} L0,${h} Z`;
+  return (
+    <svg className="nb-pulse-spark" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" aria-hidden>
+      <path d={area} className="fill" />
+      <path d={path} className="line" />
+    </svg>
+  );
+}
+
+function NBPulseStrip() {
+  const heroIds = ["memory_pct", "entities", "edges", "reports"];
+  const secondaryIds = ["avoided", "refreshed", "verified", "avg_time", "followups", "crm"];
+  const heroes = PULSE_METRICS.filter((m) => heroIds.includes(m.id));
+  const secondary = PULSE_METRICS.filter((m) => secondaryIds.includes(m.id));
+  return (
+    <section className="nb-pulse" data-layout="card-grid" data-scale="big" data-testid="exact-home-pulse-strip">
+      <header className="nb-pulse-head">
+        <div>
+          <div className="nb-kicker">Memory pulse</div>
+          <h2 className="nb-pulse-title">Every chat makes the next one faster.</h2>
+          <p className="nb-pulse-sub">Public context compounds. Private notes stay private.</p>
+        </div>
+        <span className="nb-pulse-priv" title="Private notes never leak into public counters.">
+          <span className="nb-pulse-priv-dot" /> private notes excluded
+        </span>
+      </header>
+      <div className="nb-pulse-cards">
+        {heroes.map((m) => (
+          <article key={m.id} className="nb-pulse-card" data-hero={m.id === "memory_pct"}>
+            <div className="nb-pulse-card-num">
+              {fmtNumber(m.value)}<span className="u">{m.unit}</span>
+            </div>
+            <div className="nb-pulse-card-label">{m.label.toLowerCase()}</div>
+            <div className="nb-pulse-card-trend">
+              <span className="nb-pulse-trend-dot" data-dir="up" /> {m.trend}
+            </div>
+            <PulseSparkline id={m.id} />
+          </article>
+        ))}
+      </div>
+      <div className="nb-pulse-secondary">
+        {secondary.map((m) => (
+          <div key={m.id} className="nb-pulse-mini">
+            <span className="v">{fmtNumber(m.value)}<span className="u">{m.unit}</span></span>
+            <span className="l">{m.label.toLowerCase()}</span>
+            <span className="t">{m.trend}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+type TodayLane = {
+  id: string;
+  title: string;
+  accent: "accent" | "indigo" | "success" | "warning";
+  count: number;
+  items: { hd: string; meta: string }[];
+};
+
+const TODAY_LANES: TodayLane[] = [
+  {
+    id: "signal", title: "New signals", accent: "accent", count: 4,
+    items: [
+      { hd: "Mercor hiring velocity ↑",   meta: "18 sources · 1d ago · watching" },
+      { hd: "Orbital Labs press mention",      meta: "TechCrunch · 4h ago" },
+      { hd: "DISCO files secondary",           meta: "SEC · 6h ago" },
+    ],
+  },
+  {
+    id: "updated", title: "Reports updated", accent: "indigo", count: 3,
+    items: [
+      { hd: "Ship Demo Day",              meta: "12 captures · 8 cos · 14 ppl · 9 follow-ups" },
+      { hd: "Voice-agent eval landscape", meta: "+ 4 claims · −1 weak" },
+      { hd: "Series-B litigation OS",     meta: "+ 2 entities" },
+    ],
+  },
+  {
+    id: "watchlist", title: "Watchlist changes", accent: "success", count: 5,
+    items: [
+      { hd: "Cellebrite — claim updated", meta: "gross retention 96% → 93%" },
+      { hd: "Anita Park (CRO) joined",         meta: "evidence: 2 · medium confidence" },
+      { hd: "Bessemer term sheet leak",        meta: "rumored · 2 sources" },
+    ],
+  },
+  {
+    id: "followup", title: "Follow-ups due", accent: "warning", count: 2,
+    items: [
+      { hd: "Alex @ Orbital Labs",      meta: "ask about healthcare pilot criteria" },
+      { hd: "Schedule DISCO debrief",   meta: "today · before market close" },
+    ],
+  },
+];
+
+function NBTodayIntel() {
+  return (
+    <section className="nb-home-block" data-testid="exact-home-today-intel">
+      <header className="nb-home-block-head">
+        <div>
+          <div className="nb-kicker">Today&apos;s intelligence</div>
+          <h3 className="nb-home-block-title">Pick up where memory left off.</h3>
+        </div>
+        <button type="button" className="nb-home-block-link">View all</button>
+      </header>
+      <div className="nb-today-grid">
+        {TODAY_LANES.map((lane) => (
+          <article key={lane.id} className="nb-today-lane" data-accent={lane.accent}>
+            <header className="nb-today-lane-head">
+              <span className="nb-today-lane-dot" />
+              <span className="nb-today-lane-title">{lane.title}</span>
+              <span className="nb-today-lane-count">{lane.count}</span>
+            </header>
+            <ul className="nb-today-list">
+              {lane.items.map((it, i) => (
+                <li key={i} className="nb-today-item">
+                  <div className="hd">{it.hd}</div>
+                  <div className="meta">{it.meta}</div>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const EVENT_STATS: { v: string | number; l: string; emph: boolean }[] = [
+  { v: 1482,   l: "entities discovered",      emph: false },
+  { v: "78%",  l: "answers from event corpus", emph: true  },
+  { v: 4920,   l: "repeated searches avoided", emph: false },
+  { v: 214,    l: "private capture sessions",  emph: false },
+];
+
+const RECENT_CAPTURES = [
+  { time: "0:42 ago", who: "Alex Park · Orbital Labs",   note: "voice-agent eval infra · matched first name" },
+  { time: "12m ago",  who: "Maya Cole · ex-Epic",         note: "clinical lead · ring-1 healthcare" },
+  { time: "38m ago",  who: "Sam Reichelt · ex-Olive AI",  note: "product co-founder" },
+  { time: "1h ago",   who: "Booth photo · D14-1",         note: "3 captures attached to Team" },
+];
+
+function NBActiveEvent() {
+  return (
+    <section className="nb-home-block nb-event" data-testid="exact-home-active-event">
+      <header className="nb-home-block-head">
+        <div>
+          <div className="nb-kicker">
+            <span className="nb-event-pip" /> Active workspace · Ship Demo Day
+          </div>
+          <h3 className="nb-home-block-title">Corpus is compounding in real time.</h3>
+        </div>
+        <button type="button" className="nb-home-block-link">Open event</button>
+      </header>
+      <div className="nb-event-stats">
+        {EVENT_STATS.map((s, i) => (
+          <div key={i} className="nb-event-stat" data-emph={s.emph}>
+            <div className="v">{s.v}</div>
+            <div className="l">{s.l}</div>
+          </div>
+        ))}
+      </div>
+      <div className="nb-event-captures">
+        <div className="nb-event-captures-head">
+          <span className="nb-kicker">Latest captures</span>
+          <span className="nb-event-captures-meta">corpus freshness · 2m ago</span>
+        </div>
+        <ul className="nb-event-cap-list">
+          {RECENT_CAPTURES.map((c, i) => (
+            <li key={i} className="nb-event-cap">
+              <span className="t">{c.time}</span>
+              <span className="who">{c.who}</span>
+              <span className="note">{c.note}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+type RecentEntry = {
+  id: string;
+  title: string;
+  eyebrow: string;
+  fresh: "fresh" | "updated" | "watching";
+  meta: string;
+  teaser: string;
+};
+
+const RECENT_REPORTS: RecentEntry[] = [
+  {
+    id: "orbital",
+    title: "Orbital Labs — should I follow up?",
+    eyebrow: "diligence · series A",
+    fresh: "fresh",
+    meta: "8 turns · 14 sources · 6 entities",
+    teaser: "Voice-agent eval infra. Open-core SDK; design partners with Oscar, Commure, one unnamed payer.",
+  },
+  {
+    id: "disco",
+    title: "DISCO — diligence debrief",
+    eyebrow: "diligence · series C",
+    fresh: "updated",
+    meta: "6 branches · 24 sources · 3 sections",
+    teaser: "Series-C legal-tech. $100M led by Bessemer. Concentration risk + EU regulatory exposure.",
+  },
+  {
+    id: "mercor",
+    title: "Mercor — series B signal?",
+    eyebrow: "watch · marketplace",
+    fresh: "watching",
+    meta: "4 turns · 18 sources · ring-1",
+    teaser: "Hiring velocity ↑ 62% MoM. Three new design partners. Compete: Worksome, Toptal-Pro.",
+  },
+];
+
+function NBRecentReports({ onOpenReport }: { onOpenReport: (id: string) => void }) {
+  return (
+    <section className="nb-home-block" data-testid="exact-home-recent-reports">
+      <header className="nb-home-block-head">
+        <div>
+          <div className="nb-kicker">Recent reports</div>
+          <h3 className="nb-home-block-title">Memory you can pick up at any branch.</h3>
+        </div>
+        <button type="button" className="nb-home-block-link">All reports</button>
+      </header>
+      <div className="nb-recent-grid">
+        {RECENT_REPORTS.map((r) => (
+          <article
+            key={r.id}
+            className="nb-recent-card"
+            role="button"
+            tabIndex={0}
+            onClick={() => onOpenReport(r.id)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onOpenReport(r.id);
+              }
+            }}
+          >
+            <header className="nb-recent-head">
+              <span className="nb-recent-eye">{r.eyebrow}</span>
+              <span className="nb-recent-fresh" data-state={r.fresh}>● {r.fresh}</span>
+            </header>
+            <h4 className="nb-recent-title">{r.title}</h4>
+            <p className="nb-recent-teaser">{r.teaser}</p>
+            <div className="nb-recent-meta">{r.meta}</div>
+            <div className="nb-recent-actions">
+              <button type="button" className="nb-recent-action" data-primary="true" onClick={(e) => { e.stopPropagation(); onOpenReport(r.id); }}>Brief</button>
+              <button type="button" className="nb-recent-action" onClick={(e) => { e.stopPropagation(); onOpenReport(r.id); }}>Explore</button>
+              <button type="button" className="nb-recent-action" onClick={(e) => { e.stopPropagation(); onOpenReport(r.id); }}>Chat</button>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function ExactHomeSurface(_props: WebSurfaceProps) {
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
@@ -346,8 +665,13 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
     navigate(buildCockpitPath({ surfaceId: "workspace", extra: { q: resolved, lane } }));
   };
 
+  const openReport = (id: string) => {
+    navigate(buildCockpitPath({ surfaceId: "packets", extra: { report: id } }));
+  };
+
   return (
     <ResponsiveSurface mobile="home">
+      <div className="nb-home-pulse" style={{ display: "flex", flexDirection: "column", gap: 28 }}>
       <section className="nb-composer-hero">
         <div className="nb-kicker">Entity intelligence</div>
         <h1>What are we researching today?</h1>
@@ -410,13 +734,23 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
             </button>
           ))}
         </div>
-
-        <div className="nb-install-chip">
-          <span style={{ textTransform: "uppercase", letterSpacing: ".14em" }}>Use from Claude or Cursor</span>
-          <code>npx nodebench-mcp</code>
-          <a href="/cli" style={{ color: "var(--accent-ink)", fontWeight: 800, textDecoration: "none" }}>Developer docs -&gt;</a>
-        </div>
       </section>
+
+      <NBPulseStrip />
+
+      <div className="nb-home-grid">
+        <NBTodayIntel />
+        <NBActiveEvent />
+      </div>
+
+      <NBRecentReports onOpenReport={openReport} />
+
+      <div className="nb-install-chip">
+        <span style={{ textTransform: "uppercase", letterSpacing: ".14em" }}>Use from Claude or Cursor</span>
+        <code>npx nodebench-mcp</code>
+        <a href="/cli" style={{ color: "var(--accent-ink)", fontWeight: 800, textDecoration: "none" }}>Developer docs -&gt;</a>
+      </div>
+      </div>
     </ResponsiveSurface>
   );
 }

--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -3875,3 +3875,387 @@
     display: none;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Home Pulse — full HomePulse layout matching nodebench-web kit
+   PulseStrip · TodayIntel · ActiveEvent · RecentReports
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+@keyframes nb-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 var(--accent-primary-tint); }
+  50%      { box-shadow: 0 0 0 6px transparent; }
+}
+
+.nb-home-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.1fr;
+  gap: 16px;
+}
+@media (max-width: 1100px) {
+  .nb-home-grid { grid-template-columns: 1fr; }
+}
+
+.nb-home-block {
+  padding: 22px 22px 20px;
+  display: flex; flex-direction: column; gap: 18px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+.nb-home-block-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+}
+.nb-home-block-title {
+  margin: 6px 0 0;
+  font-size: 17px; font-weight: 700; letter-spacing: -0.01em;
+  color: var(--text-primary);
+  text-wrap: balance;
+}
+.nb-home-block-link {
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  padding: 5px 10px; border-radius: 8px;
+  cursor: pointer; transition: all 140ms;
+  white-space: nowrap;
+}
+.nb-home-block-link:hover {
+  border-color: var(--accent-primary-border);
+  color: var(--accent-ink);
+  background: var(--accent-primary-tint);
+}
+
+.nb-pulse {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: 22px 22px 20px;
+  display: flex; flex-direction: column; gap: 18px;
+  position: relative; overflow: hidden;
+}
+.nb-pulse::before {
+  content: ''; position: absolute; inset: 0;
+  background: radial-gradient(900px 200px at 12% -10%, rgba(217,119,87,.08), transparent 70%);
+  pointer-events: none;
+}
+.nb-pulse > * { position: relative; }
+.nb-pulse-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+}
+.nb-pulse-title {
+  margin: 6px 0 0;
+  font-size: 22px; font-weight: 700; letter-spacing: -0.015em;
+  color: var(--text-primary);
+  text-wrap: balance;
+}
+.nb-pulse-sub { margin: 4px 0 0; font-size: 13px; color: var(--text-muted); }
+.nb-pulse-priv {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 10.5px; font-weight: 600;
+  font-family: var(--font-mono);
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--text-faint);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+  padding: 4px 10px; border-radius: 999px;
+  white-space: nowrap;
+}
+.nb-pulse-priv-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 0 3px rgba(4,120,87,.10);
+}
+.nb-pulse-cards {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 10px;
+}
+@media (max-width: 980px) { .nb-pulse-cards { grid-template-columns: 1fr 1fr; } }
+.nb-pulse-card {
+  position: relative;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 14px 14px 0;
+  display: flex; flex-direction: column; gap: 4px;
+  overflow: hidden;
+  min-height: 124px;
+  transition: border-color 140ms, transform 140ms;
+}
+.nb-pulse-card:hover { border-color: var(--accent-primary-border); }
+.nb-pulse-card[data-hero="true"] {
+  background: linear-gradient(180deg, var(--accent-primary-tint), var(--bg-surface) 70%);
+  border-color: var(--accent-primary-border);
+}
+.nb-pulse-card-num {
+  font-size: 30px; font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  line-height: 1.05;
+  font-variant-numeric: tabular-nums;
+}
+.nb-pulse-card-num .u {
+  font-size: 16px; font-weight: 600;
+  color: var(--text-muted);
+  margin-left: 2px;
+}
+.nb-pulse-card[data-hero="true"] .nb-pulse-card-num { color: var(--accent-ink); font-size: 36px; }
+.nb-pulse-card[data-hero="true"] .nb-pulse-card-num .u { color: var(--accent-primary); }
+.nb-pulse-card-label {
+  font-size: 11.5px; color: var(--text-muted);
+  text-transform: lowercase;
+  letter-spacing: 0.01em;
+}
+.nb-pulse-card-trend {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10.5px; font-weight: 600;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  margin-top: 2px;
+}
+.nb-pulse-trend-dot {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--success);
+}
+.nb-pulse-trend-dot[data-dir="down"] { background: var(--warning); }
+.nb-pulse-spark {
+  display: block;
+  width: calc(100% + 28px);
+  height: 28px;
+  margin: auto -14px 0;
+}
+.nb-pulse-spark .line {
+  fill: none; stroke: var(--accent-primary);
+  stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+.nb-pulse-spark .fill {
+  fill: var(--accent-primary-tint); opacity: 0.9;
+  stroke: none;
+}
+.nb-pulse-card:not([data-hero="true"]) .nb-pulse-spark .line { stroke: var(--text-faint); opacity: 0.7; }
+.nb-pulse-card:not([data-hero="true"]) .nb-pulse-spark .fill { fill: var(--bg-secondary); }
+
+.nb-pulse-secondary {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  border: 1px solid var(--border-subtle);
+  background: var(--border-subtle);
+  border-radius: 12px;
+  overflow: hidden;
+}
+@media (max-width: 980px) { .nb-pulse-secondary { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 600px) { .nb-pulse-secondary { grid-template-columns: repeat(2, 1fr); } }
+.nb-pulse-mini {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 10px 12px;
+  background: var(--bg-surface);
+}
+.nb-pulse-mini .v {
+  font-size: 16px; font-weight: 700;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+.nb-pulse-mini .v .u {
+  font-size: 11px; font-weight: 600;
+  color: var(--text-muted);
+  margin-left: 1px;
+}
+.nb-pulse-mini .l { font-size: 10.5px; color: var(--text-muted); text-transform: lowercase; }
+.nb-pulse-mini .t {
+  font-size: 9.5px; color: var(--text-faint);
+  font-family: var(--font-mono);
+  text-transform: uppercase; letter-spacing: 0.05em;
+  margin-top: 1px;
+}
+
+.nb-today-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  border: 1px solid var(--border-subtle);
+  background: var(--border-subtle);
+  border-radius: 12px; overflow: hidden;
+}
+.nb-today-lane {
+  background: var(--bg-surface);
+  padding: 12px 14px 14px;
+  display: flex; flex-direction: column; gap: 8px;
+  min-height: 160px;
+}
+.nb-today-lane-head { display: flex; align-items: center; gap: 8px; }
+.nb-today-lane-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent-primary);
+}
+.nb-today-lane[data-accent="indigo"]  .nb-today-lane-dot { background: var(--indigo); }
+.nb-today-lane[data-accent="success"] .nb-today-lane-dot { background: var(--success); }
+.nb-today-lane[data-accent="warning"] .nb-today-lane-dot { background: var(--warning); }
+.nb-today-lane-title { font-size: 12px; font-weight: 700; color: var(--text-primary); }
+.nb-today-lane-count {
+  margin-left: auto;
+  font-size: 10.5px; font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+  background: var(--bg-secondary);
+  padding: 1px 6px; border-radius: 4px;
+}
+.nb-today-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.nb-today-item {
+  padding: 6px 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 120ms;
+}
+.nb-today-item:hover { background: var(--bg-secondary); }
+.nb-today-item .hd { font-size: 12.5px; font-weight: 600; color: var(--text-primary); line-height: 1.3; }
+.nb-today-item .meta { font-size: 10.5px; color: var(--text-muted); font-family: var(--font-mono); margin-top: 1px; }
+
+.nb-event {
+  background: linear-gradient(180deg, color-mix(in oklab, var(--accent-primary) 5%, var(--bg-surface)), var(--bg-surface) 60%);
+  border-color: var(--accent-primary-border);
+}
+.nb-event-pip {
+  display: inline-block;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent-primary);
+  margin-right: 4px; vertical-align: 1px;
+  animation: nb-pulse 1.6s infinite;
+}
+@media (prefers-reduced-motion: reduce) { .nb-event-pip { animation: none; } }
+.nb-event-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  border: 1px solid var(--border-subtle);
+  background: var(--border-subtle);
+  border-radius: 10px; overflow: hidden;
+}
+@media (max-width: 720px) { .nb-event-stats { grid-template-columns: repeat(2, 1fr); } }
+.nb-event-stat {
+  background: var(--bg-surface);
+  padding: 12px 14px 10px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.nb-event-stat[data-emph="true"] { background: var(--accent-primary-tint); }
+.nb-event-stat .v {
+  font-size: 22px; font-weight: 700; letter-spacing: -0.01em;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.nb-event-stat[data-emph="true"] .v { color: var(--accent-ink); }
+.nb-event-stat .l { font-size: 10.5px; color: var(--text-muted); }
+.nb-event-captures { display: flex; flex-direction: column; gap: 8px; }
+.nb-event-captures-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+}
+.nb-event-captures-meta { font-size: 10.5px; color: var(--text-faint); font-family: var(--font-mono); }
+.nb-event-cap-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px; overflow: hidden;
+  background: var(--bg-surface);
+}
+.nb-event-cap {
+  display: grid;
+  grid-template-columns: 80px minmax(0, 1.1fr) minmax(0, 2fr);
+  gap: 12px;
+  padding: 8px 12px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.nb-event-cap:last-child { border-bottom: 0; }
+.nb-event-cap .t { color: var(--text-faint); font-family: var(--font-mono); font-size: 10.5px; }
+.nb-event-cap .who {
+  color: var(--text-primary); font-weight: 600;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.nb-event-cap .note {
+  color: var(--text-muted);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+.nb-recent-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+@media (max-width: 980px) { .nb-recent-grid { grid-template-columns: 1fr; } }
+.nb-recent-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 14px 16px 14px;
+  display: flex; flex-direction: column; gap: 8px;
+  cursor: pointer;
+  transition: border-color 140ms, box-shadow 140ms, transform 140ms;
+  text-align: left;
+}
+.nb-recent-card:hover {
+  border-color: var(--accent-primary-border);
+  box-shadow: var(--shadow-sm);
+}
+.nb-recent-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.nb-recent-eye {
+  font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: var(--text-faint);
+}
+.nb-recent-fresh {
+  font-size: 10px; font-weight: 700;
+  font-family: var(--font-mono);
+  text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--success);
+}
+.nb-recent-fresh[data-state="updated"]  { color: var(--indigo); }
+.nb-recent-fresh[data-state="watching"] { color: var(--accent-ink); }
+.nb-recent-title {
+  margin: 0;
+  font-size: 14.5px; font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  text-wrap: balance;
+}
+.nb-recent-teaser {
+  margin: 0;
+  font-size: 12px; color: var(--text-muted);
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+.nb-recent-meta {
+  font-size: 10.5px; color: var(--text-faint);
+  font-family: var(--font-mono);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+.nb-recent-actions { display: flex; gap: 6px; margin-top: 4px; }
+.nb-recent-action {
+  flex: 1;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  padding: 6px 10px; border-radius: 8px;
+  cursor: pointer; transition: all 140ms;
+}
+.nb-recent-action:hover {
+  border-color: var(--accent-primary-border);
+  color: var(--accent-ink);
+  background: var(--accent-primary-tint);
+}
+.nb-recent-action[data-primary="true"] {
+  border-color: var(--accent-primary-border);
+  background: var(--accent-primary);
+  color: #FFFAF8;
+}
+.nb-recent-action[data-primary="true"]:hover { background: var(--accent-primary-hover); }

--- a/tests/e2e/exact-kit-parity-prod.spec.ts
+++ b/tests/e2e/exact-kit-parity-prod.spec.ts
@@ -31,6 +31,31 @@ test("PR A4: Home renders ExactHomeSurface composer hero", async ({ page }) => {
   expect(result.lanes.length).toBeGreaterThanOrEqual(3);
 });
 
+test("PR A6: Home renders full kit HomePulse layout", async ({ page }) => {
+  await navigate(page, "ask");
+  const result = await page.evaluate(() => ({
+    pulseStrip: !!document.querySelector('[data-testid="exact-home-pulse-strip"]'),
+    pulseHeroCards: document.querySelectorAll(".nb-pulse-card").length,
+    pulseMiniCards: document.querySelectorAll(".nb-pulse-mini").length,
+    todayIntel: !!document.querySelector('[data-testid="exact-home-today-intel"]'),
+    todayLanes: document.querySelectorAll(".nb-today-lane").length,
+    activeEvent: !!document.querySelector('[data-testid="exact-home-active-event"]'),
+    eventStats: document.querySelectorAll(".nb-event-stat").length,
+    recentReports: !!document.querySelector('[data-testid="exact-home-recent-reports"]'),
+    recentCards: document.querySelectorAll(".nb-recent-card").length,
+  }));
+  console.log("HOME PULSE:", JSON.stringify(result, null, 2));
+  expect(result.pulseStrip, "PulseStrip section should render").toBe(true);
+  expect(result.pulseHeroCards, "4 hero metric cards").toBeGreaterThanOrEqual(4);
+  expect(result.pulseMiniCards, "6 secondary mini cards").toBeGreaterThanOrEqual(6);
+  expect(result.todayIntel, "Today's intelligence section").toBe(true);
+  expect(result.todayLanes, "4 today lanes").toBeGreaterThanOrEqual(4);
+  expect(result.activeEvent, "Active event section").toBe(true);
+  expect(result.eventStats, "4 event stats").toBeGreaterThanOrEqual(4);
+  expect(result.recentReports, "Recent reports section").toBe(true);
+  expect(result.recentCards, "3 recent report cards").toBeGreaterThanOrEqual(3);
+});
+
 test("PR A5: Chat renders ExactChatSurface answer packet", async ({ page }) => {
   await navigate(page, "workspace");
   const result = await page.evaluate(() => ({


### PR DESCRIPTION
## Summary
- Closes the gap between current production `?surface=ask` and `NodeBench AI Design System (1).zip`'s `ui_kits/nodebench-web/HomePulse.jsx`.
- Ports `PulseStrip`, `TodayIntel`, `ActiveEvent`, `RecentReports` as React/TS components inside `src/features/designKit/exact/ExactKit.tsx` with the kit's exact JSX class names so visual + selector parity is verifiable in raw HTML.
- Appends 384 lines of kit CSS (`.nb-pulse-*`, `.nb-today-*`, `.nb-event-*`, `.nb-recent-*`, `.nb-home-grid`, `.nb-home-block`, `@keyframes nb-pulse`) to `exactKit.css`.
- Extends Tier B regression spec with `PR A6` test that asserts all 4 new sections + minimum card counts (4 hero cards / 6 mini cards / 4 today lanes / 4 event stats / 3 recent cards).

## What the user sees now
Below the existing composer hero, every visit to `?surface=ask`:

1. **Memory pulse** strip — 4 hero cards (Entities tracked, Relationships mapped, Reports created, **71% served from memory** hero) + 6 secondary mini cards (searches avoided, sources refreshed, claims verified, avg sourced answer, follow-ups, CRM exports).
2. **Today's intelligence** — 2x2 lane grid (new signals, reports updated, watchlist changes, follow-ups due).
3. **Active workspace · Ship Demo Day** — 4 event stats with 78% hero + Latest captures list.
4. **Recent reports** — 3 cards (Orbital Labs, DISCO, Mercor) with Brief/Explore/Chat actions.

## Verification
- `npx tsc --noEmit` -> exit 0
- `npx vitest run src/layouts/ActiveSurfaceHost.test.tsx` -> 1/1 pass
- `npm run build` -> exit 0
- Tier B `PR A6: Home renders full kit HomePulse layout` will run on the Vercel preview deploy and assert: `[data-testid="exact-home-pulse-strip"]`, `[data-testid="exact-home-today-intel"]`, `[data-testid="exact-home-active-event"]`, `[data-testid="exact-home-recent-reports"]` are present in the hydrated DOM.

## Test plan
- [ ] Vercel preview deploy goes Ready
- [ ] `BASE_URL=<preview> npx playwright test tests/e2e/exact-kit-parity-prod.spec.ts` -> 6/6 pass (5 existing + 1 new PR A6)
- [ ] After merge, run again against `https://www.nodebenchai.com` -> 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)