### PR TITLE
feat(topnav): kit avatar status panel (pulse + watching + plan + sessions + theme + links)

### DIFF
--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { useConvex, useQuery } from "convex/react";
 import { useConvexApi } from "@/lib/convexApi";
@@ -1168,6 +1168,218 @@ export function ExactReportsSurface() {
         </div>
       </section>
     </ResponsiveSurface>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+   ExactAvatarMenu — kit TopNav avatar button + status panel
+   Click HS avatar → opens 380px popover with sections:
+     · Identity strip (HS gradient + Hannah Sato + email + workspace + PRO)
+     · Today's pulse (3 mini stats: Memory hits / Searches saved / Sources fresh)
+     · Watching · 12 entities (3 watch rows + See all → connect)
+     · This month · Pro (3 usage bars + Upgrade to Team button)
+     · Recent sessions (3 rows w/ THIS marker)
+     · Footer: Theme segment + Settings/Shortcuts/Help/Sign out grid
+   Class names mirror the kit verbatim.
+   ────────────────────────────────────────────────────────────────────────── */
+
+type WatchDot = "hot" | "warm" | "cool";
+
+function PulseStatTile({ label, value, trend, hot = false }: { label: string; value: string; trend: string; hot?: boolean }) {
+  return (
+    <div className="nb-avm-pulse" data-hot={hot}>
+      <div className="nb-avm-pulse-v">{value}</div>
+      <div className="nb-avm-pulse-l">{label}</div>
+      <div className="nb-avm-pulse-t">{trend}</div>
+    </div>
+  );
+}
+
+function WatchRow({ name, detail, dot, color }: { name: string; detail: string; dot: WatchDot; color: string }) {
+  return (
+    <div className="nb-avm-watch-row">
+      <div className="nb-avm-watch-mark" style={{ background: `${color}22`, color }}>{name[0]}</div>
+      <div className="nb-avm-watch-body">
+        <div className="nb-avm-watch-name">{name}</div>
+        <div className="nb-avm-watch-detail">{detail}</div>
+      </div>
+      <span className="nb-avm-watch-dot" data-dot={dot} />
+    </div>
+  );
+}
+
+function UsageBar({ label, used, cap, unit }: { label: string; used: number; cap: number; unit?: string }) {
+  const pct = Math.min(100, Math.round((used / cap) * 100));
+  const hot = pct >= 80;
+  const u = unit ? ` ${unit}` : "";
+  return (
+    <div className="nb-avm-usage">
+      <div className="nb-avm-usage-head">
+        <span className="nb-avm-usage-label">{label}</span>
+        <span className="nb-avm-usage-num" data-hot={hot}>
+          {used}{u} <span className="nb-avm-usage-cap">/ {cap}{u}</span>
+        </span>
+      </div>
+      <div className="nb-avm-usage-track">
+        <div className="nb-avm-usage-fill" data-hot={hot} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function SessionRow({ time, device, current = false }: { time: string; device: string; current?: boolean }) {
+  return (
+    <div className="nb-avm-session">
+      <span className="nb-avm-session-dot" data-current={current} />
+      <span className="nb-avm-session-time">{time}</span>
+      <span className="nb-avm-session-device">{device}</span>
+      {current && <span className="nb-avm-session-this">THIS</span>}
+    </div>
+  );
+}
+
+function ThemeSegment({ resolvedMode, setMode }: { resolvedMode: "light" | "dark"; setMode: (m: "light" | "dark") => void }) {
+  return (
+    <div className="nb-avm-theme">
+      {(["light", "dark"] as const).map((id) => {
+        const active = resolvedMode === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            className="nb-avm-theme-opt"
+            data-active={active}
+            onClick={() => { if (!active) setMode(id); }}
+          >
+            {id === "light" ? "Light" : "Dark"}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function ExactAvatarMenu({
+  resolvedMode,
+  setMode,
+  onSurfaceChange,
+}: {
+  resolvedMode: "light" | "dark";
+  setMode: (m: "light" | "dark") => void;
+  onSurfaceChange?: (s: CockpitSurfaceId) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const goConnect = () => {
+    setOpen(false);
+    onSurfaceChange?.("connect");
+  };
+
+  return (
+    <div ref={ref} className="nb-avm-root">
+      <button
+        type="button"
+        className="nb-avm-trigger"
+        data-active={open}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Open profile"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <div className="nb-avm-avatar-sm">HS</div>
+        <ChevronRight size={12} className="nb-avm-chev" data-open={open} style={{ transform: open ? "rotate(90deg)" : "rotate(90deg)" }} />
+      </button>
+      {open && (
+        <div role="menu" className="nb-avm-menu" data-testid="exact-avatar-menu">
+          <div className="nb-avm-identity">
+            <div className="nb-avm-avatar-lg">HS</div>
+            <div className="nb-avm-identity-body">
+              <div className="nb-avm-name">Hannah Sato</div>
+              <div className="nb-avm-id">hannah@orbital.ai · Orbital Labs</div>
+            </div>
+            <span className="nb-avm-pro">PRO</span>
+          </div>
+
+          <div className="nb-avm-section">
+            <div className="nb-avm-section-label">Today&apos;s pulse</div>
+            <div className="nb-avm-pulse-grid">
+              <PulseStatTile label="Memory hits" value="74%" trend="+6%" hot />
+              <PulseStatTile label="Searches saved" value="38" trend="vs 22 last wk" />
+              <PulseStatTile label="Sources fresh" value="91%" trend="2 stale" />
+            </div>
+          </div>
+
+          <div className="nb-avm-section">
+            <div className="nb-avm-section-head">
+              <span className="nb-avm-section-label">Watching · 12 entities</span>
+              <button type="button" className="nb-avm-section-link" onClick={goConnect}>See all</button>
+            </div>
+            <WatchRow name="Orbital Labs" detail="3 new signals · last 4h" dot="hot" color="#D97757" />
+            <WatchRow name="DISCO" detail="Report refreshed · 22m ago" dot="warm" color="#5E6AD2" />
+            <WatchRow name="Mira Patel" detail="Quiet · last seen 2d" dot="cool" color="#3F8F6E" />
+          </div>
+
+          <div className="nb-avm-section nb-avm-section-divided">
+            <div className="nb-avm-section-head">
+              <span className="nb-avm-section-label">This month · Pro</span>
+              <span className="nb-avm-section-meta">resets Mar 1</span>
+            </div>
+            <UsageBar label="Sourced answers" used={284} cap={500} />
+            <UsageBar label="Watched entities" used={12} cap={25} />
+            <UsageBar label="Memory store" used={68} cap={100} unit="MB" />
+            <button type="button" className="nb-avm-upgrade">
+              <Zap size={12} className="nb-avm-upgrade-ic" /> Upgrade to Team
+            </button>
+          </div>
+
+          <div className="nb-avm-section nb-avm-section-divided">
+            <div className="nb-avm-section-label">Recent sessions</div>
+            <div className="nb-avm-sessions">
+              <SessionRow time="now" device="MacBook · Safari · SF" current />
+              <SessionRow time="3h ago" device="iPhone · Native · SF" />
+              <SessionRow time="yesterday" device="MacBook · Chrome · SF" />
+            </div>
+          </div>
+
+          <div className="nb-avm-footer">
+            <div className="nb-avm-theme-row">
+              <span className="nb-avm-section-label">Theme</span>
+              <ThemeSegment resolvedMode={resolvedMode} setMode={setMode} />
+            </div>
+            <div className="nb-avm-links">
+              <button type="button" className="nb-avm-link" onClick={goConnect}>
+                <Settings size={13} /> <span>Settings</span>
+              </button>
+              <button type="button" className="nb-avm-link">
+                <Terminal size={13} /> <span>Shortcuts</span>
+                <span className="nb-avm-kbd">?</span>
+              </button>
+              <button type="button" className="nb-avm-link">
+                <BookOpen size={13} /> <span>Help</span>
+              </button>
+              <button type="button" className="nb-avm-link" data-danger>
+                <X size={13} /> <span>Sign out</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -4922,3 +4922,358 @@
   color: var(--text-primary);
   border-color: var(--accent-primary-border);
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   ExactAvatarMenu — TopNav avatar status panel
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.nb-avm-root { position: relative; display: inline-flex; }
+
+.nb-avm-trigger {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 2px 8px 2px 2px;
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 160ms;
+}
+.nb-avm-trigger:hover {
+  background: var(--bg-secondary);
+}
+.nb-avm-trigger[data-active="true"] {
+  border-color: var(--border-subtle);
+  background: var(--bg-secondary);
+}
+.nb-avm-avatar-sm {
+  width: 30px; height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #D97757, #5E6AD2);
+  color: #fff;
+  font-weight: 700; font-size: 11px;
+  display: flex; align-items: center; justify-content: center;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+.nb-avm-chev {
+  color: var(--text-faint);
+  transition: transform 160ms;
+}
+.nb-avm-chev[data-open="true"] { transform: rotate(-90deg); }
+
+.nb-avm-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 380px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  box-shadow: 0 28px 70px -20px rgba(15,23,42,.28), 0 6px 16px -4px rgba(15,23,42,.08);
+  padding: 0;
+  z-index: 100;
+  overflow: hidden;
+  animation: nb-avm-in 180ms ease-out;
+}
+@keyframes nb-avm-in {
+  from { opacity: 0; transform: translateY(4px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .nb-avm-menu { animation: none; }
+}
+
+.nb-avm-identity {
+  position: relative;
+  padding: 16px 16px 14px;
+  background: linear-gradient(135deg, rgba(217,119,87,.10) 0%, rgba(94,106,210,.08) 100%);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex; align-items: center; gap: 12px;
+}
+.nb-avm-avatar-lg {
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #D97757, #5E6AD2);
+  color: #fff;
+  font-weight: 700; font-size: 14px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  box-shadow: 0 6px 16px -6px rgba(94,106,210,.5);
+}
+.nb-avm-identity-body { min-width: 0; flex: 1; }
+.nb-avm-name {
+  font-size: 14px; font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+.nb-avm-id {
+  font-size: 11px; color: var(--text-muted);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.nb-avm-pro {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--accent-primary);
+  background: var(--bg-surface);
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--accent-primary-border);
+  flex-shrink: 0;
+}
+
+.nb-avm-section {
+  padding: 14px 14px 10px;
+}
+.nb-avm-section-divided { border-top: 1px dashed var(--border-subtle); padding-top: 12px; padding-bottom: 14px; }
+.nb-avm-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.nb-avm-section-head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 8px;
+}
+.nb-avm-section-link {
+  font-size: 11px;
+  color: var(--accent-ink);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font-weight: 500;
+}
+.nb-avm-section-link:hover { color: var(--accent-primary); text-decoration: underline; }
+.nb-avm-section-meta {
+  font-size: 11px;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+}
+
+.nb-avm-pulse-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: 8px;
+}
+.nb-avm-pulse {
+  padding: 8px 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+}
+.nb-avm-pulse[data-hot="true"] {
+  background: var(--accent-primary-tint);
+  border-color: var(--accent-primary-border);
+}
+.nb-avm-pulse-v {
+  font-size: 18px; font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.nb-avm-pulse[data-hot="true"] .nb-avm-pulse-v { color: var(--accent-primary); }
+.nb-avm-pulse-l {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 4px;
+  font-weight: 500;
+}
+.nb-avm-pulse-t {
+  font-size: 10px;
+  color: var(--text-faint);
+  margin-top: 2px;
+  font-family: var(--font-mono);
+}
+.nb-avm-pulse[data-hot="true"] .nb-avm-pulse-t { color: var(--accent-primary); }
+
+.nb-avm-watch-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 0;
+}
+.nb-avm-watch-mark {
+  width: 22px; height: 22px;
+  border-radius: 6px;
+  font-size: 11px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.nb-avm-watch-body { flex: 1; min-width: 0; }
+.nb-avm-watch-name {
+  font-size: 12px; font-weight: 500;
+  color: var(--text-primary);
+  letter-spacing: -0.005em;
+}
+.nb-avm-watch-detail {
+  font-size: 10px;
+  color: var(--text-faint);
+  margin-top: 1px;
+}
+.nb-avm-watch-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  flex-shrink: 0;
+}
+.nb-avm-watch-dot[data-dot="hot"] {
+  background: #D97757;
+  box-shadow: 0 0 0 3px rgba(217,119,87,.18);
+}
+.nb-avm-watch-dot[data-dot="warm"] { background: #E0A33C; }
+.nb-avm-watch-dot[data-dot="cool"] { background: #9CA3AF; }
+
+.nb-avm-usage { margin-bottom: 8px; }
+.nb-avm-usage-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 3px;
+}
+.nb-avm-usage-label { font-size: 11px; color: var(--text-muted); }
+.nb-avm-usage-num {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+}
+.nb-avm-usage-num[data-hot="true"] { color: var(--accent-primary); }
+.nb-avm-usage-cap { color: var(--text-faint); }
+.nb-avm-usage-track {
+  height: 4px;
+  background: var(--bg-secondary);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.nb-avm-usage-fill {
+  height: 100%;
+  background: #5E6AD2;
+  border-radius: 999px;
+  transition: width 240ms;
+}
+.nb-avm-usage-fill[data-hot="true"] { background: var(--accent-primary); }
+
+.nb-avm-upgrade {
+  width: 100%;
+  margin-top: 8px;
+  padding: 7px 10px;
+  font-size: 12px; font-weight: 600;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+  transition: border-color 140ms, background 140ms;
+}
+.nb-avm-upgrade:hover {
+  border-color: var(--accent-primary-border);
+  background: var(--accent-primary-tint);
+}
+.nb-avm-upgrade-ic { color: var(--accent-primary); }
+
+.nb-avm-sessions { margin-top: 8px; }
+.nb-avm-session {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 0;
+}
+.nb-avm-session-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  flex-shrink: 0;
+}
+.nb-avm-session-dot[data-current="true"] {
+  background: #3F8F6E;
+  box-shadow: 0 0 0 3px rgba(63,143,110,.18);
+}
+.nb-avm-session-time {
+  font-size: 11px;
+  color: var(--text-muted);
+  min-width: 64px;
+}
+.nb-avm-session-device {
+  font-size: 11px;
+  color: var(--text-primary);
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.nb-avm-session-this {
+  font-size: 9px;
+  font-family: var(--font-mono);
+  color: #3F8F6E;
+  background: rgba(63,143,110,.10);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.nb-avm-footer {
+  padding: 6px;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-subtle);
+}
+.nb-avm-theme-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 6px 8px;
+}
+.nb-avm-theme {
+  display: inline-flex;
+  background: var(--bg-surface);
+  border-radius: 999px;
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+}
+.nb-avm-theme-opt {
+  font-size: 11px; font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 0;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  transition: all 140ms;
+}
+.nb-avm-theme-opt[data-active="true"] {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: default;
+  box-shadow: 0 2px 6px -2px rgba(15,23,42,.2);
+}
+
+.nb-avm-links {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2px;
+  margin-top: 2px;
+}
+.nb-avm-link {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-size: 12px; font-weight: 500;
+  transition: background 120ms;
+}
+.nb-avm-link:hover { background: var(--bg-surface); }
+.nb-avm-link[data-danger]:hover { background: rgba(196,68,79,.10); color: #C4444F; }
+.nb-avm-link svg {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+.nb-avm-link[data-danger] svg { color: #C4444F; }
+.nb-avm-link span:nth-of-type(1) { flex: 1; min-width: 0; }
+.nb-avm-kbd {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+  background: var(--bg-secondary);
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+}

--- a/src/layouts/ProductTopNav.tsx
+++ b/src/layouts/ProductTopNav.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Bell, Command, Moon, Search, Sun } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { type CockpitSurfaceId } from "@/lib/registry/viewRegistry";
+import { ExactAvatarMenu } from "@/features/designKit/exact/ExactKit";
 
 const PRODUCT_NAV: Array<{ surfaceId: CockpitSurfaceId; label: string }> = [
   { surfaceId: "ask", label: "Home" },
@@ -97,9 +98,11 @@ export const ProductTopNav = memo(function ProductTopNav({
           >
             {resolvedMode === "dark" ? <Sun size={16} aria-hidden /> : <Moon size={16} aria-hidden />}
           </button>
-          <button type="button" className="nb-kit-topnav-avatar" aria-label="Open profile">
-            HS
-          </button>
+          <ExactAvatarMenu
+            resolvedMode={resolvedMode === "dark" ? "dark" : "light"}
+            setMode={(m) => setMode(m)}
+            onSurfaceChange={onSurfaceChange}
+          />
         </div>
       </div>
     </header>

--- a/tests/e2e/exact-kit-parity-prod.spec.ts
+++ b/tests/e2e/exact-kit-parity-prod.spec.ts
@@ -200,3 +200,61 @@ test("PR A7: Reports card click renders inline detail (no workspace redirect)", 
   expect(back.grid).toBe(true);
   expect(back.rcards).toBeGreaterThanOrEqual(3);
 });
+
+test("PR A9: Avatar HS button opens kit status panel", async ({ page }) => {
+  await navigate(page, "ask");
+
+  // Closed state — trigger present, panel not in DOM
+  const before = await page.evaluate(() => ({
+    trigger: !!document.querySelector(".nb-avm-trigger"),
+    avatarMark: document.querySelector(".nb-avm-avatar-sm")?.textContent,
+    panelClosed: !document.querySelector('[data-testid="exact-avatar-menu"]'),
+  }));
+  console.log("AVATAR (closed):", JSON.stringify(before, null, 2));
+  expect(before.trigger).toBe(true);
+  expect(before.avatarMark).toBe("HS");
+  expect(before.panelClosed).toBe(true);
+
+  // Click the trigger
+  await page.click(".nb-avm-trigger");
+  await page.waitForSelector('[data-testid="exact-avatar-menu"]', { timeout: 10_000 });
+  await page.waitForTimeout(500);
+
+  const open = await page.evaluate(() => ({
+    panel: !!document.querySelector('[data-testid="exact-avatar-menu"]'),
+    name: document.querySelector(".nb-avm-name")?.textContent,
+    proBadge: document.querySelector(".nb-avm-pro")?.textContent,
+    sectionLabels: Array.from(document.querySelectorAll(".nb-avm-section-label")).map((el) => el.textContent),
+    pulseTiles: document.querySelectorAll(".nb-avm-pulse").length,
+    pulseValues: Array.from(document.querySelectorAll(".nb-avm-pulse-v")).map((el) => el.textContent),
+    watchRows: document.querySelectorAll(".nb-avm-watch-row").length,
+    usageBars: document.querySelectorAll(".nb-avm-usage").length,
+    upgradeBtn: !!document.querySelector(".nb-avm-upgrade"),
+    sessionRows: document.querySelectorAll(".nb-avm-session").length,
+    thisMarker: !!document.querySelector(".nb-avm-session-this"),
+    themeOpts: Array.from(document.querySelectorAll(".nb-avm-theme-opt")).map((el) => el.textContent?.trim()),
+    links: Array.from(document.querySelectorAll(".nb-avm-link span:first-of-type")).map((el) => el.textContent),
+  }));
+  console.log("AVATAR (open):", JSON.stringify(open, null, 2));
+  expect(open.panel).toBe(true);
+  expect(open.name).toBe("Hannah Sato");
+  expect(open.proBadge).toBe("PRO");
+  expect(open.sectionLabels).toEqual(
+    expect.arrayContaining(["Today's pulse", "Watching · 12 entities", "This month · Pro", "Recent sessions", "Theme"]),
+  );
+  expect(open.pulseTiles, "3 pulse tiles").toBeGreaterThanOrEqual(3);
+  expect(open.pulseValues).toEqual(expect.arrayContaining(["74%", "38", "91%"]));
+  expect(open.watchRows, "3 watch rows").toBeGreaterThanOrEqual(3);
+  expect(open.usageBars, "3 usage bars").toBeGreaterThanOrEqual(3);
+  expect(open.upgradeBtn).toBe(true);
+  expect(open.sessionRows, "3 recent sessions").toBeGreaterThanOrEqual(3);
+  expect(open.thisMarker).toBe(true);
+  expect(open.themeOpts).toEqual(["Light", "Dark"]);
+  expect(open.links).toEqual(expect.arrayContaining(["Settings", "Shortcuts", "Help", "Sign out"]));
+
+  // Esc closes
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(500);
+  const closed = await page.evaluate(() => !document.querySelector('[data-testid="exact-avatar-menu"]'));
+  expect(closed, "Esc closes panel").toBe(true);
+});


### PR DESCRIPTION
## Summary
Click HS avatar in cockpit top-nav → opens 380px kit popover. Was: nothing happened.

Ported verbatim from `ui_kits/nodebench-web/TopNav.jsx`:
- **Identity** — gradient (terracotta→indigo) header, HS avatar, Hannah Sato, `hannah@orbital.ai · Orbital Labs`, PRO badge
- **Today's pulse** — 3 mini tiles: Memory hits 74% +6% (hot), Searches saved 38, Sources fresh 91%
- **Watching · 12 entities** — Orbital Labs (hot dot), DISCO (warm), Mira Patel (cool) + "See all" → connect
- **This month · Pro** — 3 usage bars (Sourced answers 284/500, Watched entities 12/25, Memory store 68/100 MB) + Upgrade to Team
- **Recent sessions** — `now MacBook · Safari · SF [THIS]`, `3h ago iPhone · Native · SF`, `yesterday MacBook · Chrome · SF`
- **Footer** — Light/Dark theme segment (wired to `useTheme`) + Settings/Shortcuts/Help/Sign out 2×2 grid

Outside-click + Escape close. Theme toggle persists via cockpit useTheme. `prefers-reduced-motion` disables pop-in.

## Tier B
New `PR A9: Avatar HS button opens kit status panel`. Asserts: closed state has trigger + "HS" mark; click → `[data-testid="exact-avatar-menu"]` mounts; panel renders all 5 section labels + 3 pulse tiles with values `74%/38/91%` + 3 watch rows + 3 usage bars + Upgrade button + 3 session rows with THIS marker + Light/Dark theme opts + Settings/Shortcuts/Help/Sign out links; Esc closes.

## Verification
- `npx tsc --noEmit` → exit 0
- `npm run build` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)