### PR TITLE
fix(a11y): remove nested-interactive on Home Recent cards (axe serious)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,14 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
   ],
   // NOTE: Tests expect dev server to be running manually
   // Run `npm run dev` in a separate terminal before running tests

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -623,18 +623,15 @@ function NBRecentReports({ onOpenReport }: { onOpenReport: (id: string) => void 
       </header>
       <div className="nb-recent-grid">
         {RECENT_REPORTS.map((r) => (
+          // Mouse onClick anywhere on the card opens the report (preserves the
+          // "whole card is clickable" affordance), but the article is NOT a
+          // role="button" with tabIndex — that nests interactive controls
+          // inside the inner Brief/Explore/Chat buttons (axe nested-interactive
+          // serious violation). Keyboard users tab through the 3 inner buttons.
           <article
             key={r.id}
             className="nb-recent-card"
-            role="button"
-            tabIndex={0}
             onClick={() => onOpenReport(r.id)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onOpenReport(r.id);
-              }
-            }}
           >
             <header className="nb-recent-head">
               <span className="nb-recent-eye">{r.eyebrow}</span>


### PR DESCRIPTION
Cross-browser dogfood (chromium+firefox+webkit) caught 1 axe serious violation. `<article role=button tabIndex=0>` containing child `<button>` elements = nested-interactive. Drop role/tabIndex; onClick on article still works for mouse, keyboard users tab through inner buttons. Also adds firefox+webkit Playwright projects.