### PR TITLE
feat(models): B-PR4 wire chain resolver into modelRouter for capability-aware failover

### DIFF
--- a/convex/domains/ai/models/modelRouter.ts
+++ b/convex/domains/ai/models/modelRouter.ts
@@ -17,6 +17,13 @@ import { internalAction } from "../../../_generated/server";
 import { internal } from "../../../_generated/api";
 import { generateText } from "ai";
 import { getLanguageModelSafe } from "../../agents/mcp_tools/models";
+// B-PR4: capability-aware fallback chain.
+// resolveChain replaces the static `[...TIER_MODELS[tier]]` candidate list
+// with a tier-floor-enforced ordering that respects requested capabilities
+// (vision, tools, reasoning, long-context). See chainResolver.ts (B-PR3)
+// and capabilityRegistry.ts (B-PR2).
+import { resolveChain } from "./chainResolver";
+import type { CapabilityRequirement, ModelTier } from "./capabilityRegistry";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -314,15 +321,54 @@ export const route = internalAction({
     }
 
     // ─── Build model candidate list ──────────────────────────────────
+    // B-PR4: capability-aware chain with tier-floor enforcement.
+    // We map the existing flat capability args onto a structured
+    // `CapabilityRequirement` and ask the chain resolver (B-PR3) for an
+    // ordered list. The static `TIER_MODELS` table remains a safety net
+    // for two cases: (a) the resolver returns an empty chain (e.g. an
+    // unusual capability requirement no registered model satisfies),
+    // (b) `pinnedModel` overrides everything for repro-pack determinism.
     let candidates: string[];
+    let chainDiagnostics: ReturnType<typeof resolveChain>["diagnostics"] | null =
+      null;
     if (args.pinnedModel) {
-      // Version pinning for repro packs — use exactly this model
+      // Version pinning for repro packs — use exactly this model.
       candidates = [args.pinnedModel];
     } else {
-      candidates = [...(TIER_MODELS[tier] ?? TIER_MODELS.cheap)];
-      // If tier is free and no candidates work, escalate to cheap
-      if (tier === "free") {
-        candidates.push(...TIER_MODELS.cheap);
+      const requirement: CapabilityRequirement = {
+        supportsTools: args.requireToolUse === true ? true : undefined,
+        supportsVision: args.requireVision === true ? true : undefined,
+        // 128k is the threshold the registry uses for `supportsLongContext`.
+        supportsLongContext:
+          (args.minContext ?? 0) >= 128_000 ? true : undefined,
+      };
+      const resolution = resolveChain({
+        requirement,
+        tierFloor: tier as ModelTier,
+        primaryModelId: TIER_MODELS[tier]?.[0] ?? null,
+        // Pre-populate `preferIds` with the tier's existing top-of-list so
+        // the resolver respects the manual ordering operators have tuned in
+        // `TIER_MODELS` while still applying tier-floor + capability gates.
+        preferIds: TIER_MODELS[tier],
+      });
+      chainDiagnostics = resolution.diagnostics;
+      candidates = resolution.chain;
+      console.log(
+        `[modelRouter] resolved chain tier=${tier} task=${args.taskCategory} length=${candidates.length} primary=${chainDiagnostics.primaryOutcome} pool=${chainDiagnostics.candidatePoolSize}`,
+      );
+
+      // HONEST_STATUS safety net — fall back to the legacy static list
+      // when the registry has no matching entry (e.g. a brand-new model
+      // not yet added to capabilityRegistry.ts). The audit log records
+      // the resolver reason so this is visible, not silent.
+      if (candidates.length === 0) {
+        console.warn(
+          `[modelRouter] chain resolver returned empty (reason=${resolution.reason}); falling back to TIER_MODELS[${tier}]`,
+        );
+        candidates = [...(TIER_MODELS[tier] ?? TIER_MODELS.cheap)];
+        if (tier === "free") {
+          candidates.push(...TIER_MODELS.cheap);
+        }
       }
     }
 


### PR DESCRIPTION
﻿## What

Replaces the static `[...TIER_MODELS[tier]]` candidate-list construction in `modelRouter.ts:route` with a `resolveChain` call (B-PR3) that produces a tier-floor-enforced, capability-aware fallback chain. The existing for-loop iteration over candidates is unchanged — only the **construction** of that list is upgraded.

## Mapping

| Old flat arg | New `CapabilityRequirement` field |
| --- | --- |
| `requireToolUse: true` | `supportsTools: true` |
| `requireVision: true` | `supportsVision: true` |
| `minContext >= 128_000` | `supportsLongContext: true` |

`tier` (already validated to `free`/`cheap`/`standard`/`premium`) becomes the chain resolver's `tierFloor`. `TIER_MODELS[tier]` is passed as `preferIds` so operators' manual ordering is respected while tier-floor + capability gates are applied on top.

## HONEST_STATUS safety net

When `resolveChain` returns an empty chain (registry has no matching entry — e.g. a brand-new model not yet added to `capabilityRegistry.ts`), the router falls back to the legacy static `TIER_MODELS` list and emits `console.warn` with the resolver `reason`. The failure is visible in audit logs, never silent. The `pinnedModel` branch is unchanged — repro packs continue to use exactly the pinned model.

## Observability

Emits a structured `console.log` after each chain resolution capturing `tier`, `taskCategory`, chain length, `primaryOutcome`, and `candidatePoolSize`. Plumbing diagnostics into the `logRouterCall` mutation requires extending the mutation schema and is deferred to a follow-up PR.

## Why

- B-PR1 covered same-model, different-host failover via OpenRouter native routing.
- B-PR2 made model capabilities a typed first-class data structure.
- B-PR3 turned that into a deterministic chain selector.
- B-PR4 (this PR) is what actually flips the live router from ad-hoc fallback to tier-floor-enforced, capability-aware failover. Without it, B-PR2/B-PR3 are unused.

## Scope discipline

Single-file change to `modelRouter.ts`. The for-loop, retry-on-429 backoff, cache, audit log, budget check, and pinning paths are all untouched. The diff is purely the candidate-list construction block.

## Plan reference

`docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md` (PR #116). This is **B-PR4** in the auto-routing subsystem — the one that closes the failover loop end-to-end.

## Risk

The pinning branch is unchanged. The non-pinning branch could in principle return a chain that excludes a model the legacy `TIER_MODELS` list would have included, but only when that excluded model fails the tier-floor or capability filter — which is exactly the desired behavior. The safety net guarantees we never start the for-loop with an empty list.

## Next PR

**B-PR5**: `ModelSwitchedCard.tsx` + visible ""switched to {model}"" chat message so the user sees when failover actually fired, instead of silent recovery.
