### PR TITLE
fix(mcp-security): close #8 — refactor execSync template literals to argv-based spawn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Los_Angeles"
+    groups:
+      gh-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "github-actions"
@@ -38,6 +42,12 @@ updates:
         patterns:
           - "convex"
           - "@convex-dev/*"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "npm"
@@ -50,6 +60,13 @@ updates:
       time: "10:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "api-headless"
@@ -62,6 +79,13 @@ updates:
       time: "10:30"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "mcp"
@@ -74,6 +98,13 @@ updates:
       time: "10:45"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "mcp"
@@ -86,6 +117,13 @@ updates:
       time: "11:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "mcp"
@@ -98,6 +136,32 @@ updates:
       time: "11:15"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "mcp"
+
+  - package-ecosystem: "pip"
+    directory: "/python-mcp-servers/research"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "11:30"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 3
+    groups:
+      python-research:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "python"

--- a/packages/mcp-local/package.json
+++ b/packages/mcp-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebench-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "mcpName": "io.github.homenshum/nodebench",
   "description": "Turn messy input into a sourced report. 15 default tools: workflow, bidirectional sync, canonical NodeBench research bridge, discover_tools, and load_toolset.",
   "type": "module",

--- a/packages/mcp-local/src/tools/prReportTools.ts
+++ b/packages/mcp-local/src/tools/prReportTools.ts
@@ -10,7 +10,7 @@
 
 import { mkdirSync, writeFileSync, existsSync, copyFileSync } from "node:fs";
 import { join } from "node:path";
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { getDb, genId } from "../db.js";
 import { getDashboardUrl } from "../dashboard/server.js";
 import type { McpTool } from "../types.js";
@@ -31,14 +31,26 @@ function gitExecOptions(repoPath?: string): {
   };
 }
 
