### PR TITLE
fix(deps): add uuid runtime dep — unstick stuck Vercel Production deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,7 @@
     "tailwind-merge": "^3.1.0",
     "tavily-mcp": "^0.2.9",
     "tweetnacl": "^1.0.3",
+    "uuid": "^14.0.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",
     "vega-lite": "^6.4.3",


### PR DESCRIPTION
Diagnosed via vercel CLI: the Vercel-Production queue stopped at 21:35 UTC because every subsequent build fails at Convex deploy with `Could not resolve "uuid"` — uuid was a devDep (@types/uuid) only. Adding it as a runtime dep fixes the queue. Once merged, Vercel retries the 7 queued deploys (Tier B / Tier C / ResilienceSettings / unit tests / Tier D 24/24) and the latest commit becomes prod.