### PR TITLE
chore(security): pin requests>=2.33.0 to close last 6 medium alerts

### DIFF
--- a/python-mcp-servers/core_agent/requirements.txt
+++ b/python-mcp-servers/core_agent/requirements.txt
@@ -3,5 +3,5 @@ uvicorn==0.24.0
 pydantic==2.5.2
 pydantic-settings==2.1.0
 python-dotenv==1.2.2
-requests==2.31.0
+requests==2.33.0
 convex

--- a/python-mcp-servers/requirements.txt
+++ b/python-mcp-servers/requirements.txt
@@ -9,6 +9,7 @@ pydantic-settings==2.1.0
 # HTTP client
 httpx==0.26.0
 aiohttp==3.13.4
+requests>=2.33.0
 
 # Utilities
 python-dotenv==1.2.2


### PR DESCRIPTION
## Summary

Final cleanup pass. After PR #124 landed, Dependabot rescan showed 6 remaining medium alerts — all on the `requests` package across two paths.

- [python-mcp-servers/requirements.txt](python-mcp-servers/requirements.txt): `requests` was a transitive dep, not directly pinned. Added explicit `requests>=2.33.0`.
- [python-mcp-servers/core_agent/requirements.txt](python-mcp-servers/core_agent/requirements.txt): bumped `2.31.0 → 2.33.0`.

Closes the last 6 medium alerts. Expected post-merge state: **0 open Dependabot alerts**.

## Test plan

- CI runs unchanged (just version pins)
- Dependabot rescan after merge confirms zero alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)