### PR TITLE
feat(chat): replace AnswerPacket with full kit ChatStream conversation surface

### DIFF
--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -1171,78 +1171,411 @@ export function ExactReportsSurface() {
   );
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+   ChatStream — full conversation surface (kit ChatStream port)
+   Was: static AnswerPacket. Now: ChatStream with thread header + save bar +
+   conversation thread (user + agent turns with run-bar / trace / capture
+   chips / follow-ups) + composer with pinned context + suggest chips.
+   Class names mirror the kit verbatim so kit.css lifts apply.
+   ────────────────────────────────────────────────────────────────────────── */
+
+type ChatRunKind = "context" | "capture" | "research" | "lookup";
+type ChatRunBar = { kind: ChatRunKind; summary: string; detail?: string };
+type ChatTraceStep = { step: string; label: string; hits?: string };
+type ChatRunUpdate = { kind: "session" | "graph" | "notebook" | "followup"; label: string; detail?: string };
+type ChatSegment =
+  | { t: "t"; v: string }
+  | { t: "strong"; v: string }
+  | { t: "pill"; kind: string; id: string; v: string; subtle?: string }
+  | { t: "cite"; n: number };
+type ChatBlock = { kind: "p"; segs: ChatSegment[] };
+
+type ChatTurn =
+  | { id: string; role: "user"; time: string; text: string }
+  | {
+      id: string;
+      role: "agent";
+      time: string;
+      run?: ChatRunBar;
+      trace?: ChatTraceStep[];
+      body?: ChatBlock[];
+      runUpdates?: ChatRunUpdate[];
+      followups?: string[];
+    };
+
+const ORBITAL_THREAD_TURNS: ChatTurn[] = [
+  { id: "t1", role: "user", time: "2:14 PM", text: "I'm at Ship Demo Day. Help me keep track." },
+  {
+    id: "t2",
+    role: "agent",
+    time: "2:14 PM",
+    run: { kind: "context", summary: "Started event context", detail: "Using event corpus · Ship Demo Day" },
+    trace: [
+      { step: "mem", label: "searched memory · 0.18s", hits: "2 prior captures" },
+      { step: "corpus", label: "event corpus · Ship Demo Day", hits: "1 active session" },
+    ],
+    body: [
+      {
+        kind: "p",
+        segs: [
+          { t: "t", v: "Got it — anchored to " },
+          { t: "pill", kind: "event", id: "ship-demo-day", v: "Ship Demo Day" },
+          { t: "t", v: ". New captures will land here as event notes. Speak, type, paste, or upload — I'll route them to the right entity." },
+        ],
+      },
+    ],
+    runUpdates: [{ kind: "session", label: "Session pinned", detail: "0 paid calls so far" }],
+    followups: ["Capture a person", "Capture a company", "Open the event report"],
+  },
+  {
+    id: "t3",
+    role: "user",
+    time: "2:21 PM",
+    text: "Met Alex from Orbital Labs. They build voice-agent eval infra. Looking for healthcare design partners.",
+  },
+  {
+    id: "t4",
+    role: "agent",
+    time: "2:21 PM",
+    run: { kind: "capture", summary: "Captured to Ship Demo Day", detail: "3 entities resolved · 1 follow-up created" },
+    trace: [
+      { step: "extract", label: "parsed capture", hits: "1 person · 1 company · 1 theme" },
+      { step: "mem", label: "searched memory · 0.22s", hits: "0 prior matches for \"Orbital Labs\"" },
+      { step: "resolve", label: "resolving entities", hits: "created · pending confirm" },
+    ],
+    body: [
+      {
+        kind: "p",
+        segs: [
+          { t: "t", v: "Captured. New entities: " },
+          { t: "pill", kind: "person", id: "alex", v: "Alex", subtle: "first name only" },
+          { t: "t", v: " · " },
+          { t: "pill", kind: "company", id: "orbital-labs", v: "Orbital Labs", subtle: "new" },
+          { t: "t", v: " · " },
+          { t: "pill", kind: "theme", id: "voice-eval", v: "voice-agent eval infra" },
+          { t: "t", v: "." },
+        ],
+      },
+      {
+        kind: "p",
+        segs: [
+          { t: "t", v: "Linked to " },
+          { t: "pill", kind: "event", id: "ship-demo-day", v: "Ship Demo Day" },
+          { t: "t", v: " · created follow-up to confirm Alex's last name and contact channel." },
+        ],
+      },
+    ],
+    runUpdates: [
+      { kind: "graph", label: "3 entities · 4 edges added" },
+      { kind: "followup", label: "1 follow-up: confirm Alex's contact" },
+    ],
+    followups: ["Research Orbital Labs", "Who else is in voice-agent eval?"],
+  },
+];
+
+const RUN_KIND_GLYPH: Record<ChatRunKind, string> = {
+  context: "◷",
+  capture: "⊕",
+  research: "⚙",
+  lookup: "⌕",
+};
+
+const RUN_UPDATE_GLYPH: Record<ChatRunUpdate["kind"], string> = {
+  session: "◷",
+  graph: "◇",
+  notebook: "☰",
+  followup: "→",
+};
+
+function ChatRunBarView({ run }: { run: ChatRunBar }) {
+  return (
+    <div className="nb-runbar" data-kind={run.kind}>
+      <span className="ic">{RUN_KIND_GLYPH[run.kind]}</span>
+      <span className="sum"><strong>{run.summary}</strong></span>
+      {run.detail && <span className="dt">· {run.detail}</span>}
+    </div>
+  );
+}
+
+function ChatTraceView({ trace }: { trace: ChatTraceStep[] }) {
+  if (!trace.length) return null;
+  const summary = `Reasoned across ${trace.length} steps`;
+  const tags = trace.map((s) => s.step).join(" + ");
+  return (
+    <details className="nb-runtrace">
+      <summary>
+        <span className="nb-runtrace-sum">{summary}</span>
+        <span className="nb-runtrace-tags">{tags}</span>
+      </summary>
+      <div className="nb-runtrace-list">
+        {trace.map((step, i) => (
+          <div key={i} className="nb-runtrace-step">
+            <span className="step">{step.step}</span>
+            <span className="lbl">{step.label}</span>
+            {step.hits && <span className="hits">· {step.hits}</span>}
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+function renderSegments(segs: ChatSegment[]) {
+  return segs.map((s, i) => {
+    if (s.t === "strong") return <strong key={i}>{s.v}</strong>;
+    if (s.t === "cite") return <sup key={i} className="nb-cite">{s.n}</sup>;
+    if (s.t === "pill") {
+      return (
+        <button key={i} type="button" className="nb-epill" data-kind={s.kind} title={`Peek ${s.v}`}>
+          <span className="d" />
+          <span className="lbl">{s.v}</span>
+          {s.subtle && <span className="sub">{s.subtle}</span>}
+        </button>
+      );
+    }
+    return <span key={i}>{s.v}</span>;
+  });
+}
+
+function ChatTurnView({
+  turn,
+  onFollowup,
+}: {
+  turn: ChatTurn;
+  onFollowup: (text: string) => void;
+}) {
+  if (turn.role === "user") {
+    return (
+      <div className="nb-turn" data-role="user">
+        <div className="nb-turn-avatar" data-role="user">HS</div>
+        <div className="nb-turn-body">
+          <div className="nb-turn-head">
+            <span className="nb-turn-who">You</span>
+            <span className="nb-turn-time">{turn.time}</span>
+          </div>
+          <div className="nb-turn-text">{turn.text}</div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="nb-turn" data-role="agent">
+      <div className="nb-turn-avatar" data-role="agent"><Sparkles size={12} /></div>
+      <div className="nb-turn-body">
+        <div className="nb-turn-head">
+          <span className="nb-turn-who">NodeBench</span>
+          <span className="nb-turn-time">{turn.time}</span>
+        </div>
+        {turn.run && <ChatRunBarView run={turn.run} />}
+        {turn.trace && turn.trace.length > 0 && <ChatTraceView trace={turn.trace} />}
+        {turn.body && (
+          <div className="nb-turn-text">
+            {turn.body.map((b, i) => (
+              <p key={i} className="nb-block-p">{renderSegments(b.segs)}</p>
+            ))}
+          </div>
+        )}
+        {turn.runUpdates && turn.runUpdates.length > 0 && (
+          <div className="nb-runups">
+            {turn.runUpdates.map((u, i) => (
+              <div key={i} className="nb-runup" data-kind={u.kind}>
+                <span className="ic">{RUN_UPDATE_GLYPH[u.kind]}</span>
+                <span className="lbl">
+                  <strong>{u.label}</strong>
+                  {u.detail && <span className="dim">{` · ${u.detail}`}</span>}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+        {turn.followups && turn.followups.length > 0 && (
+          <div className="nb-followups">
+            {turn.followups.map((f, i) => (
+              <button key={i} type="button" className="nb-followup-chip" onClick={() => onFollowup(f)}>
+                {f}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const STREAM_PROMPTS = ["Research a company", "Capture an event note", "Ask about a person"];
+
 export function ExactChatSurface() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const initialQuery = searchParams.get("q") || "DISCO - worth reaching out? Fastest debrief.";
-  const [query, setQuery] = useState(initialQuery);
+  const initialQuery = searchParams.get("q") ?? "";
+  const [composer, setComposer] = useState(initialQuery);
+  const [turns, setTurns] = useState<ChatTurn[]>(ORBITAL_THREAD_TURNS);
+  const [pins, setPins] = useState<{ kind: string; label: string }[]>([
+    { kind: "event", label: "Ship Demo Day" },
+  ]);
+
+  const sendTurn = (text: string) => {
+    const t = text.trim();
+    if (!t) return;
+    setTurns((prev) => [
+      ...prev,
+      { id: `u${Date.now()}`, role: "user", time: nowTime(), text: t },
+    ]);
+    setComposer("");
+  };
 
   return (
     <ResponsiveSurface mobile="chat">
-      <section className="nb-answer" data-testid="exact-web-chat-answer">
-        <div className="nb-badge nb-badge-accent">
-          <Sparkles size={12} />
-          Answer packet
+      <section data-testid="exact-web-chat-stream" style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+        <div>
+          <h1 style={{ fontSize: 28, fontWeight: 700, letterSpacing: "-0.02em", color: "var(--text-primary)", margin: 0 }}>
+            Chat
+          </h1>
+          <div style={{ fontSize: 13, color: "var(--text-muted)", marginTop: 4 }}>
+            6 threads. Every turn keeps the entity context, sources, and report — so you can keep going without restarting.
+          </div>
         </div>
-        <h1>DISCO is worth a fast reach-out, but only after the EU compliance claim clears review.</h1>
-        <div className="nb-reasoning">
-          <ul className="nb-reasoning-list">
-            <li><span className="nb-reasoning-dot" /> Resolved entity and existing report context</li>
-            <li><span className="nb-reasoning-dot" /> Pulled current public sources and notebook claims</li>
-            <li><span className="nb-reasoning-dot" /> Separated field-note claims from evidence-backed sources</li>
-          </ul>
-        </div>
-        <p className="nb-answer-p">
-          The strongest signal is not the launch itself. It is that the product move directly addresses the risk
-          already flagged in the saved diligence report <span className="nb-cite">1</span>. That makes the next action
-          concrete: verify the SOC 2 Type II scope, then reopen the workspace and update the outreach memo
-          <span className="nb-cite">2</span>.
-        </p>
-        <p className="nb-answer-p">
-          The report should stay in provisional mode until the claim is backed by an official source and one independent
-          customer or partner signal <span className="nb-cite">3</span>.
-        </p>
 
-        <div className="nb-sources-grid">
-          {["Company security page", "Saved DISCO diligence report", "EU launch note"].map((source, index) => (
-            <div key={source} className="nb-source-card">
-              <div style={{ color: "var(--text-faint)", fontFamily: "var(--font-mono)", fontSize: 11 }}>Source {index + 1}</div>
-              <div style={{ marginTop: 5, fontWeight: 800 }}>{source}</div>
-              <div style={{ marginTop: 5, color: "var(--text-muted)", fontSize: 12 }}>confidence {index === 0 ? "high" : "medium"}</div>
+        <div className="nb-stream-root">
+          <div className="nb-stream-main">
+            <div className="nb-stream-header">
+              <button type="button" className="nb-rail-toggle" aria-label="Toggle threads" title="Threads">
+                <Layers size={14} />
+              </button>
+              <div className="nb-chat-header-icon">O</div>
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <h2>Orbital Labs · should I follow up?</h2>
+                <div className="nb-stream-header-meta">
+                  <span className="nb-stream-fresh" data-state="fresh">● fresh</span>
+                  <span>·</span>
+                  <span>{turns.length} turns</span>
+                  <span>·</span>
+                  <span>14 sources</span>
+                  <span>·</span>
+                  <span>6 entities</span>
+                  <span>·</span>
+                  <span>1 paid calls</span>
+                </div>
+              </div>
+              <div className="nb-chat-header-actions" style={{ display: "flex" }}>
+                <button type="button" onClick={() => navigate(buildCockpitPath({ surfaceId: "packets", extra: { report: "orbital" } }))}>
+                  <BookOpen size={11} /> Open report
+                </button>
+                <button type="button">
+                  <Share2 size={11} /> Share
+                </button>
+              </div>
+              <button type="button" className="nb-rail-toggle" aria-label="Toggle context" title="Context">
+                <LayoutGrid size={14} />
+              </button>
             </div>
-          ))}
-        </div>
 
-        <div className="nb-followups">
-          {["Verify the SOC2 claim", "Open DISCO workspace", "Draft the reach-out"].map((item) => (
-            <button key={item} type="button" className="nb-followup-chip">{item}</button>
-          ))}
-        </div>
-
-        <div className="nb-composer-box" style={{ marginTop: 22 }}>
-          <textarea
-            className="nb-composer-input"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Ask another question..."
-            aria-label="Chat follow-up"
-          />
-          <div className="nb-composer-bottom">
-            <div className="nb-lanes">
-              <span className="nb-lane" data-active="true">Scoped to current answer</span>
-              <span className="nb-lane">3 citations</span>
+            <div className="nb-stream-savebar">
+              <span className="nb-stream-savebar-icon">●</span>
+              <span>Saved to <strong>Orbital Labs · diligence</strong></span>
+              <span className="dim">· 3 sections · 7 claims · 2 follow-ups</span>
+              <span style={{ flex: 1 }} />
+              <button type="button" onClick={() => navigate(buildCockpitPath({ surfaceId: "packets", extra: { report: "orbital" } }))}>Open notebook</button>
+              <button type="button">Export</button>
+              <button type="button">Track updates</button>
             </div>
-            <button type="button" className="nb-btn nb-btn-secondary" onClick={() => openWorkspace("disco-diligence", "chat")}>
-              Open workspace
-            </button>
-            <button type="button" className="nb-btn nb-btn-primary" onClick={() => navigate(buildCockpitPath({ surfaceId: "packets" }))}>
-              Save report
-            </button>
+
+            <div className="nb-stream-scroll">
+              <div className="nb-stream-inner">
+                {turns.map((turn) => (
+                  <ChatTurnView key={turn.id} turn={turn} onFollowup={sendTurn} />
+                ))}
+              </div>
+            </div>
+
+            <div className="nb-stream-composer">
+              <div className="nb-stream-composer-inner">
+                <div className="nb-composer-card">
+                  {pins.length > 0 && (
+                    <div className="nb-composer-pins">
+                      {pins.map((p, i) => (
+                        <span key={i} className="nb-pin">
+                          <span className="typ">{p.kind}</span>
+                          {p.label}
+                          <button
+                            type="button"
+                            aria-label="Remove pin"
+                            onClick={() => setPins((prev) => prev.filter((_, idx) => idx !== i))}
+                          >
+                            <X size={9} />
+                          </button>
+                        </span>
+                      ))}
+                      <button
+                        type="button"
+                        className="nb-pin-add"
+                        onClick={() => setPins((prev) => [...prev, { kind: "entity", label: "Orbital Labs" }])}
+                      >
+                        <Plus size={9} /> Add context
+                      </button>
+                    </div>
+                  )}
+                  <textarea
+                    className="nb-composer-input"
+                    value={composer}
+                    onChange={(e) => setComposer(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        sendTurn(composer);
+                      }
+                    }}
+                    placeholder="Ask, capture, paste, upload, or record…"
+                    aria-label="Chat composer"
+                  />
+                  <div className="nb-composer-footer">
+                    <div className="nb-composer-tools">
+                      <button type="button" aria-label="Attach file" title="Attach file"><Paperclip size={14} /></button>
+                      <button type="button" aria-label="Add URL" title="Add URL"><Link2 size={14} /></button>
+                      <button type="button" aria-label="Voice note" title="Voice note"><Mic size={14} /></button>
+                      <span className="nb-composer-divider" />
+                      <span className="nb-model-trigger" title="Model">
+                        <span className="dot" data-provider="anthropic" />
+                        <span className="nm">Claude Sonnet 4.5</span>
+                      </span>
+                    </div>
+                    <div className="nb-composer-send-group">
+                      <span className="nb-composer-meta">Memory-first · 0 paid calls</span>
+                      <button
+                        type="button"
+                        className="nb-composer-send"
+                        aria-label="Send"
+                        disabled={!composer.trim()}
+                        onClick={() => sendTurn(composer)}
+                      >
+                        <ChevronRight size={14} style={{ transform: "rotate(-90deg)" }} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div className="nb-composer-suggest">
+                  {STREAM_PROMPTS.map((p) => (
+                    <button key={p} type="button" className="nb-prompt-chip" onClick={() => setComposer(p + " ")}>
+                      {p}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>
     </ResponsiveSurface>
   );
+}
+
+function nowTime() {
+  const d = new Date();
+  const h = d.getHours();
+  const m = d.getMinutes();
+  const hr = ((h + 11) % 12) + 1;
+  const mm = m < 10 ? `0${m}` : `${m}`;
+  return `${hr}:${mm} ${h < 12 ? "AM" : "PM"}`;
 }
 
 /* ── Live data adapter for ExactInboxSurface ──

--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -4456,3 +4456,469 @@
   .nb-rdetail-actions { width: 100%; justify-content: flex-end; }
   .nb-rdetail-crumb-current { max-width: 200px; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   ChatStream — full conversation surface (kit ChatStream port)
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nb-stream-root {
+  position: relative;
+  min-height: 600px;
+  display: flex;
+  flex-direction: column;
+  background: transparent;
+}
+.nb-stream-main {
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  background: var(--bg-surface);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.nb-stream-header {
+  padding: 10px 22px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex; align-items: center; gap: 10px;
+  background: transparent;
+}
+.nb-stream-header h2 {
+  font-size: 13.5px; font-weight: 700;
+  letter-spacing: -0.008em;
+  color: var(--text-primary);
+  margin: 0 0 2px;
+}
+.nb-stream-header-meta {
+  font-size: 10.5px; color: var(--text-muted);
+  font-family: var(--font-mono);
+  display: flex; gap: 5px; flex-wrap: wrap;
+}
+.nb-stream-fresh { color: var(--success); font-weight: 600; }
+.nb-stream-fresh[data-state="stale"] { color: var(--warning); }
+.nb-rail-toggle {
+  width: 26px; height: 26px;
+  display: grid; place-items: center;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 7px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 120ms, color 120ms;
+}
+.nb-rail-toggle:hover { background: var(--bg-secondary); color: var(--text-primary); }
+.nb-chat-header-icon {
+  width: 28px; height: 28px;
+  border-radius: 8px;
+  display: grid; place-items: center;
+  background: var(--accent-primary-tint);
+  color: var(--accent-ink);
+  font-weight: 800; font-size: 13px;
+  flex-shrink: 0;
+}
+.nb-chat-header-actions {
+  display: inline-flex; gap: 4px;
+  border: 0; background: transparent; padding: 0;
+}
+.nb-chat-header-actions button {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 4px 9px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  border-radius: 7px;
+  font-size: 11px; font-weight: 600;
+  cursor: pointer;
+  transition: all 140ms;
+}
+.nb-chat-header-actions button:hover {
+  border-color: var(--accent-primary-border);
+  color: var(--accent-ink);
+  background: var(--accent-primary-tint);
+}
+
+.nb-stream-savebar {
+  padding: 7px 22px;
+  display: flex; align-items: center; gap: 8px;
+  font-size: 11.5px; color: var(--text-muted);
+  background: transparent;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.nb-stream-savebar-icon {
+  color: var(--accent-primary); font-size: 10px;
+  animation: nb-pulse 2s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) { .nb-stream-savebar-icon { animation: none; } }
+.nb-stream-savebar strong { color: var(--text-primary); font-weight: 600; }
+.nb-stream-savebar .dim { color: var(--text-muted); font-family: var(--font-mono); font-size: 10.5px; }
+.nb-stream-savebar button {
+  border: 1px solid var(--accent-primary-border);
+  background: var(--bg-surface);
+  color: var(--accent-ink);
+  font-size: 11px; font-weight: 600;
+  padding: 4px 10px; border-radius: 6px;
+  cursor: pointer;
+  transition: all 140ms;
+}
+.nb-stream-savebar button:hover {
+  background: var(--accent-primary);
+  color: #fff;
+  border-color: var(--accent-primary);
+}
+
+.nb-stream-scroll {
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--bg-app, var(--bg-surface));
+  min-height: 0;
+}
+.nb-stream-inner {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 28px 32px;
+  display: flex; flex-direction: column; gap: 28px;
+}
+
+.nb-turn {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 12px;
+  align-items: flex-start;
+}
+.nb-turn-avatar {
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  font-size: 11px; font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+.nb-turn-avatar[data-role="user"] {
+  background: var(--text-primary);
+}
+.nb-turn-avatar[data-role="agent"] {
+  background: var(--accent-primary);
+  color: #FFFAF8;
+}
+.nb-turn-body { min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+.nb-turn-head {
+  display: flex; align-items: baseline; gap: 8px;
+}
+.nb-turn-who { font-size: 12.5px; font-weight: 700; color: var(--text-primary); }
+.nb-turn-time {
+  font-size: 10.5px; color: var(--text-faint);
+  font-family: var(--font-mono);
+}
+.nb-turn[data-role="user"] .nb-turn-text {
+  background: var(--bg-secondary);
+  border-radius: 14px;
+  padding: 10px 14px;
+  font-size: 13.5px;
+  color: var(--text-primary);
+  line-height: 1.5;
+  max-width: 100%;
+  display: inline-block;
+}
+.nb-turn[data-role="agent"] .nb-turn-text {
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.55;
+}
+.nb-turn[data-role="agent"] .nb-turn-text p {
+  margin: 0 0 8px;
+}
+.nb-turn[data-role="agent"] .nb-turn-text p:last-child { margin-bottom: 0; }
+
+.nb-runbar {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+  flex-wrap: wrap;
+  max-width: 100%;
+  align-self: flex-start;
+}
+.nb-runbar .ic { font-size: 12px; color: var(--accent-primary); }
+.nb-runbar .sum strong { color: var(--text-primary); font-weight: 600; }
+.nb-runbar .dt { color: var(--text-faint); font-family: var(--font-mono); font-size: 10.5px; }
+
+.nb-runtrace {
+  display: block;
+  margin: 0 0 4px;
+}
+.nb-runtrace summary {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 4px 10px;
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  cursor: pointer;
+  list-style: none;
+}
+.nb-runtrace summary::-webkit-details-marker { display: none; }
+.nb-runtrace-sum { font-weight: 600; color: var(--text-primary); }
+.nb-runtrace-tags {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-faint);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+.nb-runtrace-list {
+  display: flex; flex-direction: column; gap: 4px;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: var(--bg-secondary);
+}
+.nb-runtrace-step {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  font-size: 11px; color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+.nb-runtrace-step .step {
+  color: var(--accent-ink);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
+  min-width: 60px;
+}
+.nb-runtrace-step .lbl { color: var(--text-primary); }
+.nb-runtrace-step .hits { color: var(--text-faint); }
+
+.nb-runups {
+  display: flex; flex-direction: column; gap: 5px;
+  margin: 6px 0 0;
+}
+.nb-runup {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  width: fit-content;
+  max-width: 100%;
+}
+.nb-runup .ic {
+  color: var(--accent-primary);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.nb-runup .lbl strong { color: var(--text-primary); font-weight: 600; }
+.nb-runup .lbl .dim { color: var(--text-faint); font-family: var(--font-mono); }
+
+.nb-followups {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  margin-top: 6px;
+}
+.nb-followup-chip {
+  display: inline-flex; align-items: center;
+  padding: 4px 11px;
+  border: 1px solid var(--accent-primary-border);
+  background: var(--accent-primary-tint);
+  color: var(--accent-ink);
+  border-radius: 999px;
+  font-size: 11.5px; font-weight: 600;
+  cursor: pointer;
+  transition: all 140ms;
+}
+.nb-followup-chip:hover {
+  background: var(--accent-primary);
+  color: #FFFAF8;
+}
+
+.nb-epill {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 1px 8px 1px 6px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border-radius: 999px;
+  font-size: 12px; font-weight: 500;
+  cursor: pointer;
+  vertical-align: -1px;
+  transition: border-color 120ms;
+}
+.nb-epill:hover { border-color: var(--accent-primary-border); }
+.nb-epill .d {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--text-muted);
+}
+.nb-epill[data-kind="company"] .d { background: #d97757; }
+.nb-epill[data-kind="person"] .d { background: #6b3ba3; }
+.nb-epill[data-kind="event"] .d { background: var(--success); }
+.nb-epill[data-kind="theme"] .d { background: #5e6ad2; }
+.nb-epill .lbl { color: var(--text-primary); font-weight: 600; }
+.nb-epill .sub {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.nb-block-p {
+  margin: 0 0 8px;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+/* Composer */
+.nb-stream-composer {
+  padding: 10px 22px 14px;
+  background: transparent;
+  border-top: 1px solid var(--border-subtle);
+}
+.nb-stream-composer-inner {
+  max-width: 760px; margin: 0 auto;
+}
+.nb-composer-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 10px 12px 10px;
+  display: flex; flex-direction: column;
+  transition: border-color 160ms, box-shadow 160ms;
+  box-shadow: 0 1px 0 rgba(15,23,42,.02);
+}
+.nb-composer-card:focus-within {
+  border-color: var(--border-default, var(--accent-primary-border));
+  box-shadow: 0 0 0 3px var(--accent-primary-tint), 0 1px 0 rgba(15,23,42,.02);
+}
+.nb-composer-pins {
+  display: flex; flex-wrap: wrap; gap: 5px;
+  padding: 2px 4px 8px;
+  border-bottom: 1px dashed var(--border-subtle);
+  margin: 0 0 8px;
+}
+.nb-composer-pins .nb-pin {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 2px 4px 2px 8px;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  border-radius: 999px;
+  font-size: 11px; font-weight: 500;
+}
+.nb-composer-pins .nb-pin .typ {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-faint);
+}
+.nb-composer-pins .nb-pin button {
+  width: 16px; height: 16px;
+  border: 0; background: transparent;
+  color: var(--text-muted);
+  border-radius: 50%;
+  display: grid; place-items: center;
+  cursor: pointer;
+}
+.nb-composer-pins .nb-pin button:hover { background: var(--bg-secondary); color: var(--text-primary); }
+.nb-composer-pins .nb-pin-add {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 9px;
+  background: transparent;
+  border: 1px dashed var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 11px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.nb-composer-pins .nb-pin-add:hover { color: var(--text-primary); border-color: var(--accent-primary-border); }
+.nb-composer-footer {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px;
+  padding-top: 8px;
+}
+.nb-composer-tools {
+  display: flex; align-items: center; gap: 2px;
+  min-width: 0;
+}
+.nb-composer-tools button {
+  width: 28px; height: 28px;
+  display: grid; place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 7px;
+  cursor: pointer;
+}
+.nb-composer-tools button:hover { background: var(--bg-secondary); color: var(--text-primary); }
+.nb-composer-divider {
+  width: 1px; height: 16px;
+  background: var(--border-subtle);
+  margin: 0 6px;
+}
+.nb-composer-tools .nb-model-trigger {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 22px;
+  padding: 0 8px 0 6px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.nb-composer-tools .nb-model-trigger .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--text-muted);
+}
+.nb-composer-tools .nb-model-trigger .dot[data-provider="anthropic"] { background: #C96442; }
+.nb-composer-send-group {
+  display: inline-flex; align-items: center; gap: 10px;
+}
+.nb-composer-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-faint);
+}
+.nb-composer-send {
+  width: 30px; height: 30px;
+  display: grid; place-items: center;
+  border: 0;
+  background: var(--text-primary);
+  color: var(--bg-surface);
+  border-radius: 8px;
+  cursor: pointer;
+}
+.nb-composer-send:hover { transform: translateY(-1px); }
+.nb-composer-send:disabled {
+  background: var(--bg-secondary);
+  color: var(--text-faint);
+  cursor: not-allowed;
+}
+.nb-composer-suggest {
+  display: flex; flex-wrap: wrap; gap: 5px;
+  padding: 8px 4px 0;
+}
+.nb-prompt-chip {
+  display: inline-flex; align-items: center;
+  padding: 3px 9px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  border-radius: 999px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 140ms;
+}
+.nb-prompt-chip:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-primary-border);
+}

--- a/tests/e2e/exact-kit-parity-prod.spec.ts
+++ b/tests/e2e/exact-kit-parity-prod.spec.ts
@@ -56,21 +56,48 @@ test("PR A6: Home renders full kit HomePulse layout", async ({ page }) => {
   expect(result.recentCards, "3 recent report cards").toBeGreaterThanOrEqual(3);
 });
 
-test("PR A5: Chat renders ExactChatSurface answer packet", async ({ page }) => {
+test("PR A8: Chat renders ExactChatSurface ChatStream (full conversation thread)", async ({ page }) => {
   await navigate(page, "workspace");
   const result = await page.evaluate(() => ({
-    answer: !!document.querySelector('[data-testid="exact-web-chat-answer"]'),
-    answerBadge: !!Array.from(document.querySelectorAll(".nb-badge-accent")).find((el) =>
-      el.textContent?.toLowerCase().includes("answer packet"),
-    ),
-    sources: document.querySelectorAll(".nb-source-card").length,
-    followups: document.querySelectorAll(".nb-followup-chip").length,
+    streamMount: !!document.querySelector('[data-testid="exact-web-chat-stream"]'),
+    streamRoot: !!document.querySelector(".nb-stream-root"),
+    threadHeader: !!document.querySelector(".nb-stream-header h2"),
+    headerTitle: document.querySelector(".nb-stream-header h2")?.textContent,
+    saveBar: !!document.querySelector(".nb-stream-savebar"),
+    saveBarReportName: document.querySelector(".nb-stream-savebar strong")?.textContent,
+    fresh: !!document.querySelector(".nb-stream-fresh"),
+    turns: document.querySelectorAll(".nb-turn").length,
+    userTurns: document.querySelectorAll(".nb-turn[data-role=\"user\"]").length,
+    agentTurns: document.querySelectorAll(".nb-turn[data-role=\"agent\"]").length,
+    runBars: document.querySelectorAll(".nb-runbar").length,
+    runUpdates: document.querySelectorAll(".nb-runup").length,
+    entityPills: document.querySelectorAll(".nb-epill").length,
+    followupChips: document.querySelectorAll(".nb-followup-chip").length,
+    composerCard: !!document.querySelector(".nb-composer-card"),
+    composerPin: !!document.querySelector(".nb-composer-pins .nb-pin"),
+    composerInput: !!document.querySelector(".nb-composer-input"),
+    composerSendButton: !!document.querySelector(".nb-composer-send"),
+    suggestChips: document.querySelectorAll(".nb-prompt-chip").length,
+    modelPill: !!document.querySelector(".nb-model-trigger"),
   }));
-  console.log("CHAT:", JSON.stringify(result, null, 2));
-  expect(result.answer).toBe(true);
-  expect(result.answerBadge).toBe(true);
-  expect(result.sources).toBeGreaterThan(0);
-  expect(result.followups).toBeGreaterThan(0);
+  console.log("CHAT STREAM:", JSON.stringify(result, null, 2));
+  expect(result.streamMount, "ChatStream mount").toBe(true);
+  expect(result.streamRoot).toBe(true);
+  expect(result.threadHeader).toBe(true);
+  expect(result.headerTitle).toContain("Orbital Labs");
+  expect(result.saveBar, "Save bar").toBe(true);
+  expect(result.saveBarReportName).toContain("Orbital Labs");
+  expect(result.turns, "≥4 turns (2 user + 2 agent)").toBeGreaterThanOrEqual(4);
+  expect(result.userTurns).toBeGreaterThanOrEqual(2);
+  expect(result.agentTurns).toBeGreaterThanOrEqual(2);
+  expect(result.runBars, "agent run bars").toBeGreaterThanOrEqual(2);
+  expect(result.entityPills, "inline entity pills").toBeGreaterThan(0);
+  expect(result.followupChips, "follow-up chips").toBeGreaterThan(0);
+  expect(result.composerCard).toBe(true);
+  expect(result.composerPin, "Ship Demo Day pin").toBe(true);
+  expect(result.composerInput).toBe(true);
+  expect(result.suggestChips, "3 suggest chips").toBeGreaterThanOrEqual(3);
+  expect(result.modelPill, "Claude Sonnet 4.5 pill").toBe(true);
 });
 
 test("PR A2: Reports renders ExactReportsSurface card grid", async ({ page }) => {


### PR DESCRIPTION
## Summary
**User-reported gap:** "chat is still not exactly right" — `/?surface=workspace` was showing the static AnswerPacket preview, not the kit's ChatStream conversation thread.

## Fix
Replaces `ExactChatSurface` AnswerPacket layout with the kit's full ChatStream:
- **Header**: icon + thread title (`Orbital Labs · should I follow up?`) + meta badges (`fresh · N turns · 14 sources · 6 entities · 1 paid calls`) + Open report / Share / rail toggles.
- **Save bar**: `● Saved to Orbital Labs · diligence · 3 sections · 7 claims · 2 follow-ups` + Open notebook / Export / Track updates.
- **Conversation thread** with 4 seed turns matching the design-system mock:
  - User: "I'm at Ship Demo Day. Help me keep track."
  - Agent: run-bar `Started event context · Using event corpus · Ship Demo Day`, trace (mem + corpus), prose with `Ship Demo Day` entity pill, run-update `Session pinned · 0 paid calls so far`, follow-ups (Capture a person / Capture a company / Open the event report).
  - User: "Met Alex from Orbital Labs..."
  - Agent: run-bar `Captured to Ship Demo Day · 3 entities resolved · 1 follow-up created`, trace (extract + mem + resolve), prose with Alex / Orbital Labs / voice-agent eval entity pills, "Linked to Ship Demo Day" sentence, run-updates (`3 entities · 4 edges added`, `1 follow-up: confirm Alex's contact`), follow-ups (Research Orbital Labs / Who else is in voice-agent eval?).
- **Composer**: pinned `EVENT Ship Demo Day` tag (removable) + `+ Add context` button, textarea, attach/link/voice tools, Claude Sonnet 4.5 model pill, `Memory-first · 0 paid calls` meta, send button, 3 suggest chips (Research a company / Capture an event note / Ask about a person).

Composer is interactive: sending appends a user turn locally; follow-up chips re-emit as user turns; pins are addable/removable.

CSS: ~280 lines under `nb-stream-*`, `nb-turn`, `nb-runbar`, `nb-runtrace`, `nb-runup`, `nb-followup-chip`, `nb-epill`, `nb-block-p`, `nb-composer-*`, `nb-prompt-chip` — exact kit selectors.

Sidebar (thread list) + right rail (entity/graph/sources tabs) are hidden by default — toggleable in a follow-up; not visible in the user's mock screenshot.

## Tier B
Stale `PR A5` (tested AnswerPacket `nb-source-card` / `nb-answer` selectors that no longer exist) replaced with `PR A8: Chat renders ExactChatSurface ChatStream`. Asserts:
- `[data-testid="exact-web-chat-stream"]` mounts
- `.nb-stream-root` + thread header h2 contains "Orbital Labs"
- `.nb-stream-savebar` contains "Orbital Labs" report name
- ≥4 turns (≥2 user + ≥2 agent)
- ≥2 run-bars, ≥1 entity pills, ≥1 follow-up chips
- Composer card + Ship Demo Day pin + input + send button
- ≥3 suggest chips + Claude Sonnet 4.5 model pill

## Verification
- `npx tsc --noEmit` → exit 0
- `npm run build` → exit 0
- Tier B `PR A1, A2, A3, A4, A6, A7, A8` (7 tests) will run against prod after admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)