### PR TITLE
feat(agents): wire FU-3 lesson injection + restore FU-5 unit tests

### DIFF
--- a/convex/domains/agents/canonicalPlanner.ts
+++ b/convex/domains/agents/canonicalPlanner.ts
@@ -14,6 +14,7 @@
 import { v } from "convex/values";
 import { action, internalAction } from "../../_generated/server";
 import { internal } from "../../_generated/api";
+import { injectLessonsForThread } from "./lessons/lessonInjection";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -126,12 +127,19 @@ export const planAndRunFast = internalAction({
     if (args.forceMode) {
       mode = args.forceMode;
     } else {
+      // FU-3: inject relevant lessons into system prompt (best-effort).
+      const intentSystemPrompt = await injectLessonsForThread(
+        ctx,
+        threadId,
+        INTENT_CLASSIFIER_SYSTEM,
+        { turnId: startTime },
+      );
       const classification = await ctx.runAction(
         internal.domains.models.modelRouter.route,
         {
           taskCategory: "agent_loop",
           tier: "free",
-          systemPrompt: INTENT_CLASSIFIER_SYSTEM,
+          systemPrompt: intentSystemPrompt,
           messages: [{ role: "user" as const, content: args.userMessage }],
           maxTokens: 10,
           temperature: 0,
@@ -149,12 +157,19 @@ export const planAndRunFast = internalAction({
     // 3. FAST LANE — answer from cache immediately
     if (mode === "fast") {
       const contextText = formatCacheForPrompt(cache);
+      // FU-3: inject relevant lessons into system prompt (best-effort).
+      const fastSystemPrompt = await injectLessonsForThread(
+        ctx,
+        threadId,
+        FAST_LANE_SYSTEM,
+        { turnId: startTime + 1 },
+      );
       const result = await ctx.runAction(
         internal.domains.models.modelRouter.route,
         {
           taskCategory: "synthesis",
           tier: "cheap",
-          systemPrompt: FAST_LANE_SYSTEM,
+          systemPrompt: fastSystemPrompt,
           messages: [
             {
               role: "user" as const,
@@ -310,16 +325,24 @@ export const runSlowOrchestrator = internalAction({
 
     const contextText = formatCacheForPrompt(cache);
 
+    // FU-3: inject relevant lessons into system prompt (best-effort).
+    const slowSystemPrompt = await injectLessonsForThread(
+      ctx,
+      args.threadId,
+      `You are NodeBench Slow Lane — deep research synthesis.
+Analyze the provided context and produce structured sections.
+Each section must have a title, summary, and body.
+Mark confidence: verified | corroborated | single-source | unverified.`,
+      { turnId: startTime },
+    );
+
     // Run synthesis (slow lane uses standard tier)
     const result = await ctx.runAction(
       internal.domains.models.modelRouter.route,
       {
         taskCategory: "synthesis",
         tier: "standard",
-        systemPrompt: `You are NodeBench Slow Lane — deep research synthesis.
-Analyze the provided context and produce structured sections.
-Each section must have a title, summary, and body.
-Mark confidence: verified | corroborated | single-source | unverified.`,
+        systemPrompt: slowSystemPrompt,
         messages: [
           {
             role: "user" as const,

--- a/convex/domains/agents/lessons/lessonInjection.test.ts
+++ b/convex/domains/agents/lessons/lessonInjection.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for `injectLessonsForThread`.
+ *
+ * The helper wires the lesson capture/recall system into LLM call sites
+ * (FU-3). Tests cover:
+ *   - missing threadId → unchanged prompt
+ *   - empty lessons → unchanged prompt
+ *   - lesson query throws → logs warning, returns unchanged prompt (HONEST_STATUS)
+ *   - lessons present → augmented prompt with header + lessons + footer
+ *   - threadId trimming behaviour
+ *
+ * The Convex internal API is mocked via a fake `ActionCtx` so we don't
+ * need a Convex runtime in vitest.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { injectLessonsForThread } from "./lessonInjection";
+import {
+  LESSONS_FOOTER,
+  LESSONS_HEADER,
+} from "./systemPromptBuilder";
+
+const ORIGINAL_PROMPT = "You are NodeBench Fast Lane.";
+
+function makeLesson(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    _id: "lesson_x" as unknown as never,
+    _creationTime: 1,
+    threadId: "thread_a",
+    turnId: 1,
+    type: "semantic" as const,
+    toolName: undefined,
+    mistakePattern: "Answered from memory without searching.",
+    correctPattern: "Always cite sources via web_search first.",
+    capturedAt: 1700000000000,
+    capturedBy: "system" as const,
+    expiresAfterTurn: undefined,
+    pinned: false,
+    deprecated: false,
+    sourceTurnId: 1,
+    ...overrides,
+  };
+}
+
+function makeFakeCtx(opts: {
+  lessons?: ReturnType<typeof makeLesson>[];
+  throws?: Error;
+}) {
+  const runQuery = vi.fn(async () => {
+    if (opts.throws) throw opts.throws;
+    return opts.lessons ?? [];
+  });
+  return {
+    runQuery,
+  } as unknown as Parameters<typeof injectLessonsForThread>[0];
+}
+
+describe("injectLessonsForThread", () => {
+  it("returns the original prompt when threadId is undefined", async () => {
+    const ctx = makeFakeCtx({ lessons: [] });
+    const result = await injectLessonsForThread(ctx, undefined, ORIGINAL_PROMPT);
+    expect(result).toBe(ORIGINAL_PROMPT);
+    expect((ctx as any).runQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns the original prompt when threadId is null", async () => {
+    const ctx = makeFakeCtx({ lessons: [] });
+    const result = await injectLessonsForThread(ctx, null, ORIGINAL_PROMPT);
+    expect(result).toBe(ORIGINAL_PROMPT);
+    expect((ctx as any).runQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns the original prompt when threadId is the empty string", async () => {
+    const ctx = makeFakeCtx({ lessons: [] });
+    const result = await injectLessonsForThread(ctx, "", ORIGINAL_PROMPT);
+    expect(result).toBe(ORIGINAL_PROMPT);
+    expect((ctx as any).runQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns the original prompt when there are no lessons", async () => {
+    const ctx = makeFakeCtx({ lessons: [] });
+    const result = await injectLessonsForThread(
+      ctx,
+      "thread_a",
+      ORIGINAL_PROMPT,
+    );
+    expect(result).toBe(ORIGINAL_PROMPT);
+    expect((ctx as any).runQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("augments the prompt with lessons when present", async () => {
+    const ctx = makeFakeCtx({
+      lessons: [
+        makeLesson({
+          mistakePattern: "Answered from memory.",
+          correctPattern: "Always cite sources.",
+        }),
+      ],
+    });
+    const result = await injectLessonsForThread(
+      ctx,
+      "thread_a",
+      ORIGINAL_PROMPT,
+    );
+    expect(result).not.toBe(ORIGINAL_PROMPT);
+    expect(result).toContain(LESSONS_HEADER);
+    expect(result).toContain("Always cite sources.");
+    expect(result).toContain(LESSONS_FOOTER);
+    expect(result).toContain(ORIGINAL_PROMPT);
+    // Header must come before original prompt.
+    expect(result.indexOf(LESSONS_HEADER)).toBeLessThan(
+      result.indexOf(ORIGINAL_PROMPT),
+    );
+  });
+
+  it("forwards turnId, currentToolName, and limit to the query", async () => {
+    const ctx = makeFakeCtx({ lessons: [] });
+    await injectLessonsForThread(ctx, "thread_a", ORIGINAL_PROMPT, {
+      turnId: 42,
+      currentToolName: "web_search",
+      limit: 3,
+    });
+    expect((ctx as any).runQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        threadId: "thread_a",
+        currentTurnId: 42,
+        currentToolName: "web_search",
+        limit: 3,
+      }),
+    );
+  });
+
+  it("returns the original prompt when the lesson query throws (HONEST_STATUS)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ctx = makeFakeCtx({ throws: new Error("convex transient") });
+    const result = await injectLessonsForThread(
+      ctx,
+      "thread_a",
+      ORIGINAL_PROMPT,
+    );
+    expect(result).toBe(ORIGINAL_PROMPT);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[injectLessonsForThread]"),
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/convex/domains/agents/lessons/lessonInjection.ts
+++ b/convex/domains/agents/lessons/lessonInjection.ts
@@ -1,0 +1,86 @@
+/**
+ * Lesson Injection Runtime — wires the lesson capture/recall system into
+ * actual LLM call sites.
+ *
+ * Plan: docs/agents/AUTONOMOUS_CONTINUATION_PLAN.md (FU-3 follow-up to PR #116).
+ *
+ * Design decision: pre-router injection (helper called by callers before
+ * `modelRouter.route`) rather than per-model injection (inside the router).
+ *
+ * Why pre-router:
+ *   - Keeps `modelRouter` generic — it doesn't need to know about lessons.
+ *   - Opt-in: callers without a `threadId` get unchanged behavior.
+ *   - Simpler test surface: this helper has one job.
+ *   - Token accounting stays in `buildSystemPromptPrefix` (already capped
+ *     at MAX_PROMPT_PREFIX_BYTES = 8 KB).
+ *
+ * HONEST_STATUS rule: lesson injection is best-effort. If the lesson query
+ * fails (e.g. transient Convex error), we log and return the original
+ * prompt unchanged — never a fake "succeeded with empty lessons" status.
+ *
+ * Constraint enforcement (from AUTONOMOUS_CONTINUATION_PLAN.md §5):
+ *   - Token Budget < 10 Lessons — enforced via `getRelevantLessons.limit`
+ *     default of 5 plus pinned-lesson bypass capped by 8 KB byte budget.
+ *   - No Cross-Thread Leakage — `getRelevantLessons` filters strictly by
+ *     `threadId`. This helper does NOT widen that scope in v1.
+ */
+
+import { internal } from "../../../_generated/api";
+import type { ActionCtx } from "../../../_generated/server";
+import { injectLessonsIntoSystemPrompt } from "./systemPromptBuilder";
+
+export interface InjectLessonsOptions {
+  /** Current turn — used by `getRelevantLessons` to enforce lesson expiry. */
+  turnId?: number;
+  /** Tool the agent is about to call — boosts matching lessons in scoring. */
+  currentToolName?: string;
+  /** Cap on lessons (defaults to 5). Pinned lessons bypass this cap. */
+  limit?: number;
+}
+
+/**
+ * Augment a system prompt with relevant lessons for the given thread.
+ *
+ * Returns the prompt unchanged when:
+ *   - `threadId` is falsy (caller has no thread context yet)
+ *   - There are no live lessons for the thread
+ *   - The lesson query throws (best-effort; logs warning)
+ *
+ * Otherwise returns `<lessons prefix>\n\n<originalSystemPrompt>`.
+ *
+ * Caller-side usage:
+ *   const augmented = await injectLessonsForThread(ctx, threadId, INTENT_CLASSIFIER_SYSTEM, { turnId });
+ *   await ctx.runAction(internal.domains.models.modelRouter.route, { systemPrompt: augmented, ... });
+ */
+export async function injectLessonsForThread(
+  ctx: ActionCtx,
+  threadId: string | undefined | null,
+  originalSystemPrompt: string,
+  options: InjectLessonsOptions = {},
+): Promise<string> {
+  if (!threadId) return originalSystemPrompt;
+
+  try {
+    const lessons = await ctx.runQuery(
+      internal.domains.agents.lessons.getRelevantLessons.getRelevantLessons,
+      {
+        threadId,
+        currentToolName: options.currentToolName,
+        currentTurnId: options.turnId,
+        limit: options.limit,
+      },
+    );
+
+    if (!lessons || lessons.length === 0) return originalSystemPrompt;
+
+    return injectLessonsIntoSystemPrompt(originalSystemPrompt, lessons);
+  } catch (err) {
+    // HONEST_STATUS: log but don't fail the LLM call. Missing lessons
+    // degrades quality, not correctness.
+    console.warn(
+      "[injectLessonsForThread] lesson query failed; proceeding without injection:",
+      err,
+    );
+    return originalSystemPrompt;
+  }
+}

--- a/convex/domains/agents/lessons/systemPromptBuilder.test.ts
+++ b/convex/domains/agents/lessons/systemPromptBuilder.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Unit tests for buildSystemPromptPrefix + injectLessonsIntoSystemPrompt.
+ *
+ * Pure functions — no Convex / I/O. Tests the contract surfaced in
+ * systemPromptBuilder.ts:
+ *  1. Empty input → empty string (no fake "no lessons" placeholder)
+ *  2. Type ordering: SEMANTIC → INFRASTRUCTURE → SPIRAL → BUDGET
+ *  3. Pinned lessons sort to the top within their type
+ *  4. Per-type section headings + lesson formatters
+ *  5. Byte-budget cap (MAX_PROMPT_PREFIX_BYTES = 8192) drops non-pinned
+ *     overflow lessons; pinned always survive
+ *  6. injectLessonsIntoSystemPrompt concatenates prefix + original prompt
+ *     with double-newline; returns original unchanged on empty lessons
+ *  7. Unknown lesson type → silently dropped
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildSystemPromptPrefix,
+  injectLessonsIntoSystemPrompt,
+  LESSONS_HEADER,
+  LESSONS_FOOTER,
+  MAX_PROMPT_PREFIX_BYTES,
+} from "./systemPromptBuilder";
+import type { AgentLesson } from "./captureLesson";
+
+// Helper: fabricate an AgentLesson without all the Convex Doc bookkeeping.
+// Cast through `unknown` because the test only exercises the fields the
+// formatters actually read.
+function lesson(partial: Partial<AgentLesson>): AgentLesson {
+  return {
+    _id: "fake-id" as never,
+    _creationTime: 0,
+    threadId: "test-thread",
+    turnId: 0,
+    type: "semantic",
+    pinned: false,
+    deprecated: false,
+    capturedAt: 0,
+    ...partial,
+  } as unknown as AgentLesson;
+}
+
+describe("buildSystemPromptPrefix", () => {
+  it("returns empty string when lessons list is empty (no fake placeholder)", () => {
+    expect(buildSystemPromptPrefix([])).toBe("");
+  });
+
+  describe("formatters", () => {
+    it("semantic lesson renders Don't / Do bullets", () => {
+      const result = buildSystemPromptPrefix([
+        lesson({
+          type: "semantic",
+          mistakePattern: "wrote to a stale block",
+          correctPattern: "always re-read before patching",
+          toolName: "patch_notebook",
+          capturedAt: 1,
+        }),
+      ]);
+      expect(result).toContain(LESSONS_HEADER);
+      expect(result).toContain("**Don't:** wrote to a stale block");
+      expect(result).toContain("**Do:** always re-read before patching");
+      expect(result).toContain("`patch_notebook`");
+    });
+
+    it("spiral lesson renders Loop / Break by bullets", () => {
+      const result = buildSystemPromptPrefix([
+        lesson({
+          type: "spiral",
+          mistakePattern: "kept retrying with the same diff",
+          correctPattern: "abort after 3 same-signature turns",
+          toolName: "patch_notebook",
+          capturedAt: 1,
+        }),
+      ]);
+      expect(result).toContain("**Loop:** kept retrying with the same diff");
+      expect(result).toContain("**Break by:** abort after 3 same-signature turns");
+      expect(result).toContain("via `patch_notebook`");
+    });
+
+    it("infrastructure lesson renders fromModel → toModel pattern", () => {
+      const result = buildSystemPromptPrefix([
+        lesson({
+          type: "infrastructure",
+          fromModel: "claude-3-5-sonnet",
+          toModel: "claude-haiku-4-5",
+          failedWith: 429,
+          succeeded: true,
+          count: 3,
+          capturedAt: 1,
+        }),
+      ]);
+      expect(result).toContain("`claude-3-5-sonnet`");
+      expect(result).toContain("`claude-haiku-4-5`");
+      expect(result).toContain("HTTP 429");
+      expect(result).toContain("succeeded");
+      expect(result).toContain("(×3)");
+    });
+
+    it("infrastructure lesson without fromModel/toModel renders nothing", () => {
+      const result = buildSystemPromptPrefix([
+        lesson({ type: "infrastructure", capturedAt: 1 }),
+      ]);
+      // Header still rendered (always include section even if items dropped),
+      // but the lesson body itself should be absent.
+      expect(result).not.toContain("undefined");
+      expect(result).not.toContain("→");
+    });
+
+    it("budget lesson surfaces task category + estimated tokens", () => {
+      const result = buildSystemPromptPrefix([
+        lesson({
+          type: "budget",
+          taskCategory: "deep-research",
+          estimatedTokensRemaining: 250_000,
+          capturedAt: 1,
+        }),
+      ]);
+      expect(result).toContain("deep-research");
+      // Number rendered with locale grouping ("250,000")
+      expect(result).toMatch(/250[,\s]000/);
+    });
+  });
+
+  describe("ordering + pinning", () => {
+    it("groups by TYPE_PRIORITY order: semantic → spiral → infrastructure → budget", () => {
+      // Mirrors TYPE_PRIORITY in systemPromptBuilder.ts:
+      //   semantic: 0, spiral: 1, infrastructure: 2, budget: 3
+      const result = buildSystemPromptPrefix([
+        lesson({ type: "budget", taskCategory: "x", estimatedTokensRemaining: 1, capturedAt: 4 }),
+        lesson({ type: "spiral", mistakePattern: "loop", correctPattern: "break", capturedAt: 3 }),
+        lesson({ type: "infrastructure", fromModel: "a", toModel: "b", succeeded: true, capturedAt: 2 }),
+        lesson({ type: "semantic", mistakePattern: "m", correctPattern: "c", capturedAt: 1 }),
+      ]);
+      const semIdx = result.indexOf("Don't:");
+      const spiralIdx = result.indexOf("Loop:");
+      const infraIdx = result.indexOf("`a`");
+      const budgetIdx = result.indexOf("hit budget cap");
+      expect(semIdx).toBeGreaterThan(0);
+      expect(spiralIdx).toBeGreaterThan(semIdx);
+      expect(infraIdx).toBeGreaterThan(spiralIdx);
+      expect(budgetIdx).toBeGreaterThan(infraIdx);
+    });
+
+    it("pinned lessons sort to the top with 📌 marker", () => {
+      const result = buildSystemPromptPrefix([
+        lesson({
+          type: "semantic",
+          mistakePattern: "regular",
+          correctPattern: "regular_fix",
+          capturedAt: 2,
+        }),
+        lesson({
+          type: "semantic",
+          pinned: true,
+          mistakePattern: "PINNED_FIRST",
+          correctPattern: "pinned_fix",
+          capturedAt: 1,
+        }),
+      ]);
+      const pinnedIdx = result.indexOf("PINNED_FIRST");
+      const regularIdx = result.indexOf("regular");
+      expect(pinnedIdx).toBeGreaterThan(0);
+      expect(regularIdx).toBeGreaterThan(pinnedIdx);
+      expect(result).toContain("📌");
+    });
+
+    it("within same type+pinned, more-recent capturedAt sorts first", () => {
+      const result = buildSystemPromptPrefix([
+        lesson({ type: "semantic", mistakePattern: "OLDER", correctPattern: "x", capturedAt: 100 }),
+        lesson({ type: "semantic", mistakePattern: "NEWER", correctPattern: "x", capturedAt: 200 }),
+      ]);
+      const newerIdx = result.indexOf("NEWER");
+      const olderIdx = result.indexOf("OLDER");
+      expect(newerIdx).toBeGreaterThan(0);
+      expect(olderIdx).toBeGreaterThan(newerIdx);
+    });
+  });
+
+  describe("byte budget", () => {
+    it("respects custom maxBytes — drops non-pinned overflow", () => {
+      const longBody = "x".repeat(500);
+      const lessons = Array.from({ length: 20 }, (_, i) =>
+        lesson({
+          type: "semantic",
+          mistakePattern: `m_${i}_${longBody}`,
+          correctPattern: `c_${i}_${longBody}`,
+          capturedAt: i,
+        }),
+      );
+      const result = buildSystemPromptPrefix(lessons, { maxBytes: 1500 });
+      const bytes = new TextEncoder().encode(result).length;
+      // Should respect the budget within reasonable slack (heading + first lesson allowed even if it overruns once).
+      expect(bytes).toBeLessThan(3000);
+    });
+
+    it("pinned lessons survive even when they overflow the budget", () => {
+      const longBody = "y".repeat(2000);
+      const result = buildSystemPromptPrefix(
+        [
+          lesson({
+            type: "semantic",
+            pinned: true,
+            mistakePattern: `PINNED_${longBody}`,
+            correctPattern: "fix",
+            capturedAt: 1,
+          }),
+          lesson({
+            type: "semantic",
+            mistakePattern: "REGULAR",
+            correctPattern: "fix",
+            capturedAt: 2,
+          }),
+        ],
+        { maxBytes: 200 },
+      );
+      // Pinned lesson must be present even though its size exceeds the cap.
+      expect(result).toContain("PINNED_");
+    });
+
+    it("default cap is MAX_PROMPT_PREFIX_BYTES", () => {
+      expect(MAX_PROMPT_PREFIX_BYTES).toBe(8_192);
+    });
+  });
+
+  describe("HONEST_STATUS", () => {
+    it("unknown lesson type doesn't crash and produces no formatted body line", () => {
+      const result = buildSystemPromptPrefix([
+        lesson({ type: "future_unknown" as never, capturedAt: 1 }),
+      ]);
+      // The function must not throw on an unknown type even though the
+      // schema forbids it — defensive switch in formatLesson() returns "".
+      expect(typeof result).toBe("string");
+      // No actual lesson body bullet line — formatLesson returns ""
+      // for unknown types, so no `**Don't:**` / `**Loop:**` / `→` appears.
+      expect(result).not.toContain("**Don't:**");
+      expect(result).not.toContain("**Loop:**");
+      expect(result).not.toContain("→");
+      expect(result).not.toContain("hit budget cap");
+    });
+  });
+
+  describe("introLine option", () => {
+    it("intro line precedes the lessons header when supplied", () => {
+      const result = buildSystemPromptPrefix(
+        [lesson({ type: "semantic", mistakePattern: "x", correctPattern: "y", capturedAt: 1 })],
+        { introLine: "User: alice@example.com" },
+      );
+      const introIdx = result.indexOf("User: alice");
+      const headerIdx = result.indexOf(LESSONS_HEADER);
+      expect(introIdx).toBeGreaterThanOrEqual(0);
+      expect(headerIdx).toBeGreaterThan(introIdx);
+    });
+  });
+
+  describe("LESSONS_FOOTER export", () => {
+    it("is a non-empty stable string for downstream tooling", () => {
+      expect(typeof LESSONS_FOOTER).toBe("string");
+      expect(LESSONS_FOOTER.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("injectLessonsIntoSystemPrompt", () => {
+  it("returns original prompt unchanged when lessons array is empty", () => {
+    const original = "You are a helpful assistant.";
+    expect(injectLessonsIntoSystemPrompt(original, [])).toBe(original);
+  });
+
+  it("prepends prefix with double-newline separator", () => {
+    const result = injectLessonsIntoSystemPrompt(
+      "ORIGINAL PROMPT",
+      [lesson({ type: "semantic", mistakePattern: "m", correctPattern: "c", capturedAt: 1 })],
+    );
+    // Order: prefix → \n\n → ORIGINAL PROMPT
+    expect(result).toMatch(/Don't:.*\n\n.*ORIGINAL PROMPT/s);
+    expect(result.endsWith("ORIGINAL PROMPT")).toBe(true);
+  });
+});

--- a/convex/domains/agents/spiral/spiralDetector.test.ts
+++ b/convex/domains/agents/spiral/spiralDetector.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for detectSpiral.  Pure function — no Convex / I/O.
+ *
+ * Tests the contract:
+ *  1. Returns null when fewer than windowSize turns
+ *  2. Returns null when newest turn has no toolName / argsHash (no signature)
+ *  3. Tail streak of ≥ windowSize identical signatures → returns SpiralFinding
+ *  4. Verdict logic:
+ *     - "confirmed" when every turn in streak has artifactSha256 AND all match
+ *     - "false_positive_progress" when shas differ within the streak
+ *     - "suspected" when artifactSha256 is missing on any streak turn
+ *  5. Streak count + turnIds (oldest → newest) reported correctly
+ *  6. Custom windowSize parameter respected
+ *  7. Streak walk backs only as far as the same signature persists (a
+ *     different signature anywhere in the streak ends the run)
+ */
+import { describe, expect, it } from "vitest";
+import {
+  detectSpiral,
+  SPIRAL_WINDOW_SIZE,
+  type TurnSummary,
+} from "./spiralDetector";
+
+const turn = (over: Partial<TurnSummary>): TurnSummary => ({
+  turnId: 0,
+  toolName: "patch_notebook",
+  argsHash: "deadbeef",
+  ...over,
+});
+
+describe("detectSpiral", () => {
+  describe("returns null when there's no streak to find", () => {
+    it("empty turn list", () => {
+      expect(detectSpiral([])).toBe(null);
+    });
+    it("fewer turns than windowSize", () => {
+      const turns = [turn({ turnId: 1 }), turn({ turnId: 2 })];
+      expect(detectSpiral(turns)).toBe(null);
+    });
+    it("newest turn has no toolName → no signature → null", () => {
+      const turns = [
+        turn({ turnId: 1 }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3, toolName: null }),
+      ];
+      expect(detectSpiral(turns)).toBe(null);
+    });
+    it("newest turn has no argsHash → no signature → null", () => {
+      const turns = [
+        turn({ turnId: 1 }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3, argsHash: null }),
+      ];
+      expect(detectSpiral(turns)).toBe(null);
+    });
+    it("3 turns but only 2 share signature → null", () => {
+      const turns = [
+        turn({ turnId: 1, argsHash: "diff" }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3 }),
+      ];
+      expect(detectSpiral(turns)).toBe(null);
+    });
+  });
+
+  describe("detects same-signature tail streaks", () => {
+    it("3 identical signature turns → finding with streakLength 3", () => {
+      const turns = [
+        turn({ turnId: 1 }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3 }),
+      ];
+      const result = detectSpiral(turns);
+      expect(result).not.toBe(null);
+      expect(result!.streakLength).toBe(3);
+      expect(result!.signature).toBe("patch_notebook:deadbeef");
+    });
+
+    it("ordering: turnIds reported oldest → newest", () => {
+      const turns = [
+        turn({ turnId: 5 }),
+        turn({ turnId: 7 }),
+        turn({ turnId: 9 }),
+      ];
+      const result = detectSpiral(turns);
+      expect(result!.streakTurnIds).toEqual([5, 7, 9]);
+    });
+
+    it("4 identical at tail with prior different turn → streak counts only the matching tail", () => {
+      const turns = [
+        turn({ turnId: 1, argsHash: "old" }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3 }),
+        turn({ turnId: 4 }),
+        turn({ turnId: 5 }),
+      ];
+      const result = detectSpiral(turns);
+      expect(result).not.toBe(null);
+      expect(result!.streakLength).toBe(4); // turns 2..5
+      expect(result!.streakTurnIds[0]).toBe(2);
+    });
+  });
+
+  describe("verdict logic", () => {
+    it("'confirmed' when every streak turn has same artifactSha256", () => {
+      const sha = "aaa";
+      const turns = [
+        turn({ turnId: 1, artifactSha256: sha }),
+        turn({ turnId: 2, artifactSha256: sha }),
+        turn({ turnId: 3, artifactSha256: sha }),
+      ];
+      const result = detectSpiral(turns);
+      expect(result!.verdict).toBe("confirmed");
+    });
+
+    it("'false_positive_progress' when artifact shas differ inside the streak", () => {
+      const turns = [
+        turn({ turnId: 1, artifactSha256: "aaa" }),
+        turn({ turnId: 2, artifactSha256: "bbb" }),
+        turn({ turnId: 3, artifactSha256: "ccc" }),
+      ];
+      const result = detectSpiral(turns);
+      expect(result!.verdict).toBe("false_positive_progress");
+    });
+
+    it("'suspected' when ANY streak turn lacks artifactSha256", () => {
+      const turns = [
+        turn({ turnId: 1, artifactSha256: "aaa" }),
+        turn({ turnId: 2 }), // no sha
+        turn({ turnId: 3, artifactSha256: "aaa" }),
+      ];
+      const result = detectSpiral(turns);
+      expect(result!.verdict).toBe("suspected");
+    });
+
+    it("'suspected' when no streak turn has artifactSha256", () => {
+      const turns = [
+        turn({ turnId: 1 }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3 }),
+      ];
+      const result = detectSpiral(turns);
+      expect(result!.verdict).toBe("suspected");
+    });
+  });
+
+  describe("custom windowSize", () => {
+    it("windowSize=2 detects 2-turn streaks the default ignores", () => {
+      const turns = [
+        turn({ turnId: 1, argsHash: "diff" }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3 }),
+      ];
+      // Default = 3, so the 2-tail-streak doesn't trip default detection.
+      // (The 3rd turn shares signature with 2nd but the 1st is different,
+      // and there are 3 turns total. Actually default counts streak from
+      // tail, so this one IS a 2-streak under windowSize=2 and missed
+      // under windowSize=3 unless the 1st shares too.)
+      const wDefault = detectSpiral(turns);
+      expect(wDefault).toBe(null);
+      const w2 = detectSpiral(turns, 2);
+      expect(w2).not.toBe(null);
+      expect(w2!.streakLength).toBe(2);
+    });
+
+    it("windowSize=4 requires 4 same-signature turns", () => {
+      const turns = [
+        turn({ turnId: 1 }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3 }),
+      ];
+      expect(detectSpiral(turns, 4)).toBe(null);
+    });
+  });
+
+  describe("payload shape", () => {
+    it("returns toolName + signature + mistakePattern + correctPattern", () => {
+      const turns = [
+        turn({ turnId: 1 }),
+        turn({ turnId: 2 }),
+        turn({ turnId: 3 }),
+      ];
+      const result = detectSpiral(turns);
+      expect(result!.toolName).toBe("patch_notebook");
+      expect(result!.signature).toBe("patch_notebook:deadbeef");
+      expect(result!.mistakePattern).toContain("patch_notebook");
+      expect(result!.mistakePattern).toContain("3 turns in a row");
+      expect(result!.correctPattern).toMatch(/different tool|change the args|stuck/i);
+    });
+  });
+
+  describe("constants", () => {
+    it("SPIRAL_WINDOW_SIZE is 3 (matches plan PR #116)", () => {
+      expect(SPIRAL_WINDOW_SIZE).toBe(3);
+    });
+  });
+});

--- a/convex/domains/ai/models/chainResolver.test.ts
+++ b/convex/domains/ai/models/chainResolver.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for resolveChain.  Pure function — no Convex runtime.
+ *
+ * Tests the contract surfaced in chainResolver.ts:
+ *  1. Tier-floor enforcement (no model below floor, even if it matches caps)
+ *  2. Avoid list stripping
+ *  3. preferIds pinned to front in supplied order
+ *  4. primaryModelId placed first when it passes filters
+ *  5. Empty chain when nothing matches → reason set (HONEST_STATUS)
+ *  6. Capability requirement filter (vision/tools/reasoning/long-context/streaming)
+ *  7. maxChainLength clamp
+ */
+import { describe, expect, it } from "vitest";
+import { resolveChain } from "./chainResolver";
+import { CAPABILITY_REGISTRY } from "./capabilityRegistry";
+
+// Pick a stable canary model from the registry to use across tests.
+// `qwen3-coder-free` is documented in chainResolver.ts header — free tier,
+// supports tools + reasoning + longContext + streaming.
+const REGISTERED_FREE = "qwen3-coder-free";
+
+describe("resolveChain", () => {
+  describe("registry sanity (tests depend on these IDs being registered)", () => {
+    it("free-tier canary is in the registry", () => {
+      expect(CAPABILITY_REGISTRY[REGISTERED_FREE]).toBeDefined();
+      expect(CAPABILITY_REGISTRY[REGISTERED_FREE].tier).toBe("free");
+    });
+  });
+
+  describe("tier-floor enforcement", () => {
+    it("returns at least one chain entry when requirement matches free models", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+      });
+      expect(result.chain.length).toBeGreaterThan(0);
+    });
+
+    it("with tierFloor='premium', no free model appears in the chain", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "premium",
+      });
+      for (const id of result.chain) {
+        const caps = CAPABILITY_REGISTRY[id];
+        expect(caps).toBeDefined();
+        expect(caps.tier).toBe("premium");
+      }
+    });
+
+    it("never includes models below the tier floor even when capability matches", () => {
+      const result = resolveChain({
+        requirement: {},
+        tierFloor: "standard",
+      });
+      const tierOrder = ["free", "cheap", "standard", "premium"];
+      const floorIdx = tierOrder.indexOf("standard");
+      for (const id of result.chain) {
+        const caps = CAPABILITY_REGISTRY[id];
+        const idx = tierOrder.indexOf(caps.tier);
+        expect(idx).toBeGreaterThanOrEqual(floorIdx);
+      }
+    });
+  });
+
+  describe("avoid list", () => {
+    it("strips models in avoidModelIds from the chain", () => {
+      const baseline = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+      });
+      // Pick the first chain entry to avoid; rerun and assert it's gone.
+      const toAvoid = baseline.chain[0];
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        avoidModelIds: [toAvoid],
+      });
+      expect(result.chain).not.toContain(toAvoid);
+    });
+
+    it("primary in avoid list → primaryOutcome surfaces dropped_in_avoid_list", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        primaryModelId: REGISTERED_FREE,
+        avoidModelIds: [REGISTERED_FREE],
+      });
+      expect(result.diagnostics.primaryOutcome).toBe("dropped_in_avoid_list");
+      expect(result.chain).not.toContain(REGISTERED_FREE);
+    });
+  });
+
+  describe("preferIds pinning", () => {
+    it("registered preferId moves to the front", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        preferIds: [REGISTERED_FREE],
+      });
+      expect(result.chain[0]).toBe(REGISTERED_FREE);
+      expect(result.diagnostics.preferredAccepted).toContain(REGISTERED_FREE);
+    });
+
+    it("unregistered preferId surfaces in preferredDropped diagnostics", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        preferIds: ["__not_a_real_model__"],
+      });
+      expect(result.chain).not.toContain("__not_a_real_model__");
+      expect(
+        result.diagnostics.preferredDropped.some(
+          (d) => d.modelId === "__not_a_real_model__" && d.reason === "not_in_registry",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("primaryModelId placement", () => {
+    it("registered primary appears first when it passes filters", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        primaryModelId: REGISTERED_FREE,
+      });
+      expect(result.chain[0]).toBe(REGISTERED_FREE);
+      expect(result.diagnostics.primaryOutcome).toBe("kept");
+    });
+
+    it("unregistered primary → diagnostics.primaryOutcome = dropped_not_in_registry", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        primaryModelId: "__not_a_real_model__",
+      });
+      expect(result.chain).not.toContain("__not_a_real_model__");
+      expect(result.diagnostics.primaryOutcome).toBe("dropped_not_in_registry");
+    });
+  });
+
+  describe("capability requirement filter", () => {
+    it("requirement.supportsVision=true keeps only vision-capable models", () => {
+      const result = resolveChain({
+        requirement: { supportsVision: true },
+        tierFloor: "free",
+      });
+      for (const id of result.chain) {
+        expect(CAPABILITY_REGISTRY[id].supportsVision).toBe(true);
+      }
+    });
+  });
+
+  describe("HONEST_STATUS — empty chain on no match", () => {
+    it("impossible requirement → empty chain + reason set", () => {
+      const result = resolveChain({
+        requirement: {
+          supportsVision: true,
+          supportsTools: true,
+          supportsReasoning: true,
+          supportsLongContext: true,
+          supportsStreaming: true,
+        },
+        // Force an impossible combo across all five flags at the cheapest tier.
+        tierFloor: "premium",
+        avoidModelIds: Object.keys(CAPABILITY_REGISTRY), // remove every registered model
+      });
+      expect(result.chain).toEqual([]);
+      expect(result.reason).toBeDefined();
+    });
+  });
+
+  describe("maxChainLength clamp", () => {
+    it("respects maxChainLength=2 even when more candidates exist", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        maxChainLength: 2,
+      });
+      expect(result.chain.length).toBeLessThanOrEqual(2);
+    });
+
+    it("treats maxChainLength=0 as 1 (defensive lower bound)", () => {
+      const result = resolveChain({
+        requirement: { supportsTools: true },
+        tierFloor: "free",
+        maxChainLength: 0,
+      });
+      expect(result.chain.length).toBeGreaterThanOrEqual(0);
+      expect(result.chain.length).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/src/features/chat/lib/detectRollbackIntent.test.ts
+++ b/src/features/chat/lib/detectRollbackIntent.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for detectRollbackIntent.  Pure function — no Convex / React.
+ *
+ * Covers: canonical /rollback forms, natural-language fuzzy forms, the
+ * MAX_STEPS_BACK clamp, and rejected inputs (empty, long, malformed).
+ */
+import { describe, expect, it } from "vitest";
+import { detectRollbackIntent } from "./detectRollbackIntent";
+
+describe("detectRollbackIntent", () => {
+  describe("rejects non-rollback input", () => {
+    it("returns null for empty string", () => {
+      expect(detectRollbackIntent("")).toBe(null);
+    });
+    it("returns null for whitespace-only", () => {
+      expect(detectRollbackIntent("   ")).toBe(null);
+    });
+    it("returns null for unrelated questions", () => {
+      expect(detectRollbackIntent("what's the weather like")).toBe(null);
+      expect(detectRollbackIntent("compare these two reports")).toBe(null);
+    });
+    it("returns null for long inputs that mention undo", () => {
+      const long =
+        "I've been thinking about whether I should undo the changes we made earlier today";
+      expect(long.length).toBeGreaterThan(60);
+      expect(detectRollbackIntent(long)).toBe(null);
+    });
+  });
+
+  describe("canonical /rollback slash form", () => {
+    it("/rollback → stepsBack: 1", () => {
+      expect(detectRollbackIntent("/rollback")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 1,
+      });
+    });
+    it("/rollback 3 → stepsBack: 3", () => {
+      expect(detectRollbackIntent("/rollback 3")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 3,
+      });
+    });
+    it("/rollback to 42 → turnId: 42", () => {
+      expect(detectRollbackIntent("/rollback to 42")).toEqual({
+        kind: "turnId",
+        turnId: 42,
+      });
+    });
+    it("/rollback turn 42 → turnId: 42", () => {
+      expect(detectRollbackIntent("/rollback turn 42")).toEqual({
+        kind: "turnId",
+        turnId: 42,
+      });
+    });
+    it("clamps slash-form stepsBack to MAX_STEPS_BACK=50", () => {
+      const r = detectRollbackIntent("/rollback 9999");
+      expect(r).toEqual({ kind: "stepsBack", stepsBack: 50 });
+    });
+    it("rejects /rollback 0", () => {
+      expect(detectRollbackIntent("/rollback 0")).toBe(null);
+    });
+    it("ignores trailing whitespace", () => {
+      expect(detectRollbackIntent("/rollback 2   ")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 2,
+      });
+    });
+    it("is case-insensitive on /rollback", () => {
+      expect(detectRollbackIntent("/RollBack 4")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 4,
+      });
+    });
+  });
+
+  describe("natural-language forms", () => {
+    it("'undo last 3' → stepsBack: 3", () => {
+      expect(detectRollbackIntent("undo last 3")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 3,
+      });
+    });
+    it("'rollback the last 2' → stepsBack: 2", () => {
+      expect(detectRollbackIntent("rollback the last 2")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 2,
+      });
+    });
+    it("'revert last 5' → stepsBack: 5", () => {
+      expect(detectRollbackIntent("revert last 5")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 5,
+      });
+    });
+    it("clamps natural-language stepsBack to 50", () => {
+      const r = detectRollbackIntent("undo last 9999");
+      expect(r).toEqual({ kind: "stepsBack", stepsBack: 50 });
+    });
+    it("'undo that' → stepsBack: 1", () => {
+      expect(detectRollbackIntent("undo that")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 1,
+      });
+    });
+    it("'rollback' alone (no slash) → stepsBack: 1", () => {
+      expect(detectRollbackIntent("rollback")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 1,
+      });
+    });
+    it("'undo this' → stepsBack: 1", () => {
+      expect(detectRollbackIntent("undo this")).toEqual({
+        kind: "stepsBack",
+        stepsBack: 1,
+      });
+    });
+    it("rejects 'undo last 0'", () => {
+      expect(detectRollbackIntent("undo last 0")).toBe(null);
+    });
+    it("rejects long-form sentence with 'undo' embedded mid-text", () => {
+      // Has 'undo last 3' but exceeds 60 chars.
+      const text =
+        "Hey assistant, could you maybe just undo last 3 things we did, thanks!";
+      expect(text.length).toBeGreaterThan(60);
+      expect(detectRollbackIntent(text)).toBe(null);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("'undo' followed by a non-matching suffix returns null", () => {
+      expect(detectRollbackIntent("undo nuclear launch")).toBe(null);
+    });
+    it("'/rollbackish' is not /rollback", () => {
+      expect(detectRollbackIntent("/rollbackish")).toBe(null);
+    });
+    it("does not crash on unicode + emoji", () => {
+      expect(() => detectRollbackIntent("/rollback 🚀")).not.toThrow();
+      expect(detectRollbackIntent("/rollback 🚀")).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two follow-ups to the autonomous-continuation plan that PR #165 either skipped or accidentally dropped during the squash merge:

- **FU-3 (Lesson Injection Runtime)** — wire \`buildSystemPromptPrefix\` into the actual LLM call sites in \`canonicalPlanner.ts\`. PR #165's commit message lists FU-1, FU-2 only; FU-3 was deferred ("requires additional contract design"). This delivers it.
- **FU-5 (Unit Tests)** — restore the 4 test files added by [PR #155](https://github.com/HomenShum/nodebench-ai/pull/155) that PR #165's squash merge accidentally deleted. \`git show 30543120 --stat\` shows all four as pure deletions.

## FU-3 Implementation

New helper [\`convex/domains/agents/lessons/lessonInjection.ts\`](convex/domains/agents/lessons/lessonInjection.ts):

\`\`\`ts
export async function injectLessonsForThread(
  ctx: ActionCtx,
  threadId: string | undefined | null,
  originalSystemPrompt: string,
  options?: { turnId?: number; currentToolName?: string; limit?: number },
): Promise<string>
\`\`\`

Behavior:
- No \`threadId\` → returns prompt unchanged
- Empty lessons → returns prompt unchanged
- Lesson query throws → logs warn, returns prompt unchanged (HONEST_STATUS)
- Otherwise: returns \`<lessons prefix>\n\n<originalSystemPrompt>\`

Wired into all 3 \`modelRouter.route\` call sites in [canonicalPlanner.ts](convex/domains/agents/canonicalPlanner.ts):
| Site | Line | System prompt |
|---|---|---|
| Intent classifier | ~130 | \`INTENT_CLASSIFIER_SYSTEM\` |
| Fast lane primary | ~158 | \`FAST_LANE_SYSTEM\` |
| Slow lane synthesis | ~315 | inline slow-lane prompt |

### Why pre-router (not per-model)
- Keeps \`modelRouter\` generic — lessons are an agent-runtime concern, not a routing concern
- Opt-in: callers without \`threadId\` get unchanged behavior
- Simpler test surface: helper has one job
- Token accounting stays in \`buildSystemPromptPrefix\` (already capped at 8 KB)

### Constraint enforcement (from AUTONOMOUS_CONTINUATION_PLAN.md §5)
- **Token Budget < 10 Lessons** — enforced via \`getRelevantLessons.limit\` default of 5 + 8 KB byte budget
- **No Cross-Thread Leakage** — \`getRelevantLessons\` strictly filters by \`threadId\`; helper does not widen scope

## FU-5 Restored Tests

| File | Cases | Source |
|---|---:|---|
| [systemPromptBuilder.test.ts](convex/domains/agents/lessons/systemPromptBuilder.test.ts) | 17 | restored from commit \`5f2d56af\` |
| [spiralDetector.test.ts](convex/domains/agents/spiral/spiralDetector.test.ts) | 16 | restored from commit \`5f2d56af\` |
| [chainResolver.test.ts](convex/domains/ai/models/chainResolver.test.ts) | 14 | restored from commit \`5f2d56af\` |
| [detectRollbackIntent.test.ts](src/features/chat/lib/detectRollbackIntent.test.ts) | 24 | restored from commit \`5f2d56af\` |
| [lessonInjection.test.ts](convex/domains/agents/lessons/lessonInjection.test.ts) | **7** | NEW — covers FU-3 helper |

**Total: 78 tests, all green.**

## FU-4 Status

Already implemented — the handoff doc was wrong. \`AgentResilienceConnector.tsx\` uses \`useQuery(getBudgetForOwner)\` which IS a Convex live subscription, and \`ResilienceSettings.tsx\` has a \`useEffect\` that re-syncs form state on snapshot change. No further action needed.

## Spiral Detector Integration

Deferred. Needs:
- Tool call history persistence (where to store)
- Spiral detection on a windowed history
- Intervention mechanism (model switch? system message warning?)

These are design decisions worth a focused session, not a tail-end add to this PR.

## Verification

\`\`\`
$ npx tsc --noEmit                          # root: 0 errors
$ npx tsc --noEmit -p convex/tsconfig.json  # convex: 0 errors
$ npx vitest run <5 files>                   # 78/78 pass
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)