### PR TITLE
feat(models): B-PR8 wire infrastructure lessons into the failover loop (FINAL)

### DIFF
--- a/convex/domains/agents/lessons/infraPreferIds.ts
+++ b/convex/domains/agents/lessons/infraPreferIds.ts
@@ -1,0 +1,80 @@
+/**
+ * Infra Prefer IDs — B-PR8 of the Autonomous Continuation System
+ *
+ * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (PR #116)
+ *
+ * Reads the `agentLessons` table for `type: "infrastructure"` rows and
+ * returns the `toModel` IDs that have proven good in past failovers,
+ * sorted by `count` descending so the chain resolver (B-PR3) can use
+ * them as `preferIds` to bias future routing decisions toward
+ * recovery patterns we have already verified.
+ *
+ * Why a separate file:
+ *   - Keeps the existing `getRelevantLessons.ts` focused on system
+ *     prompt injection (which has different ranking rules).
+ *   - The model router lives in a `"use node"` file and calls Convex
+ *     functions only via `ctx.runQuery`. A small dedicated query is
+ *     cheaper than over-fetching all lessons and sorting client-side.
+ *
+ * HONEST_STATUS:
+ *   - Returns `[]` when no thread is supplied OR no infrastructure
+ *     lessons exist. Caller falls through to the operator-tuned
+ *     `TIER_MODELS` ordering — never a guessed prefer list.
+ *   - Skips deprecated entries silently.
+ *   - Skips lessons where `succeeded === false`. A failed fallback
+ *     pattern is in the audit trail but should not bias future
+ *     routing toward the failure.
+ */
+
+import { v } from "convex/values";
+import { internalQuery } from "../../../_generated/server";
+
+/**
+ * Default cap on prefer IDs returned. The chain resolver caps the
+ * resolved chain at 6, so 4 prefer slots leaves room for 2 fresh
+ * candidates from the registry while still honoring proven patterns.
+ */
+export const DEFAULT_PREFER_LIMIT = 4;
+
+export const getInfraPreferIdsForThread = internalQuery({
+  args: {
+    /** Thread to scope the lookup to. */
+    threadId: v.string(),
+    /** Optional cap on returned IDs. Defaults to 4. */
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(v.string()),
+  handler: async (ctx, args) => {
+    const limit = Math.max(1, args.limit ?? DEFAULT_PREFER_LIMIT);
+
+    // Pull every infrastructure lesson for the thread. Per-thread
+    // isolation in v1 keeps this small (lessons accumulate slowly).
+    const rows = await ctx.db
+      .query("agentLessons")
+      .withIndex("by_thread_type", (q) =>
+        q.eq("threadId", args.threadId).eq("type", "infrastructure"),
+      )
+      .collect();
+
+    const prefer: Array<{ toModel: string; rank: number }> = [];
+    const seen = new Set<string>();
+
+    for (const lesson of rows) {
+      if (lesson.deprecated) continue;
+      if (lesson.succeeded !== true) continue;
+      if (!lesson.toModel) continue;
+      if (seen.has(lesson.toModel)) continue;
+      seen.add(lesson.toModel);
+      prefer.push({
+        toModel: lesson.toModel,
+        // Pinned lessons jump the line. Otherwise rank by observed
+        // success count (HONEST_STATUS — no synthetic boost).
+        rank:
+          (lesson.pinned ? 1_000_000 : 0) + (lesson.count ?? 1),
+      });
+    }
+
+    prefer.sort((a, b) => b.rank - a.rank);
+    return prefer.slice(0, limit).map((p) => p.toModel);
+  },
+});

--- a/convex/domains/ai/models/modelRouter.ts
+++ b/convex/domains/ai/models/modelRouter.ts
@@ -261,6 +261,12 @@ export const route = internalAction({
     requireVision: v.optional(v.boolean()),
     requireStructuredOutputs: v.optional(v.boolean()),
     minContext: v.optional(v.number()),
+    // B-PR8: lesson-aware failover. When supplied, the router queries
+    // past infrastructure lessons for this thread to bias `preferIds`
+    // and writes new lessons after each successful failover so future
+    // routing prefers proven-good fallback chains.
+    threadId: v.optional(v.string()),
+    turnId: v.optional(v.number()),
   },
   returns: v.object({
     text: v.string(),
@@ -342,19 +348,46 @@ export const route = internalAction({
         supportsLongContext:
           (args.minContext ?? 0) >= 128_000 ? true : undefined,
       };
+
+      // B-PR8: lesson-aware preferIds. When the caller passes a
+      // `threadId` we ask the lessons store for proven-good fallback
+      // toModels from past failovers and place them in front of the
+      // operator-tuned `TIER_MODELS[tier]` ordering. HONEST_STATUS:
+      // returns `[]` when no thread or no successful infrastructure
+      // lessons exist, so we fall through to the static prefer list.
+      let lessonPreferIds: string[] = [];
+      if (args.threadId) {
+        try {
+          lessonPreferIds = await ctx.runQuery(
+            internal.domains.agents.lessons.infraPreferIds
+              .getInfraPreferIdsForThread,
+            { threadId: args.threadId },
+          );
+        } catch (err) {
+          console.warn(
+            "[modelRouter] infraPreferIds query failed; continuing without lesson-bias:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+
+      // Lesson-derived preferIds first, then operator-tuned tier list.
+      // Duplicates are de-duped by the resolver itself.
+      const mergedPreferIds = [
+        ...lessonPreferIds,
+        ...(TIER_MODELS[tier] ?? []),
+      ];
+
       const resolution = resolveChain({
         requirement,
         tierFloor: tier as ModelTier,
         primaryModelId: TIER_MODELS[tier]?.[0] ?? null,
-        // Pre-populate `preferIds` with the tier's existing top-of-list so
-        // the resolver respects the manual ordering operators have tuned in
-        // `TIER_MODELS` while still applying tier-floor + capability gates.
-        preferIds: TIER_MODELS[tier],
+        preferIds: mergedPreferIds,
       });
       chainDiagnostics = resolution.diagnostics;
       candidates = resolution.chain;
       console.log(
-        `[modelRouter] resolved chain tier=${tier} task=${args.taskCategory} length=${candidates.length} primary=${chainDiagnostics.primaryOutcome} pool=${chainDiagnostics.candidatePoolSize}`,
+        `[modelRouter] resolved chain tier=${tier} task=${args.taskCategory} length=${candidates.length} primary=${chainDiagnostics.primaryOutcome} pool=${chainDiagnostics.candidatePoolSize} lessonPrefer=${lessonPreferIds.length}`,
       );
 
       // HONEST_STATUS safety net — fall back to the legacy static list
@@ -376,6 +409,14 @@ export const route = internalAction({
     let lastError: Error | null = null;
     let fallbacksUsed = 0;
     let actualTier = tier;
+
+    // B-PR8: track each abandoned attempt with the status code that
+    // caused us to move on. The on-success and on-terminal-failure
+    // paths consume this list to capture infrastructure lessons.
+    const failedAttempts: Array<{
+      modelId: string;
+      failedWith: number | string;
+    }> = [];
 
     for (const modelId of candidates) {
       try {
@@ -437,6 +478,37 @@ export const route = internalAction({
           }
         );
 
+        // B-PR8: capture infrastructure lessons for every fromModel ->
+        // succeeded toModel hop in this chain. Future routing decisions
+        // see these lessons via `getInfraPreferIdsForThread` and bias
+        // towards proven-good fallbacks. Best-effort — capture failures
+        // log a warning but never bring down a successful response.
+        if (args.threadId && args.turnId !== undefined && failedAttempts.length > 0) {
+          for (const failed of failedAttempts) {
+            try {
+              await ctx.runMutation(
+                internal.domains.agents.lessons.captureLesson
+                  .captureInfrastructureLesson,
+                {
+                  threadId: args.threadId,
+                  turnId: args.turnId,
+                  fromModel: failed.modelId,
+                  toModel: modelId,
+                  failedWith: failed.failedWith,
+                  succeeded: true,
+                },
+              );
+            } catch (lessonErr) {
+              console.warn(
+                `[modelRouter] captureInfrastructureLesson failed for ${failed.modelId} -> ${modelId}:`,
+                lessonErr instanceof Error
+                  ? lessonErr.message
+                  : String(lessonErr),
+              );
+            }
+          }
+        }
+
         return {
           text: result.text,
           modelId,
@@ -458,9 +530,19 @@ export const route = internalAction({
         lastError = err instanceof Error ? err : new Error(String(err));
         fallbacksUsed++;
 
+        // B-PR8: record this attempt for downstream lesson capture.
+        const rawStatus = (err as any)?.status ?? (err as any)?.statusCode;
+        const failedWith: number | string =
+          typeof rawStatus === "number"
+            ? rawStatus
+            : (lastError.message || "error").slice(0, 80);
+        failedAttempts.push({ modelId, failedWith });
+
         // Retry on 429/503 with backoff
-        const status = (err as any)?.status ?? (err as any)?.statusCode;
-        if ([429, 502, 503, 504].includes(status)) {
+        if (
+          typeof rawStatus === "number" &&
+          [429, 502, 503, 504].includes(rawStatus)
+        ) {
           const delay = Math.min(1000 * fallbacksUsed, 5000) + Math.random() * 500;
           await new Promise((r) => setTimeout(r, delay));
         }
@@ -487,6 +569,41 @@ export const route = internalAction({
         errorMessage: lastError?.message ?? "All models failed",
       }
     );
+
+    // B-PR8: record a single terminal-failure lesson with succeeded=false
+    // covering the first → last hop. Future planning sees that this chain
+    // exhausted on this thread and can request a higher tier or different
+    // capabilities up-front. Best-effort — capture errors are warned, not
+    // thrown, so the original failure surfaces to the caller intact.
+    if (
+      args.threadId &&
+      args.turnId !== undefined &&
+      failedAttempts.length >= 1
+    ) {
+      const first = failedAttempts[0];
+      const last = failedAttempts[failedAttempts.length - 1];
+      try {
+        await ctx.runMutation(
+          internal.domains.agents.lessons.captureLesson
+            .captureInfrastructureLesson,
+          {
+            threadId: args.threadId,
+            turnId: args.turnId,
+            fromModel: first.modelId,
+            toModel: last.modelId,
+            failedWith: last.failedWith,
+            succeeded: false,
+          },
+        );
+      } catch (lessonErr) {
+        console.warn(
+          "[modelRouter] terminal captureInfrastructureLesson failed:",
+          lessonErr instanceof Error
+            ? lessonErr.message
+            : String(lessonErr),
+        );
+      }
+    }
 
     throw new Error(
       `ModelRouter: All ${candidates.length} models failed for ${args.taskCategory} (tier: ${tier}). Last error: ${lastError?.message}`


### PR DESCRIPTION
﻿## What

Closes Subsystem B end-to-end with the learning loop. Two changes:

### 1. `convex/domains/agents/lessons/infraPreferIds.ts`

`internalQuery getInfraPreferIdsForThread` returns past successful fallback `toModels` for a thread, sorted by `(pinned * 1_000_000 + count)` desc, capped at 4 by default. **HONEST_STATUS**:
- Returns `[]` when no thread or no successful infra lessons exist
- Skips deprecated rows
- Skips lessons where `succeeded !== true` so failed fallback patterns never bias future routing

### 2. `modelRouter.ts:route` integration

- New optional `threadId` + `turnId` args.
- When `threadId` is set, queries `infraPreferIds` before `resolveChain` and merges those in front of operator-tuned `TIER_MODELS[tier]` as `preferIds`.
- The for-loop tracks every abandoned attempt with its status code in a `failedAttempts` array.
- **On success after fallback**: captures one infrastructure lesson per `fromModel → succeeded toModel` hop via `captureInfrastructureLesson` (which folds duplicates by incrementing `count`).
- **On terminal failure** (chain exhausted): captures a single `succeeded: false` lesson covering the `first → last` hop so future planning sees the exhausted chain.

All lesson captures are **best-effort**: failures emit `console.warn` but never bring down the response. The original error from the underlying model call always surfaces to the caller intact.

## Why

B-PR1 added OpenRouter native routing. B-PR2 made capabilities first-class. B-PR3 turned that into a deterministic chain selector. B-PR4 wired it live. B-PR5 made failover visible. A-PR-B.6 added the lesson capture / query / inject trio. A-PR-B.7 closed the spiral detection path. B-PR6 added budget caps that capture lessons on denial. B-PR7 surfaced budget caps in operator UI.

**B-PR8 is the missing edge** — it wires the model router's catch block into the lesson capture machinery so the system actually learns from its own failover decisions. Without it, every recovery is forgotten the moment the response returns.

## Scope discipline

Single new file + targeted edits to `modelRouter.ts`. The existing `route` action stays backward-compatible: callers that don't pass `threadId` see exactly the same behavior as before.

## Plan reference

`docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md` (PR #116). This is **B-PR8** — the **FINAL PR**.

**Both subsystems are now feature-complete**:
- **Subsystem A** (rollback + learning): snapshots, `/rollback` chat command, rollback action, semantic / spiral / budget lesson capture, system-prompt injection, spiral detector, LessonsPanel UI.
- **Subsystem B** (auto-routing + capability-aware failover): OpenRouter native routing, capability registry, chain resolver with tier-floor enforcement, capability-aware live router, ModelSwitchedCard, budget gates, ResilienceSettings UI, lesson-aware fallback preference.

## Risk

The non-trivial change is the `ctx.runMutation` calls on the success and terminal-failure paths. These are best-effort — every call is wrapped in `try/catch` and the original response or original error always surfaces. The lesson-aware `preferIds` query is also wrapped — failures fall through to the operator-tuned `TIER_MODELS` ordering.

## Cost estimate

- `+1` Convex query per routed request (only when `threadId` set; reads ≤ N infrastructure lessons, where N is the per-thread accumulation cap from A-PR-A.1's bounded design).
- `+0` to `+M` Convex mutations per routed request, where M = number of failed-then-succeeded hops in this single request. Typical: 0 (primary works), occasionally 1, rarely 2+.
- Net effect: lessons cap at the same per-thread bounded set, no unbounded growth.

## Next steps (post-plan)

- Wire actual chat surfaces to pass `threadId` into `route` calls.
- Wire `ResilienceSettings` and `LessonsPanel` into a settings page.
- Add Convex test harness coverage for the lesson-aware failover path.
- Wire domain-specific restore handlers into `rollbackToCheckpoint` (currently HONEST_STATUS stubs).
