### PR TITLE
fix(theme): dark mode token overrides for kit-scoped surfaces

### DIFF
--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -35,6 +35,39 @@
   font-family: var(--font-sans);
 }
 
+/* Dark mode token overrides — cockpit useTheme sets `.dark` on document root.
+   Without these, kit-scoped surfaces stay light even after toggling theme. */
+.dark .nb-kit,
+.dark .nb-mobile-kit,
+.dark .ws-kit {
+  --accent-primary: #e08a6e;
+  --accent-primary-hover: #f0a08c;
+  --accent-primary-tint: rgba(217, 119, 87, 0.16);
+  --accent-primary-border: rgba(217, 119, 87, 0.40);
+  --accent-ink: #f0a890;
+  --indigo: #7c87dc;
+  --bg-app: #0f1014;
+  --bg-surface: #16181d;
+  --bg-secondary: #1f222a;
+  --bg-tertiary: #2a2e38;
+  --bg-paper: #1a1d24;
+  --text-primary: #f3f4f6;
+  --text-secondary: #d1d5db;
+  --text-muted: #9ca3af;
+  --text-faint: #6b7280;
+  --border-subtle: rgba(255, 255, 255, 0.06);
+  --border-default: rgba(255, 255, 255, 0.10);
+  --border-strong: rgba(255, 255, 255, 0.18);
+  --shadow-sm: 0 0 0 1px rgba(255, 255, 255, 0.04), 0 1px 2px rgba(0, 0, 0, 0.40);
+  --shadow-md: 0 0 0 1px rgba(255, 255, 255, 0.04), 0 2px 4px rgba(0, 0, 0, 0.30), 0 12px 24px rgba(0, 0, 0, 0.40);
+  --shadow-lg: 0 0 0 1px rgba(255, 255, 255, 0.04), 0 4px 8px rgba(0, 0, 0, 0.40), 0 24px 48px rgba(0, 0, 0, 0.50);
+}
+
+/* Avatar panel must also flip — its identity gradient is intentional, but
+   pulse tiles that aren't `[data-hot]` need the dark surface treatment. */
+.dark .nb-avm-link:hover { background: var(--bg-secondary); }
+.dark .nb-avm-pulse:not([data-hot="true"]) { background: var(--bg-tertiary); }
+
 .nb-kit *,
 .nb-kit *::before,
 .nb-kit *::after,


### PR DESCRIPTION
## Bug
Dogfood QA caught: clicking theme toggle in avatar panel flipped the icon (sun↔moon) but kit surfaces stayed light — page bg, panel cards, text contrast all unchanged.

## Root cause
`useTheme()` adds `dark` class to `<html>` (ThemeContext.tsx:163), but `exactKit.css` defined `--bg-surface`, `--text-primary`, etc. only inside the light `.nb-kit{}` block. Zero `.dark` overrides existed for 23 tokens. Attribute flipped, tokens didn't.

## Fix
Adds `.dark .nb-kit, .dark .nb-mobile-kit, .dark .ws-kit { ... }` block overriding all tokens with dark values (bg-app `#fafafa→#0f1014`, bg-surface `#ffffff→#16181d`, text-primary `#111827→#f3f4f6`, borders flipped to rgba(255,255,255,...) etc.). Plus 2 small avatar-panel surface tweaks for non-hot pulse tiles + link hover.

## Verification
- `npx tsc --noEmit` → exit 0
- `npm run build` → exit 0
- Dogfood walkthrough re-run after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)