### PR TITLE
feat(agents): B-PR6 budget gates + userBudgets table

### DIFF
--- a/convex/domains/agents/budget/budgetGate.ts
+++ b/convex/domains/agents/budget/budgetGate.ts
@@ -1,0 +1,353 @@
+/**
+ * Budget Gate — B-PR6 of the Autonomous Continuation System
+ *
+ * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (PR #116)
+ *
+ * Per-user budget caps for agent requests. The model router (B-PR4)
+ * calls `checkAndDeductBudget` before each routed request and refuses
+ * to spend tokens / cost beyond the user's daily cap. When the gate
+ * denies a request, it captures a BUDGET lesson via A-PR-B.6 so the
+ * next planning turn can size its work to fit the remaining budget.
+ *
+ * v1 surface:
+ *   - Per-user caps keyed by `ownerKey`. Per-thread caps deferred to v2.
+ *   - Daily reset window. Wall-clock based; the row's `resetAt` field
+ *     is bumped to the next 24h boundary on the first request after
+ *     it has elapsed.
+ *   - HONEST_STATUS: every denial returns a structured reason
+ *     (`token_cap` | `cost_cap` | `not_enrolled` …) so the chat surface
+ *     can render an actionable message.
+ *   - Caps of `0` mean "no cap on this dimension". Both caps zero +
+ *     `enforced: false` means the gate auto-allows everything.
+ */
+
+import { v } from "convex/values";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+} from "../../../_generated/server";
+import { internal } from "../../../_generated/api";
+
+// ════════════════════════════════════════════════════════════════════════
+// CONFIG
+// ════════════════════════════════════════════════════════════════════════
+
+/** Default daily token cap when a user enrolls without specifying one. */
+export const DEFAULT_DAILY_TOKEN_CAP = 1_000_000;
+/** Default daily USD cap when a user enrolls without specifying one. */
+export const DEFAULT_DAILY_COST_CAP_USD = 5;
+/** 24h reset window. */
+const RESET_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+// ════════════════════════════════════════════════════════════════════════
+// VALIDATORS
+// ════════════════════════════════════════════════════════════════════════
+
+const decisionValidator = v.union(
+  v.object({
+    allowed: v.literal(true),
+    /** Tokens still available today after the deduction. */
+    dailyTokensRemaining: v.number(),
+    /** USD still available today after the deduction. */
+    dailyCostRemainingUsd: v.number(),
+    /** Whether the gate auto-created the row on first use. */
+    autoEnrolled: v.boolean(),
+  }),
+  v.object({
+    allowed: v.literal(false),
+    reason: v.union(
+      v.literal("token_cap"),
+      v.literal("cost_cap"),
+      v.literal("not_enrolled"),
+    ),
+    /** Estimated tokens remaining when the cap fired (0 when over). */
+    estimatedTokensRemaining: v.number(),
+    /** USD remaining when the cap fired (0 when over). */
+    dailyCostRemainingUsd: v.number(),
+    /** ms until the next reset. Caller can show a countdown. */
+    msUntilReset: v.number(),
+    /** ID of the captured budget lesson, if any. */
+    lessonId: v.union(v.id("agentLessons"), v.null()),
+  }),
+);
+
+const budgetRowValidator = v.union(
+  v.null(),
+  v.object({
+    _id: v.id("userBudgets"),
+    _creationTime: v.number(),
+    ownerKey: v.string(),
+    dailyTokenCap: v.number(),
+    dailyCostCapUsd: v.number(),
+    consumedTokensToday: v.number(),
+    consumedCostUsdToday: v.number(),
+    resetAt: v.number(),
+    enforced: v.boolean(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  }),
+);
+
+// ════════════════════════════════════════════════════════════════════════
+// INTERNAL HELPERS
+// ════════════════════════════════════════════════════════════════════════
+
+function nextResetAt(now: number): number {
+  return now + RESET_WINDOW_MS;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// CHECK + DEDUCT
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * Internal mutation invoked by the model router (B-PR4) before each
+ * routed request. Atomically checks the user's budget and either
+ * deducts the estimated cost or denies the request and captures a
+ * BUDGET lesson for the agent to learn from.
+ *
+ * `taskCategory` is forwarded to the lesson record so future planning
+ * can size category-specific work to fit the remaining budget.
+ */
+export const checkAndDeductBudget = internalMutation({
+  args: {
+    /** Owner identity. Anonymous + authed sessions reuse the same key. */
+    ownerKey: v.string(),
+    /** Thread the request belongs to (for lesson capture context). */
+    threadId: v.string(),
+    /** Current turn id (for lesson capture). */
+    turnId: v.number(),
+    /** Task category (research / synthesis / publishing / …). */
+    taskCategory: v.string(),
+    /** Pre-call estimate of tokens this request will consume. */
+    estimatedTokens: v.number(),
+    /** Pre-call estimate of USD this request will consume. */
+    estimatedCostUsd: v.number(),
+    /**
+     * When `true`, the gate auto-creates the budget row with the default
+     * caps if it doesn't exist. When `false`, missing rows result in
+     * `not_enrolled`. Defaults to `true`.
+     */
+    autoEnroll: v.optional(v.boolean()),
+  },
+  returns: decisionValidator,
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const autoEnroll = args.autoEnroll ?? true;
+
+    let row = await ctx.db
+      .query("userBudgets")
+      .withIndex("by_owner", (q) => q.eq("ownerKey", args.ownerKey))
+      .first();
+
+    // ─── Auto-enrol on first request ─────────────────────────────────
+    if (!row) {
+      if (!autoEnroll) {
+        return {
+          allowed: false as const,
+          reason: "not_enrolled" as const,
+          estimatedTokensRemaining: 0,
+          dailyCostRemainingUsd: 0,
+          msUntilReset: 0,
+          lessonId: null,
+        };
+      }
+      const insertedId = await ctx.db.insert("userBudgets", {
+        ownerKey: args.ownerKey,
+        dailyTokenCap: DEFAULT_DAILY_TOKEN_CAP,
+        dailyCostCapUsd: DEFAULT_DAILY_COST_CAP_USD,
+        consumedTokensToday: 0,
+        consumedCostUsdToday: 0,
+        resetAt: nextResetAt(now),
+        enforced: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const inserted = await ctx.db.get(insertedId);
+      if (!inserted) {
+        // Should be impossible right after insert, but stay HONEST.
+        throw new Error("Budget row vanished immediately after insert");
+      }
+      row = inserted;
+    }
+
+    // ─── Reset window if elapsed ─────────────────────────────────────
+    if (now >= row.resetAt) {
+      await ctx.db.patch(row._id, {
+        consumedTokensToday: 0,
+        consumedCostUsdToday: 0,
+        resetAt: nextResetAt(now),
+        updatedAt: now,
+      });
+      row = {
+        ...row,
+        consumedTokensToday: 0,
+        consumedCostUsdToday: 0,
+        resetAt: nextResetAt(now),
+        updatedAt: now,
+      };
+    }
+
+    // ─── Bypass when not enforced ────────────────────────────────────
+    if (!row.enforced) {
+      // Still bump telemetry counters for visibility, but never deny.
+      await ctx.db.patch(row._id, {
+        consumedTokensToday: row.consumedTokensToday + args.estimatedTokens,
+        consumedCostUsdToday: row.consumedCostUsdToday + args.estimatedCostUsd,
+        updatedAt: now,
+      });
+      return {
+        allowed: true as const,
+        dailyTokensRemaining: Number.POSITIVE_INFINITY,
+        dailyCostRemainingUsd: Number.POSITIVE_INFINITY,
+        autoEnrolled: false,
+      };
+    }
+
+    // ─── Compute projected usage ─────────────────────────────────────
+    const projectedTokens =
+      row.consumedTokensToday + args.estimatedTokens;
+    const projectedCost =
+      row.consumedCostUsdToday + args.estimatedCostUsd;
+    const tokenCapHit =
+      row.dailyTokenCap > 0 && projectedTokens > row.dailyTokenCap;
+    const costCapHit =
+      row.dailyCostCapUsd > 0 && projectedCost > row.dailyCostCapUsd;
+
+    if (tokenCapHit || costCapHit) {
+      const reason: "token_cap" | "cost_cap" = tokenCapHit
+        ? "token_cap"
+        : "cost_cap";
+      const remainingTokens = Math.max(
+        row.dailyTokenCap - row.consumedTokensToday,
+        0,
+      );
+      const remainingCost = Math.max(
+        row.dailyCostCapUsd - row.consumedCostUsdToday,
+        0,
+      );
+
+      // HONEST_STATUS: capture a budget lesson so future planning sizes
+      // work to fit the remaining budget. Best-effort — capture
+      // failures must not bring down the gate itself.
+      let lessonId: import("../../../_generated/dataModel").Id<"agentLessons"> | null =
+        null;
+      try {
+        lessonId = await ctx.runMutation(
+          internal.domains.agents.lessons.captureLesson.captureBudgetLesson,
+          {
+            threadId: args.threadId,
+            turnId: args.turnId,
+            taskCategory: args.taskCategory,
+            estimatedTokensRemaining: remainingTokens,
+          },
+        );
+      } catch (err) {
+        console.warn(
+          "[budgetGate] captureBudgetLesson failed; gate will still deny:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+
+      return {
+        allowed: false as const,
+        reason,
+        estimatedTokensRemaining: remainingTokens,
+        dailyCostRemainingUsd: remainingCost,
+        msUntilReset: Math.max(row.resetAt - now, 0),
+        lessonId,
+      };
+    }
+
+    // ─── Allow + deduct ──────────────────────────────────────────────
+    await ctx.db.patch(row._id, {
+      consumedTokensToday: projectedTokens,
+      consumedCostUsdToday: projectedCost,
+      updatedAt: now,
+    });
+
+    const dailyTokensRemaining =
+      row.dailyTokenCap > 0
+        ? Math.max(row.dailyTokenCap - projectedTokens, 0)
+        : Number.POSITIVE_INFINITY;
+    const dailyCostRemainingUsd =
+      row.dailyCostCapUsd > 0
+        ? Math.max(row.dailyCostCapUsd - projectedCost, 0)
+        : Number.POSITIVE_INFINITY;
+
+    return {
+      allowed: true as const,
+      dailyTokensRemaining,
+      dailyCostRemainingUsd,
+      autoEnrolled: row.consumedTokensToday === 0 && row.createdAt === now,
+    };
+  },
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// READ + UPSERT (for ResilienceSettings UI in B-PR7)
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * Read the current budget row for a user. Returns `null` (HONEST_STATUS)
+ * when the user has not been enrolled yet — UI shows the default
+ * placeholder instead of pretending zeros are real consumption.
+ */
+export const getBudgetForOwner = internalQuery({
+  args: { ownerKey: v.string() },
+  returns: budgetRowValidator,
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("userBudgets")
+      .withIndex("by_owner", (q) => q.eq("ownerKey", args.ownerKey))
+      .first();
+    return row ?? null;
+  },
+});
+
+/**
+ * Upsert the budget caps for a user. Used by the ResilienceSettings UI
+ * (B-PR7) when the operator changes their daily caps. Public mutation
+ * so the React layer can call it directly.
+ *
+ * Setting a cap to 0 means "no cap". Setting `enforced` to `false`
+ * disables the gate without losing the configured caps.
+ */
+export const upsertBudgetForOwner = mutation({
+  args: {
+    ownerKey: v.string(),
+    dailyTokenCap: v.number(),
+    dailyCostCapUsd: v.number(),
+    enforced: v.optional(v.boolean()),
+  },
+  returns: v.id("userBudgets"),
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const enforced = args.enforced ?? true;
+    const existing = await ctx.db
+      .query("userBudgets")
+      .withIndex("by_owner", (q) => q.eq("ownerKey", args.ownerKey))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        dailyTokenCap: args.dailyTokenCap,
+        dailyCostCapUsd: args.dailyCostCapUsd,
+        enforced,
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+    return await ctx.db.insert("userBudgets", {
+      ownerKey: args.ownerKey,
+      dailyTokenCap: args.dailyTokenCap,
+      dailyCostCapUsd: args.dailyCostCapUsd,
+      consumedTokensToday: 0,
+      consumedCostUsdToday: 0,
+      resetAt: nextResetAt(now),
+      enforced,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -14999,6 +14999,35 @@ export default defineSchema({
     .index("by_thread_sha", ["threadId", "contentSha256"]),
 
   /**
+   * Per-user budget caps for agent requests. One row per `ownerKey`.
+   * The budget gate (`convex/domains/agents/budget/budgetGate.ts`)
+   * looks up this row before each routed request, resets daily counters
+   * when wall-clock crosses `resetAt`, and rejects requests that would
+   * exceed `dailyTokenCap` or `dailyCostCapUsd`.
+   *
+   * v1: per-user caps only. Per-thread caps deferred to v2.
+   * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (PR #116) — B-PR6.
+   */
+  userBudgets: defineTable({
+    /** Owner identity. Anonymous sessions reuse the same key shape. */
+    ownerKey: v.string(),
+    /** Daily token cap (input + output). 0 = no cap. */
+    dailyTokenCap: v.number(),
+    /** Daily USD cap. 0 = no cap. */
+    dailyCostCapUsd: v.number(),
+    /** Consumed today (resets at `resetAt`). */
+    consumedTokensToday: v.number(),
+    consumedCostUsdToday: v.number(),
+    /** Wall-clock when daily counters reset. */
+    resetAt: v.number(),
+    /** Whether the user opted in to budget enforcement. Default true. */
+    enforced: v.boolean(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_owner", ["ownerKey"]),
+
+  /**
    * Lessons captured from rollbacks and infrastructure failures.
    * Top-K relevant lessons are injected verbatim into the next agent turn's
    * system prompt so the agent literally cannot repeat the same mistake


### PR DESCRIPTION
﻿## What

Adds per-user daily budget caps, the gate that enforces them, and the lesson-capture wiring that turns denial events into structured agent guidance.

### Schema

`userBudgets` table indexed by `ownerKey` with fields:
- `dailyTokenCap`, `dailyCostCapUsd` (`0` = no cap on that dimension)
- `consumedTokensToday`, `consumedCostUsdToday`
- `resetAt` (24h sliding reset window)
- `enforced` (boolean opt-out)
- `createdAt`, `updatedAt`

### Gate

`convex/domains/agents/budget/budgetGate.ts`:

- `checkAndDeductBudget` — internal mutation invoked by the model router (B-PR4) before each routed request. Atomically:
  1. Auto-enrolls on first request with sensible defaults (`1M` tokens/day, `` USD/day) when `autoEnroll` is on.
  2. Resets daily counters when wall-clock crosses `resetAt`.
  3. Bypasses entirely when `enforced` is `false` (still bumps telemetry counters for visibility).
  4. Computes projected usage; rejects when either cap would be exceeded.
  5. On rejection, captures a BUDGET lesson via `internal.domains.agents.lessons.captureLesson.captureBudgetLesson` so the next planning turn can size to fit the remaining budget.

### HONEST_STATUS

Every denial returns a discriminated union:
- `reason`: `token_cap` | `cost_cap` | `not_enrolled`
- `estimatedTokensRemaining`
- `dailyCostRemainingUsd`
- `msUntilReset`
- `lessonId` (or `null` if capture failed)

Capture failures are logged via `console.warn` but never bring down the gate itself.

### Read + Upsert

- `getBudgetForOwner` — internalQuery for the ResilienceSettings UI (B-PR7) and audit views.
- `upsertBudgetForOwner` — public mutation so the React layer can edit caps directly.

## Why

A-PR-B.6 added the lesson capture machinery, but the BUDGET lesson type had no caller. B-PR6 fills that gap end-to-end: real budget enforcement → denial event → captured lesson → next-turn system-prompt injection (A-PR-B.6) → agent plans inside the budget. Without this, ""budget"" was a placeholder lesson type with no producer.

## Scope discipline

- Per-user caps only. Per-thread caps deferred to v2.
- Gate is wired through internal API only — no caller flips on enforcement yet. Wiring into the model router's pre-call flow lands in a follow-up so the live `route` action diff stays separately reviewable.
- `upsertBudgetForOwner` is a public mutation but no UI consumes it yet (B-PR7 brings the `ResilienceSettings.tsx` panel that calls it).

## Plan reference

`docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md` (PR #116). This is **B-PR6**.

## Risk

Schema-additive plus a single new file. No existing tables or callers touched. Worst case: dead code until the wiring PR flips it on.

## Next PR

**B-PR7**: `ResilienceSettings.tsx` — operator panel that reads `getBudgetForOwner` and writes `upsertBudgetForOwner` so users can configure their own caps without going through the API.
