### PR TITLE
feat(failover): B-PR1 OpenRouter native routing for free-model 429 spirals

### DIFF
--- a/convex/domains/ai/models/autonomousModelResolver.ts
+++ b/convex/domains/ai/models/autonomousModelResolver.ts
@@ -375,6 +375,16 @@ export const executeWithFallback = internalAction({
                   messages: messages.map((m: { role: string; content: string }) => ({ role: m.role, content: m.content })),
                   max_tokens: maxTokens,
                   temperature,
+                  // B-PR1: OpenRouter native routing — let OpenRouter transparently
+                  // failover to alternate hosting providers when the primary returns
+                  // 429/5xx. Sort by throughput so we prefer the fastest available
+                  // provider, falling back through the rest before we have to bail
+                  // and try the next model in our chain. This is the cheapest
+                  // meaningful guard against rate-limit spirals on free models.
+                  provider: {
+                    allow_fallbacks: true,
+                    sort: "throughput",
+                  },
                 }),
                 signal: AbortSignal.timeout(AUTONOMOUS_MODEL_CONFIG.modelTimeoutMs),
               });


### PR DESCRIPTION
## What

Adds OpenRouter native routing fields to the chat completion request body in `autonomousModelResolver.ts`:

`provider: { allow_fallbacks: true, sort: throughput }`

## Why

Free models on OpenRouter are routed across multiple hosting providers. When a single hosting provider rate-limits us with 429, OpenRouter does **not** automatically failover unless `allow_fallbacks: true` is set. Without it, our chain-level retry just hammers the same throttled provider until we bail to the next model entry.

With this set, OpenRouter transparently tries alternate providers for the same model, sorted by throughput, before returning a 429 to us. This is the cheapest meaningful guard against free-model rate-limit spirals.

## Scope discipline

Single-file change to `autonomousModelResolver.ts`, ~30 minutes per the plan. Other OpenRouter call sites (`freeModelDiscovery.ts`, `glmHybridApproach.ts`, `glmFlashWithReasoning.ts`, `server/nemoclaw/agentRunner.ts`) are out of scope for B-PR1 and will be patched in follow-up PRs.

## Plan reference

`docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md` (PR #116). This is **B-PR1** in the auto-routing subsystem ship order.

## Risk

Adding two server-recognized fields to a JSON request body. No type signature changes. If OpenRouter rejects the fields it ignores them silently per their docs. Worst case: the request still works exactly as before.

## Next PR

**B-PR2**: `capabilityRegistry.ts` JSON map of model ID -> capability tags.