### PR TITLE
feat(pipelines): research pipeline + reactive streaming + document handoff

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -893,9 +893,12 @@ import type * as domains_personas_personaAutonomousAgent from "../domains/person
 import type * as domains_pipelines_codeGenPipeline from "../domains/pipelines/codeGenPipeline.js";
 import type * as domains_pipelines_designGenPipeline from "../domains/pipelines/designGenPipeline.js";
 import type * as domains_pipelines_piRuntime from "../domains/pipelines/piRuntime.js";
+import type * as domains_pipelines_pipelineDocumentHandoff from "../domains/pipelines/pipelineDocumentHandoff.js";
 import type * as domains_pipelines_pipelineRunsMutations from "../domains/pipelines/pipelineRunsMutations.js";
 import type * as domains_pipelines_pipelineRunsQueries from "../domains/pipelines/pipelineRunsQueries.js";
+import type * as domains_pipelines_pipelineStreamMutations from "../domains/pipelines/pipelineStreamMutations.js";
 import type * as domains_pipelines_pipelineTrace from "../domains/pipelines/pipelineTrace.js";
+import type * as domains_pipelines_researchPipeline from "../domains/pipelines/researchPipeline.js";
 import type * as domains_proactive_actions_emailDraftGenerator from "../domains/proactive/actions/emailDraftGenerator.js";
 import type * as domains_proactive_actions_gmailDraftActions from "../domains/proactive/actions/gmailDraftActions.js";
 import type * as domains_proactive_actions_testDraftGenerator from "../domains/proactive/actions/testDraftGenerator.js";
