### PR TITLE
feat(chat): A-PR-A.4 rollback keyword interceptor for /rollback shortcuts

### DIFF
--- a/src/features/chat/hooks/useRollbackInterceptor.ts
+++ b/src/features/chat/hooks/useRollbackInterceptor.ts
@@ -1,0 +1,167 @@
+/**
+ * useRollbackInterceptor — React hook that intercepts rollback-shortcut
+ * inputs from the chat composer and dispatches the Convex rollback action.
+ *
+ * A-PR-A.4 of the Autonomous Continuation System.
+ * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (PR #116)
+ *
+ * Usage:
+ *   const interceptor = useRollbackInterceptor({ threadId });
+ *   const handleSubmit = async () => {
+ *     const intercepted = await interceptor.tryIntercept(value);
+ *     if (intercepted) return; // rollback already fired; do not call LLM
+ *     // ...normal LLM submit flow
+ *   };
+ *
+ * The hook consumes the `detectRollbackIntent` parser and the
+ * `rollbackToCheckpoint` action. It surfaces the result via toast for
+ * v1 — A-PR-A.5 will replace the toast with a structured chat message
+ * card so the rollback shows up in the persistent thread audit trail.
+ */
+
+import { useCallback, useState } from "react";
+import { useAction } from "convex/react";
+import { toast } from "sonner";
+
+import { api } from "../../../../convex/_generated/api";
+import {
+  detectRollbackIntent,
+  type RollbackIntent,
+} from "../lib/detectRollbackIntent";
+
+export type RollbackOutcome =
+  | {
+      ok: true;
+      restoredTurnId: number;
+      fromTurnId: number;
+      restoredCount: number;
+      successCount: number;
+    }
+  | {
+      ok: false;
+      error: "no_snapshot" | "snapshot_expired" | "invalid_args";
+      detail: string;
+      oldestAvailableTurnId?: number;
+    };
+
+export interface UseRollbackInterceptorArgs {
+  /** Convex agent thread the rollback is scoped to. */
+  threadId: string | null | undefined;
+  /** Called when a rollback completes (success or failure). */
+  onRollback?: (outcome: RollbackOutcome) => void;
+  /** Disable interception entirely (for previews / read-only views). */
+  disabled?: boolean;
+}
+
+export interface RollbackInterceptor {
+  /** True when the action is in flight. */
+  pending: boolean;
+  /**
+   * Attempt to intercept the supplied composer text. Returns `true` when
+   * the text was a rollback shortcut and the action was dispatched. The
+   * caller should NOT proceed with the normal LLM submit when `true`.
+   * Returns `false` for non-rollback inputs — caller proceeds normally.
+   */
+  tryIntercept: (rawInput: string) => Promise<boolean>;
+  /**
+   * Pure-parser passthrough — useful for showing UI hints ("press Enter
+   * to roll back 3 turns") without firing the action yet.
+   */
+  detect: (rawInput: string) => RollbackIntent | null;
+}
+
+export function useRollbackInterceptor({
+  threadId,
+  onRollback,
+  disabled = false,
+}: UseRollbackInterceptorArgs): RollbackInterceptor {
+  const [pending, setPending] = useState(false);
+  const rollback = useAction(
+    api.domains.agents.snapshots.rollbackToCheckpoint.rollbackToCheckpoint,
+  );
+
+  const detect = useCallback((rawInput: string) => {
+    if (disabled) return null;
+    return detectRollbackIntent(rawInput);
+  }, [disabled]);
+
+  const tryIntercept = useCallback(
+    async (rawInput: string): Promise<boolean> => {
+      if (disabled) return false;
+      if (!threadId) return false;
+
+      const intent = detectRollbackIntent(rawInput);
+      if (!intent) return false;
+
+      setPending(true);
+      try {
+        const args =
+          intent.kind === "turnId"
+            ? { threadId, turnId: intent.turnId }
+            : { threadId, stepsBack: intent.stepsBack };
+
+        const result = await rollback(args);
+
+        if (result.ok) {
+          const successCount = result.outcomes.filter((o) => o.ok).length;
+          const restoredCount = result.outcomes.length;
+          if (successCount === restoredCount) {
+            toast.success(
+              `Rolled back to turn ${result.restoredTurnId} (${restoredCount} artifact${restoredCount === 1 ? "" : "s"} restored)`,
+            );
+          } else if (successCount === 0) {
+            toast.warning(
+              `Rolled back marker only — ${restoredCount} artifact${restoredCount === 1 ? "" : "s"} could not be restored automatically. Domain restore handlers are not wired yet.`,
+            );
+          } else {
+            toast.warning(
+              `Partial rollback: ${successCount} of ${restoredCount} artifacts restored. Unwired handlers logged.`,
+            );
+          }
+          onRollback?.({
+            ok: true,
+            restoredTurnId: result.restoredTurnId,
+            fromTurnId: result.fromTurnId,
+            restoredCount,
+            successCount,
+          });
+        } else {
+          if (result.error === "snapshot_expired") {
+            toast.error(
+              `Cannot roll back that far. ${result.detail}${
+                result.oldestAvailableTurnId !== undefined
+                  ? ` Try /rollback to ${result.oldestAvailableTurnId}.`
+                  : ""
+              }`,
+            );
+          } else if (result.error === "no_snapshot") {
+            toast.info("No snapshots recorded yet for this thread.");
+          } else {
+            toast.error(`Rollback failed: ${result.detail}`);
+          }
+          onRollback?.({
+            ok: false,
+            error: result.error,
+            detail: result.detail,
+            oldestAvailableTurnId: result.oldestAvailableTurnId,
+          });
+        }
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(`Rollback failed: ${message}`);
+        onRollback?.({
+          ok: false,
+          error: "invalid_args",
+          detail: message,
+        });
+        return true; // we still intercepted — don't fall through to LLM
+      } finally {
+        setPending(false);
+      }
+    },
+    [disabled, threadId, rollback, onRollback],
+  );
+
+  return { pending, tryIntercept, detect };
+}