-function runGit(command: string, repoPath?: string): string {
-  return execSync(command, gitExecOptions(repoPath)).toString().trim();
+function runArgv(bin: string, args: string[], repoPath?: string, timeoutMs?: number): string {
+  const result = spawnSync(bin, args, {
+    ...gitExecOptions(repoPath),
+    timeout: timeoutMs ?? 15000,
+    shell: false,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const stderr = (result.stderr || "").toString().trim();
+    throw new Error(`${bin} ${args.join(" ")} failed (exit ${result.status}): ${stderr}`);
+  }
+  return (result.stdout || "").toString().trim();
 }
 
-function runGh(command: string, repoPath?: string): string {
-  return execSync(command, { ...gitExecOptions(repoPath), timeout: 30000 })
-    .toString()
-    .trim();
+function runGit(args: string[], repoPath?: string): string {
+  return runArgv("git", args, repoPath);
+}
+
+function runGh(args: string[], repoPath?: string): string {
+  return runArgv("gh", args, repoPath, 30000);
 }
 
 function resolveSessionId(rawId?: string): string | null {
@@ -1044,7 +1056,7 @@ export const prReportTools: McpTool[] = [
 
       // Check gh availability
       try {
-        runGh("gh --version", cwd);
+        runGh(["--version"], cwd);
       } catch {
         return {
           error: true,
@@ -1055,7 +1067,7 @@ export const prReportTools: McpTool[] = [
 
       // Check gh auth
       try {
-        runGh("gh auth status", cwd);
+        runGh(["auth", "status"], cwd);
       } catch (err: any) {
         return {
           error: true,
@@ -1084,7 +1096,7 @@ export const prReportTools: McpTool[] = [
       // Get current branch
       let currentBranch: string;
       try {
-        currentBranch = runGit("git branch --show-current", cwd);
+        currentBranch = runGit(["branch", "--show-current"], cwd);
       } catch (err: any) {
         return {
           error: true,
@@ -1188,11 +1200,8 @@ export const prReportTools: McpTool[] = [
       );
       if (screenshotCount > 0) {
         try {
-          runGit(`git add "${assetDir}"`, cwd);
-          runGit(
-            `git commit -m "chore: add PR screenshot assets from UI Dive"`,
-            cwd
-          );
+          runGit(["add", "--", assetDir], cwd);
+          runGit(["commit", "-m", "chore: add PR screenshot assets from UI Dive"], cwd);
         } catch {
           // Might already be committed or nothing to add — proceed anyway
         }
@@ -1201,7 +1210,7 @@ export const prReportTools: McpTool[] = [
       // Push if requested
       if (shouldPush) {
         try {
-          runGit(`git push -u origin ${currentBranch}`, cwd);
+          runGit(["push", "-u", "origin", currentBranch], cwd);
         } catch (err: any) {
           return {
             error: true,
@@ -1212,18 +1221,17 @@ export const prReportTools: McpTool[] = [
 
       // Create PR
       try {
-        const draftFlag = isDraft ? " --draft" : "";
-        // Write body to a temp file to avoid shell escaping issues
-        const tempBody = join(
-          assetDir,
-          `_pr_body_${Date.now()}.md`
-        );
+        const tempBody = join(assetDir, `_pr_body_${Date.now()}.md`);
         writeFileSync(tempBody, markdown, "utf8");
 
-        const result = runGh(
-          `gh pr create --title "${prTitle.replace(/"/g, '\\"')}" --base "${baseBranch}" --body-file "${tempBody}"${draftFlag}`,
-          cwd
-        );
+        const ghArgs = [
+          "pr", "create",
+          "--title", prTitle,
+          "--base", baseBranch,
+          "--body-file", tempBody,
+          ...(isDraft ? ["--draft"] : []),
+        ];
+        const result = runGh(ghArgs, cwd);
 
         // Clean up temp body file
         try {

--- a/packages/mcp-local/src/tools/uiUxDiveAdvancedTools.ts
+++ b/packages/mcp-local/src/tools/uiUxDiveAdvancedTools.ts
@@ -20,7 +20,7 @@
 import { mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync } from "node:fs";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
-import { execSync } from "node:child_process";
+import { execSync, spawn, spawnSync } from "node:child_process";
 import { createConnection } from "node:net";
 import { getDb } from "../db.js";
 import { getDashboardUrl } from "../dashboard/server.js";
@@ -1101,16 +1101,39 @@ export const uiUxDiveAdvancedTools: McpTool[] = [
       const locations: Array<{ file: string; lineStart: number; lineEnd: number; snippet: string; query: string; confidence: string }> = [];
 
       for (const query of searchQueries) {
-        if (locations.length >= 10) break; // cap results
+        if (locations.length >= 10) break;
 
-        // Try ripgrep first, fall back to findstr on Windows
-        const includeFlags = exts.map(e => `--include="${e}"`).join(" ");
-        const cmd = process.platform === "win32"
-          ? `rg -n -C ${ctx} --no-heading ${includeFlags} "${query.replace(/"/g, '\\"')}" "${projectPath}" 2>nul || findstr /s /n /c:"${query.replace(/"/g, "")}" "${projectPath}\\src\\*.ts" "${projectPath}\\src\\*.tsx" 2>nul`
-          : `rg -n -C ${ctx} --no-heading ${includeFlags} "${query.replace(/"/g, '\\"')}" "${projectPath}" 2>/dev/null || grep -rnH --include='*.ts' --include='*.tsx' "${query}" "${projectPath}/src" 2>/dev/null`;
+        if (typeof query !== "string" || query.length === 0 || query.length > 512) continue;
+
+        const includeArgs: string[] = [];
+        for (const e of exts) {
+          if (typeof e === "string" && /^[A-Za-z0-9_.*\-]+$/.test(e)) {
+            includeArgs.push("--include", e);
+          }
+        }
+
+        const rgArgs = ["-n", "-C", String(Math.max(0, Math.min(20, ctx))), "--no-heading", ...includeArgs, "--", query, projectPath];
+        let output = "";
+        try {
+          const rg = spawnSync("rg", rgArgs, {
+            encoding: "utf-8",
+            maxBuffer: 1024 * 1024,
+            timeout: 15000,
+            shell: false,
+          });
+          if (rg.status === 0 && typeof rg.stdout === "string") {
+            output = rg.stdout.trim();
+          } else if (rg.error || rg.status !== 1) {
+            const fallback = process.platform === "win32"
+              ? spawnSync("findstr", ["/s", "/n", "/c:" + query, `${projectPath}\\src\\*.ts`, `${projectPath}\\src\\*.tsx`], { encoding: "utf-8", maxBuffer: 1024 * 1024, timeout: 15000, shell: false })
+              : spawnSync("grep", ["-rnH", "--include=*.ts", "--include=*.tsx", "--", query, `${projectPath}/src`], { encoding: "utf-8", maxBuffer: 1024 * 1024, timeout: 15000, shell: false });
+            output = (fallback.stdout || "").trim();
+          }
+        } catch {
+          output = "";
+        }
 
         try {
-          const output = execSync(cmd, { encoding: "utf-8", maxBuffer: 1024 * 1024, timeout: 15000 }).trim();
           if (!output) continue;
 
           // Parse ripgrep output: filename:lineNum:content or filename-lineNum-content (context)
@@ -1835,19 +1858,28 @@ ${testBlocks.join("\n\n")}
         ? `${url}#session=${encodeURIComponent(args.sessionId)}`
         : url;
 
-      // Try to open in default browser
       if (args.openBrowser !== false) {
         try {
-          const platform = process.platform;
-          if (platform === "win32") {
-            execSync(`start "" "${fullUrl}"`, { stdio: "ignore" });
-          } else if (platform === "darwin") {
-            execSync(`open "${fullUrl}"`, { stdio: "ignore" });
-          } else {
-            execSync(`xdg-open "${fullUrl}"`, { stdio: "ignore" });
+          const parsed = new URL(fullUrl);
+          if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+            throw new Error("non-http url rejected");
           }
+          const platform = process.platform;
+          const [cmd, cmdArgs]: [string, string[]] =
+            platform === "win32"
+              ? ["cmd", ["/c", "start", "", parsed.toString()]]
+              : platform === "darwin"
+                ? ["open", [parsed.toString()]]
+                : ["xdg-open", [parsed.toString()]];
+          const child = spawn(cmd, cmdArgs, {
+            stdio: "ignore",
+            detached: true,
+            shell: false,
+          });
+          child.on("error", () => {});
+          child.unref();
         } catch {
-          // Browser open is best-effort
+          // best-effort
         }
       }
 


### PR DESCRIPTION
## Summary

- Refactor command-injection-prone `execSync` sites in `nodebench-mcp` to argv-based `spawn`/`spawnSync` (shell=false)
- Bump `nodebench-mcp` 3.2.0 → 3.2.1
- Add minor/patch grouping to dependabot config + pip ecosystem entry

Closes #8.

## Root cause

AgentScore flagged `nodebench-mcp@3.2.0` HIGH for command injection: shell execution with template literal input. `execSync` invokes a shell, and template literals interpolated into the command string bypass any string-level escapes (cmd.exe / sh / zsh all have different metacharacter rules).

The "unsafe eval" finding is a false positive on `db.exec(\`...\`)` — that's better-sqlite3's tagged-template SQL, not JS eval.

## Sites fixed

| File | Lines | Vector |
|------|------:|--------|
| `packages/mcp-local/src/tools/uiUxDiveAdvancedTools.ts` | 1843–1847 | `${fullUrl}` → `start " "`, `open`, `xdg-open` (open-browser) |
| `packages/mcp-local/src/tools/uiUxDiveAdvancedTools.ts` | 1108–1113 | `${query}`, `${projectPath}`, `${exts}` → ripgrep / grep / findstr (search) |
| `packages/mcp-local/src/tools/prReportTools.ts` | helpers + 9 callers | `runGit`/`runGh` accepted shell strings; refactored to argv. Eliminates injection on `assetDir`, `currentBranch`, `prTitle`, `baseBranch` |

All fixes use `shell: false` + argv arrays so shell metacharacters cannot escape arg boundaries.

## Dependabot config

Existing config grouped react-ui / testing / convex-runtime but left every other npm package as its own PR; pip was missing entirely. The 21-PR pile-up that triggered this triage was the result.

- `github-actions`: bundle all action bumps into one PR
- `npm` (root + each package): catch-all `minor-and-patch` group
- `pip`: new entry for `/python-mcp-servers/research`
- Major bumps stay individual on purpose — they need review.

## Test plan

- [x] `npx tsc --noEmit` clean for both edited files (pre-existing errors in unrelated files unchanged)
- [ ] CI runs Build / Typecheck / Runtime smoke
- [ ] Optional: republish nodebench-mcp@3.2.1 to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)