### PR TITLE
feat(agents): A-PR-B.6 lessons capture + system prompt injection trio

### DIFF
--- a/convex/domains/agents/lessons/captureLesson.ts
+++ b/convex/domains/agents/lessons/captureLesson.ts
@@ -1,0 +1,253 @@
+/**
+ * Lesson Capture — A-PR-B.6 of the Autonomous Continuation System
+ *
+ * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (PR #116)
+ *
+ * Internal mutations that write structured "lessons" into the
+ * `agentLessons` table (schema added in A-PR-A.1). A lesson is a
+ * one-sentence pattern the next agent turn should remember in order
+ * not to repeat the failure that produced it.
+ *
+ * Four lesson types are supported by the schema:
+ *   - `semantic`         — agent broke an artifact (post-rollback)
+ *   - `infrastructure`   — model failover / rate-limit pattern
+ *   - `budget`           — request hit a cost cap
+ *   - `spiral`           — 3+ same-signature turns with no progress
+ *
+ * Each capture path is a separate `internalMutation` so callers can
+ * pass exactly the fields each lesson type needs without a sloppy
+ * "any of these are optional" contract. Writers (rollback action,
+ * model router catch block, spiral detector, budget gate) call the
+ * appropriate function — they don't share a generic "write a lesson"
+ * surface.
+ *
+ * Bound: callers should treat capture as best-effort. The agentLessons
+ * read path (getRelevantLessons.ts) caps injection at K=5 lessons per
+ * turn, and lessons never expire by default unless explicitly pinned
+ * with `expiresAfterTurns`. Per-thread isolation in v1.
+ */
+
+import { v } from "convex/values";
+import { internalMutation } from "../../../_generated/server";
+import type { Doc } from "../../../_generated/dataModel";
+
+// ════════════════════════════════════════════════════════════════════════
+// SHARED VALIDATORS
+// ════════════════════════════════════════════════════════════════════════
+
+const lessonIdReturnValidator = v.id("agentLessons");
+
+/**
+ * Capture a SEMANTIC lesson — what the agent did wrong and what it
+ * should do instead. Called by `rollbackToCheckpoint` (A-PR-A.3) when
+ * the user issues `/rollback` after the agent broke an artifact.
+ */
+export const captureSemanticLesson = internalMutation({
+  args: {
+    threadId: v.string(),
+    turnId: v.number(),
+    /** Tool that produced the failure, e.g. `patch_notebook`. */
+    toolName: v.string(),
+    /** What the agent did wrong. Surfaced verbatim in injection. */
+    mistakePattern: v.string(),
+    /** What it should do next time. Surfaced verbatim in injection. */
+    correctPattern: v.string(),
+    /** Artifact category that was affected. */
+    artifactType: v.string(),
+    /** Optional sentence the user typed in the post-rollback toast. */
+    userNote: v.optional(v.string()),
+    /** Pin to bypass injection cap and skip expiry. Defaults false. */
+    pinned: v.optional(v.boolean()),
+    /** Auto-deprecate after N more turns of inactivity. */
+    expiresAfterTurns: v.optional(v.number()),
+  },
+  returns: lessonIdReturnValidator,
+  handler: async (ctx, args) => {
+    const id = await ctx.db.insert("agentLessons", {
+      threadId: args.threadId,
+      turnId: args.turnId,
+      type: "semantic",
+      toolName: args.toolName,
+      mistakePattern: args.mistakePattern,
+      correctPattern: args.correctPattern,
+      artifactType: args.artifactType,
+      userNote: args.userNote,
+      capturedAt: Date.now(),
+      expiresAfterTurns: args.expiresAfterTurns,
+      pinned: args.pinned ?? false,
+      deprecated: false,
+    });
+    return id;
+  },
+});
+
+/**
+ * Capture an INFRASTRUCTURE lesson — model failover pattern. Called
+ * by the model router (B-PR4 follow-up) after a successful failover
+ * so the next routing decision can prefer the proven-good fallback.
+ *
+ * The schema's `count` field accumulates: when an existing lesson
+ * with the same (threadId, fromModel, toModel) tuple already exists,
+ * we increment its count rather than insert a duplicate. This keeps
+ * the audit clean and lets the read path rank by frequency.
+ */
+export const captureInfrastructureLesson = internalMutation({
+  args: {
+    threadId: v.string(),
+    turnId: v.number(),
+    /** Model that failed (origin of the chain). */
+    fromModel: v.string(),
+    /** Model that succeeded as fallback. */
+    toModel: v.string(),
+    /** HTTP status / error symbol that triggered the switch. */
+    failedWith: v.union(v.number(), v.string()),
+    /** Whether the fallback ultimately succeeded. */
+    succeeded: v.boolean(),
+  },
+  returns: lessonIdReturnValidator,
+  handler: async (ctx, args) => {
+    // Look for an existing lesson with the same fromModel/toModel pair
+    // in this thread so we can fold the count instead of inserting a
+    // duplicate. Read path uses `count` for ranking.
+    const existing = await ctx.db
+      .query("agentLessons")
+      .withIndex("by_thread_type", (q) =>
+        q.eq("threadId", args.threadId).eq("type", "infrastructure"),
+      )
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("fromModel"), args.fromModel),
+          q.eq(q.field("toModel"), args.toModel),
+        ),
+      )
+      .first();
+
+    if (existing) {
+      const nextCount = (existing.count ?? 1) + 1;
+      await ctx.db.patch(existing._id, {
+        count: nextCount,
+        succeeded: args.succeeded,
+        failedWith: args.failedWith,
+        turnId: args.turnId,
+        capturedAt: Date.now(),
+        deprecated: false,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("agentLessons", {
+      threadId: args.threadId,
+      turnId: args.turnId,
+      type: "infrastructure",
+      fromModel: args.fromModel,
+      toModel: args.toModel,
+      failedWith: args.failedWith,
+      succeeded: args.succeeded,
+      count: 1,
+      capturedAt: Date.now(),
+      pinned: false,
+      deprecated: false,
+    });
+  },
+});
+
+/**
+ * Capture a BUDGET lesson — what task category hit the cost cap with
+ * what tokens-remaining estimate. Called by the budget gate (B-PR6)
+ * when a request is rejected. Future planning can use this to size
+ * downstream calls more conservatively.
+ */
+export const captureBudgetLesson = internalMutation({
+  args: {
+    threadId: v.string(),
+    turnId: v.number(),
+    /** Task category that hit the cap. */
+    taskCategory: v.string(),
+    /** Estimated tokens remaining when the cap fired. */
+    estimatedTokensRemaining: v.number(),
+  },
+  returns: lessonIdReturnValidator,
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("agentLessons", {
+      threadId: args.threadId,
+      turnId: args.turnId,
+      type: "budget",
+      taskCategory: args.taskCategory,
+      estimatedTokensRemaining: args.estimatedTokensRemaining,
+      capturedAt: Date.now(),
+      pinned: false,
+      deprecated: false,
+    });
+  },
+});
+
+/**
+ * Capture a SPIRAL lesson — 3+ same-signature turns with no progress.
+ * Called by the spiral detector (A-PR-B.7) when it identifies a loop
+ * the agent cannot break out of without an external nudge. The
+ * `mistakePattern` here describes the loop itself, e.g. "repeatedly
+ * calling tool_X with the same args; output unchanged".
+ */
+export const captureSpiralLesson = internalMutation({
+  args: {
+    threadId: v.string(),
+    turnId: v.number(),
+    /** Tool whose calls form the loop. */
+    toolName: v.string(),
+    /** Description of the loop pattern. Injected verbatim. */
+    mistakePattern: v.string(),
+    /** What to do instead. Injected verbatim. */
+    correctPattern: v.string(),
+  },
+  returns: lessonIdReturnValidator,
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("agentLessons", {
+      threadId: args.threadId,
+      turnId: args.turnId,
+      type: "spiral",
+      toolName: args.toolName,
+      mistakePattern: args.mistakePattern,
+      correctPattern: args.correctPattern,
+      capturedAt: Date.now(),
+      pinned: false,
+      deprecated: false,
+    });
+  },
+});
+
+/**
+ * Mark a lesson as deprecated so the read path stops injecting it.
+ * Used by the LessonsPanel UI (A-PR-B.7) for "this is no longer
+ * relevant" dismissals. We never hard-delete lessons in v1 so the
+ * audit trail is preserved.
+ */
+export const deprecateLesson = internalMutation({
+  args: {
+    lessonId: v.id("agentLessons"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.lessonId, { deprecated: true });
+    return null;
+  },
+});
+
+/**
+ * Pin a lesson so it bypasses the per-turn injection cap and never
+ * expires. Used by the LessonsPanel UI for "always remind me" actions.
+ */
+export const pinLesson = internalMutation({
+  args: {
+    lessonId: v.id("agentLessons"),
+    pinned: v.boolean(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.lessonId, { pinned: args.pinned });
+    return null;
+  },
+});
+
+/** Re-export of the lesson document type so callers don't need to dig
+ * through `_generated/dataModel.d.ts`. */
+export type AgentLesson = Doc<"agentLessons">;