--- a/src/features/chat/lib/detectRollbackIntent.ts
+++ b/src/features/chat/lib/detectRollbackIntent.ts
@@ -1,0 +1,85 @@
+/**
+ * detectRollbackIntent — pure parser for chat composer rollback shortcuts.
+ *
+ * A-PR-A.4 of the Autonomous Continuation System.
+ * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (PR #116)
+ *
+ * Recognizes:
+ *   `/rollback`              → { kind: "stepsBack", stepsBack: 1 }
+ *   `/rollback 3`            → { kind: "stepsBack", stepsBack: 3 }
+ *   `/rollback to 42`        → { kind: "turnId", turnId: 42 }
+ *   `/rollback turn 42`      → { kind: "turnId", turnId: 42 }
+ *   "undo that"              → { kind: "stepsBack", stepsBack: 1 }
+ *   "revert that"            → { kind: "stepsBack", stepsBack: 1 }
+ *   "rollback that"          → { kind: "stepsBack", stepsBack: 1 }
+ *   "undo last 3"            → { kind: "stepsBack", stepsBack: 3 }
+ *   "rollback the last 2"    → { kind: "stepsBack", stepsBack: 2 }
+ *
+ * Returns `null` for inputs that do not match any rollback shortcut.
+ *
+ * Pure function (no React, no Convex). Easy to unit test.
+ */
+
+export type RollbackIntent =
+  | { kind: "stepsBack"; stepsBack: number }
+  | { kind: "turnId"; turnId: number };
+
+/** Maximum stepsBack we will accept from natural-language phrases. Protects
+ * against absurd inputs like "undo last 9999". The action enforces its own
+ * upper bound at 50 (the snapshot retention window). */
+const MAX_STEPS_BACK = 50;
+
+/**
+ * Try to interpret the supplied composer input as a rollback shortcut.
+ * Returns `null` when the text is anything other than a rollback command.
+ */
+export function detectRollbackIntent(rawInput: string): RollbackIntent | null {
+  if (!rawInput) return null;
+  const text = rawInput.trim();
+  if (!text) return null;
+
+  // ── Slash-prefixed canonical form ──────────────────────────────────────
+  // `/rollback`, `/rollback 3`, `/rollback to 42`, `/rollback turn 42`
+  const slashMatch = text.match(
+    /^\/rollback(?:\s+(?:to|turn)?\s*(\d+))?\s*$/i,
+  );
+  if (slashMatch) {
+    const numberPart = slashMatch[1];
+    if (numberPart === undefined) {
+      return { kind: "stepsBack", stepsBack: 1 };
+    }
+    const n = Number.parseInt(numberPart, 10);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    // `/rollback to 42` and `/rollback turn 42` are absolute turnIds.
+    const isTurnIdForm = /to|turn/i.test(slashMatch[0]);
+    if (isTurnIdForm) return { kind: "turnId", turnId: n };
+    return { kind: "stepsBack", stepsBack: Math.min(n, MAX_STEPS_BACK) };
+  }
+
+  // ── Fuzzy natural-language forms ───────────────────────────────────────
+  // Only fire on short inputs (<= 60 chars) to avoid swallowing real
+  // questions that happen to mention "undo".
+  if (text.length > 60) return null;
+
+  const lower = text.toLowerCase();
+
+  // "undo last 3", "rollback the last 2", "revert last 5"
+  const lastNMatch = lower.match(
+    /\b(?:undo|revert|rollback)(?:\s+(?:the|that))?\s+last\s+(\d+)\b/,
+  );
+  if (lastNMatch) {
+    const n = Number.parseInt(lastNMatch[1], 10);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    return { kind: "stepsBack", stepsBack: Math.min(n, MAX_STEPS_BACK) };
+  }
+
+  // "undo that", "revert that", "rollback that", plus "undo it"/"undo this"
+  const fuzzySingleMatch = lower.match(
+    /^(?:undo|revert|rollback)(?:\s+(?:that|it|this|my\s+last|the\s+last))?$/,
+  );
+  if (fuzzySingleMatch) {
+    return { kind: "stepsBack", stepsBack: 1 };
+  }
+
+  return null;
+}

