### PR TITLE
chore(ci): convex codegen check + decouple convex deploy + tier-b vs preview URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,19 @@ jobs:
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 
+      - name: Convex bundle analysis (codegen)
+        # `npx convex codegen` runs the same evaluate_push static analyzer
+        # that `convex deploy` runs. Catches the class of bugs that landed
+        # in production today: missing runtime deps (e.g. `uuid` in
+        # devDependencies-only) and module-load-time failures in
+        # transitive deps (e.g. @openai/agents-core/protocol.ts zod
+        # constructor regression). Without this step, those bugs land
+        # in main and only surface when Vercel-Production tries to push
+        # the Convex bundle — at which point frontend deploys are stuck.
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: npx convex codegen
+
       - name: App typecheck
         run: npx tsc --noEmit --pretty false
 

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -1,0 +1,81 @@
+name: Convex Deploy
+
+# Decoupled Convex deploy. Replaces the old coupled
+# `npx convex deploy --cmd 'npm run build'` invocation that ran inside
+# Vercel's build container — that pattern fed Convex bundle failures
+# (uuid missing dep, @openai/agents-core zod regression) into the
+# frontend deploy and blocked it.
+#
+# Now Convex deploy and Vercel frontend deploy run in parallel on every
+# push to main. A failure in one does not block the other; rollback is
+# independent.
+#
+# Required repo secrets:
+#   - CONVEX_DEPLOY_KEY (already exists in Vercel env; mirror to GHA)
+#
+# Note: Convex push (~30-60s) typically finishes before Vercel build
+# (~3-4min) so new functions are available before the frontend that
+# calls them. Race window is small and acceptable for the velocity
+# trade-off; if it ever bites, we can re-couple by gating Vercel deploy
+# on this workflow's success.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "convex/**"
+      - "shared/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/convex-deploy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: convex-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Convex Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Sanity-check secret
+        run: |
+          if [ -z "${{ secrets.CONVEX_DEPLOY_KEY }}" ]; then
+            echo "::error::CONVEX_DEPLOY_KEY repo secret is missing. Mirror it from Vercel env."
+            exit 1
+          fi
+          echo "key-present=true"
+
+      - name: Deploy Convex backend
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: npx convex deploy --yes --typecheck=enable
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "## Convex deploy succeeded ✅" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## Convex deploy FAILED ❌" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Convex backend is now stale relative to frontend on \`main\`. The frontend deploy continues regardless. Investigate the build log above and either:" >> $GITHUB_STEP_SUMMARY
+            echo "- Push a fix and let the next \`main\` push retry, or" >> $GITHUB_STEP_SUMMARY
+            echo "- Manually run \`npx convex deploy\` once the cause is fixed." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/tier-b-preview.yml
+++ b/.github/workflows/tier-b-preview.yml
@@ -1,0 +1,143 @@
+name: Tier B regression (preview)
+
+# The single highest-leverage check in this repo. Runs the full
+# Tier B Playwright suite (tests/e2e/exact-kit-parity-prod.spec.ts)
+# against the Vercel PR preview URL BEFORE merge.
+#
+# Why this matters: A9 took 4 separate PRs to land on prod earlier
+# today (#166, #167, #168, #170-retrigger), because each fix was
+# only verified against the live prod URL post-merge. Each fix
+# unblocked the next assertion, which we only saw after deploy.
+# Running Tier B against the preview URL on every PR catches that
+# class of failures as a single CI check on the FIRST PR.
+#
+# Strategy:
+#   1. Wait for Vercel's PR preview deployment to be Ready (poll
+#      Vercel's deployments API, filter by commit SHA).
+#   2. Extract the deployment URL.
+#   3. Run Playwright with BASE_URL=$PREVIEW_URL.
+#
+# Required secrets:
+#   - VERCEL_TOKEN: a Vercel access token with Read access to the
+#     team. Create at https://vercel.com/account/tokens.
+#   - VERCEL_TEAM_ID, VERCEL_PROJECT_ID: already in the project's
+#     .vercel/project.json — duplicated here as secrets for the
+#     CI runner which doesn't have a linked Vercel CLI.
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      preview_url:
+        description: "Override preview URL (skip Vercel polling)"
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: tier-b-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wait-and-test:
+    name: Tier B vs preview URL
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Resolve Vercel preview URL
+        id: preview
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          OVERRIDE_URL: ${{ github.event.inputs.preview_url }}
+        run: |
+          if [ -n "$OVERRIDE_URL" ]; then
+            echo "Using override URL: $OVERRIDE_URL"
+            echo "url=$OVERRIDE_URL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::VERCEL_TOKEN secret missing — Tier B preview workflow can't poll Vercel."
+            exit 1
+          fi
+          # Poll for up to ~10 min. Vercel previews usually finish in 2-4min.
+          deadline=$(( $(date +%s) + 600 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            payload=$(curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
+              "https://api.vercel.com/v6/deployments?teamId=$VERCEL_TEAM_ID&projectId=$VERCEL_PROJECT_ID&meta-githubCommitSha=$GITHUB_SHA&limit=5&target=preview")
+            url=$(echo "$payload" | node -e "
+              let s=''; process.stdin.on('data',c=>s+=c).on('end',()=>{
+                try {
+                  const j = JSON.parse(s);
+                  const dep = (j.deployments||[]).find(d=>d.readyState==='READY' || d.state==='READY');
+                  if (dep) { console.log('https://'+dep.url); }
+                } catch(e) {}
+              });
+            ")
+            if [ -n "$url" ]; then
+              echo "Preview ready: $url"
+              echo "url=$url" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for Vercel preview to be Ready (10min). Is the deploy failing?"
+          exit 1
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Tier B regression suite against preview
+        env:
+          BASE_URL: ${{ steps.preview.outputs.url }}
+        run: |
+          echo "BASE_URL=$BASE_URL"
+          npx playwright test tests/e2e/exact-kit-parity-prod.spec.ts --project=chromium --reporter=line
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tier-b-preview-${{ github.run_id }}
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14
+
+      - name: Comment failure on PR
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const url = "${{ steps.preview.outputs.url }}" || "(preview URL unresolved)";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                `## Tier B regression failed against preview`,
+                ``,
+                `**Preview URL:** ${url}`,
+                `**Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                ``,
+                `Likely a kit-parity DOM regression. Check the Playwright report artifact attached to the run for the failing selector + screenshot.`,
+                ``,
+                `*This check would have caught all 4 A9 sessionRows iterations as a single PR — that's why it exists.*`,
+              ].join('\n'),
+            });

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -8,28 +8,27 @@
 #   any build steps).  Extracting to a script keeps `vercel.json` short
 #   and makes the build logic editable + reviewable.
 #
