### PR TITLE
feat(entities): promote startups + digest spotlights; tighten link matching

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -418,6 +418,7 @@ import type * as domains_enrichment_deleteDuplicates from "../domains/enrichment
 import type * as domains_enrichment_documentStore from "../domains/enrichment/documentStore.js";
 import type * as domains_enrichment_enrichmentQueue from "../domains/enrichment/enrichmentQueue.js";
 import type * as domains_enrichment_enrichmentWorker from "../domains/enrichment/enrichmentWorker.js";
+import type * as domains_enrichment_entityBackfill from "../domains/enrichment/entityBackfill.js";
 import type * as domains_enrichment_entityLinkingJudge from "../domains/enrichment/entityLinkingJudge.js";
 import type * as domains_enrichment_entityLinkingMutations from "../domains/enrichment/entityLinkingMutations.js";
 import type * as domains_enrichment_entityLinkingQueries from "../domains/enrichment/entityLinkingQueries.js";
@@ -1871,6 +1872,7 @@ declare const fullApi: ApiFromModules<{
   "domains/enrichment/documentStore": typeof domains_enrichment_documentStore;
   "domains/enrichment/enrichmentQueue": typeof domains_enrichment_enrichmentQueue;
   "domains/enrichment/enrichmentWorker": typeof domains_enrichment_enrichmentWorker;
+  "domains/enrichment/entityBackfill": typeof domains_enrichment_entityBackfill;
   "domains/enrichment/entityLinkingJudge": typeof domains_enrichment_entityLinkingJudge;
   "domains/enrichment/entityLinkingMutations": typeof domains_enrichment_entityLinkingMutations;
   "domains/enrichment/entityLinkingQueries": typeof domains_enrichment_entityLinkingQueries;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1184,6 +1184,7 @@ import type * as domains_social_linkedinArchiveCleanup from "../domains/social/l
 import type * as domains_social_linkedinArchiveCleanupMutations from "../domains/social/linkedinArchiveCleanupMutations.js";
 import type * as domains_social_linkedinArchiveEdits from "../domains/social/linkedinArchiveEdits.js";
 import type * as domains_social_linkedinArchiveEditsMutations from "../domains/social/linkedinArchiveEditsMutations.js";
+import type * as domains_social_linkedinArchiveEntityLinks from "../domains/social/linkedinArchiveEntityLinks.js";
 import type * as domains_social_linkedinArchiveMaintenance from "../domains/social/linkedinArchiveMaintenance.js";
 import type * as domains_social_linkedinArchiveMaintenanceQueries from "../domains/social/linkedinArchiveMaintenanceQueries.js";
 import type * as domains_social_linkedinArchivePurge from "../domains/social/linkedinArchivePurge.js";
@@ -2636,6 +2637,7 @@ declare const fullApi: ApiFromModules<{
   "domains/social/linkedinArchiveCleanupMutations": typeof domains_social_linkedinArchiveCleanupMutations;
   "domains/social/linkedinArchiveEdits": typeof domains_social_linkedinArchiveEdits;
   "domains/social/linkedinArchiveEditsMutations": typeof domains_social_linkedinArchiveEditsMutations;
+  "domains/social/linkedinArchiveEntityLinks": typeof domains_social_linkedinArchiveEntityLinks;
   "domains/social/linkedinArchiveMaintenance": typeof domains_social_linkedinArchiveMaintenance;
   "domains/social/linkedinArchiveMaintenanceQueries": typeof domains_social_linkedinArchiveMaintenanceQueries;
   "domains/social/linkedinArchivePurge": typeof domains_social_linkedinArchivePurge;

--- a/convex/domains/enrichment/entityBackfill.ts
+++ b/convex/domains/enrichment/entityBackfill.ts
@@ -638,6 +638,86 @@ export const backfillEntityContextsCanonicalKey = internalMutation({
   },
 });
 
+/**
+ * Repair pass: ensure every canonicalKey has exactly one non-stale
+ * representative. The earlier `backfillEntityContextsCanonicalKey`
+ * could over-stale (a re-run that processes already-stale rows skips
+ * them, but a row marked stale on a previous run never gets un-staled
+ * even when no other live row exists for its canonicalKey). This
+ * mutation walks all rows, groups by canonicalKey, keeps the earliest
+ * non-stale-or-stale row alive, and marks everything else stale.
+ */
+export const repairEntityCanonicalDedup = internalMutation({
+  args: {},
+  returns: v.object({
+    totalRows: v.number(),
+    keysSeen: v.number(),
+    revived: v.number(),
+    markedStale: v.number(),
+    sample: v.array(v.string()),
+  }),
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("entityContexts").collect();
+    rows.sort((a, b) => a._creationTime - b._creationTime);
+
+    const groups = new Map<
+      string,
+      Array<{ id: Id<"entityContexts">; isStale: boolean; ts: number }>
+    >();
+
+    for (const row of rows) {
+      const key =
+        row.canonicalKey ??
+        buildCanonicalKey(
+          row.entityType as "company" | "person",
+          row.entityName,
+        );
+      const arr = groups.get(key) ?? [];
+      arr.push({
+        id: row._id,
+        isStale: row.isStale === true,
+        ts: row._creationTime,
+      });
+      groups.set(key, arr);
+    }
+
+    let revived = 0;
+    let markedStale = 0;
+    const sample: string[] = [];
+
+    for (const [key, members] of groups.entries()) {
+      members.sort((a, b) => a.ts - b.ts);
+      const winner = members[0];
+      if (winner.isStale) {
+        await ctx.db.patch(winner.id, { isStale: false, canonicalKey: key });
+        revived += 1;
+        if (sample.length < 12) sample.push(`revived ${key}`);
+      } else if (members.length > 0) {
+        // ensure canonicalKey is set even if it was undefined
+        const row = await ctx.db.get(winner.id);
+        if (row && row.canonicalKey !== key) {
+          await ctx.db.patch(winner.id, { canonicalKey: key });
+        }
+      }
+      for (let i = 1; i < members.length; i++) {
+        const m = members[i];
+        if (!m.isStale) {
+          await ctx.db.patch(m.id, { isStale: true, canonicalKey: key });
+          markedStale += 1;
+        }
+      }
+    }
+
+    return {
+      totalRows: rows.length,
+      keysSeen: groups.size,
+      revived,
+      markedStale,
+      sample,
+    };
+  },
+});
+
 /* -------------------------------------------------------------------------- */
 /*  Combined: full backfill + relink                                           */
 /* -------------------------------------------------------------------------- */

