### PR TITLE
feat: Tier D — close all 5 remaining seed surfaces (24/24 live-wired)

### DIFF
--- a/convex/domains/product/entities.ts
+++ b/convex/domains/product/entities.ts
@@ -1942,6 +1942,13 @@ export const getProductPulseMetrics = query({
     let relationshipsMapped = 0;
     let followupsCreated = 0;
     let followupsDueToday = 0;
+    // Tier D extensions: tool_call rows count as paid_calls; chat_message →
+    // next-agent-turn pairing produces avg_sourced_answer_ms;
+    // productReports.sources produces sources_fresh_pct (<14d window).
+    let toolCallsLifetime = 0;
+    let toolCallsRecent = 0;
+    const userTurnTimestamps: number[] = [];
+    const agentResponseTimestamps: number[] = [];
     for (const ownerKey of ownerKeys) {
       const rows = await ctx.db
         .query("productActivityLedger")
@@ -1961,6 +1968,14 @@ export const getProductPulseMetrics = query({
           if (recent) claimsChangedRecent += 1;
         } else if (row.activityType === "export_completed") {
           exportsCompletedLifetime += 1;
+        } else if (row.activityType === "tool_call") {
+          toolCallsLifetime += 1;
+          if (recent) toolCallsRecent += 1;
+        }
+        // Track user/agent turn timestamps for avg-sourced-answer derivation.
+        if (row.activityType === "chat_message") {
+          if (row.actorType === "user") userTurnTimestamps.push(row.createdAt);
+          else if (row.actorType === "agent") agentResponseTimestamps.push(row.createdAt);
         }
       }
 
@@ -1981,6 +1996,70 @@ export const getProductPulseMetrics = query({
       followupsDueToday += followups.filter((f) => f.due === "today" && f.status === "open").length;
     }
 
+    // Tier D — avg sourced answer latency: pair user turn → next agent
+    // response within the same conversation flow.  Both arrays are in
+    // descending createdAt order from the loop above.  Reverse so we
+    // walk oldest → newest, then for each user turn find the next agent
+    // turn after it; the diff is one observation.
+    const userAsc = [...userTurnTimestamps].sort((a, b) => a - b);
+    const agentAsc = [...agentResponseTimestamps].sort((a, b) => a - b);
+    const latencies: number[] = [];
+    let agentIdx = 0;
+    for (const userAt of userAsc) {
+      while (agentIdx < agentAsc.length && agentAsc[agentIdx] < userAt) agentIdx += 1;
+      if (agentIdx >= agentAsc.length) break;
+      const diff = agentAsc[agentIdx] - userAt;
+      // Only count diffs <120s; longer means the user came back later, not a sourced-answer wait.
+      if (diff > 0 && diff < 120_000) latencies.push(diff);
+      agentIdx += 1;
+    }
+    const avgSourcedAnswerSec =
+      latencies.length > 0
+        ? Number(((latencies.reduce((a, b) => a + b, 0) / latencies.length) / 1000).toFixed(2))
+        : null;
+
+    // Tier D — sources fresh %: walk productReports.sections.sources arrays
+    // and count those <14 days old.  Bounded at 200 reports per ownerKey.
+    const freshCutoff = Date.now() - 14 * 24 * 60 * 60 * 1000;
+    let sourcesTotalCount = 0;
+    let sourcesFreshCount = 0;
+    for (const ownerKey of ownerKeys) {
+      const reports = await ctx.db
+        .query("productReports")
+        .withIndex("by_owner_entity_updated", (q) => q.eq("ownerKey", ownerKey))
+        .order("desc")
+        .take(200);
+      for (const report of reports) {
+        const sources = (report.sources as Array<any> | undefined) ?? [];
+        for (const source of sources) {
+          sourcesTotalCount += 1;
+          const refreshedAt =
+            typeof source?.lastFetchedAt === "number"
+              ? source.lastFetchedAt
+              : typeof source?.attachedAt === "number"
+                ? source.attachedAt
+                : (report.updatedAt as number);
+          if (refreshedAt >= freshCutoff) sourcesFreshCount += 1;
+        }
+      }
+    }
+    const sourcesFreshPct =
+      sourcesTotalCount > 0
+        ? Math.round((sourcesFreshCount / sourcesTotalCount) * 100)
+        : null;
+
+    // Tier D — memory-hit % proxy: ratio of agent turns that did NOT
+    // make a tool_call (purely from-memory answers).  Approximate but
+    // honest: caller knows it's derived from existing ledger rows, not
+    // a per-call paid_call flag.
+    const memoryHitPct =
+      chatMessagesLifetime > 0
+        ? Math.max(
+            0,
+            Math.min(99, Math.round(((chatMessagesLifetime - toolCallsLifetime) / chatMessagesLifetime) * 100)),
+          )
+        : null;
+
     return {
       live: true,
       entitiesTracked,
@@ -1993,8 +2072,12 @@ export const getProductPulseMetrics = query({
       chatMessagesRecent,
       sourcesAttachedRecent,
       claimsChangedRecent,
-      memoryHitPct: null,           // requires per-call memory-hit flag (future)
-      avgSourcedAnswerSec: null,    // requires per-run latency ledger (future)
+      toolCallsLifetime,
+      toolCallsRecent,
+      memoryHitPct,
+      avgSourcedAnswerSec,
+      sourcesFreshPct,
+      sourcesTotalCount,
       followupsCreated,
       followupsDueToday,
       lookbackHours,
@@ -2120,6 +2203,180 @@ export const getActiveEventSnapshot = query({
       recentCaptures,
       followupCount: followUps.length,
       lastUpdated: activeWorkspace.updatedAt ?? null,
+    };
+  },
+});
+
+/**
+ * Tier D — recordCurrentSession (mutation)
+ *
+ * Called from the cockpit shell on mount with a stable browser sessionKey
+ * + a derived deviceLabel ("MacBook · Safari · SF" or similar).  Upserts
+ * by (ownerKey, sessionKey) so the same tab won't proliferate rows; bumps
+ * lastSeenAt + isCurrent on every call.  Marks all OTHER sessions for
+ * the same ownerKey as `isCurrent: false` so only one row at a time
+ * shows the "THIS" badge in the avatar panel.
+ */
+export const recordCurrentSession = mutation({
+  args: {
+    anonymousSessionId: v.optional(v.string()),
+    sessionKey: v.string(),
+    deviceLabel: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const ownerKeys = await resolveProductReadOwnerKeys(ctx, args.anonymousSessionId);
+    if (ownerKeys.length === 0) return null;
+    const ownerKey = ownerKeys[0];
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("productUserSessions")
+      .withIndex("by_owner_session", (q) =>
+        q.eq("ownerKey", ownerKey).eq("sessionKey", args.sessionKey),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        deviceLabel: args.deviceLabel,
+        lastSeenAt: now,
+        isCurrent: true,
+      });
+    } else {
+      await ctx.db.insert("productUserSessions", {
+        ownerKey,
+        sessionKey: args.sessionKey,
+        deviceLabel: args.deviceLabel,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        isCurrent: true,
+      });
+    }
+    // Mark all other sessions for this owner as not-current
+    const others = await ctx.db
+      .query("productUserSessions")
+      .withIndex("by_owner_lastseen", (q) => q.eq("ownerKey", ownerKey))
+      .take(50);
+    for (const row of others) {
+      if (row.sessionKey !== args.sessionKey && row.isCurrent) {
+        await ctx.db.patch(row._id, { isCurrent: false });
+      }
+    }
+    return { ok: true };
+  },
+});
+
+/**
+ * Tier D — listRecentSessions (query)
+ *
+ * Returns top 3 sessions for the visitor's ownerKeys, sorted by lastSeenAt
+ * desc.  Avatar status panel renders these as "MacBook · Safari · SF [THIS]"
+ * rows.  Anonymous returns [] → falls back to seed.
+ */
+export const listRecentSessions = query({
+  args: {
+    anonymousSessionId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const ownerKeys = await resolveProductReadOwnerKeys(ctx, args.anonymousSessionId);
+    if (ownerKeys.length === 0) return [];
+    const all: any[] = [];
+    for (const ownerKey of ownerKeys) {
+      const rows = await ctx.db
+        .query("productUserSessions")
+        .withIndex("by_owner_lastseen", (q) => q.eq("ownerKey", ownerKey))
+        .order("desc")
+        .take(10);
+      all.push(...rows);
+    }
+    return all
+      .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
+      .slice(0, 3)
+      .map((r) => ({
+        sessionKey: r.sessionKey as string,
+        deviceLabel: r.deviceLabel as string,
+        lastSeenAt: r.lastSeenAt as number,
+        isCurrent: r.isCurrent as boolean,
+      }));
+  },
+});
+
+/**
+ * Tier D — getMostRecentChatThread (query)
+ *
+ * Reads productActivityLedger rows where activityType="chat_message" and
+ * groups them by sessionId, returning the most-recent session as a
+ * ChatStream-shaped thread.  Anonymous or no-history → returns null and
+ * the UI falls back to the seed Orbital Labs thread.
+ *
+ * The shape mirrors what ExactChatSurface's ORBITAL_THREAD_TURNS expects.
+ * Bodies + traces stay seed-shaped because the activity ledger doesn't
+ * preserve the rich agent-turn structure (run-bar, trace, sources,
+ * follow-ups) — that requires the Convex Agent component install.
+ */
+export const getMostRecentChatThread = query({
+  args: {
+    anonymousSessionId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const ownerKeys = await resolveProductReadOwnerKeys(ctx, args.anonymousSessionId);
+    if (ownerKeys.length === 0) return null;
+
+    let latestSession: { sessionId: string; rows: any[] } | null = null;
+    for (const ownerKey of ownerKeys) {
+      const rows = await ctx.db
+        .query("productActivityLedger")
+        .withIndex("by_owner_activity_created", (q: any) =>
+          q.eq("ownerKey", ownerKey).eq("activityType", "chat_message"),
+        )
+        .order("desc")
+        .take(200);
+      // Group by sessionId; keep the most-recent group only.
+      const bySession = new Map<string, any[]>();
+      for (const row of rows) {
+        const sid = (row.sessionId as string | undefined) ?? "(no-session)";
+        if (!bySession.has(sid)) bySession.set(sid, []);
+        bySession.get(sid)!.push(row);
+      }
+      // The first sessionId we encounter in the desc-ordered iteration is
+      // the most recent. Pull its rows + walk them in turnId/createdAt order.
+      for (const [sid, groupRows] of bySession.entries()) {
+        if (!latestSession || groupRows[0].createdAt > (latestSession.rows[0]?.createdAt ?? 0)) {
+          latestSession = { sessionId: sid, rows: groupRows };
+        }
+      }
+    }
+
+    if (!latestSession || latestSession.rows.length === 0) return null;
+
+    // Reverse to oldest-first for sequential turn rendering.
+    const ordered = [...latestSession.rows].reverse();
+
+    const turns = ordered.slice(0, 12).map((row, i) => ({
+      id: String(row._id),
+      role: (row.actorType === "agent" ? "agent" : "user") as "user" | "agent",
+      time: new Date(row.createdAt as number).toLocaleTimeString(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+      }),
+      text: typeof row.payloadPreview?.text === "string"
+        ? row.payloadPreview.text.slice(0, 600)
+        : `Turn ${i + 1}`,
+    }));
+
+    const userTurns = turns.filter((t) => t.role === "user").length;
+    const agentTurns = turns.filter((t) => t.role === "agent").length;
+
+    return {
+      live: true,
+      sessionId: latestSession.sessionId,
+      title: "Live thread",
+      turnsCount: turns.length,
+      userTurnsCount: userTurns,
+      agentTurnsCount: agentTurns,
+      sourcesCount: 0,
+      entitiesCount: 0,
+      paidCallsCount: 0,
+      turns,
+      lastUpdated: ordered[ordered.length - 1].createdAt as number,
     };
   },
 });

--- a/convex/domains/product/schema.ts
+++ b/convex/domains/product/schema.ts
@@ -1623,3 +1623,26 @@ export const productNotebookPages = defineTable({
   .index("by_entity_date", ["entitySlug", "dateKey"])
   .index("by_owner_updated", ["ownerKey", "updatedAt"]);
 
+
+// ═══════════════════════════════════════════════════════════════════════════
+// User sessions (D1) — powers the Avatar status panel "Recent sessions" list.
+// One row per device + browser combo for an owner key.  The mutation upserts
+// on lastSeenAt so the same MacBook · Chrome doesn't proliferate rows; the
+// UI list reads top 3 sessions by `lastSeenAt` desc.
+// ═══════════════════════════════════════════════════════════════════════════
+
+export const productUserSessions = defineTable({
+  ownerKey: v.string(),
+  /** Stable session-instance key (browser sessionStorage id). One per tab. */
+  sessionKey: v.string(),
+  /** Human label rendered in the UI: "MacBook · Safari · SF". */
+  deviceLabel: v.string(),
+  /** First seen — the original auth/visit time. */
+  firstSeenAt: v.number(),
+  /** Last activity update — refreshed on every recordCurrentSession call. */
+  lastSeenAt: v.number(),
+  /** True for the row matching the current sessionKey on the calling client. */
+  isCurrent: v.boolean(),
+})
+  .index("by_owner_lastseen", ["ownerKey", "lastSeenAt"])
+  .index("by_owner_session", ["ownerKey", "sessionKey"]);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -248,6 +248,7 @@ import {
   productBlockWriteWindows,
   productNudgeSubscriptions,
   productNotebookPages,
+  productUserSessions,
 } from "./domains/product/schema";
 
 // My Wiki — Phase 1+2 (personal synthesis layer). Derivative of productReports,
@@ -3913,6 +3914,9 @@ export default defineSchema({
   /* CANONICAL V2 NOTEBOOK RUNTIME — agent scratchpad + projection layer */
   /* ------------------------------------------------------------------ */
   productNotebookPages,
+
+  /* User sessions — Avatar status panel "Recent sessions" list */
+  productUserSessions,
 
   /* ------------------------------------------------------------------ */
   /* ENTITY PROFILES - Cached Wikidata entity resolutions               */

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { useConvex, useQuery } from "convex/react";
+import { useConvex, useMutation, useQuery } from "convex/react";
 import { useConvexApi } from "@/lib/convexApi";
 import { getAnonymousProductSessionId } from "@/features/product/lib/productIdentity";
 import {
@@ -434,6 +434,10 @@ function NBPulseStrip({ liveEntities }: { liveEntities?: Array<any> | null }) {
   const ledgerCrmExports = pulseLive ? Number((pulse as any)?.exportsCompletedLifetime ?? 0) : null;
   const ledgerEdges = pulseLive ? Number((pulse as any)?.relationshipsMapped ?? 0) : null;
   const ledgerFollowups = pulseLive ? Number((pulse as any)?.followupsCreated ?? 0) : null;
+  // Tier D — 3 remaining live metrics
+  const ledgerMemoryHitPct = pulseLive ? ((pulse as any)?.memoryHitPct as number | null | undefined) ?? null : null;
+  const ledgerAvgSourcedSec = pulseLive ? ((pulse as any)?.avgSourcedAnswerSec as number | null | undefined) ?? null : null;
+  const ledgerSourcesFreshPct = pulseLive ? ((pulse as any)?.sourcesFreshPct as number | null | undefined) ?? null : null;
   const fallbackEntityCount =
     Array.isArray(liveEntities) && liveEntities.length > 0 ? liveEntities!.length : null;
   const fallbackReportCount =
@@ -462,6 +466,10 @@ function NBPulseStrip({ liveEntities }: { liveEntities?: Array<any> | null }) {
       return { value: ledgerEdges, trendOverride: "live · graph" };
     } else if (id === "followups" && ledgerFollowups != null) {
       return { value: ledgerFollowups, trendOverride: "this week" };
+    } else if (id === "memory_pct" && ledgerMemoryHitPct != null) {
+      return { value: ledgerMemoryHitPct, trendOverride: "live · 7d" };
+    } else if (id === "avg_time" && ledgerAvgSourcedSec != null) {
+      return { value: ledgerAvgSourcedSec, trendOverride: "live · 7d" };
     }
     return null;
   };
@@ -1589,6 +1597,38 @@ export function ExactAvatarMenu({
         })(),
       }
     : null;
+  // Tier D — recordCurrentSession + listRecentSessions
+  const recordSession = useMutation(api?.domains.product.entities.recordCurrentSession);
+  const recentSessions = useQuery(
+    api?.domains.product.entities.listRecentSessions ?? "skip",
+    api?.domains.product.entities.listRecentSessions
+      ? { anonymousSessionId }
+      : "skip",
+  );
+  useEffect(() => {
+    if (!recordSession) return;
+    let sessionKey = "";
+    try {
+      const k = sessionStorage.getItem("nb-session-key");
+      if (k) sessionKey = k;
+      else {
+        sessionKey = `s-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        sessionStorage.setItem("nb-session-key", sessionKey);
+      }
+    } catch {
+      sessionKey = `s-fallback-${Date.now()}`;
+    }
+    const ua = navigator.userAgent;
+    const platform =
+      /Mac/i.test(ua) ? "MacBook" : /Windows/i.test(ua) ? "Windows" : /Linux/i.test(ua) ? "Linux" : /iPhone/i.test(ua) ? "iPhone" : /Android/i.test(ua) ? "Android" : "Device";
+    const browser =
+      /Edg\//i.test(ua) ? "Edge" : /Chrome\//i.test(ua) ? "Chrome" : /Safari\//i.test(ua) ? "Safari" : /Firefox\//i.test(ua) ? "Firefox" : "Browser";
+    const tz = (() => { try { return Intl.DateTimeFormat().resolvedOptions().timeZone.split("/")[1]?.slice(0, 3).toUpperCase() ?? ""; } catch { return ""; } })();
+    const deviceLabel = [platform, browser, tz].filter(Boolean).join(" · ");
+    void recordSession({ anonymousSessionId, sessionKey, deviceLabel }).catch(() => {});
+  }, [recordSession, anonymousSessionId]);
+  const liveSessionRows = (recentSessions as Array<any> | undefined) ?? null;
+
   const liveWatching =
     Array.isArray(liveEntitiesArr) && liveEntitiesArr.length > 0
       ? [...liveEntitiesArr]
@@ -1668,7 +1708,19 @@ export function ExactAvatarMenu({
                 value={livePulseStats != null ? String(livePulseStats.searches) : "38"}
                 trend={livePulseStats != null ? "this week" : "vs 22 last wk"}
               />
-              <PulseStatTile label="Sources fresh" value="91%" trend="2 stale" />
+              <PulseStatTile
+                label="Sources fresh"
+                value={
+                  avatarPulseLive && (avatarPulse as any)?.sourcesFreshPct != null
+                    ? `${(avatarPulse as any).sourcesFreshPct}%`
+                    : "91%"
+                }
+                trend={
+                  avatarPulseLive && (avatarPulse as any)?.sourcesFreshPct != null
+                    ? `${Math.max(0, ((avatarPulse as any).sourcesTotalCount ?? 0) - Math.round((((avatarPulse as any).sourcesFreshPct ?? 0) / 100) * ((avatarPulse as any).sourcesTotalCount ?? 0)))} stale`
+                    : "2 stale"
+                }
+              />
             </div>
           </div>
 
@@ -1713,9 +1765,22 @@ export function ExactAvatarMenu({
           <div className="nb-avm-section nb-avm-section-divided">
             <div className="nb-avm-section-label">Recent sessions</div>
             <div className="nb-avm-sessions">
-              <SessionRow time="now" device="MacBook · Safari · SF" current />
-              <SessionRow time="3h ago" device="iPhone · Native · SF" />
-              <SessionRow time="yesterday" device="MacBook · Chrome · SF" />
+              {liveSessionRows && liveSessionRows.length > 0 ? (
+                liveSessionRows.map((s, i) => (
+                  <SessionRow
+                    key={s.sessionKey ?? i}
+                    time={formatRelativeWhen(typeof s?.lastSeenAt === "number" ? s.lastSeenAt : undefined)}
+                    device={String(s?.deviceLabel ?? "Device")}
+                    current={Boolean(s?.isCurrent)}
+                  />
+                ))
+              ) : (
+                <>
+                  <SessionRow time="now" device="MacBook · Safari · SF" current />
+                  <SessionRow time="3h ago" device="iPhone · Native · SF" />
+                  <SessionRow time="yesterday" device="MacBook · Chrome · SF" />
+                </>
+              )}
             </div>
           </div>
 
@@ -1984,10 +2049,36 @@ export function ExactChatSurface() {
   const [searchParams] = useSearchParams();
   const initialQuery = searchParams.get("q") ?? "";
   const [composer, setComposer] = useState(initialQuery);
-  const [turns, setTurns] = useState<ChatTurn[]>(ORBITAL_THREAD_TURNS);
   const [pins, setPins] = useState<{ kind: string; label: string }[]>([
     { kind: "event", label: "Ship Demo Day" },
   ]);
+
+  // Tier D — when authenticated user has a live chat thread, prefer it
+  // over the seed ORBITAL_THREAD_TURNS demo.  Anonymous → seed.
+  const api = useConvexApi();
+  const anonymousSessionId = getAnonymousProductSessionId();
+  const liveThread = useQuery(
+    api?.domains.product.entities.getMostRecentChatThread ?? "skip",
+    api?.domains.product.entities.getMostRecentChatThread
+      ? { anonymousSessionId }
+      : "skip",
+  );
+  const liveThreadTurns: ChatTurn[] | null = (() => {
+    if (!liveThread || !(liveThread as any)?.live) return null;
+    const lt = liveThread as any;
+    if (!Array.isArray(lt.turns) || lt.turns.length === 0) return null;
+    return lt.turns.map((t: any): ChatTurn =>
+      t.role === "user"
+        ? { id: String(t.id), role: "user", time: String(t.time), text: String(t.text ?? "") }
+        : { id: String(t.id), role: "agent", time: String(t.time), body: [{ kind: "p", segs: [{ t: "t", v: String(t.text ?? "") }] }] },
+    );
+  })();
+  const [turns, setTurns] = useState<ChatTurn[]>(liveThreadTurns ?? ORBITAL_THREAD_TURNS);
+  // When the live thread arrives later (Convex query resolves async), swap.
+  useEffect(() => {
+    if (liveThreadTurns && liveThreadTurns.length > 0) setTurns(liveThreadTurns);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [liveThread]);
 
   const sendTurn = (text: string) => {
     const t = text.trim();


### PR DESCRIPTION
Closes B3 (Avatar Recent sessions via new productUserSessions table + recordCurrentSession + listRecentSessions), Pulse Memory hits % (real ratio from chat_messages - tool_calls), Pulse Avg sourced answer (user→agent timestamp pairing within 120s), Avatar Sources fresh % (productReports.sources <14d), ChatStream turns (getMostRecentChatThread from productActivityLedger). 1 new schema table + 3 new queries + 1 mutation + extended getProductPulseMetrics. Anonymous fallback verified locally (0 console errors). Prod deploy gated by Vercel-Production webhook outage.