### PR TITLE
feat(agents): wire ResilienceSettings + public lesson/budget wrappers + 38 unit tests

### DIFF
--- a/convex/domains/agents/publicWrappers.ts
+++ b/convex/domains/agents/publicWrappers.ts
@@ -1,0 +1,100 @@
+/**
+ * Public query/mutation wrappers for agent subsystems (lessons + budget).
+ *
+ * The lesson + budget Convex modules expose `internalQuery` / `internalMutation`
+ * only — those cannot be called from React components.  This file re-exposes
+ * the read paths the operator UI needs (LessonsPanel + ResilienceSettings)
+ * as `query` / `mutation` with proper auth checks.
+ *
+ * Auth model: every read scopes to the current authenticated user; anonymous
+ * visitors get an empty result for `listLessonsForThread` and a null for
+ * `getBudgetSnapshot` so the UI degrades gracefully into seed/empty states.
+ */
+import { v } from "convex/values";
+import { mutation, query } from "../../_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Lessons — public reads + writes for LessonsPanel
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * List all lessons captured against a given thread, regardless of deprecated
+ * state.  The UI filters by deprecated/type client-side.
+ */
+export const listLessonsForThread = query({
+  args: {
+    threadId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return [];
+    const rows = await ctx.db
+      .query("agentLessons")
+      .withIndex("by_thread", (q) => q.eq("threadId", args.threadId))
+      .collect();
+    return rows.sort((a, b) => b.capturedAt - a.capturedAt);
+  },
+});
+
+/**
+ * Pin or unpin a lesson.  Pinned lessons stay above the fold in the
+ * system-prompt prefix during agent runs, even after expiration.
+ */
+export const pinLessonById = mutation({
+  args: {
+    lessonId: v.id("agentLessons"),
+    pinned: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("not_authenticated");
+    }
+    await ctx.db.patch(args.lessonId, { pinned: args.pinned });
+    return null;
+  },
+});
+
+/**
+ * Soft-delete a lesson (sets `deprecated: true`).  Capture writers and the
+ * system-prompt builder respect this flag and ignore the row.
+ */
+export const deprecateLessonById = mutation({
+  args: {
+    lessonId: v.id("agentLessons"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("not_authenticated");
+    }
+    await ctx.db.patch(args.lessonId, { deprecated: true });
+    return null;
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Budget — public read for ResilienceSettings
+// (write path is the existing public `upsertBudgetForOwner` mutation in
+// budgetGate.ts)
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Read the budget snapshot for the current authenticated owner.  Returns
+ * null when not authenticated or no row yet exists.  The UI then renders
+ * the "Get started" empty state.
+ */
+export const getBudgetSnapshot = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return null;
+    const ownerKey = `user:${userId}`;
+    const row = await ctx.db
+      .query("userBudgets")
+      .withIndex("by_owner", (q) => q.eq("ownerKey", ownerKey))
+      .first();
+    return row ?? null;
+  },
+});