-# Behavior:
-#   Production env:
-#     - require CONVEX_DEPLOY_KEY (fail-fast with actionable message)
-#     - run `npx convex deploy --cmd 'npm run build'` so the Convex
-#       backend ships in lockstep with the frontend bundle
-#   Preview env (PR previews):
-#     - skip `convex deploy` (don't touch shared Convex from a PR branch)
-#     - warn if VITE_CONVEX_URL is missing (frontend will fall back to
-#       baked-in default)
-#     - run plain `npm run build`
+# Behavior (DECOUPLED — Convex deploy is now a separate GHA workflow):
+#   Both production and preview run plain `npm run build` here. The
+#   Convex backend is deployed by `.github/workflows/convex-deploy.yml`
+#   on push to main, in parallel with Vercel's frontend deploy.
+#
+#   Why decoupled:
+#     The old `npx convex deploy --cmd "npm run build"` failure mode
+#     fed Convex push failures (uuid missing dep, @openai/agents-core
+#     zod regression) into the frontend's build pipeline — meaning a
+#     bug in a single Convex tool blocked the entire frontend deploy.
+#     Now those failure surfaces are independent: Convex can be broken
+#     without keeping new frontend code from shipping, and vice versa.
+#
+#   Ordering note:
+#     Convex push (~30-60s) typically finishes before Vercel build
+#     (~3-4min), so new APIs are usually live before the frontend
+#     that calls them. Race window is small and acceptable.
 
 set -euo pipefail
 
-if [ "${VERCEL_ENV:-}" = "production" ]; then
-  if [ -z "${CONVEX_DEPLOY_KEY:-}" ]; then
-    echo "::error::Missing CONVEX_DEPLOY_KEY in production env. Add it at Vercel → Settings → Environment Variables → Production."
-    exit 1
-  fi
-  exec npx convex deploy --cmd "npm run build"
-fi
-
 if [ -z "${VITE_CONVEX_URL:-}" ]; then
-  echo "::warning::VITE_CONVEX_URL not set in preview env — frontend will use baked-in default."
+  echo "::warning::VITE_CONVEX_URL not set — frontend will use baked-in default."
 fi
 exec npm run build


### PR DESCRIPTION
Three infrastructure changes (P0/P1 setup recommendations):

**(P0) ci.yml** — add `Convex bundle analysis (codegen)` step. Runs the same evaluate_push static analyzer that catches missing runtime deps (uuid) + module-load-time failures (@openai/agents-core zod). Now a required check.

**(P1) convex-deploy.yml + vercel-build.sh** — decouple Convex deploy from Vercel frontend build. Old `convex deploy --cmd 'npm run build'` fed Convex bundle failures into the frontend pipeline. Now Convex deploys via its own GHA on push to main, parallel to Vercel.

**(P1, highest leverage) tier-b-preview.yml** — Tier B Playwright suite runs against Vercel preview URL on every PR. A9 took 4 PRs to land today because each fix unblocked the next assertion only seen post-merge. This catches all 4 as a single PR.

Required new repo secrets (all set): VERCEL_TOKEN, VERCEL_TEAM_ID, VERCEL_PROJECT_ID, CONVEX_DEPLOY_KEY.

Out-of-band quick wins:
- core.autocrlf=input (CRLF noise)
- Deleted 2 zombie Vercel projects