--- a/convex/domains/agents/lessons/getRelevantLessons.ts
+++ b/convex/domains/agents/lessons/getRelevantLessons.ts
@@ -1,0 +1,178 @@
+/**
+ * Get Relevant Lessons — A-PR-B.6 of the Autonomous Continuation System
+ *
+ * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (PR #116)
+ *
+ * Read-side companion of `captureLesson.ts`. Returns the top-K lessons
+ * for a thread that are NOT deprecated and (when not pinned) have not
+ * outlived their `expiresAfterTurns` budget.
+ *
+ * Ranking rules (in order of precedence):
+ *   1. Pinned lessons first, in capture-time order (newest first).
+ *      Pins bypass the K cap — they always inject.
+ *   2. Tool-relevant lessons next — when the caller passes
+ *      `currentToolName`, lessons whose `toolName` matches are ranked
+ *      higher than tool-agnostic lessons.
+ *   3. Infrastructure lessons ranked by `count` descending so frequent
+ *      failover patterns surface above one-offs.
+ *   4. Tie-break by `capturedAt` descending (newer wins).
+ *
+ * HONEST_STATUS:
+ *   - Returns `[]` when no lessons exist (never a fake "all-clear"
+ *     placeholder).
+ *   - Skips deprecated lessons silently — they remain in the table for
+ *     audit, but the agent never sees them.
+ *   - Expiry is computed against `currentTurnId` so a stale read with
+ *     no turnId hint just returns everything still on file.
+ */
+
+import { v } from "convex/values";
+import { internalQuery } from "../../../_generated/server";
+import type { Doc } from "../../../_generated/dataModel";
+
+/** Default cap on lessons returned per turn. Pinned lessons bypass. */
+export const DEFAULT_LESSON_LIMIT = 5;
+
+/** Validator describing the lesson document shape returned to callers. */
+const lessonDocValidator = v.object({
+  _id: v.id("agentLessons"),
+  _creationTime: v.number(),
+  threadId: v.string(),
+  turnId: v.number(),
+  type: v.union(
+    v.literal("semantic"),
+    v.literal("infrastructure"),
+    v.literal("budget"),
+    v.literal("spiral"),
+  ),
+  toolName: v.optional(v.string()),
+  mistakePattern: v.optional(v.string()),
+  correctPattern: v.optional(v.string()),
+  artifactType: v.optional(v.string()),
+  fromModel: v.optional(v.string()),
+  toModel: v.optional(v.string()),
+  failedWith: v.optional(v.union(v.number(), v.string())),
+  succeeded: v.optional(v.boolean()),
+  count: v.optional(v.number()),
+  taskCategory: v.optional(v.string()),
+  estimatedTokensRemaining: v.optional(v.number()),
+  capturedAt: v.number(),
+  expiresAfterTurns: v.optional(v.number()),
+  pinned: v.boolean(),
+  deprecated: v.boolean(),
+  userNote: v.optional(v.string()),
+});
+
+/**
+ * Score a lesson against the caller's context. Higher score wins.
+ * Pinned lessons get a separate fast path and never enter scoring.
+ */
+function scoreLesson(
+  lesson: Doc<"agentLessons">,
+  currentToolName: string | undefined,
+): number {
+  let score = 0;
+
+  // Tool match is the strongest signal — give it 1000 points so it
+  // dominates count + recency.
+  if (currentToolName && lesson.toolName === currentToolName) {
+    score += 1000;
+  }
+
+  // Infrastructure lessons rank by frequency. Cap contribution at 100
+  // so a single very-frequent pair doesn't drown out tool relevance.
+  if (lesson.type === "infrastructure" && typeof lesson.count === "number") {
+    score += Math.min(lesson.count * 10, 100);
+  }
+
+  // Successful infrastructure failovers matter more than failed ones.
+  if (lesson.type === "infrastructure" && lesson.succeeded) {
+    score += 5;
+  }
+
+  // Recency bonus — every minute of age reduces score by 1, floor 0.
+  const ageMinutes = (Date.now() - lesson.capturedAt) / 60_000;
+  score -= Math.min(ageMinutes, 60);
+
+  return score;
+}
+
+/** True when an unpinned lesson has outlived its expiresAfterTurns budget. */
+function isExpired(
+  lesson: Doc<"agentLessons">,
+  currentTurnId: number | undefined,
+): boolean {
+  if (lesson.pinned) return false;
+  if (lesson.expiresAfterTurns === undefined) return false;
+  if (currentTurnId === undefined) return false;
+  return currentTurnId - lesson.turnId > lesson.expiresAfterTurns;
+}
+
+/**
+ * Internal query — returns the top-K relevant lessons for a thread.
+ * Caller passes `currentToolName` to bias toward tool-specific
+ * lessons, and `currentTurnId` to enforce expiry.
+ */
+export const getRelevantLessons = internalQuery({
+  args: {
+    threadId: v.string(),
+    /** Tool the agent is about to call. Boosts matching lessons. */
+    currentToolName: v.optional(v.string()),
+    /** Current turn — used to enforce expiry on unpinned lessons. */
+    currentTurnId: v.optional(v.number()),
+    /** Cap on returned lessons. Pinned lessons bypass. Default 5. */
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(lessonDocValidator),
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? DEFAULT_LESSON_LIMIT;
+
+    // Pull every non-deprecated lesson for the thread. With per-thread
+    // isolation in v1 and the normal "lessons accumulate slowly" usage
+    // pattern, this is well within Convex's per-query read limit.
+    const all = await ctx.db
+      .query("agentLessons")
+      .withIndex("by_thread", (q) => q.eq("threadId", args.threadId))
+      .collect();
+
+    const live = all.filter(
+      (l) => !l.deprecated && !isExpired(l, args.currentTurnId),
+    );
+
+    // Pinned lessons bypass the K cap and the scoring pass entirely.
+    const pinned = live
+      .filter((l) => l.pinned)
+      .sort((a, b) => b.capturedAt - a.capturedAt);
+
+    const unpinned = live
+      .filter((l) => !l.pinned)
+      .map((l) => ({ lesson: l, score: scoreLesson(l, args.currentToolName) }))
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return b.lesson.capturedAt - a.lesson.capturedAt;
+      })
+      .slice(0, limit)
+      .map((entry) => entry.lesson);
+
+    return [...pinned, ...unpinned];
+  },
+});
+
+/**
+ * Internal query — returns ALL lessons for a thread for audit / panel
+ * views. Includes deprecated and expired ones so the user can see the
+ * full history. Sorted newest-first.
+ */
+export const listAllLessonsForThread = internalQuery({
+  args: {
+    threadId: v.string(),
+  },
+  returns: v.array(lessonDocValidator),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("agentLessons")
+      .withIndex("by_thread", (q) => q.eq("threadId", args.threadId))
+      .collect();
+    return rows.sort((a, b) => b.capturedAt - a.capturedAt);
+  },
+});