@@ -2353,9 +2356,12 @@ declare const fullApi: ApiFromModules<{
   "domains/pipelines/codeGenPipeline": typeof domains_pipelines_codeGenPipeline;
   "domains/pipelines/designGenPipeline": typeof domains_pipelines_designGenPipeline;
   "domains/pipelines/piRuntime": typeof domains_pipelines_piRuntime;
+  "domains/pipelines/pipelineDocumentHandoff": typeof domains_pipelines_pipelineDocumentHandoff;
   "domains/pipelines/pipelineRunsMutations": typeof domains_pipelines_pipelineRunsMutations;
   "domains/pipelines/pipelineRunsQueries": typeof domains_pipelines_pipelineRunsQueries;
+  "domains/pipelines/pipelineStreamMutations": typeof domains_pipelines_pipelineStreamMutations;
   "domains/pipelines/pipelineTrace": typeof domains_pipelines_pipelineTrace;
+  "domains/pipelines/researchPipeline": typeof domains_pipelines_researchPipeline;
   "domains/proactive/actions/emailDraftGenerator": typeof domains_proactive_actions_emailDraftGenerator;
   "domains/proactive/actions/gmailDraftActions": typeof domains_proactive_actions_gmailDraftActions;
   "domains/proactive/actions/testDraftGenerator": typeof domains_proactive_actions_testDraftGenerator;

--- a/convex/domains/pipelines/pipelineDocumentHandoff.ts
+++ b/convex/domains/pipelines/pipelineDocumentHandoff.ts
@@ -1,0 +1,320 @@
+/**
+ * Pipeline Document Handoff
+ *
+ * Best-effort: when a pipeline run has `ownerKey: "user:<userId>"`,
+ * write the bundle as a Workspace `documents` row so RichNotebookEditor
+ * + the existing workspace surface render it natively. For anonymous
+ * runs (no userId), the storage-bundle export remains the only path.
+ *
+ * Why a separate file instead of inline: keeps the per-pipeline action
+ * focused on the pi-ai work; the documents handoff has its own
+ * concerns (auth shape, content format, archive vs publish).
+ *
+ * Output format (for the documents.content field):
+ *   - JSON-stringified ProseMirror doc with sections derived from the
+ *     bundle. Top-level sections: spec → output (files / decomposition
+ *     / synthesis) → verdict → sources.
+ */
+
+import { v } from "convex/values";
+import { internalMutation } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+
+interface BundleSummaryArgs {
+  pipelineKind: "code_gen" | "design_gen" | "research" | "custom";
+  spec: string;
+  // Code-gen specific
+  files?: Array<{ path: string; content: string }>;
+  // Design-gen specific
+  brief?: any;
+  decomposition?: any;
+  imageStorageId?: Id<"_storage">;
+  // Research specific
+  synthesis?: string;
+  citations?: Array<{ idx: number; title?: string; url?: string }>;
+  // Common
+  verdict?: { tier: string; passing: number; failing: number; notes: string[] };
+}
+
+function buildProseMirrorDoc(args: BundleSummaryArgs): string {
+  const blocks: any[] = [];
+
+  // Title
+  blocks.push({
+    type: "heading",
+    attrs: { level: 1 },
+    content: [{ type: "text", text: pipelineHeading(args.pipelineKind) }],
+  });
+
+  // Spec
+  blocks.push({
+    type: "heading",
+    attrs: { level: 2 },
+    content: [{ type: "text", text: "Spec" }],
+  });
+  blocks.push({
+    type: "paragraph",
+    content: [{ type: "text", text: args.spec }],
+  });
+
+  // Per-pipeline body
+  if (args.pipelineKind === "code_gen" && args.files) {
+    blocks.push({
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: `Generated files (${args.files.length})` }],
+    });
+    for (const f of args.files) {
+      blocks.push({
+        type: "heading",
+        attrs: { level: 3 },
+        content: [{ type: "text", text: f.path }],
+      });
+      blocks.push({
+        type: "codeBlock",
+        attrs: { language: detectLang(f.path) },
+        content: [{ type: "text", text: f.content.slice(0, 8000) }],
+      });
+    }
+  } else if (args.pipelineKind === "design_gen") {
+    if (args.brief) {
+      blocks.push({
+        type: "heading",
+        attrs: { level: 2 },
+        content: [{ type: "text", text: "Brief" }],
+      });
+      blocks.push({
+        type: "codeBlock",
+        attrs: { language: "json" },
+        content: [{ type: "text", text: JSON.stringify(args.brief, null, 2) }],
+      });
+    }
+    if (args.decomposition?.components?.length) {
+      blocks.push({
+        type: "heading",
+        attrs: { level: 2 },
+        content: [{ type: "text", text: "Components" }],
+      });
+      const items = args.decomposition.components.map((c: any) => ({
+        type: "listItem",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", marks: [{ type: "strong" }], text: c.name },
+              { type: "text", text: ` — ${c.role}` },
+            ],
+          },
+        ],
+      }));
+      blocks.push({ type: "bulletList", content: items });
+    }
+  } else if (args.pipelineKind === "research" && args.synthesis) {
+    blocks.push({
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "Synthesis" }],
+    });
+    blocks.push({
+      type: "paragraph",
+      content: [{ type: "text", text: args.synthesis }],
+    });
+    if (args.citations?.length) {
+      blocks.push({
+        type: "heading",
+        attrs: { level: 2 },
+        content: [{ type: "text", text: "Citations" }],
+      });
+      const items = args.citations.map((c) => ({
+        type: "listItem",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: `[${c.idx}] ${c.title ?? ""} ` },
+              ...(c.url
+                ? [
+                    {
+                      type: "text",
+                      marks: [{ type: "link", attrs: { href: c.url } }],
+                      text: c.url,
+                    },
+                  ]
+                : []),
+            ],
+          },
+        ],
+      }));
+      blocks.push({ type: "bulletList", content: items });
+    }
+  }
+
+  // Verdict
+  if (args.verdict) {
+    blocks.push({
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "Verdict" }],
+    });
+    blocks.push({
+      type: "paragraph",
+      content: [
+        { type: "text", marks: [{ type: "strong" }], text: `${args.verdict.tier}` },
+        {
+          type: "text",
+          text: ` — passing=${args.verdict.passing}, failing=${args.verdict.failing}`,
+        },
+      ],
+    });
+    if (args.verdict.notes.length > 0) {
+      blocks.push({
+        type: "bulletList",
+        content: args.verdict.notes.map((n) => ({
+          type: "listItem",
+          content: [{ type: "paragraph", content: [{ type: "text", text: n }] }],
+        })),
+      });
+    }
+  }
+
+  return JSON.stringify({ type: "doc", content: blocks });
+}
+
+function pipelineHeading(kind: BundleSummaryArgs["pipelineKind"]): string {
+  switch (kind) {
+    case "code_gen":
+      return "Generated code bundle";
+    case "design_gen":
+      return "Generated design bundle";
+    case "research":
+      return "Research synthesis";
+    default:
+      return "Pipeline output";
+  }
+}
+
+function detectLang(path: string): string {
+  const ext = path.toLowerCase().split(".").pop();
+  return (
+    {
+      ts: "typescript",
+      tsx: "typescript",
+      js: "javascript",
+      jsx: "javascript",
+      py: "python",
+      rb: "ruby",
+      go: "go",
+      rs: "rust",
+      java: "java",
+      json: "json",
+      yaml: "yaml",
+      yml: "yaml",
+      md: "markdown",
+      sh: "bash",
+      sql: "sql",
+      css: "css",
+      html: "html",
+    }[ext ?? ""] ?? "plaintext"
+  );
+}
+
+/**
+ * Create a Workspace document from a pipeline bundle. Returns the
+ * documentId or null when the run isn't owned by a real user (auth
+ * fallback — anonymous runs export via storage bundle only).
+ *
+ * Idempotent: re-runs against the same `pipelineRunId` overwrite the
+ * existing document's content (the run's verdict is the latest source
+ * of truth).
+ */
+export const createPipelineDocument = internalMutation({
+  args: {
+    pipelineRunId: v.id("pipelineRuns"),
+    runId: v.string(),
+    bundle: v.object({
+      pipelineKind: v.union(
+        v.literal("code_gen"),
+        v.literal("design_gen"),
+        v.literal("research"),
+        v.literal("custom"),
+      ),
+      spec: v.string(),
+      files: v.optional(
+        v.array(v.object({ path: v.string(), content: v.string() })),
+      ),
+      brief: v.optional(v.any()),
+      decomposition: v.optional(v.any()),
+      imageStorageId: v.optional(v.id("_storage")),
+      synthesis: v.optional(v.string()),
+      citations: v.optional(
+        v.array(
+          v.object({
+            idx: v.number(),
+            title: v.optional(v.string()),
+            url: v.optional(v.string()),
+          }),
+        ),
+      ),
+      verdict: v.optional(
+        v.object({
+          tier: v.string(),
+          passing: v.number(),
+          failing: v.number(),
+          notes: v.array(v.string()),
+        }),
+      ),
+    }),
+  },
+  returns: v.object({
+    documentId: v.optional(v.id("documents")),
+    skipped: v.boolean(),
+    skipReason: v.optional(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get(args.pipelineRunId);
+    if (!run) {
+      return { documentId: undefined, skipped: true, skipReason: "run_not_found" };
+    }
+
+    // Auth contract: only user:<id>-owned runs get a Workspace document.
+    // Anon runs use the storage bundle export.
+    const ownerKey = run.ownerKey;
+    if (!ownerKey || !ownerKey.startsWith("user:")) {
+      return {
+        documentId: undefined,
+        skipped: true,
+        skipReason: "no_user_ownerKey",
+      };
+    }
+    const userId = ownerKey.slice("user:".length) as Id<"users">;
+
+    const content = buildProseMirrorDoc(args.bundle);
+    const title = run.title || pipelineHeading(args.bundle.pipelineKind);
+
+    // Idempotent: overwrite if we already wrote a document for this run.
+    if (run.outputDocumentId) {
+      const existing = await ctx.db.get(run.outputDocumentId);
+      if (existing) {
+        await ctx.db.patch(run.outputDocumentId, {
+          title,
+          content,
+          lastModified: Date.now(),
+        });
+        return { documentId: run.outputDocumentId, skipped: false };
+      }
+    }
+
+    const documentId = await ctx.db.insert("documents", {
+      title,
+      content,
+      createdBy: userId,
+      lastEditedBy: userId,
+      isPublic: false,
+      lastModified: Date.now(),
+      summary: `pipeline_run:${args.runId}`,
+      icon: args.bundle.pipelineKind === "code_gen" ? "code" : args.bundle.pipelineKind === "design_gen" ? "image" : "book-open",
+    });
+    await ctx.db.patch(args.pipelineRunId, { outputDocumentId: documentId });
+    return { documentId, skipped: false };
+  },
+});

--- a/convex/domains/pipelines/pipelineStreamMutations.ts
+++ b/convex/domains/pipelines/pipelineStreamMutations.ts
@@ -1,0 +1,155 @@
+/**
+ * Pipeline Stream Mutations
+ *
+ * Reactive partial-text streaming for pipeline steps. Mirrors the
+ * `@convex-dev/persistent-text-streaming` chunk-append shape, but uses
+ * a plain Convex table so any pipeline `internalAction` can stream
+ * without an HTTP entry point.
+ *
+ * Pattern: append-then-replace. Each call concatenates a new delta
+ * onto `partialText` and bumps `updatedAt`. Clients subscribed via
+ * `getPipelineStream` see the text grow in real-time.
+ *
+ * Bounded: partialText is capped at MAX_STREAM_BYTES to prevent OOM
+ * under long-running pipelines (BOUND invariant).
+ */
+
+import { v } from "convex/values";
+import { internalMutation, query } from "../../_generated/server";
+
+const MAX_STREAM_BYTES = 64_000;
+
+export const startPipelineStream = internalMutation({
+  args: {
+    pipelineRunId: v.id("pipelineRuns"),
+    runId: v.string(),
+    stepName: v.string(),
+  },
+  returns: v.id("pipelineRunStreams"),
+  handler: async (ctx, args) => {
+    // Idempotent: if a row already exists for (runId, stepName), reset
+    // it so a re-run starts fresh. Avoids cross-run text bleed.
+    const existing = await ctx.db
+      .query("pipelineRunStreams")
+      .withIndex("by_runId_stepName", (q) =>
+        q.eq("runId", args.runId).eq("stepName", args.stepName),
+      )
+      .first();
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        partialText: "",
+        status: "streaming",
+        startedAt: now,
+        updatedAt: now,
+        errorMessage: undefined,
+      });
+      return existing._id;
+    }
+    return await ctx.db.insert("pipelineRunStreams", {
+      runId: args.runId,
+      pipelineRunId: args.pipelineRunId,
+      stepName: args.stepName,
+      partialText: "",
+      status: "streaming",
+      startedAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const appendPipelineStreamChunk = internalMutation({
+  args: {
+    streamId: v.id("pipelineRunStreams"),
+    delta: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.streamId);
+    if (!row) return { ok: false, reason: "not_found" };
+    if (row.status !== "streaming") {
+      // Refuse to append to a closed stream — HONEST_STATUS.
+      return { ok: false, reason: `stream_is_${row.status}` };
+    }
+    const next = row.partialText + args.delta;
+    const clamped =
+      next.length > MAX_STREAM_BYTES
+        ? next.slice(0, MAX_STREAM_BYTES - 3) + "..."
+        : next;
+    await ctx.db.patch(args.streamId, {
+      partialText: clamped,
+      updatedAt: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+export const finalizePipelineStream = internalMutation({
+  args: {
+    streamId: v.id("pipelineRunStreams"),
+    status: v.union(v.literal("complete"), v.literal("error")),
+    errorMessage: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.streamId, {
+      status: args.status,
+      updatedAt: Date.now(),
+      errorMessage: args.errorMessage,
+    });
+    return { ok: true };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Public: client subscribes via this query                                   */
+/* -------------------------------------------------------------------------- */
+
+export const getPipelineStream = query({
+  args: {
+    runId: v.string(),
+    stepName: v.optional(v.string()),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      _id: v.id("pipelineRunStreams"),
+      runId: v.string(),
+      stepName: v.string(),
+      partialText: v.string(),
+      status: v.string(),
+      startedAt: v.number(),
+      updatedAt: v.number(),
+      errorMessage: v.optional(v.string()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    let row;
+    if (args.stepName) {
+      row = await ctx.db
+        .query("pipelineRunStreams")
+        .withIndex("by_runId_stepName", (q) =>
+          q.eq("runId", args.runId).eq("stepName", args.stepName!),
+        )
+        .first();
+    } else {
+      // Latest stream for this run (most recent updatedAt) — used by the
+      // panel to show whichever step is currently streaming.
+      const all = await ctx.db
+        .query("pipelineRunStreams")
+        .withIndex("by_runId_stepName", (q) => q.eq("runId", args.runId))
+        .collect();
+      all.sort((a, b) => b.updatedAt - a.updatedAt);
+      row = all[0];
+    }
+    if (!row) return null;
+    return {
+      _id: row._id,
+      runId: row.runId,
+      stepName: row.stepName,
+      partialText: row.partialText,
+      status: row.status,
+      startedAt: row.startedAt,
+      updatedAt: row.updatedAt,
+      errorMessage: row.errorMessage,
+    };
+  },
+});

--- a/convex/domains/pipelines/researchPipeline.ts
+++ b/convex/domains/pipelines/researchPipeline.ts
@@ -1,0 +1,517 @@
+/**
+ * Research Pipeline (pi-ai, streamed synthesis)
+ *
+ * Three-step pipeline that exercises the streamed runtime end-to-end:
+ *
+ *   1. research.scope     — pi-ai parses the question into 3-5
+ *                           sub-questions + an initial outline. Single-shot.
+ *   2. research.synthesize — STREAMED via `runPiCompletionStreamed`.
+ *                            Each text delta is pushed to
+ *                            `pipelineRunStreams.partialText` so
+ *                            clients subscribed via `getPipelineStream`
+ *                            see the answer grow in real-time.
+ *   3. research.verify    — pi-ai checks the synthesis's internal
+ *                           consistency + flags hedged claims.
+ *
+ * Note: v1 does NOT make external web calls — synthesis comes from the
+ * model's internal knowledge. To swap in real web search later, replace
+ * the synthesize prompt with retrieved snippets (Linkup / Brave / etc.)
+ * before sending. The shape of the rest of the pipeline doesn't change.
+ *
+ * Output handoff:
+ *   - JSON bundle (sub-questions + synthesis + verdict) → Convex storage
+ *   - If `ownerKey` starts with `user:`, also write a Workspace document
+ *     via `createPipelineDocument` so RichNotebookEditor renders it.
+ */
+
+"use node";
+
+import { v } from "convex/values";
+import { internalAction } from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import {
+  runPiCompletionStreamed,
+  runPiOrAiSdkCompletion,
+} from "./piRuntime";
+import { appendPipelineTraceEntry } from "./pipelineTrace";
+
+function stableHash(input: string): string {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) {
+    h = (h << 5) - h + input.charCodeAt(i);
+    h = h & h;
+  }
+  return Math.abs(h).toString(36);
+}
+
+function newRunId(): string {
+  return `pipeline_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function trimScratchpad(input: string, max = 32_000): string {
+  return input.length > max ? input.slice(0, max - 3) + "..." : input;
+}
+
+interface ResearchScope {
+  question: string;
+  subQuestions: string[];
+  outline: string[];
+}
+
+interface ResearchVerdict {
+  tier: "verified" | "provisionally_verified" | "needs_review" | "failed";
+  passing: number;
+  failing: number;
+  notes: string[];
+}
+
+export const runResearchPipeline = internalAction({
+  args: {
+    spec: v.string(),
+    title: v.optional(v.string()),
+    modelId: v.optional(v.string()),
+    ownerKey: v.optional(v.string()),
+    forceFresh: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    runId: v.string(),
+    pipelineRunId: v.id("pipelineRuns"),
+    status: v.string(),
+    verdict: v.optional(v.string()),
+    synthesis: v.optional(v.string()),
+    documentId: v.optional(v.id("documents")),
+    bundleStorageId: v.optional(v.id("_storage")),
+  }),
+  handler: async (ctx, args) => {
+    const pipelineKind = "research" as const;
+    const modelId = args.modelId ?? "openai:gpt-4o-mini";
+    const title = args.title ?? args.spec.slice(0, 80);
+    const idempotencyKey = stableHash(
+      [pipelineKind, args.spec, args.ownerKey ?? "anon"].sort().join(" "),
+    );
+    const runId = newRunId();
+
+    const create = await ctx.runMutation(
+      internal.domains.pipelines.pipelineRunsMutations.createOrGetRun,
+      {
+        pipelineKind,
+        title,
+        spec: args.spec,
+        modelId,
+        ownerKey: args.ownerKey,
+        runId,
+        idempotencyKey,
+      },
+    );
+    const pipelineRunId: Id<"pipelineRuns"> = create.pipelineRunId;
+    const effectiveRunId = create.runId;
+
+    if (
+      !create.created &&
+      !args.forceFresh &&
+      (create.status === "succeeded" || create.status === "running")
+    ) {
+      return {
+        runId: effectiveRunId,
+        pipelineRunId,
+        status: create.status,
+        verdict: undefined,
+        synthesis: undefined,
+        documentId: undefined,
+        bundleStorageId: undefined,
+      };
+    }
+
+    await ctx.runMutation(
+      internal.domains.pipelines.pipelineRunsMutations.transitionRunStatus,
+      { pipelineRunId, status: "running" },
+    );
+
+    let totalIn = 0;
+    let totalOut = 0;
+    let totalUsd = 0;
+    let traceSeq = 0;
+
+    const recordStep = async (
+      name: string,
+      status: "ok" | "error" | "skipped",
+      input: { startedAt: number; tokens?: { in?: number; out?: number; usd?: number } },
+      scratchpad?: string,
+      errorMessage?: string,
+      traceChoiceType:
+        | "gather_info"
+        | "execute_data_op"
+        | "execute_output"
+        | "finalize" = "execute_data_op",
+      traceDescription?: string,
+    ) => {
+      const durationMs = Date.now() - input.startedAt;
+      totalIn += input.tokens?.in ?? 0;
+      totalOut += input.tokens?.out ?? 0;
+      totalUsd += input.tokens?.usd ?? 0;
+      await ctx.runMutation(
+        internal.domains.pipelines.pipelineRunsMutations.appendStep,
+        {
+          pipelineRunId,
+          runId: effectiveRunId,
+          name,
+          status,
+          durationMs,
+          inputTokens: input.tokens?.in,
+          outputTokens: input.tokens?.out,
+          estimatedUsd: input.tokens?.usd,
+          modelId,
+          scratchpad,
+          errorMessage,
+        },
+      );
+      await appendPipelineTraceEntry({
+        ctx,
+        runId: effectiveRunId,
+        seq: traceSeq++,
+        toolName: name,
+        description: traceDescription ?? name,
+        choiceType: traceChoiceType,
+        durationMs,
+        success: status === "ok",
+        errorMessage,
+        originalRequest: traceSeq === 1 ? args.spec.slice(0, 280) : undefined,
+      });
+    };
+
+    try {
+      // ── Step 1: research.scope ─────────────────────────────────────
+      const scopeStart = Date.now();
+      const scopePrompt = [
+        "You are a research analyst. Decompose the question into a research scope.",
+        "STRICT JSON: { \"question\": string, \"subQuestions\": string[],",
+        "\"outline\": string[] } with 3-5 subQuestions and 4-6 outline points.",
+        "",
+        "Output ONLY JSON. No prose.",
+        "",
+        "QUESTION:",
+        args.spec,
+      ].join("\n");
+      const scopeRes = await runPiOrAiSdkCompletion({
+        model: modelId,
+        prompt: scopePrompt,
+        temperature: 0.2,
+        maxOutputTokens: 1000,
+        timeoutMs: 30_000,
+      });
+      let scope: ResearchScope;
+      try {
+        const cleaned = scopeRes.text
+          .replace(/^```(?:json)?\s*/i, "")
+          .replace(/\s*```$/i, "");
+        scope = JSON.parse(cleaned);
+      } catch {
+        scope = {
+          question: args.spec,
+          subQuestions: [args.spec],
+          outline: ["Background", "Key signals", "Implications", "Open questions"],
+        };
+      }
+      await recordStep(
+        "research.scope",
+        "ok",
+        {
+          startedAt: scopeStart,
+          tokens: {
+            in: scopeRes.usage.inputTokens,
+            out: scopeRes.usage.outputTokens,
+            usd: scopeRes.usage.estimatedUsd,
+          },
+        },
+        trimScratchpad(JSON.stringify({ raw: scopeRes.text, scope })),
+        undefined,
+        "gather_info",
+        `Decomposed into ${scope.subQuestions.length} sub-question(s)`,
+      );
+
+      // ── Step 2: research.synthesize (STREAMED) ─────────────────────
+      const synthStart = Date.now();
+      const streamId = await ctx.runMutation(
+        internal.domains.pipelines.pipelineStreamMutations.startPipelineStream,
+        {
+          pipelineRunId,
+          runId: effectiveRunId,
+          stepName: "research.synthesize",
+        },
+      );
+
+      const synthPrompt = [
+        "Write a clear, structured research synthesis answering the question.",
+        "Cover each sub-question. Use the outline. Hedge appropriately when",
+        "evidence is uncertain. Do NOT fabricate citations or numbers.",
+        "",
+        "QUESTION:",
+        scope.question,
+        "",
+        "SUB-QUESTIONS:",
+        scope.subQuestions.map((q, i) => `${i + 1}. ${q}`).join("\n"),
+        "",
+        "OUTLINE:",
+        scope.outline.map((p, i) => `${i + 1}. ${p}`).join("\n"),
+      ].join("\n");
+
+      let synthesis = "";
+      let synthError: string | undefined = undefined;
+      try {
+        const synthRes = await runPiCompletionStreamed({
+          model: modelId,
+          prompt: synthPrompt,
+          temperature: 0.4,
+          maxOutputTokens: 3000,
+          timeoutMs: 90_000,
+          onTextDelta: async (delta) => {
+            await ctx.runMutation(
+              internal.domains.pipelines.pipelineStreamMutations.appendPipelineStreamChunk,
+              { streamId, delta },
+            );
+          },
+        });
+        synthesis = synthRes.text;
+        totalIn += synthRes.usage.inputTokens;
+        totalOut += synthRes.usage.outputTokens;
+        totalUsd += synthRes.usage.estimatedUsd;
+        await ctx.runMutation(
+          internal.domains.pipelines.pipelineStreamMutations.finalizePipelineStream,
+          { streamId, status: "complete" },
+        );
+        await ctx.runMutation(
+          internal.domains.pipelines.pipelineRunsMutations.appendStep,
+          {
+            pipelineRunId,
+            runId: effectiveRunId,
+            name: "research.synthesize",
+            status: "ok",
+            durationMs: Date.now() - synthStart,
+            inputTokens: synthRes.usage.inputTokens,
+            outputTokens: synthRes.usage.outputTokens,
+            estimatedUsd: synthRes.usage.estimatedUsd,
+            modelId,
+            scratchpad: trimScratchpad(`streamed; len=${synthesis.length}`),
+          },
+        );
+        await appendPipelineTraceEntry({
+          ctx,
+          runId: effectiveRunId,
+          seq: traceSeq++,
+          toolName: "research.synthesize",
+          description: `Streamed ${synthesis.length} chars`,
+          choiceType: "execute_data_op",
+          durationMs: Date.now() - synthStart,
+          success: true,
+        });
+      } catch (e) {
+        synthError = e instanceof Error ? e.message : String(e);
+        await ctx.runMutation(
+          internal.domains.pipelines.pipelineStreamMutations.finalizePipelineStream,
+          { streamId, status: "error", errorMessage: synthError },
+        );
+        await recordStep(
+          "research.synthesize",
+          "error",
+          { startedAt: synthStart },
+          undefined,
+          synthError,
+          "execute_data_op",
+          `Synthesis failed: ${synthError}`,
+        );
+      }
+
+      if (synthError) {
+        await ctx.runMutation(
+          internal.domains.pipelines.pipelineRunsMutations.transitionRunStatus,
+          {
+            pipelineRunId,
+            status: "failed",
+            verdict: "failed",
+            errorMessage: synthError,
+            inputTokens: totalIn,
+            outputTokens: totalOut,
+            estimatedUsd: totalUsd,
+          },
+        );
+        return {
+          runId: effectiveRunId,
+          pipelineRunId,
+          status: "failed",
+          verdict: "failed",
+          synthesis: undefined,
+          documentId: undefined,
+          bundleStorageId: undefined,
+        };
+      }
+
+      // ── Step 3: research.verify ────────────────────────────────────
+      const verifyStart = Date.now();
+      const verifyPrompt = [
+        "Review the synthesis for internal consistency and unhedged speculative",
+        "claims. STRICT JSON: { \"tier\": \"verified\"|\"provisionally_verified\"|\"needs_review\"|\"failed\",",
+        "\"passing\": number, \"failing\": number, \"notes\": string[] }.",
+        "Hedge appropriately — no real web search, so hard numerical claims",
+        "should be flagged \"needs_review\" unless the model explicitly hedges.",
+        "",
+        "QUESTION:",
+        scope.question,
+        "",
+        "SYNTHESIS (first 4000 chars):",
+        synthesis.slice(0, 4000),
+      ].join("\n");
+      const verifyRes = await runPiOrAiSdkCompletion({
+        model: modelId,
+        prompt: verifyPrompt,
+        temperature: 0,
+        maxOutputTokens: 600,
+        timeoutMs: 30_000,
+      });
+      let verdict: ResearchVerdict;
+      try {
+        const cleaned = verifyRes.text
+          .replace(/^```(?:json)?\s*/i, "")
+          .replace(/\s*```$/i, "");
+        verdict = JSON.parse(cleaned);
+      } catch {
+        verdict = {
+          tier: "needs_review",
+          passing: 0,
+          failing: 0,
+          notes: ["judge returned non-JSON; manual review required"],
+        };
+      }
+      await recordStep(
+        "research.verify",
+        "ok",
+        {
+          startedAt: verifyStart,
+          tokens: {
+            in: verifyRes.usage.inputTokens,
+            out: verifyRes.usage.outputTokens,
+            usd: verifyRes.usage.estimatedUsd,
+          },
+        },
+        trimScratchpad(JSON.stringify({ raw: verifyRes.text, verdict })),
+        undefined,
+        "finalize",
+        `Verdict: ${verdict.tier} (passing=${verdict.passing} failing=${verdict.failing})`,
+      );
+
+      const verdictTier =
+        verdict.tier === "verified"
+          ? "verified"
+          : verdict.tier === "provisionally_verified"
+            ? "provisionally_verified"
+            : verdict.tier === "failed"
+              ? "failed"
+              : "needs_review";
+
+      // ── Step 4: bundle.persist + document handoff ─────────────────
+      const persistStart = Date.now();
+      let bundleStorageId: Id<"_storage"> | undefined = undefined;
+      try {
+        const bundleJson = JSON.stringify(
+          {
+            runId: effectiveRunId,
+            pipelineKind,
+            spec: args.spec,
+            scope,
+            synthesis,
+            verdict,
+          },
+          null,
+          2,
+        );
+        const blob = new Blob([bundleJson], { type: "application/json" });
+        bundleStorageId = await ctx.storage.store(blob);
+      } catch (e) {
+        console.warn(
+          "[researchPipeline] bundle.persist failed:",
+          e instanceof Error ? e.message : String(e),
+        );
+      }
+      await recordStep(
+        "bundle.persist",
+        bundleStorageId ? "ok" : "skipped",
+        { startedAt: persistStart },
+        bundleStorageId ? `bundle_storage_id=${bundleStorageId}` : "no_storage_id",
+        bundleStorageId ? undefined : "no_storage_id",
+        "execute_output",
+        bundleStorageId ? "Persisted research bundle" : "Skipped bundle persistence",
+      );
+
+      // Document handoff (best-effort; only when ownerKey="user:<id>").
+      let documentId: Id<"documents"> | undefined = undefined;
+      try {
+        const handoff = await ctx.runMutation(
+          internal.domains.pipelines.pipelineDocumentHandoff.createPipelineDocument,
+          {
+            pipelineRunId,
+            runId: effectiveRunId,
+            bundle: {
+              pipelineKind,
+              spec: args.spec,
+              synthesis,
+              verdict,
+            },
+          },
+        );
+        if (!handoff.skipped) documentId = handoff.documentId;
+      } catch (e) {
+        console.warn(
+          "[researchPipeline] document handoff failed:",
+          e instanceof Error ? e.message : String(e),
+        );
+      }
+
+      await ctx.runMutation(
+        internal.domains.pipelines.pipelineRunsMutations.transitionRunStatus,
+        {
+          pipelineRunId,
+          status: verdictTier === "failed" ? "failed" : "succeeded",
+          verdict: verdictTier as any,
+          inputTokens: totalIn,
+          outputTokens: totalOut,
+          estimatedUsd: totalUsd,
+          outputZipStorageId: bundleStorageId,
+          outputDocumentId: documentId,
+        },
+      );
+
+      return {
+        runId: effectiveRunId,
+        pipelineRunId,
+        status: verdictTier === "failed" ? "failed" : "succeeded",
+        verdict: verdictTier,
+        synthesis,
+        documentId,
+        bundleStorageId,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await ctx.runMutation(
+        internal.domains.pipelines.pipelineRunsMutations.transitionRunStatus,
+        {
+          pipelineRunId,
+          status: "failed",
+          verdict: "failed",
+          errorMessage: message,
+          inputTokens: totalIn,
+          outputTokens: totalOut,
+          estimatedUsd: totalUsd,
+        },
+      );
+      return {
+        runId: effectiveRunId,
+        pipelineRunId,
+        status: "failed",
+        verdict: "failed",
+        synthesis: undefined,
+        documentId: undefined,
+        bundleStorageId: undefined,
+      };
+    }
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2326,6 +2326,30 @@ const pipelineRuns = defineTable({
   .index("by_status_createdAt", ["status", "createdAt"]);
 
 /* ------------------------------------------------------------------ */
+/* Pi-AI Pipeline Run Streams — reactive partial-text rows for live    */
+/* streaming UX. One row per (runId, stepName) pair; updated on every  */
+/* delta during streamed pi-ai completions. Convex's reactive query    */
+/* layer means clients see the text grow in real-time without HTTP     */
+/* infrastructure (no PersistentTextStreaming HTTP endpoint required). */
+/* ------------------------------------------------------------------ */
+const pipelineRunStreams = defineTable({
+  runId: v.string(),
+  pipelineRunId: v.id("pipelineRuns"),
+  stepName: v.string(), // e.g., "research.synthesize"
+  partialText: v.string(),
+  status: v.union(
+    v.literal("streaming"),
+    v.literal("complete"),
+    v.literal("error"),
+  ),
+  startedAt: v.number(),
+  updatedAt: v.number(),
+  errorMessage: v.optional(v.string()),
+})
+  .index("by_runId_stepName", ["runId", "stepName"])
+  .index("by_pipelineRunId", ["pipelineRunId"]);
+
+/* ------------------------------------------------------------------ */
 /* Pi-AI Pipeline Steps — normalized step events for cheap timeline    */
 /* rendering. Each row = one observable event in a pipelineRuns row.   */
 /* ------------------------------------------------------------------ */
@@ -4017,6 +4041,7 @@ export default defineSchema({
   linkedinArchiveEntityLinks,
   pipelineRuns,
   pipelineSteps,
+  pipelineRunStreams,
   linkedinHeldPosts,
   linkedinContentQueue,
   userApiKeys,

--- a/src/features/pipelines/views/PipelineRunsPanel.tsx
+++ b/src/features/pipelines/views/PipelineRunsPanel.tsx
@@ -7,10 +7,21 @@
  * cheap-retrieval substrates over Convex queries.
  */
 
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { api } from "../../../../convex/_generated/api";
 import { useStableQuery } from "@/hooks/useStableQuery";
-import { Cpu, AlertCircle, CheckCircle2, Loader2, FileText, Download, Image as ImageIcon } from "lucide-react";
+import {
+  Cpu,
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  FileText,
+  Download,
+  Image as ImageIcon,
+  ChevronDown,
+  ChevronRight,
+  Radio,
+} from "lucide-react";
 
 const statusBadge: Record<string, { label: string; className: string; Icon: any }> = {
   queued: {
@@ -71,7 +82,73 @@ function formatDuration(ms: number | undefined): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+/**
+ * Live stream preview — subscribes to `getPipelineStream` for the run
+ * and renders the partial text as it grows. Shown when a row is
+ * expanded. Streaming state badge ("Live" / "Complete") reflects the
+ * real-time mutation chain in `pipelineRunStreams`.
+ */
+const PipelineRunStreamPreview: React.FC<{ runId: string }> = ({ runId }) => {
+  const stream = useStableQuery(
+    api.domains.pipelines.pipelineStreamMutations.getPipelineStream,
+    { runId },
+  );
+  if (stream === undefined) {
+    return (
+      <div
+        data-testid="pipeline-run-stream-loading"
+        className="text-[11px] text-content-muted"
+      >
+        Loading stream…
+      </div>
+    );
+  }
+  if (stream === null) {
+    return (
+      <div
+        data-testid="pipeline-run-stream-empty"
+        className="text-[11px] text-content-muted"
+      >
+        No live output for this run.
+      </div>
+    );
+  }
+  const isLive = stream.status === "streaming";
+  return (
+    <div
+      data-testid="pipeline-run-stream"
+      data-pipeline-stream-status={stream.status}
+      className="rounded-md bg-surface/60 border border-edge/40 px-3 py-2 space-y-1.5"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-1.5 text-[11px] text-content-muted">
+          <Radio
+            className={`w-3 h-3 ${
+              isLive ? "text-emerald-500 animate-pulse" : "text-content-muted"
+            }`}
+          />
+          {stream.stepName} · {stream.status}
+          {stream.errorMessage ? ` · ${stream.errorMessage}` : ""}
+        </span>
+        <span className="text-[10px] text-content-muted">
+          {stream.partialText.length.toLocaleString()} chars
+        </span>
+      </div>
+      <pre
+        data-testid="pipeline-run-stream-text"
+        className="whitespace-pre-wrap break-words text-[11px] text-content max-h-64 overflow-y-auto font-mono leading-snug"
+      >
+        {stream.partialText.length > 0
+          ? stream.partialText.slice(0, 4000) +
+            (stream.partialText.length > 4000 ? "\n\n[…truncated]" : "")
+          : "(waiting for first delta)"}
+      </pre>
+    </div>
+  );
+};
+
 export const PipelineRunsPanel: React.FC = () => {
+  const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
   const runs = useStableQuery(
     api.domains.pipelines.pipelineRunsQueries.listRecentRuns,
     { limit: 8 },
@@ -213,6 +290,26 @@ export const PipelineRunsPanel: React.FC = () => {
                   {run.errorMessage}
                 </p>
               ) : null}
+              {expandedRunId === run.runId ? (
+                <PipelineRunStreamPreview runId={run.runId} />
+              ) : null}
+              <div className="flex items-center gap-3 pt-1">
+                <button
+                  type="button"
+                  data-testid="pipeline-run-toggle"
+                  onClick={() =>
+                    setExpandedRunId((prev) => (prev === run.runId ? null : run.runId))
+                  }
+                  className="inline-flex items-center gap-1 text-[11px] text-content-muted hover:text-content"
+                >
+                  {expandedRunId === run.runId ? (
+                    <ChevronDown className="w-3 h-3" />
+                  ) : (
+                    <ChevronRight className="w-3 h-3" />
+                  )}
+                  {expandedRunId === run.runId ? "Hide live output" : "Show live output"}
+                </button>
+              </div>
               {(run.bundleUrl || run.imageUrl) ? (
                 <div className="flex items-center gap-3 pt-1">
                   {run.imageUrl ? (


### PR DESCRIPTION
## Summary

Closes the third batch of pi-ai integration follow-ups, layered on [#211](https://github.com/HomenShum/nodebench-ai/pull/211) + [#212](https://github.com/HomenShum/nodebench-ai/pull/212). All three pieces ship end-to-end with live browser verification.

## What lands

### 1. Research pipeline (\`researchPipeline.ts\`)
3-step orchestrator-workers: \`research.scope\` → \`research.synthesize\` (streamed) → \`research.verify\`.

v1 uses model internal knowledge — no external web calls. Verdict tier reflects this (most runs land \`needs_review\` because hard numbers get flagged). Wire Linkup/Brave/etc. later by injecting snippets into the synthesize prompt.

**Live**: \`pipeline_mokpvi1b_yoj8ot\` — succeeded · needs_review · 4317-char synthesis · 38.5s · $0.001.

### 2. Reactive streaming (\`pipelineRunStreams\` + \`pipelineStreamMutations.ts\`)
- New \`pipelineRunStreams\` table (runId + stepName + partialText + status, BOUND-capped at 64 KB).
- \`startPipelineStream\` / \`appendPipelineStreamChunk\` / \`finalizePipelineStream\` mutations.
- Public \`getPipelineStream(runId, stepName?)\` query.

Convex's reactive query layer means clients see \`partialText\` grow in real time without HTTP infrastructure. No PersistentTextStreaming HTTP route required for server-side \`internalAction\` pipelines.

### 3. Document handoff (\`pipelineDocumentHandoff.ts\`)
Best-effort: when \`ownerKey: "user:<id>"\`, write the bundle as a Workspace \`documents\` row so RichNotebookEditor renders it natively. Anonymous runs export via storage bundle only.

ProseMirror-shaped doc with kind-specific sections:
- code_gen → Spec / Generated files / Verdict
- design_gen → Spec / Brief / Components / Verdict
- research → Spec / Synthesis / Citations / Verdict

Idempotent: same pipelineRunId overwrites the existing document.

### 4. UI live-stream preview
Each row in \`PipelineRunsPanel\` gets a "Show live output" toggle. Expanded rows render \`PipelineRunStreamPreview\` subscribed to \`getPipelineStream\` — partial text scrolls in with a pulsing "Live" badge that switches to "Complete".

**Live-verified**: 5 rows · 4 succeeded · expand research row → 4014-char stream preview with status="complete".

## Smoke test

\`\`\`bash
npx convex run domains/pipelines/researchPipeline:runResearchPipeline \
  '{"spec": "What are the practical tradeoffs of X vs Y?", "modelId": "gpt-4o-mini", "forceFresh": true}'
\`\`\`

Returns \`{ runId, status, verdict, synthesis, documentId?, bundleStorageId }\`.

## Stacking

Branched off [#212](https://github.com/HomenShum/nodebench-ai/pull/212). When #212 merges, this branch's rebase will skip the duplicated commits (git cherry-pick analysis already verified clean against #211 → #212 chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)