--- a/convex/domains/enrichment/entityBackfill.ts
+++ b/convex/domains/enrichment/entityBackfill.ts
@@ -1,0 +1,678 @@
+/**
+ * Entity Backfill
+ *
+ * Promotes startups (from `fundingEvents`) and digest-spotlight entities
+ * (from `digestCache.digest.entitySpotlight`) into `entityContexts` so the
+ * `linkedinArchiveEntityLinks` join table picks them up on the next
+ * rebuild. Fixes the orphan-row gap where 19/32 archive rows had no
+ * matching `entityContexts` because the entity registry was hand-curated.
+ *
+ * Idempotent: keyed by `canonicalKey` (`buildCanonicalKey(type, name)`).
+ * Re-runs upsert in place rather than creating duplicates.
+ *
+ * Note: replaces the legacy `entityPromotion.ts` createEntityFromFunding
+ * mutation, which writes fields that no longer exist in the schema
+ * (`name`, `status`, `priority`, `sector` at top level — schema has
+ * `entityName`, `crmFields.industry`, etc.).
+ */
+
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import { buildCanonicalKey } from "../../lib/entityResolution";
+
+/* -------------------------------------------------------------------------- */
+/*  Helpers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function normalizeForMatch(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[‘’“”'"`]/g, "")
+    .replace(/,?\s+(inc\.?|llc|ltd\.?|corp\.?|corporation|co\.?)$/i, "")
+    .replace(/[–—\-]/g, " ")
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isGenericName(name: string | undefined | null): boolean {
+  if (!name) return true;
+  const n = name.trim().toLowerCase();
+  if (n.length < 2) return true;
+  if (
+    n === "unknown" ||
+    n === "company" ||
+    n === "n/a" ||
+    n === "tbd" ||
+    n.startsWith("unknown ") ||
+    /^(seed|series\s*[a-z]|growth|debt)$/i.test(n)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function formatUsd(amountUsd?: number, fallback?: string): string {
+  if (typeof amountUsd === "number" && Number.isFinite(amountUsd) && amountUsd > 0) {
+    if (amountUsd >= 1_000_000_000) return `$${(amountUsd / 1_000_000_000).toFixed(1)}B`;
+    if (amountUsd >= 1_000_000) return `$${Math.round(amountUsd / 1_000_000)}M`;
+    if (amountUsd >= 1_000) return `$${Math.round(amountUsd / 1_000)}K`;
+    return `$${amountUsd}`;
+  }
+  return fallback ?? "n/a";
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Path 1: Funding events → entityContexts                                    */
+/* -------------------------------------------------------------------------- */
+
+export const upsertEntityFromFunding = internalMutation({
+  args: {
+    fundingEventId: v.id("fundingEvents"),
+  },
+  returns: v.object({
+    fundingEventId: v.id("fundingEvents"),
+    companyId: v.optional(v.id("entityContexts")),
+    created: v.boolean(),
+    skipped: v.boolean(),
+    skipReason: v.optional(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const event = await ctx.db.get(args.fundingEventId);
+    if (!event) {
+      return {
+        fundingEventId: args.fundingEventId,
+        companyId: undefined,
+        created: false,
+        skipped: true,
+        skipReason: "funding_event_not_found",
+      };
+    }
+    if (isGenericName(event.companyName)) {
+      return {
+        fundingEventId: args.fundingEventId,
+        companyId: undefined,
+        created: false,
+        skipped: true,
+        skipReason: "generic_company_name",
+      };
+    }
+
+    const canonicalKey = buildCanonicalKey("company", event.companyName);
+
+    // Already linked → just confirm and exit.
+    if (event.companyId) {
+      return {
+        fundingEventId: args.fundingEventId,
+        companyId: event.companyId,
+        created: false,
+        skipped: true,
+        skipReason: "already_linked",
+      };
+    }
+
+    const existing = await ctx.db
+      .query("entityContexts")
+      .withIndex("by_canonicalKey", (q) => q.eq("canonicalKey", canonicalKey))
+      .first();
+
+    let entityId: Id<"entityContexts">;
+    let created = false;
+
+    if (existing) {
+      entityId = existing._id;
+      // Refresh access metadata so the freshness signal is honest.
+      await ctx.db.patch(entityId, {
+        lastAccessedAt: Date.now(),
+        accessCount: (existing.accessCount ?? 0) + 1,
+      });
+    } else {
+      const now = Date.now();
+      const summary =
+        event.description && event.description.trim().length > 0
+          ? event.description.trim()
+          : `${event.companyName} raised ${formatUsd(event.amountUsd, event.amountRaw)} (${event.roundType}).`;
+      const sources = (event.sourceUrls ?? []).slice(0, 5).map((url, i) => ({
+        name: event.sourceNames?.[i] ?? "source",
+        url,
+      }));
+      const keyFacts: string[] = [];
+      keyFacts.push(`${event.roundType} round: ${formatUsd(event.amountUsd, event.amountRaw)}`);
+      if (event.sector) keyFacts.push(`Sector: ${event.sector}`);
+      if (event.location) keyFacts.push(`Location: ${event.location}`);
+      if (event.valuation) keyFacts.push(`Valuation: ${event.valuation}`);
+      if (Array.isArray(event.leadInvestors) && event.leadInvestors.length > 0) {
+        keyFacts.push(`Lead investors: ${event.leadInvestors.slice(0, 3).join(", ")}`);
+      }
+
+      entityId = await ctx.db.insert("entityContexts", {
+        entityName: event.companyName,
+        entityType: "company",
+        summary,
+        keyFacts,
+        sources,
+        crmFields: {
+          companyName: event.companyName,
+          description:
+            event.description && event.description.trim().length > 0
+              ? event.description
+              : "",
+          headline: "",
+          hqLocation: event.location ?? "",
+          city: "",
+          state: "",
+          country: "",
+          website: "",
+          email: "",
+          phone: "",
+          founders: [],
+          foundersBackground: "",
+          keyPeople: [],
+          industry: event.sector ?? "",
+          companyType: "",
+          foundingYear: undefined,
+          product: "",
+          targetMarket: "",
+          businessModel: "",
+          fundingStage: event.roundType,
+          totalFunding: formatUsd(event.amountUsd, event.amountRaw),
+          lastFundingDate: new Date(event.announcedAt).toISOString().split("T")[0],
+          investors: event.leadInvestors ?? [],
+          investorBackground: "",
+          competitors: [],
+          competitorAnalysis: "",
+          fdaApprovalStatus: "",
+          fdaTimeline: "",
+          newsTimeline: [],
+          recentNews: "",
+          keyEntities: [],
+          researchPapers: [],
+          partnerships: [],
+          completenessScore: 25,
+          dataQuality: "incomplete",
+        },
+        canonicalKey,
+        researchedAt: now,
+        researchedBy: undefined,
+        lastAccessedAt: now,
+        accessCount: 1,
+        version: 1,
+        isStale: false,
+        ingestedAt: now,
+      });
+      created = true;
+    }
+
+    // Patch the funding event so future per-entity queries hit the
+    // by_companyId index instead of the normalized-name fallback.
+    await ctx.db.patch(args.fundingEventId, { companyId: entityId });
+
+    return {
+      fundingEventId: args.fundingEventId,
+      companyId: entityId,
+      created,
+      skipped: false,
+      skipReason: undefined,
+    };
+  },
+});
+
+export const listFundingEventsForBackfill = internalQuery({
+  args: {},
+  returns: v.array(
+    v.object({
+      _id: v.id("fundingEvents"),
+      companyName: v.string(),
+      hasCompanyId: v.boolean(),
+    }),
+  ),
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("fundingEvents").collect();
+    return rows.map((r) => ({
+      _id: r._id,
+      companyName: r.companyName,
+      hasCompanyId: !!r.companyId,
+    }));
+  },
+});
+
+export const promoteFundingEventsToEntities = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun ?? true;
+    const limit = args.limit ?? 1000;
+
+    const events = await ctx.runQuery(
+      internal.domains.enrichment.entityBackfill.listFundingEventsForBackfill,
+      {},
+    );
+
+    let created = 0;
+    let linkedExisting = 0;
+    let skipped = 0;
+    const sample: Array<{ fundingEventId: string; status: string }> = [];
+
+    for (const event of events.slice(0, limit)) {
+      if (dryRun) {
+        sample.push({
+          fundingEventId: event._id,
+          status: event.hasCompanyId
+            ? "would_skip_already_linked"
+            : isGenericName(event.companyName)
+              ? "would_skip_generic"
+              : "would_create_or_link",
+        });
+        if (event.hasCompanyId || isGenericName(event.companyName)) {
+          skipped += 1;
+        } else {
+          created += 1;
+        }
+        continue;
+      }
+
+      const result = await ctx.runMutation(
+        internal.domains.enrichment.entityBackfill.upsertEntityFromFunding,
+        { fundingEventId: event._id },
+      );
+      if (result.skipped) {
+        skipped += 1;
+      } else if (result.created) {
+        created += 1;
+      } else {
+        linkedExisting += 1;
+      }
+      if (sample.length < 10) {
+        sample.push({
+          fundingEventId: event._id,
+          status: result.skipped
+            ? `skipped:${result.skipReason}`
+            : result.created
+              ? "created"
+              : "linked_existing",
+        });
+      }
+    }
+
+    const summary = {
+      totalEvents: events.length,
+      considered: Math.min(events.length, limit),
+      created,
+      linkedExisting,
+      skipped,
+      dryRun,
+    };
+    console.log(`[entityBackfill:funding] ${JSON.stringify(summary)}`);
+    return { summary, sample };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Path 2: digestCache.entitySpotlight → entityContexts                       */
+/* -------------------------------------------------------------------------- */
+
+export const upsertEntityFromDigestSpotlight = internalMutation({
+  args: {
+    name: v.string(),
+    type: v.string(),
+    keyInsight: v.string(),
+    fundingStage: v.optional(v.string()),
+    sourceDateString: v.string(),
+  },
+  returns: v.object({
+    name: v.string(),
+    companyId: v.optional(v.id("entityContexts")),
+    created: v.boolean(),
+    skipped: v.boolean(),
+    skipReason: v.optional(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    if (isGenericName(args.name)) {
+      return {
+        name: args.name,
+        companyId: undefined,
+        created: false,
+        skipped: true,
+        skipReason: "generic_name",
+      };
+    }
+
+    // The digest agent emits entityType strings like "company", "person",
+    // "biotech", "tech". Normalize to the schema's two-value union.
+    const entityType: "company" | "person" =
+      args.type.toLowerCase().includes("person") || args.type.toLowerCase().includes("founder")
+        ? "person"
+        : "company";
+
+    const canonicalKey = buildCanonicalKey(entityType, args.name);
+
+    const existing = await ctx.db
+      .query("entityContexts")
+      .withIndex("by_canonicalKey", (q) => q.eq("canonicalKey", canonicalKey))
+      .first();
+
+    if (existing) {
+      // Append the insight as a new keyFact if not already present.
+      const insight = args.keyInsight.trim();
+      const facts = existing.keyFacts ?? [];
+      const alreadyHas = facts.some(
+        (f) => normalizeForMatch(f) === normalizeForMatch(insight),
+      );
+      const nextFacts = alreadyHas ? facts : [...facts, insight].slice(-10);
+      await ctx.db.patch(existing._id, {
+        keyFacts: nextFacts,
+        lastAccessedAt: Date.now(),
+        accessCount: (existing.accessCount ?? 0) + 1,
+      });
+      return {
+        name: args.name,
+        companyId: existing._id,
+        created: false,
+        skipped: false,
+        skipReason: undefined,
+      };
+    }
+
+    const now = Date.now();
+    const entityId = await ctx.db.insert("entityContexts", {
+      entityName: args.name,
+      entityType,
+      summary: args.keyInsight.trim() || `${args.name} — observed in ${args.sourceDateString} digest.`,
+      keyFacts: args.fundingStage ? [args.keyInsight, `Stage: ${args.fundingStage}`] : [args.keyInsight],
+      sources: [],
+      crmFields:
+        entityType === "company"
+          ? {
+              companyName: args.name,
+              description: args.keyInsight.trim(),
+              headline: "",
+              hqLocation: "",
+              city: "",
+              state: "",
+              country: "",
+              website: "",
+              email: "",
+              phone: "",
+              founders: [],
+              foundersBackground: "",
+              keyPeople: [],
+              industry: "",
+              companyType: "",
+              foundingYear: undefined,
+              product: "",
+              targetMarket: "",
+              businessModel: "",
+              fundingStage: args.fundingStage ?? "",
+              totalFunding: "",
+              lastFundingDate: "",
+              investors: [],
+              investorBackground: "",
+              competitors: [],
+              competitorAnalysis: "",
+              fdaApprovalStatus: "",
+              fdaTimeline: "",
+              newsTimeline: [],
+              recentNews: "",
+              keyEntities: [],
+              researchPapers: [],
+              partnerships: [],
+              completenessScore: 15,
+              dataQuality: "incomplete",
+            }
+          : undefined,
+      canonicalKey,
+      researchedAt: now,
+      researchedBy: undefined,
+      lastAccessedAt: now,
+      accessCount: 1,
+      version: 1,
+      isStale: false,
+      ingestedAt: now,
+    });
+
+    return {
+      name: args.name,
+      companyId: entityId,
+      created: true,
+      skipped: false,
+      skipReason: undefined,
+    };
+  },
+});
+
+export const listDigestSpotlightForBackfill = internalQuery({
+  args: {},
+  returns: v.array(
+    v.object({
+      dateString: v.string(),
+      spotlight: v.array(
+        v.object({
+          name: v.string(),
+          type: v.string(),
+          keyInsight: v.string(),
+          fundingStage: v.optional(v.string()),
+        }),
+      ),
+    }),
+  ),
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("digestCache").collect();
+    return rows
+      .map((r) => ({
+        dateString: r.dateString,
+        spotlight: r.digest?.entitySpotlight ?? [],
+      }))
+      .filter((r) => r.spotlight.length > 0);
+  },
+});
+
+export const promoteDigestEntitiesToEntities = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun ?? true;
+    const rows = await ctx.runQuery(
+      internal.domains.enrichment.entityBackfill.listDigestSpotlightForBackfill,
+      {},
+    );
+
+    // Deduplicate by (entityType, normalized name) — the digest agent
+    // emits the same entity in multiple cached digests.
+    const seen = new Map<
+      string,
+      {
+        name: string;
+        type: string;
+        keyInsight: string;
+        fundingStage?: string;
+        sourceDateString: string;
+      }
+    >();
+    for (const row of rows) {
+      for (const entity of row.spotlight) {
+        if (isGenericName(entity.name)) continue;
+        const entityType: "company" | "person" = entity.type
+          .toLowerCase()
+          .includes("person")
+          ? "person"
+          : "company";
+        const key = `${entityType}:${normalizeForMatch(entity.name)}`;
+        if (!seen.has(key)) {
+          seen.set(key, {
+            name: entity.name,
+            type: entity.type,
+            keyInsight: entity.keyInsight,
+            fundingStage: entity.fundingStage,
+            sourceDateString: row.dateString,
+          });
+        }
+      }
+    }
+
+    let created = 0;
+    let linkedExisting = 0;
+    let skipped = 0;
+    const sample: Array<{ name: string; status: string }> = [];
+
+    for (const [, entity] of seen) {
+      if (dryRun) {
+        sample.push({ name: entity.name, status: "would_create_or_link" });
+        created += 1;
+        continue;
+      }
+      const result = await ctx.runMutation(
+        internal.domains.enrichment.entityBackfill.upsertEntityFromDigestSpotlight,
+        {
+          name: entity.name,
+          type: entity.type,
+          keyInsight: entity.keyInsight,
+          fundingStage: entity.fundingStage,
+          sourceDateString: entity.sourceDateString,
+        },
+      );
+      if (result.skipped) skipped += 1;
+      else if (result.created) created += 1;
+      else linkedExisting += 1;
+      if (sample.length < 10) {
+        sample.push({
+          name: entity.name,
+          status: result.skipped
+            ? `skipped:${result.skipReason}`
+            : result.created
+              ? "created"
+              : "linked_existing",
+        });
+      }
+    }
+
+    const summary = {
+      digestsScanned: rows.length,
+      uniqueEntities: seen.size,
+      created,
+      linkedExisting,
+      skipped,
+      dryRun,
+    };
+    console.log(`[entityBackfill:digest] ${JSON.stringify(summary)}`);
+    return { summary, sample };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Path 3: backfill canonicalKey on legacy entityContexts                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Some legacy entityContexts rows (created before canonicalKey was added
+ * to the schema) lack the field, so the `by_canonicalKey` upsert path
+ * misses them and creates duplicates. Walk all rows, fill in
+ * canonicalKey where absent — keyed by (entityType, entityName).
+ *
+ * If two rows hash to the same canonicalKey, keep the earlier one and
+ * mark the later as `isStale: true` so it's de-prioritized in the UI
+ * (we don't delete — that would break inbound foreign keys).
+ */
+export const backfillEntityContextsCanonicalKey = internalMutation({
+  args: {},
+  returns: v.object({
+    totalRows: v.number(),
+    patched: v.number(),
+    duplicateMarkedStale: v.number(),
+    sample: v.array(v.string()),
+  }),
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("entityContexts").collect();
+    const byKey = new Map<string, Id<"entityContexts">>();
+    let patched = 0;
+    let duplicateMarkedStale = 0;
+    const sample: string[] = [];
+
+    // Sort by creation time so the earliest row wins on collision.
+    rows.sort((a, b) => a._creationTime - b._creationTime);
+
+    for (const row of rows) {
+      const wantedKey = buildCanonicalKey(
+        row.entityType as "company" | "person",
+        row.entityName,
+      );
+      const existing = byKey.get(wantedKey);
+      if (existing) {
+        // Duplicate — mark as stale.
+        if (!row.isStale) {
+          await ctx.db.patch(row._id, {
+            isStale: true,
+            canonicalKey: row.canonicalKey ?? wantedKey,
+          });
+          duplicateMarkedStale += 1;
+          if (sample.length < 10) {
+            sample.push(`stale_dup ${row.entityName} (${row._id})`);
+          }
+        }
+        continue;
+      }
+      byKey.set(wantedKey, row._id);
+      if (row.canonicalKey !== wantedKey) {
+        await ctx.db.patch(row._id, { canonicalKey: wantedKey });
+        patched += 1;
+        if (sample.length < 10) {
+          sample.push(`patched ${row.entityName} → ${wantedKey}`);
+        }
+      }
+    }
+
+    return {
+      totalRows: rows.length,
+      patched,
+      duplicateMarkedStale,
+      sample,
+    };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Combined: full backfill + relink                                           */
+/* -------------------------------------------------------------------------- */
+
+export const fullEntityBackfillAndRelink = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun ?? true;
+    // Step 0: canonicalKey backfill — ensures the upsert path dedupes
+    // against legacy rows (Google, etc.) that were created before
+    // canonicalKey was added to the schema.
+    let canonical: any = null;
+    if (!dryRun) {
+      canonical = await ctx.runMutation(
+        internal.domains.enrichment.entityBackfill.backfillEntityContextsCanonicalKey,
+        {},
+      );
+    }
+    const funding = await ctx.runAction(
+      internal.domains.enrichment.entityBackfill.promoteFundingEventsToEntities,
+      { dryRun },
+    );
+    const digest = await ctx.runAction(
+      internal.domains.enrichment.entityBackfill.promoteDigestEntitiesToEntities,
+      { dryRun },
+    );
+    let relink: any = null;
+    if (!dryRun) {
+      relink = await ctx.runAction(
+        internal.domains.social.linkedinArchiveEntityLinks.rebuildAllArchiveEntityLinks,
+        { dryRun: false },
+      );
+    }
+    return { canonical, funding, digest, relink, dryRun };
+  },
+});

--- a/convex/domains/social/linkedinArchiveEntityLinks.ts
+++ b/convex/domains/social/linkedinArchiveEntityLinks.ts
@@ -1,0 +1,487 @@
+/**
+ * Linkedin Archive Entity Links
+ *
+ * Denormalized many-to-many between `linkedinPostArchive` and
+ * `entityContexts`. Convex doesn't index array fields for `contains`
+ * queries, so we materialize one row per `(archiveRow, entity)` pair to
+ * make per-entity retrieval cheap (single `withIndex("by_company_postedAt")`
+ * call instead of an O(N) scan).
+ *
+ * Pattern: scratchpad-first → structuring → join-table compaction.
+ * Prior art: Anthropic Claude Code MEMORY.md (file-system layered memory),
+ * generic Convex many-to-many denormalization.
+ *
+ * Populated by:
+ *   - rebuildAllArchiveEntityLinks (one-shot full rebuild from scratch)
+ *   - upsertArchiveRowEntityLinks  (per-row, called by the funding backfill)
+ *
+ * Read by:
+ *   - getEntityFindings (public, EntityPage / report cards)
+ */
+
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+  query,
+} from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+import { internal } from "../../_generated/api";
+
+/**
+ * Normalize a name for case-insensitive substring matching.
+ *  - Lowercase
+ *  - Strip punctuation that the digest agent or LLMs add (.,!?:;'"`)
+ *  - Collapse whitespace
+ *  - Strip common suffixes like ", Inc." that wouldn't appear in casual mentions
+ */
+function normalizeForMatch(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[‘’“”'"`]/g, "")
+    .replace(/,?\s+(inc\.?|llc|ltd\.?|corp\.?|corporation|co\.?)$/i, "")
+    .replace(/[–—\-]/g, " ")
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Word-boundary regex for an entity name. Required so "Google" doesn't
+ * match "Googleplex" and "MCP" doesn't match arbitrary letter sequences.
+ */
+function entityRegex(entityName: string): RegExp {
+  const escaped = entityName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|[^a-zA-Z0-9])${escaped}([^a-zA-Z0-9]|$)`, "i");
+}
+
+type LinkPlan = {
+  companyId: Id<"entityContexts">;
+  matchSource: "findings_round" | "content_mention";
+};
+
+function planLinksForRow(
+  row: {
+    content: string;
+    metadata?: any;
+  },
+  entities: Array<{
+    _id: Id<"entityContexts">;
+    entityName: string;
+    normalized: string;
+    regex: RegExp;
+  }>,
+): LinkPlan[] {
+  const plans = new Map<string, LinkPlan>();
+
+  // 1) Findings rounds (highest signal — the post is literally about this round)
+  const rounds: any[] = row.metadata?.findings?.rounds ?? [];
+  for (const round of rounds) {
+    const roundCompany = typeof round?.companyName === "string" ? round.companyName : "";
+    const roundCompanyId = round?.companyId;
+    if (typeof roundCompanyId === "string" && roundCompanyId.length > 0) {
+      // Direct ID — trust it.
+      plans.set(roundCompanyId, {
+        companyId: roundCompanyId as Id<"entityContexts">,
+        matchSource: "findings_round",
+      });
+      continue;
+    }
+    if (!roundCompany) continue;
+    const roundNormalized = normalizeForMatch(roundCompany);
+    if (!roundNormalized) continue;
+    for (const entity of entities) {
+      if (
+        roundNormalized === entity.normalized ||
+        roundNormalized.includes(entity.normalized) ||
+        entity.normalized.includes(roundNormalized)
+      ) {
+        if (!plans.has(entity._id)) {
+          plans.set(entity._id, { companyId: entity._id, matchSource: "findings_round" });
+        }
+      }
+    }
+  }
+
+  // 2) Plain-text mention scan (covers daily_digest signals and prose)
+  for (const entity of entities) {
+    if (plans.has(entity._id)) continue;
+    if (entity.regex.test(row.content)) {
+      plans.set(entity._id, { companyId: entity._id, matchSource: "content_mention" });
+    }
+  }
+
+  return [...plans.values()];
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Mutation: upsert links for a single archive row                            */
+/* -------------------------------------------------------------------------- */
+
+export const upsertArchiveRowEntityLinks = internalMutation({
+  args: {
+    archiveRowId: v.id("linkedinPostArchive"),
+  },
+  returns: v.object({
+    archiveRowId: v.id("linkedinPostArchive"),
+    linksCreated: v.number(),
+    linksDeleted: v.number(),
+    linksKept: v.number(),
+    matchedEntityIds: v.array(v.id("entityContexts")),
+  }),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.archiveRowId);
+    if (!row) {
+      return {
+        archiveRowId: args.archiveRowId,
+        linksCreated: 0,
+        linksDeleted: 0,
+        linksKept: 0,
+        matchedEntityIds: [],
+      };
+    }
+
+    const entityDocs = await ctx.db.query("entityContexts").collect();
+    const entities = entityDocs.map((e) => ({
+      _id: e._id,
+      entityName: e.entityName,
+      normalized: normalizeForMatch(e.entityName),
+      regex: entityRegex(e.entityName),
+    }));
+
+    const desired = planLinksForRow({ content: row.content, metadata: row.metadata }, entities);
+    const desiredById = new Map(desired.map((p) => [p.companyId, p]));
+
+    const existing = await ctx.db
+      .query("linkedinArchiveEntityLinks")
+      .withIndex("by_archive_row", (q) => q.eq("archiveRowId", args.archiveRowId))
+      .collect();
+
+    let linksCreated = 0;
+    let linksDeleted = 0;
+    let linksKept = 0;
+
+    // Delete stale, keep valid.
+    for (const link of existing) {
+      const want = desiredById.get(link.companyId);
+      if (!want) {
+        await ctx.db.delete(link._id);
+        linksDeleted += 1;
+        continue;
+      }
+      if (link.matchSource !== want.matchSource || link.postedAt !== row.postedAt) {
+        await ctx.db.patch(link._id, {
+          matchSource: want.matchSource,
+          postedAt: row.postedAt,
+          postType: row.postType,
+          dateString: row.dateString,
+        });
+      }
+      desiredById.delete(link.companyId);
+      linksKept += 1;
+    }
+
+    // Insert remaining desired links.
+    for (const plan of desiredById.values()) {
+      await ctx.db.insert("linkedinArchiveEntityLinks", {
+        archiveRowId: args.archiveRowId,
+        companyId: plan.companyId,
+        postedAt: row.postedAt,
+        postType: row.postType,
+        dateString: row.dateString,
+        matchSource: plan.matchSource,
+      });
+      linksCreated += 1;
+    }
+
+    return {
+      archiveRowId: args.archiveRowId,
+      linksCreated,
+      linksDeleted,
+      linksKept,
+      matchedEntityIds: desired.map((d) => d.companyId),
+    };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Internal queries                                                           */
+/* -------------------------------------------------------------------------- */
+
+export const getAllArchiveRowsForLinking = internalQuery({
+  args: {},
+  returns: v.array(
+    v.object({
+      _id: v.id("linkedinPostArchive"),
+      content: v.string(),
+      metadata: v.optional(v.any()),
+      postedAt: v.number(),
+      postType: v.string(),
+      dateString: v.string(),
+    }),
+  ),
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("linkedinPostArchive").collect();
+    return rows.map((r) => ({
+      _id: r._id,
+      content: r.content,
+      metadata: r.metadata,
+      postedAt: r.postedAt,
+      postType: r.postType,
+      dateString: r.dateString,
+    }));
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Action: rebuild all links from scratch                                     */
+/* -------------------------------------------------------------------------- */
+
+export const rebuildAllArchiveEntityLinks = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun ?? true;
+    const rows = await ctx.runQuery(
+      internal.domains.social.linkedinArchiveEntityLinks.getAllArchiveRowsForLinking,
+      {},
+    );
+
+    let created = 0;
+    let deleted = 0;
+    let kept = 0;
+    const perRow: Array<{ id: string; matched: number }> = [];
+
+    for (const row of rows) {
+      if (dryRun) {
+        perRow.push({ id: row._id, matched: 0 });
+        continue;
+      }
+      const result = await ctx.runMutation(
+        internal.domains.social.linkedinArchiveEntityLinks.upsertArchiveRowEntityLinks,
+        { archiveRowId: row._id },
+      );
+      created += result.linksCreated;
+      deleted += result.linksDeleted;
+      kept += result.linksKept;
+      if (result.matchedEntityIds.length > 0) {
+        perRow.push({ id: row._id, matched: result.matchedEntityIds.length });
+      }
+    }
+
+    const summary = {
+      totalRows: rows.length,
+      created,
+      deleted,
+      kept,
+      rowsWithMatches: perRow.length,
+      dryRun,
+    };
+    console.log(`[archiveEntityLinks] ${JSON.stringify(summary)}`);
+    return { summary, perRow: perRow.slice(0, 20) };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Public query: getEntityFindings                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * List entities that have at least one archive link, with link counts.
+ * Used by the LinkedInPostArchiveView "By entity" pivot to populate the
+ * entity selector without scanning all archive content client-side.
+ */
+export const listEntitiesWithArchiveLinks = query({
+  args: {},
+  returns: v.array(
+    v.object({
+      companyId: v.id("entityContexts"),
+      entityName: v.string(),
+      entityType: v.string(),
+      linkCount: v.number(),
+      latestPostedAt: v.number(),
+      postTypes: v.array(v.string()),
+    }),
+  ),
+  handler: async (ctx) => {
+    const links = await ctx.db
+      .query("linkedinArchiveEntityLinks")
+      .collect();
+    const byCompany = new Map<
+      string,
+      { count: number; latestPostedAt: number; postTypes: Set<string> }
+    >();
+    for (const link of links) {
+      const existing = byCompany.get(link.companyId);
+      if (!existing) {
+        byCompany.set(link.companyId, {
+          count: 1,
+          latestPostedAt: link.postedAt,
+          postTypes: new Set([link.postType]),
+        });
+      } else {
+        existing.count += 1;
+        existing.latestPostedAt = Math.max(existing.latestPostedAt, link.postedAt);
+        existing.postTypes.add(link.postType);
+      }
+    }
+    const out: Array<{
+      companyId: Id<"entityContexts">;
+      entityName: string;
+      entityType: string;
+      linkCount: number;
+      latestPostedAt: number;
+      postTypes: string[];
+    }> = [];
+    for (const [companyId, info] of byCompany.entries()) {
+      const entity = await ctx.db.get(companyId as Id<"entityContexts">);
+      if (!entity) continue;
+      out.push({
+        companyId: companyId as Id<"entityContexts">,
+        entityName: entity.entityName,
+        entityType: entity.entityType,
+        linkCount: info.count,
+        latestPostedAt: info.latestPostedAt,
+        postTypes: [...info.postTypes].sort(),
+      });
+    }
+    out.sort((a, b) => b.latestPostedAt - a.latestPostedAt);
+    return out;
+  },
+});
+
+export const getEntityFindings = query({
+  args: {
+    companyId: v.id("entityContexts"),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({
+    entity: v.object({
+      _id: v.id("entityContexts"),
+      entityName: v.string(),
+      entityType: v.string(),
+    }),
+    fundingEvents: v.array(
+      v.object({
+        _id: v.id("fundingEvents"),
+        companyName: v.string(),
+        roundType: v.string(),
+        amountRaw: v.string(),
+        amountUsd: v.optional(v.number()),
+        leadInvestors: v.array(v.string()),
+        sector: v.optional(v.string()),
+        valuation: v.optional(v.string()),
+        sourceUrls: v.array(v.string()),
+        sourceNames: v.array(v.string()),
+        confidence: v.number(),
+        verificationStatus: v.string(),
+        announcedAt: v.number(),
+      }),
+    ),
+    archivePosts: v.array(
+      v.object({
+        _id: v.id("linkedinPostArchive"),
+        dateString: v.string(),
+        postType: v.string(),
+        persona: v.string(),
+        postUrl: v.optional(v.string()),
+        postedAt: v.number(),
+        matchSource: v.string(),
+        contentExcerpt: v.string(),
+        sourceUrls: v.array(v.string()),
+      }),
+    ),
+  }),
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 25;
+    const entity = await ctx.db.get(args.companyId);
+    if (!entity) {
+      throw new Error(`Entity not found: ${args.companyId}`);
+    }
+
+    // ---- Funding events (by direct companyId link if populated, else by name) ----
+    const byIdEvents = await ctx.db
+      .query("fundingEvents")
+      .withIndex("by_companyId", (q) => q.eq("companyId", args.companyId))
+      .collect();
+
+    const normalizedEntity = normalizeForMatch(entity.entityName);
+    let fundingEventDocs = byIdEvents;
+    if (fundingEventDocs.length === 0 && normalizedEntity.length >= 3) {
+      // Cap to a reasonable scan budget — fundingEvents is bounded (~hundreds).
+      const scan = await ctx.db
+        .query("fundingEvents")
+        .withIndex("by_announcedAt")
+        .order("desc")
+        .take(500);
+      fundingEventDocs = scan.filter(
+        (e) => normalizeForMatch(e.companyName) === normalizedEntity,
+      );
+    }
+
+    fundingEventDocs.sort((a, b) => b.announcedAt - a.announcedAt);
+    const fundingEvents = fundingEventDocs.slice(0, limit).map((e) => ({
+      _id: e._id,
+      companyName: e.companyName,
+      roundType: e.roundType,
+      amountRaw: e.amountRaw,
+      amountUsd: e.amountUsd,
+      leadInvestors: e.leadInvestors,
+      sector: e.sector,
+      valuation: e.valuation,
+      sourceUrls: e.sourceUrls,
+      sourceNames: e.sourceNames,
+      confidence: e.confidence,
+      verificationStatus: e.verificationStatus,
+      announcedAt: e.announcedAt,
+    }));
+
+    // ---- Archive posts (via denormalized link table) ----
+    const links = await ctx.db
+      .query("linkedinArchiveEntityLinks")
+      .withIndex("by_company_postedAt", (q) => q.eq("companyId", args.companyId))
+      .order("desc")
+      .take(limit);
+
+    const archivePosts = await Promise.all(
+      links.map(async (link) => {
+        const row = await ctx.db.get(link.archiveRowId);
+        if (!row) return null;
+        const sourceUrls: string[] = [];
+        const rounds: any[] = row.metadata?.findings?.rounds ?? [];
+        for (const round of rounds) {
+          if (Array.isArray(round?.sourceUrls)) {
+            for (const url of round.sourceUrls) {
+              if (typeof url === "string" && url.length > 0 && !sourceUrls.includes(url)) {
+                sourceUrls.push(url);
+              }
+            }
+          }
+        }
+        return {
+          _id: row._id,
+          dateString: row.dateString,
+          postType: row.postType,
+          persona: row.persona,
+          postUrl: row.postUrl,
+          postedAt: row.postedAt,
+          matchSource: link.matchSource,
+          contentExcerpt: row.content.slice(0, 280),
+          sourceUrls: sourceUrls.slice(0, 5),
+        };
+      }),
+    );
+
+    return {
+      entity: {
+        _id: entity._id,
+        entityName: entity.entityName,
+        entityType: entity.entityType,
+      },
+      fundingEvents,
+      archivePosts: archivePosts.filter((p): p is NonNullable<typeof p> => p !== null),
+    };
+  },
+});

--- a/convex/domains/social/linkedinArchiveEntityLinks.ts
+++ b/convex/domains/social/linkedinArchiveEntityLinks.ts
@@ -53,7 +53,45 @@ function normalizeForMatch(input: string): string {
  */
 function entityRegex(entityName: string): RegExp {
   const escaped = entityName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(^|[^a-zA-Z0-9])${escaped}([^a-zA-Z0-9]|$)`, "i");
+  return new RegExp(`(^|[^a-zA-Z0-9])${escaped}([^a-zA-Z0-9]|$)`, "gi");
+}
+
+/**
+ * Detect the funding-tracker formatter's `Trace:` prefix line:
+ *
+ *     Trace: single-source | 1 sources | confidence 100% | event nd7…
+ *
+ * If an entity's only matches in the post are inside such a line,
+ * we skip the link — the mention is the formatter literal, not a
+ * real company reference. Otherwise the entityContext "Trace" (a
+ * real $3M-seed company) accidentally links to every funding-tracker
+ * post regardless of who the post is actually about.
+ */
+function isFormatterPrefixLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  if (line.length - trimmed.length < 2) return false; // must be indented
+  return /^(Trace|Sources|Risk|Audience|Opportunity|Founder lens|Product|Industry):/i.test(
+    trimmed,
+  );
+}
+
+/**
+ * Count "real" mentions of an entity in the post content — excluding
+ * matches that fall inside formatter prefix lines.
+ */
+function countRealMentions(content: string, regex: RegExp): number {
+  // Reset lastIndex defensively in case the regex was re-used.
+  regex.lastIndex = 0;
+  let real = 0;
+  for (const match of content.matchAll(regex)) {
+    const idx = match.index ?? 0;
+    const lineStart = content.lastIndexOf("\n", idx - 1) + 1;
+    const lineEnd = content.indexOf("\n", idx);
+    const line = content.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+    if (isFormatterPrefixLine(line)) continue;
+    real += 1;
+  }
+  return real;
 }
 
 type LinkPlan = {
@@ -104,10 +142,16 @@ function planLinksForRow(
     }
   }
 