--- a/src/features/product/components/ProductIntakeComposer.tsx
+++ b/src/features/product/components/ProductIntakeComposer.tsx
@@ -6,6 +6,10 @@ import { LENSES, type LensId } from "@/features/controlPlane/components/searchTy
 import type { ProductDraftFile } from "@/features/product/lib/productSession";
 import { useScreenCapture } from "@/hooks/useScreenCapture";
 import { useVoiceRecording } from "@/hooks/useVoiceRecording";
+import {
+  useRollbackInterceptor,
+  type RollbackOutcome,
+} from "@/features/chat/hooks/useRollbackInterceptor";
 
 export type ProductComposerMode = "ask" | "note" | "task";
 
@@ -50,6 +54,15 @@ type ProductIntakeComposerProps = {
   researchLanes?: readonly ProductResearchLane[];
   selectedResearchLane?: string;
   onResearchLaneChange?: (laneId: string) => void;
+  /**
+   * When provided, the composer intercepts rollback shortcuts (`/rollback`,
+   * `/rollback 3`, "undo that", "revert that", etc.) before invoking
+   * `onSubmit`. The interceptor calls the `rollbackToCheckpoint` Convex
+   * action and surfaces a toast. Leave undefined to disable. (A-PR-A.4)
+   */
+  rollbackThreadId?: string | null;
+  /** Optional callback fired after a rollback dispatches (success or failure). */
+  onRollbackComplete?: (outcome: RollbackOutcome) => void;
 };
 
 export function ProductIntakeComposer({
@@ -87,6 +100,8 @@ export function ProductIntakeComposer({
   researchLanes,
   selectedResearchLane,
   onResearchLaneChange,
+  rollbackThreadId = null,
+  onRollbackComplete,
 }: ProductIntakeComposerProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -178,9 +193,35 @@ export function ProductIntakeComposer({
       ? submitPending || !value.trim()
       : captureSavePending || !value.trim() || !onSaveCapture);
 
+  // A-PR-A.4: rollback interceptor — short-circuits `/rollback`,
+  // `/rollback N`, "undo that", "revert that", etc. before the LLM is
+  // invoked. Disabled when no `rollbackThreadId` is provided so non-chat
+  // composer instances behave exactly as before.
+  const rollbackInterceptor = useRollbackInterceptor({
+    threadId: rollbackThreadId ?? null,
+    onRollback: onRollbackComplete,
+    disabled: !rollbackThreadId,
+  });
+
   const handlePrimaryAction = () => {
     if (primaryDisabled || !value.trim()) return;
     if (mode === "ask") {
+      // Rollback shortcut takes precedence over the LLM submit. The
+      // interceptor returns true when it consumed the input; the
+      // composer is responsible for clearing the input afterward.
+      if (rollbackThreadId) {
+        const consumed = rollbackInterceptor.tryIntercept(value);
+        void consumed.then((didIntercept) => {
+          if (didIntercept) {
+            onChange("");
+          }
+        });
+        // We optimistically detect synchronously to decide whether to
+        // bail from the LLM submit. Async dispatch continues in parallel.
+        if (rollbackInterceptor.detect(value)) {
+          return;
+        }
+      }
       onSubmit();
       return;
     }


### PR DESCRIPTION
﻿## What

Wires the rollback action from A-PR-A.3 into the chat composer via three new files plus an additive prop on `ProductIntakeComposer`:

1. `src/features/chat/lib/detectRollbackIntent.ts` — pure parser. Matches:
   - `/rollback`, `/rollback N`, `/rollback to N`, `/rollback turn N`
   - `undo that`, `revert that`, `rollback that`, `undo it`, `undo this`
   - `undo last 3`, `revert last 5`, `rollback the last 2`
   - Caps `stepsBack` at 50 and bails on inputs over 60 chars to avoid swallowing real questions that happen to contain `undo`.

2. `src/features/chat/hooks/useRollbackInterceptor.ts` — React hook wrapping the parser + `rollbackToCheckpoint` action. Exposes `tryIntercept(value)` returning `true` when consumed. Toast feedback for v1.

3. `ProductIntakeComposer.tsx` — adds optional `rollbackThreadId` + `onRollbackComplete` props. `handlePrimaryAction` now tries the interceptor first when `rollbackThreadId` is set, short-circuiting before `onSubmit` so the LLM is never invoked for rollback shortcuts. Default off — all non-chat composer instances behave exactly as before.

## Why

Without this, the `rollbackToCheckpoint` action from A-PR-A.3 has no surface. Users could only call it via raw API. Now `/rollback` works directly in the same input box as normal chat, with no new UI footprint.

## Scope discipline

- No callers wired yet (Chat composer instances do not pass `rollbackThreadId` in this PR). Wiring lands in a small follow-up so existing chat flows remain untouched while we land A-PR-A.5 (`RollbackMessageCard`).
- Toast surface is intentionally temporary. A-PR-A.5 replaces it with a structured chat message kind so rollbacks become a permanent part of the thread audit trail, not just a transient toast.

## Plan reference

`docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md` (PR #116). This is A-PR-A.4 in the foundation ship order.

## Risk

Pure additions. The composer's existing `onSubmit` flow is unchanged when `rollbackThreadId` is unset. With it set, the interceptor only fires on inputs that match the strict parser — no false positives expected on real questions.

## Next PR

A-PR-A.5: `RollbackMessageCard.tsx` + new `ChatMessage.kind = 'rollback'` so rollbacks render as visible audit cards in the thread instead of transient toasts. After that, a final wiring PR will pass `rollbackThreadId` from chat surfaces into the composer.
