### PR TITLE
fix(ci): post-deploy-verify preview SSO graceful skip

### DIFF
--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -20,14 +20,19 @@ concurrency:
 
 jobs:
   verify:
-    # Skip Vercel Preview deployments unless we have an SSO bypass secret —
-    # otherwise the preview URL returns HTTP 401 and verify always fails.
-    # Production env, scheduled runs, and manual dispatch always run.
+    # On deployment_status events, only run when state is success (skip pending,
+    # failure, in_progress). The PRIOR if-clause also tried to skip Preview URLs
+    # without a bypass secret using `vars.VERCEL_AUTOMATION_BYPASS_SECRET_PRESENT`,
+    # but that var drifted out of sync with `secrets.VERCEL_AUTOMATION_BYPASS_SECRET`
+    # and false-failed every dependabot PR's preview deploy with HTTP 401 SSO.
+    #
+    # The robust fix lives in scripts/post-deploy-verify.mjs: when running against
+    # a Vercel preview URL (*.vercel.app) with no bypass secret in env, the script
+    # now skips cleanly (exit 0 with skipped=true) instead of throwing 401. That
+    # safety net works regardless of the var/secret sync state.
     if: |
-      (github.event_name != 'deployment_status') ||
-      (github.event.deployment_status.state == 'success' &&
-       (github.event.deployment_status.environment != 'Preview' ||
-        vars.VERCEL_AUTOMATION_BYPASS_SECRET_PRESENT == 'true'))
+      github.event_name != 'deployment_status' ||
+      github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/scripts/post-deploy-verify.mjs
+++ b/scripts/post-deploy-verify.mjs
@@ -76,6 +76,20 @@ async function fetchHtml() {
   return response.text();
 }
 
+/**
+ * Vercel preview deployments are SSO-protected by default. When this script
+ * runs against a preview URL without a bypass secret configured, every check
+ * will hit HTTP 401 — but that's a misconfiguration of the workflow, not a
+ * regression of the deployed app. Treat it as a clean skip (exit 0) so the
+ * Post-Deploy Verify check stops false-failing on every dependabot PR.
+ *
+ * The workflow's `if:` clause is supposed to gate this, but it depends on
+ * `vars.VERCEL_AUTOMATION_BYPASS_SECRET_PRESENT` being kept in sync with the
+ * actual secret state. This script-level guard is the safety net — if the var
+ * drifts from reality, we skip cleanly instead of failing every CI run.
+ */
+const shouldSkipPreviewWithoutBypass = isVercelPreview && !vercelBypassSecret;
+
 function tail(text, lines = 18) {
   return text.split("\n").slice(-lines).join("\n").trim();
 }
@@ -127,23 +141,38 @@ const steps = [
 const results = [];
 let firstFailure = null;
 
-for (const step of steps) {
-  if (skips.has(step.id)) {
-    results.push({ id: step.id, name: step.name, ok: true, skipped: true });
-    continue;
+if (shouldSkipPreviewWithoutBypass) {
+  const skipDetail =
+    "Vercel preview URL with no VERCEL_AUTOMATION_BYPASS_SECRET configured — " +
+    "skipping verify (preview SSO returns 401, not a regression).";
+  for (const step of steps) {
+    results.push({
+      id: step.id,
+      name: step.name,
+      ok: true,
+      skipped: true,
+      detail: skipDetail,
+    });
   }
-  const started = Date.now();
-  let result;
-  try {
-    result = await step.check();
-  } catch (error) {
-    result = { ok: false, detail: error instanceof Error ? error.message : "step threw" };
-  }
-  const entry = { id: step.id, name: step.name, durationMs: Date.now() - started, ...result };
-  results.push(entry);
-  if (!entry.ok) {
-    firstFailure = entry;
-    break;
+} else {
+  for (const step of steps) {
+    if (skips.has(step.id)) {
+      results.push({ id: step.id, name: step.name, ok: true, skipped: true });
+      continue;
+    }
+    const started = Date.now();
+    let result;
+    try {
+      result = await step.check();
+    } catch (error) {
+      result = { ok: false, detail: error instanceof Error ? error.message : "step threw" };
+    }
+    const entry = { id: step.id, name: step.name, durationMs: Date.now() - started, ...result };
+    results.push(entry);
+    if (!entry.ok) {
+      firstFailure = entry;
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Post-Deploy Verify false-failed twice on main HEAD (0af232d1) because dependabot PR previews returned HTTP 401 SSO. The workflow's `if:` clause was supposed to skip them but depended on a repo var that drifted out of sync with the actual bypass secret.

**Two-layer fix:**
- **Script safety net** (`scripts/post-deploy-verify.mjs`): when URL matches `*.vercel.app` AND no `VERCEL_AUTOMATION_BYPASS_SECRET` in env → skip all 3 steps cleanly, exit 0. Works regardless of var/secret sync state.
- **Workflow simplification** (`.github/workflows/post-deploy-verify.yml`): drop the var-based environment check; just gate on `deployment_status.state == 'success'`. Script owns preview-vs-production distinction.

## Diagnosis trail
- Failing runs: 25035082026 + 25035073807, both step "Verify deployed app"
- Artifact `post-deploy-result.json`: `firstFailure: html-shell, HTTP 401`
- URL: `nodebench-2zd83oiop-...vercel.app` (preview, not `www.nodebenchai.com`)
- Production fine on same SHA: `Surface crawl` SUCCESS, Tier A `verify-live.ts` 5/5 pass

## Smoke tests (manual, both paths)
- ✅ Preview URL no bypass → `failed=0`, all 3 skipped, exit 0
- ✅ Production URL → `html-shell` ran (html bytes=11506), exit 0

## Test plan
- [x] Script smoke-tested locally on both preview + production URLs
- [x] Workflow `if:` clause simplified — `state == 'success'` is necessary AND sufficient
- [ ] CI pipeline (Typecheck/Runtime smoke/Build/Tier B preview URL — Tier B will skip-green since no BUILD_RELEVANT paths touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)