-  // 2) Plain-text mention scan (covers daily_digest signals and prose)
+  // 2) Plain-text mention scan (covers daily_digest signals and prose).
+  // Skip matches that appear ONLY inside a formatter prefix line — those
+  // are formatter literals like "Trace:" / "Risk:" rather than real
+  // entity mentions. Also skip very-short names (<= 3 chars) entirely:
+  // their false-positive rate against arbitrary prose is unworkable.
   for (const entity of entities) {
     if (plans.has(entity._id)) continue;
-    if (entity.regex.test(row.content)) {
+    if (entity.entityName.trim().length <= 3) continue;
+    const realMentions = countRealMentions(row.content, entity.regex);
+    if (realMentions > 0) {
       plans.set(entity._id, { companyId: entity._id, matchSource: "content_mention" });
     }
   }
@@ -142,13 +186,17 @@ export const upsertArchiveRowEntityLinks = internalMutation({
       };
     }
 
+    // Exclude stale entityContexts (duplicates marked by the canonicalKey
+    // backfill) so per-entity link counts aren't split across dupes.
     const entityDocs = await ctx.db.query("entityContexts").collect();
-    const entities = entityDocs.map((e) => ({
-      _id: e._id,
-      entityName: e.entityName,
-      normalized: normalizeForMatch(e.entityName),
-      regex: entityRegex(e.entityName),
-    }));
+    const entities = entityDocs
+      .filter((e) => !e.isStale)
+      .map((e) => ({
+        _id: e._id,
+        entityName: e.entityName,
+        normalized: normalizeForMatch(e.entityName),
+        regex: entityRegex(e.entityName),
+      }));
 
     const desired = planLinksForRow({ content: row.content, metadata: row.metadata }, entities);
     const desiredById = new Map(desired.map((p) => [p.companyId, p]));
@@ -338,6 +386,7 @@ export const listEntitiesWithArchiveLinks = query({
     for (const [companyId, info] of byCompany.entries()) {
       const entity = await ctx.db.get(companyId as Id<"entityContexts">);
       if (!entity) continue;
+      if (entity.isStale) continue; // hide duplicates marked stale by the canonicalKey backfill
       out.push({
         companyId: companyId as Id<"entityContexts">,
         entityName: entity.entityName,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2235,6 +2235,30 @@ const linkedinPostArchive = defineTable({
   .index("by_target_postedAt", ["target", "postedAt"]);
 
 /* ------------------------------------------------------------------ */
+/* LinkedIn Archive Entity Links — denormalized many-to-many index     */
+/* Each row: (archiveRowId, companyId) with copy of postedAt/postType  */
+/* for cheap reverse lookups: "all posts mentioning entity X".         */
+/* Populated by linkArchiveRowsToEntities + the funding-tracker        */
+/* backfill. Convex doesn't natively index array fields for `contains` */
+/* queries, so we denormalize.                                          */
+/* ------------------------------------------------------------------ */
+const linkedinArchiveEntityLinks = defineTable({
+  archiveRowId: v.id("linkedinPostArchive"),
+  companyId: v.id("entityContexts"),
+  postedAt: v.number(),
+  postType: v.string(),
+  // Soft denormalized fields the UI uses without joining back to the post:
+  dateString: v.string(),
+  matchSource: v.union(
+    v.literal("findings_round"), // matched via metadata.findings.rounds[].companyName
+    v.literal("content_mention"), // matched via plain-text scan of content
+  ),
+})
+  .index("by_company_postedAt", ["companyId", "postedAt"])
+  .index("by_archive_row", ["archiveRowId"])
+  .index("by_archive_company", ["archiveRowId", "companyId"]);
+
+/* ------------------------------------------------------------------ */
 /* LinkedIn Held Posts - Posts blocked by engagement quality gate     */
 /* ------------------------------------------------------------------ */
 const linkedinHeldPosts = defineTable({
@@ -3893,6 +3917,7 @@ export default defineSchema({
   linkedinResearchPosts,
   linkedinMaPosts,
   linkedinPostArchive,
+  linkedinArchiveEntityLinks,
   linkedinHeldPosts,
   linkedinContentQueue,
   userApiKeys,

--- a/convex/workflows/dailyLinkedInPost.ts
+++ b/convex/workflows/dailyLinkedInPost.ts
@@ -4094,6 +4094,12 @@ export const backfillFundingTrackerPosts = internalAction({
             metadataPatch: { findings },
           },
         );
+        // Refresh the entity-link join table so per-entity queries find
+        // this row immediately. Idempotent — diffs against existing links.
+        await ctx.runMutation(
+          internal.domains.social.linkedinArchiveEntityLinks.upsertArchiveRowEntityLinks,
+          { archiveRowId: post._id },
+        );
       }
 
       results.push({

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -51,6 +51,7 @@ import {
 
 import { buildCockpitPath, type CockpitSurfaceId } from "@/lib/registry/viewRegistry";
 import { RichNotebookEditor } from "@/features/notebook/components/RichNotebookEditor";
+import { EntityFindingsPanel } from "@/features/narrative/components/social/EntityFindingsPanel";
 import {
   buildLocalWorkspacePath,
   buildWorkspaceUrl,
@@ -1412,6 +1413,10 @@ export function ExactReportsSurface() {
               <button type="button" data-active={view === "list"} onClick={() => setView("list")}><List size={13} /> List</button>
             </div>
           </div>
+        </div>
+
+        <div data-testid="reports-findings-panel-slot" style={{ marginBottom: 16 }}>
+          <EntityFindingsPanel />
         </div>
 
         <div className="nb-reports-grid" data-view={view}>

--- a/src/features/narrative/components/social/EntityFindingsPanel.tsx
+++ b/src/features/narrative/components/social/EntityFindingsPanel.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useState, useEffect } from "react";
+import { api } from "../../../../../convex/_generated/api";
+import type { Id } from "../../../../../convex/_generated/dataModel";
+import { useStableQuery } from "@/hooks/useStableQuery";
+import { Building2, ExternalLink, FileText } from "lucide-react";
+
+const formatUsd = (amountUsd?: number, fallback?: string): string => {
+  if (typeof amountUsd === "number" && Number.isFinite(amountUsd) && amountUsd > 0) {
+    if (amountUsd >= 1_000_000_000) return `$${(amountUsd / 1_000_000_000).toFixed(1)}B`;
+    if (amountUsd >= 1_000_000) return `$${Math.round(amountUsd / 1_000_000)}M`;
+    if (amountUsd >= 1_000) return `$${Math.round(amountUsd / 1_000)}K`;
+    return `$${amountUsd}`;
+  }
+  return fallback ?? "n/a";
+};
+
+const formatDate = (ms: number) =>
+  new Date(ms).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+
+const POST_TYPE_LABEL: Record<string, string> = {
+  daily_digest: "Daily Digest",
+  funding_tracker: "Funding Tracker",
+  funding_brief: "Funding Brief",
+  fda: "FDA Update",
+  clinical: "Clinical Trial",
+  research: "Research",
+  ma: "Deal",
+};
+
+interface Props {
+  initialEntityId?: string;
+  onEntityChange?: (companyId: string | null) => void;
+}
+
+export const EntityFindingsPanel: React.FC<Props> = ({ initialEntityId, onEntityChange }) => {
+  const [selected, setSelected] = useState<string | null>(initialEntityId ?? null);
+
+  const entities = useStableQuery(
+    api.domains.social.linkedinArchiveEntityLinks.listEntitiesWithArchiveLinks,
+    {},
+  );
+
+  const findings = useStableQuery(
+    api.domains.social.linkedinArchiveEntityLinks.getEntityFindings,
+    selected ? { companyId: selected as Id<"entityContexts">, limit: 25 } : "skip",
+  );
+
+  // Auto-select the first entity once the list loads (so we render something useful by default).
+  useEffect(() => {
+    if (selected) return;
+    if (!entities || entities.length === 0) return;
+    setSelected(entities[0].companyId);
+    onEntityChange?.(entities[0].companyId);
+  }, [entities, selected, onEntityChange]);
+
+  const entityOptions = useMemo(() => entities ?? [], [entities]);
+
+  if (entityOptions.length === 0) {
+    return (
+      <div
+        data-testid="entity-findings-empty"
+        className="nb-surface-card p-4 text-sm text-content-muted"
+      >
+        No entity-linked findings yet. Run{" "}
+        <code className="text-xs">rebuildAllArchiveEntityLinks</code> to populate.
+      </div>
+    );
+  }
+
+  return (
+    <section
+      data-testid="entity-findings-panel"
+      aria-label="Findings by entity"
+      className="nb-surface-card p-4 space-y-4"
+    >
+      <header className="flex items-start justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-md bg-indigo-500/15 flex items-center justify-center">
+            <Building2 className="w-4 h-4 text-indigo-500 dark:text-indigo-300" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-content">Findings by entity</h3>
+            <p className="text-[11px] text-content-muted">
+              Funding events + LinkedIn posts tied to the selected company
+            </p>
+          </div>
+        </div>
+        <label className="flex items-center gap-2 text-xs text-content-muted">
+          <span>Entity</span>
+          <select
+            data-testid="entity-findings-select"
+            className="bg-surface border border-edge rounded-md text-xs px-2 py-1 text-content"
+            value={selected ?? ""}
+            onChange={(e) => {
+              const next = e.target.value || null;
+              setSelected(next);
+              onEntityChange?.(next);
+            }}
+          >
+            {entityOptions.map((entity) => (
+              <option key={entity.companyId} value={entity.companyId}>
+                {entity.entityName} · {entity.linkCount}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      {findings === undefined ? (
+        <div className="text-xs text-content-muted">Loading findings…</div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* Funding events column */}
+            <div>
+              <h4 className="text-[11px] uppercase tracking-[0.2em] text-content-muted mb-2">
+                Funding events
+              </h4>
+              {findings.fundingEvents.length === 0 ? (
+                <p data-testid="entity-findings-no-funding" className="text-xs text-content-muted">
+                  No funding events recorded for {findings.entity.entityName}.
+                </p>
+              ) : (
+                <ul data-testid="entity-findings-funding-list" className="space-y-2">
+                  {findings.fundingEvents.map((event) => (
+                    <li
+                      key={event._id}
+                      data-testid="entity-findings-funding-row"
+                      className="rounded-md border border-edge/60 px-3 py-2 text-xs"
+                    >
+                      <div className="flex items-baseline justify-between gap-2 flex-wrap">
+                        <span className="font-medium text-content">
+                          {formatUsd(event.amountUsd, event.amountRaw)}
+                        </span>
+                        <span className="text-content-muted text-[11px] uppercase tracking-wide">
+                          {event.roundType}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-[11px] text-content-muted">
+                        {formatDate(event.announcedAt)} · {event.verificationStatus}
+                        {event.sector ? ` · ${event.sector}` : ""}
+                      </div>
+                      {event.leadInvestors && event.leadInvestors.length > 0 ? (
+                        <div className="mt-1 text-[11px] text-content-muted">
+                          Leads: {event.leadInvestors.slice(0, 3).join(", ")}
+                        </div>
+                      ) : null}
+                      {event.sourceUrls.length > 0 ? (
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {event.sourceUrls.slice(0, 3).map((url) => (
+                            <a
+                              key={url}
+                              href={url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-[11px] text-indigo-600 dark:text-indigo-300 hover:underline inline-flex items-center gap-1"
+                            >
+                              <ExternalLink className="w-3 h-3" />
+                              source
+                            </a>
+                          ))}
+                        </div>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {/* Archive posts column */}
+            <div>
+              <h4 className="text-[11px] uppercase tracking-[0.2em] text-content-muted mb-2">
+                LinkedIn coverage
+              </h4>
+              {findings.archivePosts.length === 0 ? (
+                <p data-testid="entity-findings-no-posts" className="text-xs text-content-muted">
+                  No LinkedIn posts mention {findings.entity.entityName} yet.
+                </p>
+              ) : (
+                <ul data-testid="entity-findings-post-list" className="space-y-2">
+                  {findings.archivePosts.map((post) => (
+                    <li
+                      key={post._id}
+                      data-testid="entity-findings-post-row"
+                      className="rounded-md border border-edge/60 px-3 py-2 text-xs"
+                    >
+                      <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <span className="font-medium text-content inline-flex items-center gap-1.5">
+                          <FileText className="w-3.5 h-3.5 text-content-muted" />
+                          {POST_TYPE_LABEL[post.postType] ?? post.postType}
+                        </span>
+                        <span className="text-[11px] text-content-muted">
+                          {formatDate(post.postedAt)} · match: {post.matchSource.replace("_", " ")}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-[11px] text-content-muted line-clamp-3">
+                        {post.contentExcerpt}
+                      </p>
+                      {post.sourceUrls.length > 0 ? (
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {post.sourceUrls.slice(0, 3).map((url) => (
+                            <a
+                              key={url}
+                              href={url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-[11px] text-indigo-600 dark:text-indigo-300 hover:underline inline-flex items-center gap-1"
+                            >
+                              <ExternalLink className="w-3 h-3" />
+                              source
+                            </a>
+                          ))}
+                        </div>
+                      ) : null}
+                      {post.postUrl ? (
+                        <a
+                          href={post.postUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-2 inline-flex items-center gap-1 text-[11px] text-indigo-600 dark:text-indigo-300 hover:underline"
+                        >
+                          <ExternalLink className="w-3 h-3" />
+                          View post
+                        </a>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default EntityFindingsPanel;

--- a/src/features/narrative/components/social/LinkedInPostArchiveView.tsx
+++ b/src/features/narrative/components/social/LinkedInPostArchiveView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback } from "react";
 import { api } from "../../../../../convex/_generated/api";
 import { useStableQuery } from "@/hooks/useStableQuery";
 import { LinkedInPostCard } from "./LinkedInPostCard";
+import { EntityFindingsPanel } from "./EntityFindingsPanel";
 import {
   Linkedin,
   Filter,
@@ -167,6 +168,11 @@ export const LinkedInPostArchiveView: React.FC = () => {
             })}
           </div>
         </div>
+      </div>
+
+      {/* Findings by entity (cheap retrieval substrate for chat) */}
+      <div className="px-4 pt-6">
+        <EntityFindingsPanel />
       </div>
 
       {/* Content */}


### PR DESCRIPTION
## Summary

Closes the orphan-row gap: **13/32 → 31/32 archive rows linked** (97%), **3 → 36 distinct entities matched**, **8 → 467 entityContexts rows**.

## Three new paths

1. `promoteFundingEventsToEntities` — upserts each non-generic startup from `fundingEvents` into `entityContexts` via `canonicalKey`, patches `companyId` back. **230 entities created from 300 funding events** (70 skipped: generic names).

2. `promoteDigestEntitiesToEntities` — walks `digestCache.digest.entitySpotlight` and upserts each unique name. **232 created from 259 cached digests** (236 unique).

3. `backfillEntityContextsCanonicalKey` — patches the 8 legacy entityContexts that lacked `canonicalKey`, marks 4 collision-dupes as `isStale` so they no longer split link counts (fixes the visible "Google × 2" bug).

## Link-matching robustness (`linkedinArchiveEntityLinks.ts`)

- Skip formatter-prefix matches (`   Trace: single-source | 1 sources` was previously matching the real $3M-seed company "Trace" against every funding-tracker post — 11 false positives → 0).
- Skip names ≤ 3 chars (false-positive rate vs arbitrary prose).
- Skip `isStale` entities in queries + linker so split counts never reach the UI.
- 54 stale links scrubbed during the relink pass.

## Final state (verified live, prod)

| Metric | Before | After |
|---|---|---|
| `entityContexts` rows | 8 | **467** |
| `fundingEvents.companyId` populated | 0 / 300 | **230 / 300** |
| Archive rows linked | 13 / 32 | **31 / 32** |
| Distinct entities matched | 3 | **36** |
| Top coverage | OpenAI 7, Google 6, Anthropic 4 | + Reddit 8, GitHub 6, Claude Code 4, Apple 2, Nvidia 2 |

The single remaining orphan (2026-04-01 daily_digest part 2) is structural — its content is about Bernie Sanders / AOC / FBI Director Kash Patel. None of those entities are in the promoted set.

## Pipeline note (also answers "is it pi-ai")

The LLM stack is **Vercel AI SDK** (`ai`, `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`) on top of `@convex-dev/agent`. OpenRouter routes through `@ai-sdk/openai` with custom baseURL (default model `kimi-k2.6`). `@mariozechner/pi-ai` is referenced in **exactly one file** (`openaiAgentsAdapter.ts`) which doesn't currently resolve — not part of the live path.

## Why legacy `entityPromotion.ts` wasn't reused

Its `createEntityFromFunding` mutation writes fields that no longer exist on `entityContexts` (`name`, `status`, `priority`, `sector` at top level instead of `entityName`, `crmFields.industry`, etc.). Out of sync with the schema; would fail at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)