### PR TITLE
feat(pipelines): schedule UI + session ownerKey + MCP HTTP + eval scorecard

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -896,6 +896,8 @@ import type * as domains_pipelines_designGenPipeline from "../domains/pipelines/
 import type * as domains_pipelines_linkupAdapter from "../domains/pipelines/linkupAdapter.js";
 import type * as domains_pipelines_piRuntime from "../domains/pipelines/piRuntime.js";
 import type * as domains_pipelines_pipelineDocumentHandoff from "../domains/pipelines/pipelineDocumentHandoff.js";
+import type * as domains_pipelines_pipelineEvalQueries from "../domains/pipelines/pipelineEvalQueries.js";
+import type * as domains_pipelines_pipelineMcpHttp from "../domains/pipelines/pipelineMcpHttp.js";
 import type * as domains_pipelines_pipelineRunsMutations from "../domains/pipelines/pipelineRunsMutations.js";
 import type * as domains_pipelines_pipelineRunsQueries from "../domains/pipelines/pipelineRunsQueries.js";
 import type * as domains_pipelines_pipelineSchedule from "../domains/pipelines/pipelineSchedule.js";
@@ -2363,6 +2365,8 @@ declare const fullApi: ApiFromModules<{
   "domains/pipelines/linkupAdapter": typeof domains_pipelines_linkupAdapter;
   "domains/pipelines/piRuntime": typeof domains_pipelines_piRuntime;
   "domains/pipelines/pipelineDocumentHandoff": typeof domains_pipelines_pipelineDocumentHandoff;
+  "domains/pipelines/pipelineEvalQueries": typeof domains_pipelines_pipelineEvalQueries;
+  "domains/pipelines/pipelineMcpHttp": typeof domains_pipelines_pipelineMcpHttp;
   "domains/pipelines/pipelineRunsMutations": typeof domains_pipelines_pipelineRunsMutations;
   "domains/pipelines/pipelineRunsQueries": typeof domains_pipelines_pipelineRunsQueries;
   "domains/pipelines/pipelineSchedule": typeof domains_pipelines_pipelineSchedule;

--- a/convex/domains/pipelines/pipelineEvalQueries.ts
+++ b/convex/domains/pipelines/pipelineEvalQueries.ts
@@ -1,0 +1,183 @@
+/**
+ * Pipeline Eval Queries
+ *
+ * Aggregate scoring over recent `pipelineRuns`:
+ *
+ *   - Verdict accuracy: % of runs landing on `verified` vs the rest.
+ *     A simple proxy for "did the run produce trustworthy output."
+ *   - Brier score: applied to the verify-step's pass-rate vs binary
+ *     verdict outcome. Lower is better; <0.15 = good calibration.
+ *   - Cost/quality breakdown: $ per verdict tier.
+ *
+ * Pattern: deterministic aggregation. No LLM calls — pure SQL-style
+ * aggregation over the runs table. Cheap to compute, reactive on every
+ * new run row.
+ */
+
+import { v } from "convex/values";
+import { query } from "../../_generated/server";
+
+const VERDICT_TO_TARGET: Record<string, number> = {
+  verified: 1,
+  provisionally_verified: 0.7,
+  needs_review: 0.4,
+  failed: 0,
+};
+
+export const getPipelineEvalScorecard = query({
+  args: {
+    pipelineKind: v.optional(
+      v.union(
+        v.literal("code_gen"),
+        v.literal("design_gen"),
+        v.literal("research"),
+      ),
+    ),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({
+    samples: v.number(),
+    verdictCounts: v.object({
+      verified: v.number(),
+      provisionally_verified: v.number(),
+      needs_review: v.number(),
+      failed: v.number(),
+      other: v.number(),
+    }),
+    verdictAccuracy: v.number(),
+    brier: v.optional(v.number()),
+    avgDurationMs: v.optional(v.number()),
+    avgUsd: v.optional(v.number()),
+    costByVerdict: v.array(
+      v.object({
+        verdict: v.string(),
+        count: v.number(),
+        usd: v.number(),
+      }),
+    ),
+    byKind: v.array(
+      v.object({
+        pipelineKind: v.string(),
+        samples: v.number(),
+        verifiedShare: v.number(),
+        avgDurationMs: v.optional(v.number()),
+        avgUsd: v.optional(v.number()),
+      }),
+    ),
+  }),
+  handler: async (ctx, args) => {
+    const limit = Math.min(args.limit ?? 100, 500);
+    let q;
+    if (args.pipelineKind) {
+      q = ctx.db
+        .query("pipelineRuns")
+        .withIndex("by_kind_createdAt", (q) =>
+          q.eq("pipelineKind", args.pipelineKind!),
+        )
+        .order("desc");
+    } else {
+      q = ctx.db.query("pipelineRuns").order("desc");
+    }
+    const rows = await q.take(limit);
+    const samples = rows.length;
+
+    const verdictCounts = {
+      verified: 0,
+      provisionally_verified: 0,
+      needs_review: 0,
+      failed: 0,
+      other: 0,
+    };
+    let totalDuration = 0;
+    let durationSamples = 0;
+    let totalUsd = 0;
+    let usdSamples = 0;
+    let brierSum = 0;
+    let brierSamples = 0;
+    const costByVerdictMap = new Map<string, { count: number; usd: number }>();
+    const byKindMap = new Map<
+      string,
+      { samples: number; verified: number; durSum: number; durN: number; usdSum: number; usdN: number }
+    >();
+
+    for (const r of rows) {
+      const v = r.verdict ?? "other";
+      if (v === "verified") verdictCounts.verified += 1;
+      else if (v === "provisionally_verified") verdictCounts.provisionally_verified += 1;
+      else if (v === "needs_review") verdictCounts.needs_review += 1;
+      else if (v === "failed") verdictCounts.failed += 1;
+      else verdictCounts.other += 1;
+
+      if (typeof r.durationMs === "number") {
+        totalDuration += r.durationMs;
+        durationSamples += 1;
+      }
+      if (typeof r.estimatedUsd === "number") {
+        totalUsd += r.estimatedUsd;
+        usdSamples += 1;
+      }
+
+      const cbvKey = v;
+      const existing = costByVerdictMap.get(cbvKey) ?? { count: 0, usd: 0 };
+      existing.count += 1;
+      existing.usd += r.estimatedUsd ?? 0;
+      costByVerdictMap.set(cbvKey, existing);
+
+      const kindEntry = byKindMap.get(r.pipelineKind) ?? {
+        samples: 0,
+        verified: 0,
+        durSum: 0,
+        durN: 0,
+        usdSum: 0,
+        usdN: 0,
+      };
+      kindEntry.samples += 1;
+      if (v === "verified") kindEntry.verified += 1;
+      if (typeof r.durationMs === "number") {
+        kindEntry.durSum += r.durationMs;
+        kindEntry.durN += 1;
+      }
+      if (typeof r.estimatedUsd === "number") {
+        kindEntry.usdSum += r.estimatedUsd;
+        kindEntry.usdN += 1;
+      }
+      byKindMap.set(r.pipelineKind, kindEntry);
+
+      // Brier: forecast = VERDICT_TO_TARGET[verdict], outcome = 1 if status==succeeded.
+      const forecast = VERDICT_TO_TARGET[v];
+      if (typeof forecast === "number") {
+        const outcome = r.status === "succeeded" ? 1 : 0;
+        brierSum += (forecast - outcome) ** 2;
+        brierSamples += 1;
+      }
+    }
+
+    const verdictAccuracy = samples > 0 ? verdictCounts.verified / samples : 0;
+    const brier = brierSamples > 0 ? brierSum / brierSamples : undefined;
+    const avgDurationMs = durationSamples > 0 ? totalDuration / durationSamples : undefined;
+    const avgUsd = usdSamples > 0 ? totalUsd / usdSamples : undefined;
+
+    const costByVerdict = [...costByVerdictMap.entries()]
+      .map(([verdict, { count, usd }]) => ({ verdict, count, usd }))
+      .sort((a, b) => b.count - a.count);
+
+    const byKind = [...byKindMap.entries()].map(([pipelineKind, k]) => ({
+      pipelineKind,
+      samples: k.samples,
+      verifiedShare: k.samples > 0 ? k.verified / k.samples : 0,
+      avgDurationMs: k.durN > 0 ? k.durSum / k.durN : undefined,
+      avgUsd: k.usdN > 0 ? k.usdSum / k.usdN : undefined,
+    }));
+
+    return {
+      samples,
+      verdictCounts,
+      verdictAccuracy,
+      brier,
+      avgDurationMs,
+      avgUsd,
+      costByVerdict,
+      byKind,
+    };
+  },
+});

--- a/convex/domains/pipelines/pipelineMcpHttp.ts
+++ b/convex/domains/pipelines/pipelineMcpHttp.ts
@@ -1,0 +1,173 @@
+/**
+ * Pipeline MCP HTTP Bridge
+ *
+ * Lightweight HTTP entry points so external MCP servers, agents, and
+ * `curl`-based integrations can drive pipelines without holding a
+ * Convex client.
+ *
+ *   POST /mcp/pipeline/run          → kicks off any pipeline kind
+ *   POST /mcp/pipeline/run-composed → kicks off a composed pipeline
+ *   GET  /mcp/pipeline/status       → reads a run + steps + stream
+ *   GET  /mcp/pipeline/list         → lists recent runs
+ *
+ * Auth: shared-secret header `x-mcp-secret`. Set via `MCP_SECRET` env var.
+ * SSRF: endpoints are read/write but URLs are constant; no user-controlled
+ * fetches.
+ */
+
+import { httpAction } from "../../_generated/server";
+import { api, internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+
+function unauthorized(): Response {
+  return new Response(JSON.stringify({ error: "unauthorized" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function check(req: Request): boolean {
+  const provided = req.headers.get("x-mcp-secret") ?? "";
+  const expected = process.env.MCP_SECRET ?? "";
+  return Boolean(expected) && provided === expected;
+}
+
+export const runPipelineHttp = httpAction(async (ctx, request) => {
+  if (!check(request)) return unauthorized();
+  let body: any = {};
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid_json" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const { pipelineKind, spec, title, modelId, ownerKey, forceFresh, linkupDepth } = body ?? {};
+  if (
+    pipelineKind !== "code_gen" &&
+    pipelineKind !== "design_gen" &&
+    pipelineKind !== "research"
+  ) {
+    return new Response(
+      JSON.stringify({ error: "invalid_pipelineKind", got: pipelineKind }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+  if (typeof spec !== "string" || spec.length === 0) {
+    return new Response(JSON.stringify({ error: "spec_required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const result = await ctx.runMutation(
+    api.domains.pipelines.pipelineWorkflow.startPipelineRun,
+    {
+      pipelineKind,
+      spec,
+      title,
+      modelId,
+      ownerKey,
+      forceFresh: forceFresh === true,
+      linkupDepth: linkupDepth === "deep" ? "deep" : undefined,
+    },
+  );
+  return new Response(JSON.stringify(result), {
+    status: 202, // accepted; durable workflow runs async
+    headers: { "Content-Type": "application/json" },
+  });
+});
+
+export const runComposedPipelineHttp = httpAction(async (ctx, request) => {
+  if (!check(request)) return unauthorized();
+  let body: any = {};
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid_json" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const { composition, spec, title, modelId, ownerKey, forceFresh, linkupDepth } = body ?? {};
+  const validCompositions = new Set([
+    "research_then_code",
+    "research_then_design",
+    "code_then_design",
+  ]);
+  if (!validCompositions.has(composition)) {
+    return new Response(
+      JSON.stringify({ error: "invalid_composition", got: composition }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+  if (typeof spec !== "string" || spec.length === 0) {
+    return new Response(JSON.stringify({ error: "spec_required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const result = await ctx.runMutation(
+    api.domains.pipelines.pipelineWorkflow.startComposedPipelineRun,
+    {
+      composition,
+      spec,
+      title,
+      modelId,
+      ownerKey,
+      forceFresh: forceFresh === true,
+      linkupDepth: linkupDepth === "deep" ? "deep" : undefined,
+    },
+  );
+  return new Response(JSON.stringify(result), {
+    status: 202,
+    headers: { "Content-Type": "application/json" },
+  });
+});
+
+export const getPipelineStatusHttp = httpAction(async (ctx, request) => {
+  if (!check(request)) return unauthorized();
+  const url = new URL(request.url);
+  const runId = url.searchParams.get("runId");
+  if (!runId) {
+    return new Response(JSON.stringify({ error: "runId_required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const detail = await ctx.runQuery(
+    api.domains.pipelines.pipelineRunsQueries.getRunDetail,
+    { runId },
+  );
+  if (!detail) {
+    return new Response(JSON.stringify({ error: "not_found", runId }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(JSON.stringify(detail), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});
+
+export const listPipelineRunsHttp = httpAction(async (ctx, request) => {
+  if (!check(request)) return unauthorized();
+  const url = new URL(request.url);
+  const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "25", 10) || 25, 100);
+  const ownerKey = url.searchParams.get("ownerKey") ?? undefined;
+  const result = await ctx.runQuery(
+    api.domains.pipelines.pipelineRunsQueries.listRecentRuns,
+    { limit, ownerKey: ownerKey ?? undefined },
+  );
+  return new Response(JSON.stringify({ runs: result }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/convex/domains/pipelines/pipelineSchedule.ts
+++ b/convex/domains/pipelines/pipelineSchedule.ts
@@ -89,6 +89,15 @@ export const setScheduleEnabled = mutation({
   },
 });
 
+export const deleteSchedule = mutation({
+  args: { scheduleId: v.id("scheduledPipelineRuns") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.delete(args.scheduleId);
+    return null;
+  },
+});
+
 export const listSchedules = query({
   args: { ownerKey: v.optional(v.string()), limit: v.optional(v.number()) },
   returns: v.array(

--- a/convex/router.ts
+++ b/convex/router.ts
@@ -65,6 +65,14 @@ function base64EncodeAscii(input: string): string {
 // Voice agent helpers - Import from integrations domain
 import { voiceAction, voiceConnect } from "./domains/integrations/voice/voiceActions";
 
+// Pi-AI Pipeline MCP HTTP bridge
+import {
+  runPipelineHttp,
+  runComposedPipelineHttp,
+  getPipelineStatusHttp,
+  listPipelineRunsHttp,
+} from "./domains/pipelines/pipelineMcpHttp";
+
 // JSON-RPC 2.0 MCP-compatible endpoint (minimal, JSON-only)
 // Methods supported:
 // - initialize
@@ -1076,6 +1084,20 @@ http.route({
   method: "POST",
   handler: voiceAction,
 });
+
+// ============================================================================
+// Pi-AI Pipeline MCP HTTP bridge — external agents drive pipelines via curl
+// Auth: x-mcp-secret header matching MCP_SECRET env var.
+// ============================================================================
+
+http.route({ path: "/mcp/pipeline/run", method: "POST", handler: runPipelineHttp });
+http.route({
+  path: "/mcp/pipeline/run-composed",
+  method: "POST",
+  handler: runComposedPipelineHttp,
+});
+http.route({ path: "/mcp/pipeline/status", method: "GET", handler: getPipelineStatusHttp });
+http.route({ path: "/mcp/pipeline/list", method: "GET", handler: listPipelineRunsHttp });
 
 // ============================================================================
 // Twilio SMS Webhooks (for A2P 10DLC compliance)

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -54,6 +54,8 @@ import { RichNotebookEditor } from "@/features/notebook/components/RichNotebookE
 import { EntityFindingsPanel } from "@/features/narrative/components/social/EntityFindingsPanel";
 import { PipelineRunsPanel } from "@/features/pipelines/views/PipelineRunsPanel";
 import { PipelineLauncher } from "@/features/pipelines/views/PipelineLauncher";
+import { PipelineSchedulesPanel } from "@/features/pipelines/views/PipelineSchedulesPanel";
+import { PipelineEvalScorecard } from "@/features/pipelines/views/PipelineEvalScorecard";
 import {
   buildLocalWorkspacePath,
   buildWorkspaceUrl,
@@ -1423,6 +1425,14 @@ export function ExactReportsSurface() {
 
         <div data-testid="reports-pipeline-launcher-slot" style={{ marginBottom: 16 }}>
           <PipelineLauncher />
+        </div>
+
+        <div data-testid="reports-pipeline-schedules-slot" style={{ marginBottom: 16 }}>
+          <PipelineSchedulesPanel />
+        </div>
+
+        <div data-testid="reports-pipeline-eval-slot" style={{ marginBottom: 16 }}>
+          <PipelineEvalScorecard />
         </div>
 
         <div data-testid="reports-pipelines-panel-slot" style={{ marginBottom: 16 }}>

--- a/src/features/pipelines/views/PipelineEvalScorecard.tsx
+++ b/src/features/pipelines/views/PipelineEvalScorecard.tsx
@@ -1,0 +1,186 @@
+/**
+ * PipelineEvalScorecard
+ *
+ * Surfaces aggregate eval metrics over the most recent pipelineRuns:
+ *   - Verdict accuracy (% verified)
+ *   - Brier score (forecast-vs-outcome calibration)
+ *   - Avg duration / cost
+ *   - Per-kind breakdown
+ *
+ * Pure-data view — no LLM calls. Uses the existing `pipelineRuns`
+ * substrate to derive scores deterministically.
+ */
+
+import React from "react";
+import { useStableQuery } from "@/hooks/useStableQuery";
+import { api } from "../../../../convex/_generated/api";
+import { Gauge, TrendingUp } from "lucide-react";
+
+function pct(n: number): string {
+  return `${Math.round(n * 1000) / 10}%`;
+}
+
+function ms(n?: number): string {
+  if (typeof n !== "number" || !Number.isFinite(n)) return "—";
+  if (n < 1000) return `${Math.round(n)}ms`;
+  return `${(n / 1000).toFixed(1)}s`;
+}
+
+function usd(n?: number): string {
+  if (typeof n !== "number" || !Number.isFinite(n) || n <= 0) return "—";
+  if (n < 0.01) return "<$0.01";
+  return `$${n.toFixed(3)}`;
+}
+
+function brierLabel(b?: number): { label: string; tone: string } {
+  if (typeof b !== "number") return { label: "—", tone: "text-content-muted" };
+  if (b < 0.15)
+    return {
+      label: `${b.toFixed(3)} · well-calibrated`,
+      tone: "text-emerald-700 dark:text-emerald-300",
+    };
+  if (b < 0.25)
+    return {
+      label: `${b.toFixed(3)} · acceptable`,
+      tone: "text-amber-700 dark:text-amber-300",
+    };
+  return {
+    label: `${b.toFixed(3)} · poorly calibrated`,
+    tone: "text-red-700 dark:text-red-300",
+  };
+}
+
+export const PipelineEvalScorecard: React.FC = () => {
+  const stats = useStableQuery(
+    api.domains.pipelines.pipelineEvalQueries.getPipelineEvalScorecard,
+    { limit: 100 },
+  );
+
+  if (stats === undefined) {
+    return (
+      <section
+        data-testid="pipeline-eval-scorecard"
+        className="nb-surface-card p-4 text-xs text-content-muted"
+      >
+        Loading eval scorecard…
+      </section>
+    );
+  }
+  if (stats.samples === 0) {
+    return (
+      <section
+        data-testid="pipeline-eval-scorecard-empty"
+        className="nb-surface-card p-4 space-y-2"
+      >
+        <header className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-md bg-violet-500/15 flex items-center justify-center">
+            <Gauge className="w-4 h-4 text-violet-600 dark:text-violet-300" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-content">Eval scorecard</h3>
+            <p className="text-[11px] text-content-muted">
+              Brier + verdict accuracy across recent runs · empty until runs land.
+            </p>
+          </div>
+        </header>
+      </section>
+    );
+  }
+
+  const brier = brierLabel(stats.brier);
+
+  return (
+    <section
+      data-testid="pipeline-eval-scorecard"
+      aria-label="Pipeline eval scorecard"
+      className="nb-surface-card p-4 space-y-3"
+    >
+      <header className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-md bg-violet-500/15 flex items-center justify-center">
+            <Gauge className="w-4 h-4 text-violet-600 dark:text-violet-300" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-content">Eval scorecard</h3>
+            <p className="text-[11px] text-content-muted">
+              Aggregated over the last {stats.samples} run(s)
+            </p>
+          </div>
+        </div>
+        <div className="text-[11px] text-content-muted">
+          <span data-testid="pipeline-eval-accuracy">
+            verified {pct(stats.verdictAccuracy)}
+          </span>{" "}
+          ·{" "}
+          <span data-testid="pipeline-eval-brier" className={brier.tone}>
+            Brier {brier.label}
+          </span>{" "}
+          · avg {ms(stats.avgDurationMs)} / {usd(stats.avgUsd)}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
+        {(
+          [
+            ["verified", "emerald"],
+            ["provisionally_verified", "amber"],
+            ["needs_review", "amber"],
+            ["failed", "red"],
+            ["other", "content-muted"],
+          ] as const
+        ).map(([key, tone]) => (
+          <div
+            key={key}
+            data-testid={`pipeline-eval-count-${key}`}
+            className="rounded-md border border-edge/60 px-2 py-1.5"
+          >
+            <div className="text-[10px] uppercase tracking-wide text-content-muted">
+              {key.replace("_", " ")}
+            </div>
+            <div className={`text-sm font-semibold text-${tone}-700 dark:text-${tone}-300`}>
+              {(stats.verdictCounts as any)[key]}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {stats.byKind.length > 0 ? (
+        <div data-testid="pipeline-eval-by-kind" className="text-[11px]">
+          <div className="text-content-muted mb-1 inline-flex items-center gap-1">
+            <TrendingUp className="w-3 h-3" /> Per-kind breakdown
+          </div>
+          <table className="w-full">
+            <thead>
+              <tr className="text-[10px] uppercase text-content-muted">
+                <th className="text-left py-0.5">Kind</th>
+                <th className="text-right py-0.5">Samples</th>
+                <th className="text-right py-0.5">Verified%</th>
+                <th className="text-right py-0.5">Avg duration</th>
+                <th className="text-right py-0.5">Avg cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.byKind.map((k) => (
+                <tr key={k.pipelineKind} className="border-t border-edge/40">
+                  <td className="py-0.5 text-content">{k.pipelineKind.replace("_", " ")}</td>
+                  <td className="py-0.5 text-right text-content-muted">{k.samples}</td>
+                  <td className="py-0.5 text-right text-content-muted">
+                    {pct(k.verifiedShare)}
+                  </td>
+                  <td className="py-0.5 text-right text-content-muted">
+                    {ms(k.avgDurationMs)}
+                  </td>
+                  <td className="py-0.5 text-right text-content-muted">
+                    {usd(k.avgUsd)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+export default PipelineEvalScorecard;

--- a/src/features/pipelines/views/PipelineLauncher.tsx
+++ b/src/features/pipelines/views/PipelineLauncher.tsx
@@ -9,10 +9,11 @@
  * refresh required.
  */
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
-import { Play, Loader2, Layers } from "lucide-react";
+import { Play, Loader2, Layers, Calendar } from "lucide-react";
+import { getAnonymousProductSessionId } from "@/features/product/lib/productIdentity";
 
 const PIPELINE_KINDS = [
   { value: "research", label: "Research" },
@@ -71,16 +72,35 @@ export const PipelineLauncher: React.FC = () => {
   const startComposedPipelineRun = useMutation(
     api.domains.pipelines.pipelineWorkflow.startComposedPipelineRun,
   );
+  const createSchedule = useMutation(
+    api.domains.pipelines.pipelineSchedule.createSchedule,
+  );
 
   // Auth-aware ownerKey: when signed in, runs are attributed to the
   // user (`user:<id>`) so the document handoff fires automatically and
-  // /reports filtering works. Anonymous runs export storage-only.
+  // /reports filtering works. When anonymous, fall back to the persistent
+  // anonymous session id (`session:<id>`) so shareable run links resolve
+  // for the same browser session even before signup. Storage-bundle export
+  // is the only handoff path until they sign in (auth-gated).
   const loggedInUser = useQuery(
     (api as any)?.domains?.auth?.auth?.loggedInUser ?? "skip",
   );
+  const anonymousSessionId = useMemo(() => getAnonymousProductSessionId(), []);
   const ownerKey = loggedInUser?._id
     ? `user:${loggedInUser._id}`
-    : undefined;
+    : anonymousSessionId
+      ? `session:${anonymousSessionId}`
+      : undefined;
+  const ownerLabel = loggedInUser?._id
+    ? "Signed in — output also lands as a Workspace document."
+    : `Session ${anonymousSessionId?.slice(0, 8) ?? "?"} — bundle export only (sign in for document handoff).`;
+  // Schedule mode: when ON, submit creates a scheduledPipelineRuns row
+  // instead of firing the workflow immediately. Cron sweeps the row
+  // hourly and kicks off the run when nextRunAt elapses.
+  const [scheduleMode, setScheduleMode] = useState(false);
+  const [scheduleCadence, setScheduleCadence] = useState<
+    "once" | "hourly" | "daily" | "weekly"
+  >("daily");
   const isComposed = COMPOSED_KINDS.has(pipelineKind);
   const showLinkupDepth =
     pipelineKind === "research" || pipelineKind === "research_then_code" ||
@@ -93,9 +113,36 @@ export const PipelineLauncher: React.FC = () => {
       setFeedback({ kind: "error", message: "Spec required." });
       return;
     }
+    if (scheduleMode && isComposed) {
+      setFeedback({
+        kind: "error",
+        message: "Composed pipelines can't be scheduled yet. Pick a primitive kind.",
+      });
+      return;
+    }
     setSubmitting(true);
     setFeedback(null);
     try {
+      if (scheduleMode) {
+        const result = await createSchedule({
+          ownerKey,
+          pipelineKind: pipelineKind as "research" | "code_gen" | "design_gen",
+          spec: spec.trim(),
+          title: title.trim() || undefined,
+          modelId,
+          cadence: scheduleCadence,
+          nextRunAt: Date.now(), // fire immediately on next cron sweep
+          options: showLinkupDepth ? { linkupDepth } : undefined,
+        });
+        setFeedback({
+          kind: "ok",
+          message: `Schedule ${result.scheduleId} created — fires on next ${scheduleCadence} cron sweep.`,
+        });
+        setSpec("");
+        setTitle("");
+        setSubmitting(false);
+        return;
+      }
       let workflowId: string;
       if (isComposed) {
         const result = await startComposedPipelineRun({
@@ -246,6 +293,43 @@ export const PipelineLauncher: React.FC = () => {
             <span>Composed run: two pipelineRuns rows will appear (stage 1 → stage 2).</span>
           </div>
         ) : null}
+        <div className="flex items-center gap-3 flex-wrap text-[11px] text-content-muted">
+          <label className="inline-flex items-center gap-1.5 cursor-pointer">
+            <input
+              type="checkbox"
+              data-testid="pipeline-launcher-schedule-toggle"
+              checked={scheduleMode}
+              onChange={(e) => setScheduleMode(e.target.checked)}
+              disabled={submitting || isComposed}
+              className="h-3 w-3"
+            />
+            <Calendar className="w-3 h-3" />
+            <span>Schedule instead of run now</span>
+          </label>
+          {scheduleMode ? (
+            <select
+              data-testid="pipeline-launcher-schedule-cadence"
+              className="bg-surface border border-edge rounded-md text-xs px-2 py-0.5 text-content"
+              value={scheduleCadence}
+              onChange={(e) =>
+                setScheduleCadence(
+                  e.target.value as "once" | "hourly" | "daily" | "weekly",
+                )
+              }
+              disabled={submitting}
+            >
+              <option value="once">Once</option>
+              <option value="hourly">Hourly</option>
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly</option>
+            </select>
+          ) : null}
+          {scheduleMode && isComposed ? (
+            <span className="text-amber-700 dark:text-amber-300">
+              (composed schedules not supported)
+            </span>
+          ) : null}
+        </div>
         <label className="flex flex-col gap-1 text-xs text-content-muted">
           <span>Spec</span>
           <textarea
@@ -267,10 +351,10 @@ export const PipelineLauncher: React.FC = () => {
             Runs durably via{" "}
             <code className="text-[10px]">@convex-dev/workflow</code> — retries on transient
             failure, idempotent on resubmit.
-            {ownerKey ? (
-              <span data-testid="pipeline-launcher-owner-signedin"> Signed in — output also lands as a Workspace document.</span>
+            {loggedInUser?._id ? (
+              <span data-testid="pipeline-launcher-owner-signedin"> {ownerLabel}</span>
             ) : (
-              <span data-testid="pipeline-launcher-owner-anon"> Anonymous — bundle export only (sign in for document handoff).</span>
+              <span data-testid="pipeline-launcher-owner-anon"> {ownerLabel}</span>
             )}
           </div>
           <button

--- a/src/features/pipelines/views/PipelineSchedulesPanel.tsx
+++ b/src/features/pipelines/views/PipelineSchedulesPanel.tsx
@@ -1,0 +1,197 @@
+/**
+ * PipelineSchedulesPanel
+ *
+ * Lists `scheduledPipelineRuns` rows for the signed-in user (or session)
+ * with toggle / delete affordances. Drives the cron sweep that fires
+ * pipelines on cadence (once / hourly / daily / weekly).
+ */
+
+import React from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import {
+  Calendar,
+  CheckCircle2,
+  Pause,
+  Play,
+  Trash2,
+} from "lucide-react";
+
+interface ScheduleRow {
+  _id: Id<"scheduledPipelineRuns">;
+  ownerKey?: string;
+  pipelineKind: string;
+  spec: string;
+  title?: string;
+  modelId: string;
+  cadence: string;
+  enabled: boolean;
+  nextRunAt: number;
+  lastRunAt?: number;
+  lastRunId?: string;
+  lastStatus?: string;
+  options?: any;
+  createdAt: number;
+}
+
+function formatRelative(ms: number): string {
+  const diff = ms - Date.now();
+  const abs = Math.abs(diff);
+  const m = Math.round(abs / 60_000);
+  if (m < 1) return diff > 0 ? "in <1 min" : "<1 min ago";
+  if (m < 60) return diff > 0 ? `in ${m} min` : `${m} min ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return diff > 0 ? `in ${h}h` : `${h}h ago`;
+  const d = Math.round(h / 24);
+  return diff > 0 ? `in ${d}d` : `${d}d ago`;
+}
+
+export const PipelineSchedulesPanel: React.FC<{ ownerKey?: string }> = ({ ownerKey }) => {
+  const schedules = useQuery(
+    api.domains.pipelines.pipelineSchedule.listSchedules,
+    { ownerKey, limit: 25 },
+  ) as ScheduleRow[] | undefined;
+  const setEnabled = useMutation(
+    api.domains.pipelines.pipelineSchedule.setScheduleEnabled,
+  );
+  const deleteSchedule = useMutation(
+    api.domains.pipelines.pipelineSchedule.deleteSchedule,
+  );
+
+  if (schedules === undefined) {
+    return (
+      <section
+        data-testid="pipeline-schedules-panel"
+        className="nb-surface-card p-4 text-xs text-content-muted"
+      >
+        Loading schedules…
+      </section>
+    );
+  }
+
+  if (schedules.length === 0) {
+    return (
+      <section
+        data-testid="pipeline-schedules-empty"
+        className="nb-surface-card p-4 space-y-2"
+      >
+        <header className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-md bg-blue-500/15 flex items-center justify-center">
+            <Calendar className="w-4 h-4 text-blue-600 dark:text-blue-300" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-content">Pipeline schedules</h3>
+            <p className="text-[11px] text-content-muted">
+              Cron-fired pipeline runs land here. Empty — none scheduled yet.
+            </p>
+          </div>
+        </header>
+        <p className="text-xs text-content-muted">
+          Create one via{" "}
+          <code className="text-[11px]">
+            npx convex run domains/pipelines/pipelineSchedule:createSchedule …
+          </code>
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      data-testid="pipeline-schedules-panel"
+      aria-label="Pipeline schedules"
+      className="nb-surface-card p-4 space-y-3"
+    >
+      <header className="flex items-center gap-2">
+        <div className="w-8 h-8 rounded-md bg-blue-500/15 flex items-center justify-center">
+          <Calendar className="w-4 h-4 text-blue-600 dark:text-blue-300" />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-content">Pipeline schedules</h3>
+          <p className="text-[11px] text-content-muted">
+            Cron sweeps every hour · {schedules.filter((s) => s.enabled).length} enabled ·{" "}
+            {schedules.length} total
+          </p>
+        </div>
+      </header>
+      <ul data-testid="pipeline-schedule-list" className="space-y-2">
+        {schedules.map((row) => (
+          <li
+            key={row._id}
+            data-testid="pipeline-schedule-row"
+            data-enabled={row.enabled ? "1" : "0"}
+            className="rounded-md border border-edge/60 px-3 py-2 text-xs space-y-1"
+          >
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+              <span className="inline-flex items-center gap-1.5 text-content font-medium truncate max-w-[55%]">
+                {row.title ?? row.spec.slice(0, 60)}
+              </span>
+              <span className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-content-muted">
+                {row.pipelineKind.replace("_", " ")} · {row.cadence}
+                {row.enabled ? (
+                  <span className="text-emerald-700 dark:text-emerald-300">enabled</span>
+                ) : (
+                  <span className="text-content-muted">paused</span>
+                )}
+              </span>
+            </div>
+            <div className="text-[11px] text-content-muted">
+              Next run {formatRelative(row.nextRunAt)} · model {row.modelId}
+              {row.lastRunAt
+                ? ` · last fired ${formatRelative(row.lastRunAt)}${row.lastStatus ? ` (${row.lastStatus})` : ""}`
+                : " · never fired"}
+            </div>
+            <div className="flex items-center gap-2 pt-1">
+              <button
+                type="button"
+                data-testid="pipeline-schedule-toggle"
+                onClick={() => setEnabled({ scheduleId: row._id, enabled: !row.enabled })}
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md border text-[11px] ${
+                  row.enabled
+                    ? "border-edge text-content-muted hover:bg-surface-hover"
+                    : "border-emerald-500/40 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10"
+                }`}
+              >
+                {row.enabled ? (
+                  <>
+                    <Pause className="w-3 h-3" /> Pause
+                  </>
+                ) : (
+                  <>
+                    <Play className="w-3 h-3" /> Resume
+                  </>
+                )}
+              </button>
+              <button
+                type="button"
+                data-testid="pipeline-schedule-delete"
+                onClick={() => {
+                  if (
+                    typeof window !== "undefined" &&
+                    !window.confirm(
+                      `Delete schedule "${row.title ?? row.spec.slice(0, 40)}"? This cannot be undone.`,
+                    )
+                  ) {
+                    return;
+                  }
+                  deleteSchedule({ scheduleId: row._id });
+                }}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-edge text-[11px] text-red-700 dark:text-red-300 hover:bg-red-500/10"
+              >
+                <Trash2 className="w-3 h-3" /> Delete
+              </button>
+              {row.lastStatus === "kicked" ? (
+                <span className="inline-flex items-center gap-1 text-[10px] text-emerald-700 dark:text-emerald-300">
+                  <CheckCircle2 className="w-3 h-3" /> last sweep ok
+                </span>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default PipelineSchedulesPanel;


### PR DESCRIPTION
## Summary

Sixth pi-ai batch — completes the four "Ready for next" follow-ups. Stacks on #211 → #212 → #213 → #214 → #215. All four live-verified.

## What lands

### 1. Schedule-management UI (\`PipelineSchedulesPanel\`)
Lists \`scheduledPipelineRuns\` with toggle/pause/delete. Shows next-run + last-run relative times + cadence + status. New \`deleteSchedule\` mutation.

### 2. Session ownerKey + schedule toggle in launcher
- \`PipelineLauncher\` reads \`getAnonymousProductSessionId()\` as fallback
- \`ownerKey\` = \`user:<id>\` when signed in, \`session:<id>\` when anon (shareable)
- New schedule toggle creates \`scheduledPipelineRuns\` row instead of running immediately
- Cadence picker: once / hourly / daily / weekly

### 3. MCP HTTP bridge
External agents drive pipelines via curl:
- \`POST /mcp/pipeline/run\`
- \`POST /mcp/pipeline/run-composed\`
- \`GET /mcp/pipeline/status?runId=…\`
- \`GET /mcp/pipeline/list\`

Auth: \`x-mcp-secret\` header matching \`MCP_SECRET\` env. 202 on accept (durable workflow).

### 4. Eval scorecard (\`PipelineEvalScorecard\`)
Aggregates over recent \`pipelineRuns\`:
- **Verdict accuracy** (% verified)
- **Brier score** over verdict-tier vs status-success (0 perfect, 0.25 random)
- Avg duration / cost
- Per-kind breakdown table

**Live**: verified 41.7% · Brier 0.135 (well-calibrated) over 12 runs.

## Live browser state (\`/?surface=packets\`)

\`\`\`
Run a pipeline                                    [▷ Run pipeline]
  Kind / Model / Title · Schedule toggle · Cadence
  "Session 7545f859 — bundle export only (sign in for document handoff)."

Pipeline schedules            (empty / list with toggle + delete)

Eval scorecard
  verified 41.7% · Brier 0.135 · well-calibrated
  [verified 5] [provisionally 0] [needs_review 6] [failed 1] [other 0]
  Per-kind table

Findings by entity            (existing)

Pipeline runs                 (12 rows · expand-to-stream · downloads)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)