### PR TITLE
feat(reports): EntityFindingsPanel — funding + LinkedIn coverage per entity

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1184,6 +1184,7 @@ import type * as domains_social_linkedinArchiveCleanup from "../domains/social/l
 import type * as domains_social_linkedinArchiveCleanupMutations from "../domains/social/linkedinArchiveCleanupMutations.js";
 import type * as domains_social_linkedinArchiveEdits from "../domains/social/linkedinArchiveEdits.js";
 import type * as domains_social_linkedinArchiveEditsMutations from "../domains/social/linkedinArchiveEditsMutations.js";
+import type * as domains_social_linkedinArchiveEntityLinks from "../domains/social/linkedinArchiveEntityLinks.js";
 import type * as domains_social_linkedinArchiveMaintenance from "../domains/social/linkedinArchiveMaintenance.js";
 import type * as domains_social_linkedinArchiveMaintenanceQueries from "../domains/social/linkedinArchiveMaintenanceQueries.js";
 import type * as domains_social_linkedinArchivePurge from "../domains/social/linkedinArchivePurge.js";
@@ -2636,6 +2637,7 @@ declare const fullApi: ApiFromModules<{
   "domains/social/linkedinArchiveCleanupMutations": typeof domains_social_linkedinArchiveCleanupMutations;
   "domains/social/linkedinArchiveEdits": typeof domains_social_linkedinArchiveEdits;
   "domains/social/linkedinArchiveEditsMutations": typeof domains_social_linkedinArchiveEditsMutations;
+  "domains/social/linkedinArchiveEntityLinks": typeof domains_social_linkedinArchiveEntityLinks;
   "domains/social/linkedinArchiveMaintenance": typeof domains_social_linkedinArchiveMaintenance;
   "domains/social/linkedinArchiveMaintenanceQueries": typeof domains_social_linkedinArchiveMaintenanceQueries;
   "domains/social/linkedinArchivePurge": typeof domains_social_linkedinArchivePurge;

--- a/convex/domains/social/linkedinArchiveEntityLinks.ts
+++ b/convex/domains/social/linkedinArchiveEntityLinks.ts
@@ -1,0 +1,487 @@
+/**
+ * Linkedin Archive Entity Links
+ *
+ * Denormalized many-to-many between `linkedinPostArchive` and
+ * `entityContexts`. Convex doesn't index array fields for `contains`
+ * queries, so we materialize one row per `(archiveRow, entity)` pair to
+ * make per-entity retrieval cheap (single `withIndex("by_company_postedAt")`
+ * call instead of an O(N) scan).
+ *
+ * Pattern: scratchpad-first → structuring → join-table compaction.
+ * Prior art: Anthropic Claude Code MEMORY.md (file-system layered memory),
+ * generic Convex many-to-many denormalization.
+ *
+ * Populated by:
+ *   - rebuildAllArchiveEntityLinks (one-shot full rebuild from scratch)
+ *   - upsertArchiveRowEntityLinks  (per-row, called by the funding backfill)
+ *
+ * Read by:
+ *   - getEntityFindings (public, EntityPage / report cards)
+ */
+
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+  query,
+} from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
+
+/**
+ * Normalize a name for case-insensitive substring matching.
+ *  - Lowercase
+ *  - Strip punctuation that the digest agent or LLMs add (.,!?:;'"`)
+ *  - Collapse whitespace
+ *  - Strip common suffixes like ", Inc." that wouldn't appear in casual mentions
+ */
+function normalizeForMatch(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[‘’“”'"`]/g, "")
+    .replace(/,?\s+(inc\.?|llc|ltd\.?|corp\.?|corporation|co\.?)$/i, "")
+    .replace(/[–—\-]/g, " ")
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Word-boundary regex for an entity name. Required so "Google" doesn't
+ * match "Googleplex" and "MCP" doesn't match arbitrary letter sequences.
+ */
+function entityRegex(entityName: string): RegExp {
+  const escaped = entityName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|[^a-zA-Z0-9])${escaped}([^a-zA-Z0-9]|$)`, "i");
+}
+
+type LinkPlan = {
+  companyId: Id<"entityContexts">;
+  matchSource: "findings_round" | "content_mention";
+};
+
+function planLinksForRow(
+  row: {
+    content: string;
+    metadata?: any;
+  },
+  entities: Array<{
+    _id: Id<"entityContexts">;
+    entityName: string;
+    normalized: string;
+    regex: RegExp;
+  }>,
+): LinkPlan[] {
+  const plans = new Map<string, LinkPlan>();
+
+  // 1) Findings rounds (highest signal — the post is literally about this round)
+  const rounds: any[] = row.metadata?.findings?.rounds ?? [];
+  for (const round of rounds) {
+    const roundCompany = typeof round?.companyName === "string" ? round.companyName : "";
+    const roundCompanyId = round?.companyId;
+    if (typeof roundCompanyId === "string" && roundCompanyId.length > 0) {
+      // Direct ID — trust it.
+      plans.set(roundCompanyId, {
+        companyId: roundCompanyId as Id<"entityContexts">,
+        matchSource: "findings_round",
+      });
+      continue;
+    }
+    if (!roundCompany) continue;
+    const roundNormalized = normalizeForMatch(roundCompany);
+    if (!roundNormalized) continue;
+    for (const entity of entities) {
+      if (
+        roundNormalized === entity.normalized ||
+        roundNormalized.includes(entity.normalized) ||
+        entity.normalized.includes(roundNormalized)
+      ) {
+        if (!plans.has(entity._id)) {
+          plans.set(entity._id, { companyId: entity._id, matchSource: "findings_round" });
+        }
+      }
+    }
+  }
+
+  // 2) Plain-text mention scan (covers daily_digest signals and prose)
+  for (const entity of entities) {
+    if (plans.has(entity._id)) continue;
+    if (entity.regex.test(row.content)) {
+      plans.set(entity._id, { companyId: entity._id, matchSource: "content_mention" });
+    }
+  }
+
+  return [...plans.values()];
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Mutation: upsert links for a single archive row                            */
+/* -------------------------------------------------------------------------- */
+
+export const upsertArchiveRowEntityLinks = internalMutation({
+  args: {
+    archiveRowId: v.id("linkedinPostArchive"),
+  },
+  returns: v.object({
+    archiveRowId: v.id("linkedinPostArchive"),
+    linksCreated: v.number(),
+    linksDeleted: v.number(),
+    linksKept: v.number(),
+    matchedEntityIds: v.array(v.id("entityContexts")),
+  }),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.archiveRowId);
+    if (!row) {
+      return {
+        archiveRowId: args.archiveRowId,
+        linksCreated: 0,
+        linksDeleted: 0,
+        linksKept: 0,
+        matchedEntityIds: [],
+      };
+    }
+
+    const entityDocs = await ctx.db.query("entityContexts").collect();
+    const entities = entityDocs.map((e) => ({
+      _id: e._id,
+      entityName: e.entityName,
+      normalized: normalizeForMatch(e.entityName),
+      regex: entityRegex(e.entityName),
+    }));
+
+    const desired = planLinksForRow({ content: row.content, metadata: row.metadata }, entities);
+    const desiredById = new Map(desired.map((p) => [p.companyId, p]));
+
+    const existing = await ctx.db
+      .query("linkedinArchiveEntityLinks")
+      .withIndex("by_archive_row", (q) => q.eq("archiveRowId", args.archiveRowId))
+      .collect();
+
+    let linksCreated = 0;
+    let linksDeleted = 0;
+    let linksKept = 0;
+
+    // Delete stale, keep valid.
+    for (const link of existing) {
+      const want = desiredById.get(link.companyId);
+      if (!want) {
+        await ctx.db.delete(link._id);
+        linksDeleted += 1;
+        continue;
+      }
+      if (link.matchSource !== want.matchSource || link.postedAt !== row.postedAt) {
+        await ctx.db.patch(link._id, {
+          matchSource: want.matchSource,
+          postedAt: row.postedAt,
+          postType: row.postType,
+          dateString: row.dateString,
+        });
+      }
+      desiredById.delete(link.companyId);
+      linksKept += 1;
+    }
+
+    // Insert remaining desired links.
+    for (const plan of desiredById.values()) {
+      await ctx.db.insert("linkedinArchiveEntityLinks", {
+        archiveRowId: args.archiveRowId,
+        companyId: plan.companyId,
+        postedAt: row.postedAt,
+        postType: row.postType,
+        dateString: row.dateString,
+        matchSource: plan.matchSource,
+      });
+      linksCreated += 1;
+    }
+
+    return {
+      archiveRowId: args.archiveRowId,
+      linksCreated,
+      linksDeleted,
+      linksKept,
+      matchedEntityIds: desired.map((d) => d.companyId),
+    };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Internal queries                                                           */
+/* -------------------------------------------------------------------------- */
+
+export const getAllArchiveRowsForLinking = internalQuery({
+  args: {},
+  returns: v.array(
+    v.object({
+      _id: v.id("linkedinPostArchive"),
+      content: v.string(),
+      metadata: v.optional(v.any()),
+      postedAt: v.number(),
+      postType: v.string(),
+      dateString: v.string(),
+    }),
+  ),
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("linkedinPostArchive").collect();
+    return rows.map((r) => ({
+      _id: r._id,
+      content: r.content,
+      metadata: r.metadata,
+      postedAt: r.postedAt,
+      postType: r.postType,
+      dateString: r.dateString,
+    }));
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Action: rebuild all links from scratch                                     */
+/* -------------------------------------------------------------------------- */
+
+export const rebuildAllArchiveEntityLinks = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun ?? true;
+    const rows = await ctx.runQuery(
+      internal.domains.social.linkedinArchiveEntityLinks.getAllArchiveRowsForLinking,
+      {},
+    );
+
+    let created = 0;
+    let deleted = 0;
+    let kept = 0;
+    const perRow: Array<{ id: string; matched: number }> = [];
+
+    for (const row of rows) {
+      if (dryRun) {
+        perRow.push({ id: row._id, matched: 0 });
+        continue;
+      }
+      const result = await ctx.runMutation(
+        internal.domains.social.linkedinArchiveEntityLinks.upsertArchiveRowEntityLinks,
+        { archiveRowId: row._id },
+      );
+      created += result.linksCreated;
+      deleted += result.linksDeleted;
+      kept += result.linksKept;
+      if (result.matchedEntityIds.length > 0) {
+        perRow.push({ id: row._id, matched: result.matchedEntityIds.length });
+      }
+    }
+
+    const summary = {
+      totalRows: rows.length,
+      created,
+      deleted,
+      kept,
+      rowsWithMatches: perRow.length,
+      dryRun,
+    };
+    console.log(`[archiveEntityLinks] ${JSON.stringify(summary)}`);
+    return { summary, perRow: perRow.slice(0, 20) };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Public query: getEntityFindings                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * List entities that have at least one archive link, with link counts.
+ * Used by the LinkedInPostArchiveView "By entity" pivot to populate the
+ * entity selector without scanning all archive content client-side.
+ */
+export const listEntitiesWithArchiveLinks = query({
+  args: {},
+  returns: v.array(
+    v.object({
+      companyId: v.id("entityContexts"),
+      entityName: v.string(),
+      entityType: v.string(),
+      linkCount: v.number(),
+      latestPostedAt: v.number(),
+      postTypes: v.array(v.string()),
+    }),
+  ),
+  handler: async (ctx) => {
+    const links = await ctx.db
+      .query("linkedinArchiveEntityLinks")
+      .collect();
+    const byCompany = new Map<
+      string,
+      { count: number; latestPostedAt: number; postTypes: Set<string> }
+    >();
+    for (const link of links) {
+      const existing = byCompany.get(link.companyId);
+      if (!existing) {
+        byCompany.set(link.companyId, {
+          count: 1,
+          latestPostedAt: link.postedAt,
+          postTypes: new Set([link.postType]),
+        });
+      } else {
+        existing.count += 1;
+        existing.latestPostedAt = Math.max(existing.latestPostedAt, link.postedAt);
+        existing.postTypes.add(link.postType);
+      }
+    }
+    const out: Array<{
+      companyId: Id<"entityContexts">;
+      entityName: string;
+      entityType: string;
+      linkCount: number;
+      latestPostedAt: number;
+      postTypes: string[];
+    }> = [];
+    for (const [companyId, info] of byCompany.entries()) {
+      const entity = await ctx.db.get(companyId as Id<"entityContexts">);
+      if (!entity) continue;
+      out.push({
+        companyId: companyId as Id<"entityContexts">,
+        entityName: entity.entityName,
+        entityType: entity.entityType,
+        linkCount: info.count,
+        latestPostedAt: info.latestPostedAt,
+        postTypes: [...info.postTypes].sort(),
+      });
+    }
+    out.sort((a, b) => b.latestPostedAt - a.latestPostedAt);
+    return out;
+  },
+});
+
+export const getEntityFindings = query({
+  args: {
+    companyId: v.id("entityContexts"),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({
+    entity: v.object({
+      _id: v.id("entityContexts"),
+      entityName: v.string(),
+      entityType: v.string(),
+    }),
+    fundingEvents: v.array(
+      v.object({
+        _id: v.id("fundingEvents"),
+        companyName: v.string(),
+        roundType: v.string(),
+        amountRaw: v.string(),
+        amountUsd: v.optional(v.number()),
+        leadInvestors: v.array(v.string()),
+        sector: v.optional(v.string()),
+        valuation: v.optional(v.string()),
+        sourceUrls: v.array(v.string()),
+        sourceNames: v.array(v.string()),
+        confidence: v.number(),
+        verificationStatus: v.string(),
+        announcedAt: v.number(),
+      }),
+    ),
+    archivePosts: v.array(
+      v.object({
+        _id: v.id("linkedinPostArchive"),
+        dateString: v.string(),
+        postType: v.string(),
+        persona: v.string(),
+        postUrl: v.optional(v.string()),
+        postedAt: v.number(),
+        matchSource: v.string(),
+        contentExcerpt: v.string(),
+        sourceUrls: v.array(v.string()),
+      }),
+    ),
+  }),
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 25;
+    const entity = await ctx.db.get(args.companyId);
+    if (!entity) {
+      throw new Error(`Entity not found: ${args.companyId}`);
+    }
+
+    // ---- Funding events (by direct companyId link if populated, else by name) ----
+    const byIdEvents = await ctx.db
+      .query("fundingEvents")
+      .withIndex("by_companyId", (q) => q.eq("companyId", args.companyId))
+      .collect();
+
+    const normalizedEntity = normalizeForMatch(entity.entityName);
+    let fundingEventDocs = byIdEvents;
+    if (fundingEventDocs.length === 0 && normalizedEntity.length >= 3) {
+      // Cap to a reasonable scan budget — fundingEvents is bounded (~hundreds).
+      const scan = await ctx.db
+        .query("fundingEvents")
+        .withIndex("by_announcedAt")
+        .order("desc")
+        .take(500);
+      fundingEventDocs = scan.filter(
+        (e) => normalizeForMatch(e.companyName) === normalizedEntity,
+      );
+    }
+
+    fundingEventDocs.sort((a, b) => b.announcedAt - a.announcedAt);
+    const fundingEvents = fundingEventDocs.slice(0, limit).map((e) => ({
+      _id: e._id,
+      companyName: e.companyName,
+      roundType: e.roundType,
+      amountRaw: e.amountRaw,
+      amountUsd: e.amountUsd,
+      leadInvestors: e.leadInvestors,
+      sector: e.sector,
+      valuation: e.valuation,
+      sourceUrls: e.sourceUrls,
+      sourceNames: e.sourceNames,
+      confidence: e.confidence,
+      verificationStatus: e.verificationStatus,
+      announcedAt: e.announcedAt,
+    }));
+
+    // ---- Archive posts (via denormalized link table) ----
+    const links = await ctx.db
+      .query("linkedinArchiveEntityLinks")
+      .withIndex("by_company_postedAt", (q) => q.eq("companyId", args.companyId))
+      .order("desc")
+      .take(limit);
+
+    const archivePosts = await Promise.all(
+      links.map(async (link) => {
+        const row = await ctx.db.get(link.archiveRowId);
+        if (!row) return null;
+        const sourceUrls: string[] = [];
+        const rounds: any[] = row.metadata?.findings?.rounds ?? [];
+        for (const round of rounds) {
+          if (Array.isArray(round?.sourceUrls)) {
+            for (const url of round.sourceUrls) {
+              if (typeof url === "string" && url.length > 0 && !sourceUrls.includes(url)) {
+                sourceUrls.push(url);
+              }
+            }
+          }
+        }
+        return {
+          _id: row._id,
+          dateString: row.dateString,
+          postType: row.postType,
+          persona: row.persona,
+          postUrl: row.postUrl,
+          postedAt: row.postedAt,
+          matchSource: link.matchSource,
+          contentExcerpt: row.content.slice(0, 280),
+          sourceUrls: sourceUrls.slice(0, 5),
+        };
+      }),
+    );
+
+    return {
+      entity: {
+        _id: entity._id,
+        entityName: entity.entityName,
+        entityType: entity.entityType,
+      },
+      fundingEvents,
+      archivePosts: archivePosts.filter((p): p is NonNullable<typeof p> => p !== null),
+    };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2235,6 +2235,30 @@ const linkedinPostArchive = defineTable({
   .index("by_target_postedAt", ["target", "postedAt"]);
 
 /* ------------------------------------------------------------------ */
+/* LinkedIn Archive Entity Links — denormalized many-to-many index     */
+/* Each row: (archiveRowId, companyId) with copy of postedAt/postType  */
+/* for cheap reverse lookups: "all posts mentioning entity X".         */
+/* Populated by linkArchiveRowsToEntities + the funding-tracker        */
+/* backfill. Convex doesn't natively index array fields for `contains` */
+/* queries, so we denormalize.                                          */
+/* ------------------------------------------------------------------ */
+const linkedinArchiveEntityLinks = defineTable({
+  archiveRowId: v.id("linkedinPostArchive"),
+  companyId: v.id("entityContexts"),
+  postedAt: v.number(),
+  postType: v.string(),
+  // Soft denormalized fields the UI uses without joining back to the post:
+  dateString: v.string(),
+  matchSource: v.union(
+    v.literal("findings_round"), // matched via metadata.findings.rounds[].companyName
+    v.literal("content_mention"), // matched via plain-text scan of content
+  ),
+})
+  .index("by_company_postedAt", ["companyId", "postedAt"])
+  .index("by_archive_row", ["archiveRowId"])
+  .index("by_archive_company", ["archiveRowId", "companyId"]);
+
+/* ------------------------------------------------------------------ */
 /* LinkedIn Held Posts - Posts blocked by engagement quality gate     */
 /* ------------------------------------------------------------------ */
 const linkedinHeldPosts = defineTable({
@@ -3893,6 +3917,7 @@ export default defineSchema({
   linkedinResearchPosts,
   linkedinMaPosts,
   linkedinPostArchive,
+  linkedinArchiveEntityLinks,
   linkedinHeldPosts,
   linkedinContentQueue,
   userApiKeys,

--- a/convex/workflows/dailyLinkedInPost.ts
+++ b/convex/workflows/dailyLinkedInPost.ts
@@ -4094,6 +4094,12 @@ export const backfillFundingTrackerPosts = internalAction({
             metadataPatch: { findings },
           },
         );
+        // Refresh the entity-link join table so per-entity queries find
+        // this row immediately. Idempotent — diffs against existing links.
+        await ctx.runMutation(
+          internal.domains.social.linkedinArchiveEntityLinks.upsertArchiveRowEntityLinks,
+          { archiveRowId: post._id },
+        );
       }
 
       results.push({

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -51,6 +51,7 @@ import {
 
 import { buildCockpitPath, type CockpitSurfaceId } from "@/lib/registry/viewRegistry";
 import { RichNotebookEditor } from "@/features/notebook/components/RichNotebookEditor";
+import { EntityFindingsPanel } from "@/features/narrative/components/social/EntityFindingsPanel";
 import {
   buildLocalWorkspacePath,
   buildWorkspaceUrl,
@@ -1412,6 +1413,10 @@ export function ExactReportsSurface() {
               <button type="button" data-active={view === "list"} onClick={() => setView("list")}><List size={13} /> List</button>
             </div>
           </div>
+        </div>
+
+        <div data-testid="reports-findings-panel-slot" style={{ marginBottom: 16 }}>
+          <EntityFindingsPanel />
         </div>
 
         <div className="nb-reports-grid" data-view={view}>

--- a/src/features/narrative/components/social/EntityFindingsPanel.tsx
+++ b/src/features/narrative/components/social/EntityFindingsPanel.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useState, useEffect } from "react";
+import { api } from "../../../../../convex/_generated/api";
+import type { Id } from "../../../../../convex/_generated/dataModel";
+import { useStableQuery } from "@/hooks/useStableQuery";
+import { Building2, ExternalLink, FileText } from "lucide-react";
+
+const formatUsd = (amountUsd?: number, fallback?: string): string => {
+  if (typeof amountUsd === "number" && Number.isFinite(amountUsd) && amountUsd > 0) {
+    if (amountUsd >= 1_000_000_000) return `$${(amountUsd / 1_000_000_000).toFixed(1)}B`;
+    if (amountUsd >= 1_000_000) return `$${Math.round(amountUsd / 1_000_000)}M`;
+    if (amountUsd >= 1_000) return `$${Math.round(amountUsd / 1_000)}K`;
+    return `$${amountUsd}`;
+  }
+  return fallback ?? "n/a";
+};
+
+const formatDate = (ms: number) =>
+  new Date(ms).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+
+const POST_TYPE_LABEL: Record<string, string> = {
+  daily_digest: "Daily Digest",
+  funding_tracker: "Funding Tracker",
+  funding_brief: "Funding Brief",
+  fda: "FDA Update",
+  clinical: "Clinical Trial",
+  research: "Research",
+  ma: "Deal",
+};
+
+interface Props {
+  initialEntityId?: string;
+  onEntityChange?: (companyId: string | null) => void;
+}
+
+export const EntityFindingsPanel: React.FC<Props> = ({ initialEntityId, onEntityChange }) => {
+  const [selected, setSelected] = useState<string | null>(initialEntityId ?? null);
+
+  const entities = useStableQuery(
+    api.domains.social.linkedinArchiveEntityLinks.listEntitiesWithArchiveLinks,
+    {},
+  );
+
+  const findings = useStableQuery(
+    api.domains.social.linkedinArchiveEntityLinks.getEntityFindings,
+    selected ? { companyId: selected as Id<"entityContexts">, limit: 25 } : "skip",
+  );
+
+  // Auto-select the first entity once the list loads (so we render something useful by default).
+  useEffect(() => {
+    if (selected) return;
+    if (!entities || entities.length === 0) return;
+    setSelected(entities[0].companyId);
+    onEntityChange?.(entities[0].companyId);
+  }, [entities, selected, onEntityChange]);
+
+  const entityOptions = useMemo(() => entities ?? [], [entities]);
+
+  if (entityOptions.length === 0) {
+    return (
+      <div
+        data-testid="entity-findings-empty"
+        className="nb-surface-card p-4 text-sm text-content-muted"
+      >
+        No entity-linked findings yet. Run{" "}
+        <code className="text-xs">rebuildAllArchiveEntityLinks</code> to populate.
+      </div>
+    );
+  }
+
+  return (
+    <section
+      data-testid="entity-findings-panel"
+      aria-label="Findings by entity"
+      className="nb-surface-card p-4 space-y-4"
+    >
+      <header className="flex items-start justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-md bg-indigo-500/15 flex items-center justify-center">
+            <Building2 className="w-4 h-4 text-indigo-500 dark:text-indigo-300" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-content">Findings by entity</h3>
+            <p className="text-[11px] text-content-muted">
+              Funding events + LinkedIn posts tied to the selected company
+            </p>
+          </div>
+        </div>
+        <label className="flex items-center gap-2 text-xs text-content-muted">
+          <span>Entity</span>
+          <select
+            data-testid="entity-findings-select"
+            className="bg-surface border border-edge rounded-md text-xs px-2 py-1 text-content"
+            value={selected ?? ""}
+            onChange={(e) => {
+              const next = e.target.value || null;
+              setSelected(next);
+              onEntityChange?.(next);
+            }}
+          >
+            {entityOptions.map((entity) => (
+              <option key={entity.companyId} value={entity.companyId}>
+                {entity.entityName} · {entity.linkCount}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      {findings === undefined ? (
+        <div className="text-xs text-content-muted">Loading findings…</div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* Funding events column */}
+            <div>
+              <h4 className="text-[11px] uppercase tracking-[0.2em] text-content-muted mb-2">
+                Funding events
+              </h4>
+              {findings.fundingEvents.length === 0 ? (
+                <p data-testid="entity-findings-no-funding" className="text-xs text-content-muted">
+                  No funding events recorded for {findings.entity.entityName}.
+                </p>
+              ) : (
+                <ul data-testid="entity-findings-funding-list" className="space-y-2">
+                  {findings.fundingEvents.map((event) => (
+                    <li
+                      key={event._id}
+                      data-testid="entity-findings-funding-row"
+                      className="rounded-md border border-edge/60 px-3 py-2 text-xs"
+                    >
+                      <div className="flex items-baseline justify-between gap-2 flex-wrap">
+                        <span className="font-medium text-content">
+                          {formatUsd(event.amountUsd, event.amountRaw)}
+                        </span>
+                        <span className="text-content-muted text-[11px] uppercase tracking-wide">
+                          {event.roundType}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-[11px] text-content-muted">
+                        {formatDate(event.announcedAt)} · {event.verificationStatus}
+                        {event.sector ? ` · ${event.sector}` : ""}
+                      </div>
+                      {event.leadInvestors && event.leadInvestors.length > 0 ? (
+                        <div className="mt-1 text-[11px] text-content-muted">
+                          Leads: {event.leadInvestors.slice(0, 3).join(", ")}
+                        </div>
+                      ) : null}
+                      {event.sourceUrls.length > 0 ? (
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {event.sourceUrls.slice(0, 3).map((url) => (
+                            <a
+                              key={url}
+                              href={url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-[11px] text-indigo-600 dark:text-indigo-300 hover:underline inline-flex items-center gap-1"
+                            >
+                              <ExternalLink className="w-3 h-3" />
+                              source
+                            </a>
+                          ))}
+                        </div>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {/* Archive posts column */}
+            <div>
+              <h4 className="text-[11px] uppercase tracking-[0.2em] text-content-muted mb-2">
+                LinkedIn coverage
+              </h4>
+              {findings.archivePosts.length === 0 ? (
+                <p data-testid="entity-findings-no-posts" className="text-xs text-content-muted">
+                  No LinkedIn posts mention {findings.entity.entityName} yet.
+                </p>
+              ) : (
+                <ul data-testid="entity-findings-post-list" className="space-y-2">
+                  {findings.archivePosts.map((post) => (
+                    <li
+                      key={post._id}
+                      data-testid="entity-findings-post-row"
+                      className="rounded-md border border-edge/60 px-3 py-2 text-xs"
+                    >
+                      <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <span className="font-medium text-content inline-flex items-center gap-1.5">
+                          <FileText className="w-3.5 h-3.5 text-content-muted" />
+                          {POST_TYPE_LABEL[post.postType] ?? post.postType}
+                        </span>
+                        <span className="text-[11px] text-content-muted">
+                          {formatDate(post.postedAt)} · match: {post.matchSource.replace("_", " ")}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-[11px] text-content-muted line-clamp-3">
+                        {post.contentExcerpt}
+                      </p>
+                      {post.sourceUrls.length > 0 ? (
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {post.sourceUrls.slice(0, 3).map((url) => (
+                            <a
+                              key={url}
+                              href={url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-[11px] text-indigo-600 dark:text-indigo-300 hover:underline inline-flex items-center gap-1"
+                            >
+                              <ExternalLink className="w-3 h-3" />
+                              source
+                            </a>
+                          ))}
+                        </div>
+                      ) : null}
+                      {post.postUrl ? (
+                        <a
+                          href={post.postUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-2 inline-flex items-center gap-1 text-[11px] text-indigo-600 dark:text-indigo-300 hover:underline"
+                        >
+                          <ExternalLink className="w-3 h-3" />
+                          View post
+                        </a>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default EntityFindingsPanel;

--- a/src/features/narrative/components/social/LinkedInPostArchiveView.tsx
+++ b/src/features/narrative/components/social/LinkedInPostArchiveView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback } from "react";
 import { api } from "../../../../../convex/_generated/api";
 import { useStableQuery } from "@/hooks/useStableQuery";
 import { LinkedInPostCard } from "./LinkedInPostCard";
+import { EntityFindingsPanel } from "./EntityFindingsPanel";
 import {
   Linkedin,
   Filter,
@@ -167,6 +168,11 @@ export const LinkedInPostArchiveView: React.FC = () => {
             })}
           </div>
         </div>
+      </div>
+
+      {/* Findings by entity (cheap retrieval substrate for chat) */}
+      <div className="px-4 pt-6">
+        <EntityFindingsPanel />
       </div>
 
       {/* Content */}


### PR DESCRIPTION
## Summary
Closes the entity-linkage gap behind "show findings on the report page". Adds a new schema-backed join table, four queries, and a UI panel mounted on the Reports surface.

Live-verified on `/?surface=packets`:
- OpenAI: 2 funding events ($110B + $6.6B) and 7 daily_digest posts spanning Mar 8 - Apr 3, 2026
- Google: 6 posts. Anthropic: 4 posts.
- 17 entity links created across 13 archive rows by the rebuild action

## What landed

**Schema** (`convex/schema.ts`)
- New `linkedinArchiveEntityLinks` table with `by_company_postedAt`, `by_archive_row`, `by_archive_company` indexes. Convex doesn't index array fields for "contains" queries, so we denormalize one row per `(archiveRow, entity)` pair.

**Backend** (`convex/domains/social/linkedinArchiveEntityLinks.ts`)
- `upsertArchiveRowEntityLinks` — internal mutation, idempotent diff-based, scans `content` + `metadata.findings.rounds[].companyName` for entity mentions (normalized + word-boundary regex).
- `rebuildAllArchiveEntityLinks` — one-shot full rebuild action.
- `listEntitiesWithArchiveLinks` — public query returning entities with link counts.
- `getEntityFindings` — public query joining `fundingEvents.by_companyId` (with normalized-name fallback for legacy events lacking `companyId`) + archive posts via the new index.

**Backfill integration** (`convex/workflows/dailyLinkedInPost.ts`)
- `backfillFundingTrackerPosts` now calls `upsertArchiveRowEntityLinks` after each content patch — re-runs keep links in sync.

**UI** (`src/features/narrative/components/social/EntityFindingsPanel.tsx`, mounted on `ExactReportsSurface`)
- Entity selector + dual column (Funding events / LinkedIn coverage) with source URLs + verification status.
- Cheap retrieval — single Convex query, no LLM, no parsing of stored prose.

## Test plan
- [ ] On `/?surface=packets`, verify the "Findings by entity" panel renders above the report grid
- [ ] Confirm the entity selector defaults to the most-recent entity
- [ ] Switch entities — funding + posts list updates
- [ ] Source links open in new tab and resolve
- [ ] After backfill re-runs, `linkedinArchiveEntityLinks` row counts are stable (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)