--- a/convex/domains/agents/lessons/systemPromptBuilder.ts
+++ b/convex/domains/agents/lessons/systemPromptBuilder.ts
@@ -1,0 +1,220 @@
+/**
+ * System Prompt Builder — A-PR-B.6 of the Autonomous Continuation System
+ *
+ * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (PR #116)
+ *
+ * Pure function (no Convex, no I/O) that turns an array of `agentLessons`
+ * rows into a markdown-formatted system-prompt prefix. The agent runtime
+ * concatenates this prefix to the model's existing system prompt before
+ * each turn so previously-captured lessons literally cannot be ignored.
+ *
+ * Format design notes:
+ *   - Lessons are grouped by type so the agent doesn't have to scan a
+ *     mixed list. Order: SEMANTIC → INFRASTRUCTURE → SPIRAL → BUDGET.
+ *     Semantic + spiral are "what NOT to do" (highest priority);
+ *     infrastructure + budget are "what to expect at the system level".
+ *   - Pinned lessons get a 📌 prefix so the agent can tell which ones
+ *     the user explicitly elevated.
+ *   - The block opens with a stable header so downstream tooling
+ *     (lesson-injection telemetry, prompt cache invalidation) can
+ *     detect it deterministically.
+ *   - Empty input returns an empty string — never a fake "no lessons"
+ *     placeholder. Caller decides whether to concatenate.
+ *
+ * Bound: total prefix capped at `MAX_PROMPT_PREFIX_BYTES` UTF-8 bytes
+ * (8 KB by default). When over budget, lower-priority lessons are
+ * dropped from the tail. Pinned lessons are kept regardless.
+ */
+
+import type { AgentLesson } from "./captureLesson";
+
+// ════════════════════════════════════════════════════════════════════════
+// CONFIG
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * Hard ceiling on the system-prompt prefix size. 8 KB is generous for
+ * 5-10 lesson sentences but small enough to not derail context windows.
+ */
+export const MAX_PROMPT_PREFIX_BYTES = 8_192;
+
+/** Stable header so downstream tooling can detect the prefix block. */
+export const LESSONS_HEADER = "## Active lessons (auto-injected)";
+export const LESSONS_FOOTER = "## End of lessons";
+
+// ════════════════════════════════════════════════════════════════════════
+// PRIORITY ORDER
+// ════════════════════════════════════════════════════════════════════════
+
+const TYPE_PRIORITY: Record<AgentLesson["type"], number> = {
+  semantic: 0, // highest
+  spiral: 1,
+  infrastructure: 2,
+  budget: 3, // lowest
+};
+
+const TYPE_HEADING: Record<AgentLesson["type"], string> = {
+  semantic: "### Past mistakes to avoid",
+  spiral: "### Loop patterns to break",
+  infrastructure: "### Known model failover patterns",
+  budget: "### Budget signals",
+};
+
+// ════════════════════════════════════════════════════════════════════════
+// FORMATTERS
+// ════════════════════════════════════════════════════════════════════════
+
+function pinPrefix(lesson: AgentLesson): string {
+  return lesson.pinned ? "📌 " : "";
+}
+
+function formatSemantic(lesson: AgentLesson): string {
+  const tool = lesson.toolName ? ` (\`${lesson.toolName}\`)` : "";
+  const note = lesson.userNote ? ` — user note: "${lesson.userNote}"` : "";
+  return `- ${pinPrefix(lesson)}**Don't:** ${
+    lesson.mistakePattern ?? "(unspecified mistake)"
+  }${tool}${note}\n  **Do:** ${
+    lesson.correctPattern ?? "(unspecified correct pattern)"
+  }`;
+}
+
+function formatSpiral(lesson: AgentLesson): string {
+  const tool = lesson.toolName ? ` via \`${lesson.toolName}\`` : "";
+  return `- ${pinPrefix(lesson)}**Loop:** ${
+    lesson.mistakePattern ?? "(unspecified loop)"
+  }${tool}\n  **Break by:** ${
+    lesson.correctPattern ?? "(unspecified break pattern)"
+  }`;
+}
+
+function formatInfrastructure(lesson: AgentLesson): string {
+  if (!lesson.fromModel || !lesson.toModel) return "";
+  const status =
+    typeof lesson.failedWith === "number"
+      ? `HTTP ${lesson.failedWith}`
+      : lesson.failedWith ?? "error";
+  const outcome = lesson.succeeded ? "succeeded" : "failed";
+  const count =
+    lesson.count && lesson.count > 1 ? ` (×${lesson.count})` : "";
+  return `- ${pinPrefix(lesson)}\`${lesson.fromModel}\` → \`${lesson.toModel}\` after ${status}; fallback ${outcome}${count}`;
+}
+
+function formatBudget(lesson: AgentLesson): string {
+  const cat = lesson.taskCategory ?? "(unknown task)";
+  const tokens = lesson.estimatedTokensRemaining ?? 0;
+  return `- ${pinPrefix(lesson)}**${cat}** hit budget cap with ~${tokens.toLocaleString()} tokens estimated remaining`;
+}
+
+function formatLesson(lesson: AgentLesson): string {
+  switch (lesson.type) {
+    case "semantic":
+      return formatSemantic(lesson);
+    case "spiral":
+      return formatSpiral(lesson);
+    case "infrastructure":
+      return formatInfrastructure(lesson);
+    case "budget":
+      return formatBudget(lesson);
+    default:
+      // HONEST_STATUS: unknown lesson type → drop quietly. Future lesson
+      // types added to the schema must extend this switch in the same PR.
+      return "";
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// PUBLIC
+// ════════════════════════════════════════════════════════════════════════
+
+export interface BuildPromptPrefixOptions {
+  /** Override the byte ceiling. Defaults to MAX_PROMPT_PREFIX_BYTES. */
+  maxBytes?: number;
+  /** Optional intro line above the header (e.g. "User: alice"). */
+  introLine?: string;
+}
+
+/**
+ * Render an ordered list of lessons into a markdown prompt prefix.
+ *
+ * Returns the empty string when `lessons` is empty so the caller can
+ * `prefix + originalSystemPrompt` without conditionals.
+ */
+export function buildSystemPromptPrefix(
+  lessons: readonly AgentLesson[],
+  options: BuildPromptPrefixOptions = {},
+): string {
+  if (lessons.length === 0) return "";
+
+  const maxBytes = options.maxBytes ?? MAX_PROMPT_PREFIX_BYTES;
+
+  // Sort by (pinned desc, type priority asc, capturedAt desc).
+  const sorted = [...lessons].sort((a, b) => {
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+    const tDelta = TYPE_PRIORITY[a.type] - TYPE_PRIORITY[b.type];
+    if (tDelta !== 0) return tDelta;
+    return b.capturedAt - a.capturedAt;
+  });
+
+  const lines: string[] = [];
+  if (options.introLine) lines.push(options.introLine, "");
+  lines.push(LESSONS_HEADER);
+
+  let currentType: AgentLesson["type"] | null = null;
+  let currentBytes = byteLengthOf(lines.join("\n"));
+  const droppedTypes = new Set<AgentLesson["type"]>();
+
+  for (const lesson of sorted) {
+    if (lesson.type !== currentType) {
+      const heading = TYPE_HEADING[lesson.type];
+      // Always include the heading even if subsequent lessons get
+      // dropped; otherwise the section headers would dangle.
+      const headingLine = `\n${heading}`;
+      currentBytes += byteLengthOf(headingLine + "\n");
+      lines.push(headingLine);
+      currentType = lesson.type;
+    }
+
+    const formatted = formatLesson(lesson);
+    if (!formatted) continue;
+    const lineBytes = byteLengthOf(formatted + "\n");
+    if (!lesson.pinned && currentBytes + lineBytes > maxBytes) {
+      droppedTypes.add(lesson.type);
+      continue; // skip non-pinned lessons that overflow the budget
+    }
+    lines.push(formatted);
+    currentBytes += lineBytes;
+  }
+
+  if (droppedTypes.size > 0) {
+    lines.push("");
+    lines.push(
+      `> Note: some lessons were trimmed to fit the ${maxBytes}-byte prompt budget.`,
+    );
+  }
+
+  lines.push("");
+  lines.push(LESSONS_FOOTER);
+  return lines.join("\n");
+}
+
+/** UTF-8 byte length of a string. Cheap and dependency-free. */
+function byteLengthOf(s: string): number {
+  // TextEncoder is available in both V8 isolate and Node runtimes.
+  return new TextEncoder().encode(s).length;
+}
+
+/**
+ * Helper for the agent runtime — concatenate the lesson prefix in
+ * front of an existing system prompt. Returns the original prompt
+ * unchanged when the lesson list is empty so the call site stays
+ * unconditional.
+ */
+export function injectLessonsIntoSystemPrompt(
+  originalSystemPrompt: string,
+  lessons: readonly AgentLesson[],
+  options: BuildPromptPrefixOptions = {},
+): string {
+  const prefix = buildSystemPromptPrefix(lessons, options);
+  if (!prefix) return originalSystemPrompt;
+  return `${prefix}\n\n${originalSystemPrompt}`;
+}


### PR DESCRIPTION
﻿## What

Adds three files under `convex/domains/agents/lessons/` that close the learning loop for the `agentLessons` table introduced in A-PR-A.1:

### 1. `captureLesson.ts`

One `internalMutation` per lesson type so callers cannot mix fields incorrectly:

- `captureSemanticLesson` — post-rollback (mistake/correct/artifact pattern)
- `captureInfrastructureLesson` — post-failover; **folds duplicates** by incrementing `count` when `(threadId, fromModel, toModel)` already exists
- `captureBudgetLesson` — post-cap (taskCategory + estimated tokens remaining)
- `captureSpiralLesson` — post-loop (mistakePattern + correctPattern + toolName)
- `deprecateLesson` and `pinLesson` for the LessonsPanel UI in A-PR-B.7

### 2. `getRelevantLessons.ts`

`internalQuery` returning the top-K relevant lessons for a thread.

- Pinned lessons bypass the K cap
- Scoring: tool match (+1000), infrastructure `count` (capped +100), success bonus (+5), recency penalty (up to −60)
- HONEST_STATUS: returns `[]` when no lessons exist; skips deprecated and expired silently
- Plus `listAllLessonsForThread` for the audit panel

### 3. `systemPromptBuilder.ts`

Pure utility (no Convex, no I/O) rendering an array of lessons into a markdown system-prompt prefix:

- Groups by type (`semantic` → `spiral` → `infrastructure` → `budget`)
- 📌 emoji prefix for pinned lessons
- 8 KB byte ceiling with non-pinned tail-drop when over budget; pins kept regardless
- `injectLessonsIntoSystemPrompt` helper for the agent runtime to concatenate before the model's existing prompt

## Why

A-PR-A.1 added the schema. This PR adds the read/write/render trio so the agent runtime can:
1. **Capture** lessons after every rollback / failover / spiral / budget event.
2. **Query** the most relevant lessons before each turn.
3. **Inject** them verbatim into the system prompt so the model literally cannot ignore the captured pattern without explicit deprecation.

Without this trio, the `agentLessons` schema is dead weight.

## Scope discipline

- Per-thread isolation in v1; cross-thread guardrails deferred.
- No callers wire this in yet — the rollback action (A-PR-A.3) and model router (B-PR4) get capture wiring in a follow-up.
- The agent runtime's system-prompt assembly gets injection wiring once the lessons capture wiring is in place.

## Plan reference

`docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md` (PR #116). This is **A-PR-B.6** in the learning subsystem.

## Risk

Three additive files. No existing tables or callers touched. Safe to ship as scaffolding.

## Next PR

**A-PR-B.7**: `spiralDetector.ts` + `LessonsPanel.tsx` — closes Subsystem A end-to-end with loop detection that auto-captures spiral lessons, plus the operator panel for inspecting / pinning / deprecating accumulated lessons.