--- a/convex/domains/ai/models/chainResolver.test.ts
+++ b/convex/domains/ai/models/chainResolver.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for resolveChain.  Pure function — no Convex runtime.
+ *
+ * Tests the contract surfaced in chainResolver.ts:
+ *  1. Tier-floor enforcement (no model below floor, even if it matches caps)
+ *  2. Avoid list stripping
+ *  3. preferIds pinned to front in supplied order
+ *  4. primaryModelId placed first when it passes filters
+ *  5. Empty chain when nothing matches → reason set (HONEST_STATUS)
+ *  6. Capability requirement filter (vision/tools/reasoning/long-context/streaming)
+ *  7. maxChainLength clamp
+ */
+import { describe, expect, it } from "vitest";
+import { resolveChain } from "./chainResolver";
+import { CAPABILITY_REGISTRY } from "./capabilityRegistry";
+
+// Pick a stable canary model from the registry to use across tests.
+// `qwen3-coder-free` is documented in chainResolver.ts header — free tier,
+// supports tools + reasoning + longContext + streaming.
+const REGISTERED_FREE = "qwen3-coder-free";
+
+describe("resolveChain", () => {
+  describe("registry sanity (tests depend on these IDs being registered)", () => {
+    it("free-tier canary is in the registry", () => {
+      expect(CAPABILITY_REGISTRY[REGISTERED_FREE]).toBeDefined();
+      expect(CAPABILITY_REGISTRY[REGISTERED_FREE].tier).toBe("free");
+    });
+  });
+
+  describe("tier-floor enforcement", () => {
+    it("returns at least one chain entry when requirement matches free models", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+      });
+      expect(result.chain.length).toBeGreaterThan(0);
+    });
+
+    it("with tierFloor='premium', no free model appears in the chain", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "premium",
+      });
+      for (const id of result.chain) {
+        const caps = CAPABILITY_REGISTRY[id];
+        expect(caps).toBeDefined();
+        expect(caps.tier).toBe("premium");
+      }
+    });
+
+    it("never includes models below the tier floor even when capability matches", () => {
+      const result = resolveChain({
+        requirement: {},
+        tierFloor: "standard",
+      });
+      const tierOrder = ["free", "cheap", "standard", "premium"];
+      const floorIdx = tierOrder.indexOf("standard");
+      for (const id of result.chain) {
+        const caps = CAPABILITY_REGISTRY[id];
+        const idx = tierOrder.indexOf(caps.tier);
+        expect(idx).toBeGreaterThanOrEqual(floorIdx);
+      }
+    });
+  });
+
+  describe("avoid list", () => {
+    it("strips models in avoidModelIds from the chain", () => {
+      const baseline = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+      });
+      // Pick the first chain entry to avoid; rerun and assert it's gone.
+      const toAvoid = baseline.chain[0];
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        avoidModelIds: [toAvoid],
+      });
+      expect(result.chain).not.toContain(toAvoid);
+    });
+
+    it("primary in avoid list → primaryOutcome surfaces dropped_in_avoid_list", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        primaryModelId: REGISTERED_FREE,
+        avoidModelIds: [REGISTERED_FREE],
+      });
+      expect(result.diagnostics.primaryOutcome).toBe("dropped_in_avoid_list");
+      expect(result.chain).not.toContain(REGISTERED_FREE);
+    });
+  });
+
+  describe("preferIds pinning", () => {
+    it("registered preferId moves to the front", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        preferIds: [REGISTERED_FREE],
+      });
+      expect(result.chain[0]).toBe(REGISTERED_FREE);
+      expect(result.diagnostics.preferredAccepted).toContain(REGISTERED_FREE);
+    });
+
+    it("unregistered preferId surfaces in preferredDropped diagnostics", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        preferIds: ["__not_a_real_model__"],
+      });
+      expect(result.chain).not.toContain("__not_a_real_model__");
+      expect(
+        result.diagnostics.preferredDropped.some(
+          (d) => d.modelId === "__not_a_real_model__" && d.reason === "not_in_registry",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("primaryModelId placement", () => {
+    it("registered primary appears first when it passes filters", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        primaryModelId: REGISTERED_FREE,
+      });
+      expect(result.chain[0]).toBe(REGISTERED_FREE);
+      expect(result.diagnostics.primaryOutcome).toBe("kept");
+    });
+
+    it("unregistered primary → diagnostics.primaryOutcome = dropped_not_in_registry", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        primaryModelId: "__not_a_real_model__",
+      });
+      expect(result.chain).not.toContain("__not_a_real_model__");
+      expect(result.diagnostics.primaryOutcome).toBe("dropped_not_in_registry");
+    });
+  });
+
+  describe("capability requirement filter", () => {
+    it("requirement.supportsVision=true keeps only vision-capable models", () => {
+      const result = resolveChain({
+        requirement: { supportsVision: true },
+        tierFloor: "free",
+      });
+      for (const id of result.chain) {
+        expect(CAPABILITY_REGISTRY[id].supportsVision).toBe(true);
+      }
+    });
+  });
+
+  describe("HONEST_STATUS — empty chain on no match", () => {
+    it("impossible requirement → empty chain + reason set", () => {
+      const result = resolveChain({
+        requirement: {
+          supportsVision: true,
+          supportsTools: true,
+          supportsReasoning: true,
+          supportsLongContext: true,
+          supportsStreaming: true,
+        },
+        // Force an impossible combo across all five flags at the cheapest tier.
+        tierFloor: "premium",
+        avoidModelIds: Object.keys(CAPABILITY_REGISTRY), // remove every registered model
+      });
+      expect(result.chain).toEqual([]);
+      expect(result.reason).toBeDefined();
+    });
+  });
+
+  describe("maxChainLength clamp", () => {
+    it("respects maxChainLength=2 even when more candidates exist", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        maxChainLength: 2,
+      });
+      expect(result.chain.length).toBeLessThanOrEqual(2);
+    });
+
+    it("treats maxChainLength=0 as 1 (defensive lower bound)", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        maxChainLength: 0,
+      });
+      expect(result.chain.length).toBeGreaterThanOrEqual(0);
+      expect(result.chain.length).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/src/features/chat/lib/detectRollbackIntent.test.ts
+++ b/src/features/chat/lib/detectRollbackIntent.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for detectRollbackIntent.  Pure function — no Convex / React.
+ *
+ * Covers: canonical /rollback forms, natural-language fuzzy forms, the
+ * MAX_STEPS_BACK clamp, and rejected inputs (empty, long, malformed).
+ */
+import { describe, expect, it } from "vitest";
+import { detectRollbackIntent } from "./detectRollbackIntent";
+
+describe("detectRollbackIntent", () => {
+  describe("rejects non-rollback input", () => {
+    it("returns null for empty string", () => {
+      expect(detectRollbackIntent("")).toBe(null);
+    });
+    it("returns null for whitespace-only", () => {
+      expect(detectRollbackIntent("   ")).toBe(null);
+    });
+    it("returns null for unrelated questions", () => {
+      expect(detectRollbackIntent("what's the weather like")).toBe(null);
+      expect(detectRollbackIntent("compare these two reports")).toBe(null);
+    });
+    it("returns null for long inputs that mention undo", () => {
+      const long =
+        "I've been thinking about whether I should undo the changes we made earlier today";
+      expect(long.length).toBeGreaterThan(60);
+      expect(detectRollbackIntent(long)).toBe(null);
+    });
+  });
+
+  describe("canonical /rollback slash form", () => {
+    it("/rollback → stepsBack: 1", () => {
+      expect(detectRollbackIntent("/rollback")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 1,
+      });
+    });
+    it("/rollback 3 → stepsBack: 3", () => {
+      expect(detectRollbackIntent("/rollback 3")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 3,
+      });
+    });
+    it("/rollback to 42 → turnId: 42", () => {
+      expect(detectRollbackIntent("/rollback to 42")).toEqual({
+        kind: "turnId",
+        turnId: 42,
+      });
+    });
+    it("/rollback turn 42 → turnId: 42", () => {
+      expect(detectRollbackIntent("/rollback turn 42")).toEqual({
+        kind: "turnId",
+        turnId: 42,
+      });
+    });
+    it("clamps slash-form stepsBack to MAX_STEPS_BACK=50", () => {
+      const r = detectRollbackIntent("/rollback 9999");
+      expect(r).toEqual({ kind: "stepsBack", stepsBack: 50 });
+    });
+    it("rejects /rollback 0", () => {
+      expect(detectRollbackIntent("/rollback 0")).toBe(null);
+    });
+    it("ignores trailing whitespace", () => {
+      expect(detectRollbackIntent("/rollback 2   ")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 2,
+      });
+    });
+    it("is case-insensitive on /rollback", () => {
+      expect(detectRollbackIntent("/RollBack 4")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 4,
+      });
+    });
+  });
+
+  describe("natural-language forms", () => {
+    it("'undo last 3' → stepsBack: 3", () => {
+      expect(detectRollbackIntent("undo last 3")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 3,
+      });
+    });
+    it("'rollback the last 2' → stepsBack: 2", () => {
+      expect(detectRollbackIntent("rollback the last 2")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 2,
+      });
+    });
+    it("'revert last 5' → stepsBack: 5", () => {
+      expect(detectRollbackIntent("revert last 5")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 5,
+      });
+    });
+    it("clamps natural-language stepsBack to 50", () => {
+      const r = detectRollbackIntent("undo last 9999");
+      expect(r).toEqual({ kind: "stepsBack", stepsBack: 50 });
+    });
+    it("'undo that' → stepsBack: 1", () => {
+      expect(detectRollbackIntent("undo that")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 1,
+      });
+    });
+    it("'rollback' alone (no slash) → stepsBack: 1", () => {
+      expect(detectRollbackIntent("rollback")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 1,
+      });
+    });
+    it("'undo this' → stepsBack: 1", () => {
+      expect(detectRollbackIntent("undo this")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 1,
+      });
+    });
+    it("rejects 'undo last 0'", () => {
+      expect(detectRollbackIntent("undo last 0")).toBe(null);
+    });
+    it("rejects long-form sentence with 'undo' embedded mid-text", () => {
+      // Has 'undo last 3' but exceeds 60 chars.
+      const text =
+        "Hey assistant, could you maybe just undo last 3 things we did, thanks!";
+      expect(text.length).toBeGreaterThan(60);
+      expect(detectRollbackIntent(text)).toBe(null);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("'undo' followed by a non-matching suffix returns null", () => {
+      expect(detectRollbackIntent("undo nuclear launch")).toBe(null);
+    });
+    it("'/rollbackish' is not /rollback", () => {
+      expect(detectRollbackIntent("/rollbackish")).toBe(null);
+    });
+    it("does not crash on unicode + emoji", () => {
+      expect(() => detectRollbackIntent("/rollback 🚀")).not.toThrow();
+      expect(detectRollbackIntent("/rollback 🚀")).toBe(null);
+    });
+  });
+});

--- a/src/layouts/settings/SettingsModal.tsx
+++ b/src/layouts/settings/SettingsModal.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { ApiUsageDisplay } from "../../features/admin/components/ApiUsageDisplay";
 import { NotificationActivityPanel } from "../../features/agents/components/NotificationActivityPanel";
+import { ResilienceSettings, type ResilienceSettingsValues } from "../../features/chat/components/ResilienceSettings";
 import { ThemeCustomizer } from "./ThemeCustomizer";
 import { DialogOverlay } from "@/shared/components/DialogOverlay";
 import { useTheme } from "../../contexts/ThemeContext";
@@ -245,6 +246,31 @@ export function SettingsModal({ isOpen, onClose, initialTab }: Props) {
   const saveEncryptedApiKey = useMutation(api?.domains.auth.apiKeys.saveEncryptedApiKeyPublic);
   const deleteApiKey = useMutation(api?.domains.auth.apiKeys.deleteApiKey);
   const createPolarCheckout = useAction(api.domains.billing.billing.createPolarCheckout);
+
+  // Resilience (budget caps) — auto-failover guards from Subsystem B (B-PR6/B-PR7).
+  const budgetSnapshot = useQuery(api?.domains.agents.publicWrappers.getBudgetSnapshot ?? {});
+  const upsertBudget = useMutation(api?.domains.agents.budget.budgetGate.upsertBudgetForOwner);
+  const [savingBudget, setSavingBudget] = useState(false);
+  const [budgetSaveError, setBudgetSaveError] = useState<string | null>(null);
+  const handleBudgetSave = async (values: ResilienceSettingsValues) => {
+    if (!upsertBudget) return;
+    setSavingBudget(true);
+    setBudgetSaveError(null);
+    try {
+      await upsertBudget({
+        dailyTokenCap: values.dailyTokenCap,
+        dailyCostCapUsd: values.dailyCostCapUsd,
+        enforced: values.enforced,
+      });
+      toast.success("Budget caps saved");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to save budget";
+      setBudgetSaveError(message);
+      toast.error(`Couldn't save budget: ${message}`);
+    } finally {
+      setSavingBudget(false);
+    }
+  };
   const runGmailIngest = useAction(api.domains.integrations.gmail.ingestMessages);
   const runGcalSync = useAction(api.domains.integrations.gcal.syncPrimaryCalendar);
 
@@ -684,6 +710,15 @@ export function SettingsModal({ isOpen, onClose, initialTab }: Props) {
 
                 {/* API Usage Tracking */}
                 <ApiUsageDisplay />
+
+                {/* Auto-failover budget caps (Subsystem B: B-PR6/B-PR7).
+                    Guards token + cost spend against runaway agent loops. */}
+                <ResilienceSettings
+                  snapshot={budgetSnapshot ?? null}
+                  onSave={handleBudgetSave}
+                  saving={savingBudget}
+                  saveError={budgetSaveError}
+                />
 
                 {/* Billing (merged) */}
                 <div className="rounded-lg border border-edge bg-surface p-4">


### PR DESCRIPTION
Closes 3 of the parallel-session 15-PR drop's wiring gaps. ResilienceSettings auto-mounts in SettingsModal Usage tab via new getBudgetSnapshot public wrapper + existing upsertBudgetForOwner mutation. Public listLessonsForThread / pinLessonById / deprecateLessonById query/mutations added so any future surface can mount LessonsPanel with a threadId (UI auto-mount deferred — chat sidebar is the right host but separate complex setup). 38 new unit tests across detectRollbackIntent (24) + resolveChain (14), all green.