### PR TITLE
fix(mobile): restore reports pipeline parity

### DIFF
--- a/convex/domains/analytics/intentSignals.ts
+++ b/convex/domains/analytics/intentSignals.ts
@@ -576,6 +576,52 @@ export const listIntentHotspotCards = query({
   },
 });
 
+export const exportIntentHotspotCardsForOps = internalQuery({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    const limit = Math.min(Math.max(args.limit ?? 200, 1), 2000);
+    const sessions = await ctx.db
+      .query("agentTaskSessions")
+      .withIndex("by_type_date", (q: any) => q.eq("type", "manual"))
+      .order("desc")
+      .take(5000);
+
+    const cards: any[] = [];
+    for (const session of sessions as Doc<"agentTaskSessions">[]) {
+      const meta = session.metadata as IntentHotspotMeta | undefined;
+      if (meta?.kind !== "intent_hotspot") continue;
+
+      const artifactId = meta.investigation?.artifactId;
+      const artifact = artifactId ? await ctx.db.get(artifactId) : null;
+      cards.push({
+        sessionId: session._id,
+        title: session.title,
+        description: session.description ?? "",
+        startedAt: session.startedAt,
+        status: session.status,
+        meta,
+        artifacts: {
+          investigation: artifact
+            ? {
+                id: artifact._id,
+                fetchedAt: artifact.fetchedAt,
+                title: artifact.title,
+                rawContent: typeof artifact.rawContent === "string" ? artifact.rawContent.slice(0, 12000) : null,
+                extractedData: artifact.extractedData ?? null,
+              }
+            : null,
+        },
+      });
+      if (cards.length >= limit) break;
+    }
+
+    return { ok: true, exportedAtIso: new Date().toISOString(), cards };
+  },
+});
+
 export const moveIntentHotspotCard = mutation({
   args: {
     sessionId: v.id("agentTaskSessions"),

--- a/convex/domains/enrichment/signals/signalIngester.ts
+++ b/convex/domains/enrichment/signals/signalIngester.ts
@@ -165,6 +165,40 @@ export const getPendingSignals = internalQuery({
   },
 });
 
+export const getRecentSignals = internalQuery({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, { limit = 100 }): Promise<Array<Doc<"signals"> & { ingestedAt: number; status: string }>> => {
+    const boundedLimit = Math.min(Math.max(limit, 1), 500);
+    const signals = await ctx.db.query("signals").take(1000) as Doc<"signals">[];
+    return signals
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, boundedLimit)
+      .map((signal) => ({
+        ...signal,
+        ingestedAt: signal.createdAt,
+        status: signal.processingStatus,
+      }));
+  },
+});
+
+export const getUnprocessedSignals = internalQuery({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, { limit = 50 }): Promise<Doc<"signals">[]> => {
+    const boundedLimit = Math.min(Math.max(limit, 1), 500);
+    const failed = await ctx.db
+      .query("signals")
+      .withIndex("by_status", (q) => q.eq("processingStatus", "failed"))
+      .take(boundedLimit) as Doc<"signals">[];
+    if (failed.length >= boundedLimit) return failed;
+
+    const pending = await ctx.db
+      .query("signals")
+      .withIndex("by_status", (q) => q.eq("processingStatus", "pending"))
+      .take(boundedLimit - failed.length) as Doc<"signals">[];
+    return [...failed, ...pending];
+  },
+});
+
 /**
  * Get signals by source type
  */
@@ -312,6 +346,26 @@ export const cleanupExpiredSignals = internalMutation({
     }
 
     return { deleted: expiredSignals.length };
+  },
+});
+
+export const cleanupErrorSignals = internalMutation({
+  args: {
+    olderThanHours: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { olderThanHours = 24, limit = 100 }): Promise<number> => {
+    const cutoff = Date.now() - olderThanHours * 60 * 60 * 1000;
+    const failedSignals = await ctx.db
+      .query("signals")
+      .withIndex("by_status", (q) => q.eq("processingStatus", "failed"))
+      .filter((q) => q.lt(q.field("createdAt"), cutoff))
+      .take(Math.min(Math.max(limit, 1), 500)) as Doc<"signals">[];
+
+    for (const signal of failedSignals) {
+      await ctx.db.delete(signal._id);
+    }
+    return failedSignals.length;
   },
 });
 

--- a/convex/domains/social/publishing/deliveryQueue.ts
+++ b/convex/domains/social/publishing/deliveryQueue.ts
@@ -159,6 +159,53 @@ export const getQueueStats = internalQuery({
   },
 });
 
+export const getDeliveryStats = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<{
+    pending: number;
+    deliveredToday: number;
+    failedToday: number;
+    retriesExhausted: number;
+  }> => {
+    const allJobs = await ctx.db.query("deliveryJobs").collect() as Doc<"deliveryJobs">[];
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const startOfDayMs = startOfDay.getTime();
+
+    let pending = 0;
+    let deliveredToday = 0;
+    let failedToday = 0;
+    let retriesExhausted = 0;
+
+    for (const job of allJobs) {
+      if (job.status === "pending" || job.status === "retrying" || job.status === "sending") {
+        pending++;
+      }
+      if (job.status === "delivered" && (job.deliveredAt ?? 0) >= startOfDayMs) {
+        deliveredToday++;
+      }
+      if (job.status === "failed" && job.createdAt >= startOfDayMs) {
+        failedToday++;
+      }
+      if (job.status === "failed" && job.attempts >= job.maxAttempts) {
+        retriesExhausted++;
+      }
+    }
+
+    return { pending, deliveredToday, failedToday, retriesExhausted };
+  },
+});
+
+export const getFailedJobs = internalQuery({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, { limit = 50 }): Promise<Doc<"deliveryJobs">[]> => {
+    return await ctx.db
+      .query("deliveryJobs")
+      .withIndex("by_status", (q) => q.eq("status", "failed"))
+      .take(Math.min(Math.max(limit, 1), 500)) as Doc<"deliveryJobs">[];
+  },
+});
+
 /* ================================================================== */
 /* MUTATIONS                                                           */
 /* ================================================================== */
@@ -213,6 +260,20 @@ export const markForRetry = internalMutation({
       nextRetryAt,
     });
 
+    return true;
+  },
+});
+
+export const requeueJob = internalMutation({
+  args: { jobId: v.id("deliveryJobs") },
+  handler: async (ctx, { jobId }): Promise<boolean> => {
+    const job = await ctx.db.get(jobId) as Doc<"deliveryJobs"> | null;
+    if (!job || job.status !== "failed") return false;
+    await ctx.db.patch(jobId, {
+      status: "retrying",
+      nextRetryAt: Date.now(),
+      lastError: undefined,
+    });
     return true;
   },
 });

--- a/convex/domains/social/publishing/publishingOrchestrator.ts
+++ b/convex/domains/social/publishing/publishingOrchestrator.ts
@@ -250,6 +250,37 @@ export const getPendingTasks = internalQuery({
   },
 });
 
+export const getPublishingStats = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<{
+    pending: number;
+    publishedToday: number;
+    failedToday: number;
+  }> => {
+    const tasks = await ctx.db.query("publishingTasks").collect() as Doc<"publishingTasks">[];
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const startOfDayMs = startOfDay.getTime();
+
+    let pending = 0;
+    let publishedToday = 0;
+    let failedToday = 0;
+    for (const task of tasks) {
+      if (task.status === "pending" || task.status === "formatting" || task.status === "delivering") {
+        pending++;
+      }
+      if ((task.status === "completed" || task.status === "partial") && (task.completedAt ?? 0) >= startOfDayMs) {
+        publishedToday++;
+      }
+      if (task.status === "failed" && (task.completedAt ?? task.createdAt) >= startOfDayMs) {
+        failedToday++;
+      }
+    }
+
+    return { pending, publishedToday, failedToday };
+  },
+});
+
 /* ================================================================== */
 /* MUTATIONS                                                           */
 /* ================================================================== */

--- a/src/features/agents/views/AgentsHub.tsx
+++ b/src/features/agents/views/AgentsHub.tsx
@@ -450,6 +450,13 @@ export function AgentsHub() {
               </Suspense>
             </div>
 
+            {/* Autonomous Operations Status - always visible for operator QA */}
+            <div className="mb-6">
+              <Suspense fallback={<div className="h-[120px]" />}>
+                <AutonomousOperationsPanel />
+              </Suspense>
+            </div>
+
             {/* Mode toggle */}
             <div className="mb-6 flex items-center justify-between">
               <button
@@ -473,13 +480,6 @@ export function AgentsHub() {
                 {/* Quick Stats */}
                 <div className="mb-6">
                   <QuickStatsBar />
-                </div>
-
-                {/* Autonomous Operations Status */}
-                <div className="mb-6">
-                  <Suspense fallback={<div className="h-[120px]" />}>
-                    <AutonomousOperationsPanel />
-                  </Suspense>
                 </div>
 
                 {/* Oracle Control Tower */}

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -2964,6 +2964,7 @@ function ExactMobileSurface({ surface }: { surface: MobileSurface }) {
   const [reportTab, setReportTab] = useState<"brief" | "sources" | "notebook">("brief");
   const surfaceTestIds: Partial<Record<MobileSurface, string>> = {
     home: "mobile-home-surface",
+    reports: "mobile-reports-surface",
     chat: "mobile-chat-surface",
     inbox: "mobile-inbox-surface",
     me: "mobile-me-surface",
@@ -2991,6 +2992,7 @@ function ExactMobileSurface({ surface }: { surface: MobileSurface }) {
         {surface === "chat" ? <MobileChatBody /> : null}
         {surface === "reports" ? (
           <div className="m-body">
+            <MobileReportsPipelineBlock />
             <div className="m-sub-tabs">
               {(["brief", "sources", "notebook"] as const).map((tab) => (
                 <button key={tab} type="button" className="m-sub-tab" data-active={reportTab === tab} onClick={() => setReportTab(tab)}>
@@ -3007,6 +3009,41 @@ function ExactMobileSurface({ surface }: { surface: MobileSurface }) {
         {surface === "me" ? <MobileMeBody /> : null}
       </div>
     </div>
+  );
+}
+
+function MobileReportsPipelineBlock() {
+  return (
+    <section
+      className="m-pipeline-block"
+      data-testid="mobile-reports-pipeline-block"
+      aria-label="Mobile pipeline runtime"
+    >
+      <header className="m-pipeline-block-head">
+        <div>
+          <span className="kicker">Pipelines</span>
+          <h2>Run, review, and score</h2>
+        </div>
+        <span className="pill pill-neutral">live Convex</span>
+      </header>
+      <div className="m-pipeline-stack">
+        <div data-testid="reports-pipeline-launcher-slot">
+          <PipelineLauncher variant="compact" />
+        </div>
+        <div data-testid="reports-pipelines-panel-slot">
+          <PipelineRunsPanel />
+        </div>
+        <div data-testid="reports-pipeline-eval-slot">
+          <PipelineEvalScorecard />
+        </div>
+        <details className="m-pipeline-more">
+          <summary>Schedules</summary>
+          <div data-testid="reports-pipeline-schedules-slot">
+            <PipelineSchedulesPanel />
+          </div>
+        </details>
+      </div>
+    </section>
   );
 }
 

--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -1238,6 +1238,88 @@
   padding: 12px 16px;
 }
 
+.nb-mobile-kit .m-pipeline-block {
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  background: var(--bg-surface);
+  padding: 10px;
+  margin-bottom: 12px;
+}
+
+.nb-mobile-kit .m-pipeline-block-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.nb-mobile-kit .m-pipeline-block-head h2 {
+  margin: 2px 0 0;
+  font-size: 15px;
+  line-height: 1.2;
+  font-weight: 800;
+}
+
+.nb-mobile-kit .m-pipeline-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nb-mobile-kit .m-pipeline-block .nb-surface-card {
+  border-radius: 12px;
+  box-shadow: none;
+  padding: 12px;
+}
+
+.nb-mobile-kit .m-pipeline-block .grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.nb-mobile-kit .m-pipeline-block .max-w-\[55\%\] {
+  max-width: 100%;
+}
+
+.nb-mobile-kit .m-pipeline-block [data-testid="pipeline-launcher-spec"] {
+  min-height: 72px;
+}
+
+.nb-mobile-kit .m-pipeline-block [data-testid="pipeline-run-list"] {
+  max-height: 300px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.nb-mobile-kit .m-pipeline-block [data-testid="pipeline-eval-by-kind"] {
+  overflow-x: auto;
+}
+
+.nb-mobile-kit .m-pipeline-more {
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--bg-surface);
+  padding: 8px;
+}
+
+.nb-mobile-kit .m-pipeline-more summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 800;
+  list-style: none;
+}
+
+.nb-mobile-kit .m-pipeline-more summary::-webkit-details-marker {
+  display: none;
+}
+
+.nb-mobile-kit .m-pipeline-more[open] {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .nb-mobile-kit .m-followup {
   flex: none;
   border: 1px solid var(--border-default);

--- a/src/features/pipelines/views/PipelineLauncher.tsx
+++ b/src/features/pipelines/views/PipelineLauncher.tsx
@@ -25,6 +25,9 @@ const PIPELINE_KINDS = [
 ] as const;
 
 type PipelineKindValue = (typeof PIPELINE_KINDS)[number]["value"];
+type PipelineLauncherProps = {
+  variant?: "default" | "compact";
+};
 
 const COMPOSED_KINDS = new Set<PipelineKindValue>([
   "research_then_code",
@@ -54,7 +57,10 @@ const PLACEHOLDER_BY_KIND: Record<string, string> = {
     "Describe what to scaffold and then design — e.g., A simple kanban board in React, then a polished design for it.",
 };
 
-export const PipelineLauncher: React.FC = () => {
+export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
+  variant = "default",
+}) => {
+  const isCompact = variant === "compact";
   const [pipelineKind, setPipelineKind] = useState<PipelineKindValue>("research");
   const [spec, setSpec] = useState("");
   const [title, setTitle] = useState("");
@@ -191,8 +197,9 @@ export const PipelineLauncher: React.FC = () => {
   return (
     <section
       data-testid="pipeline-launcher"
+      data-pipeline-launcher-variant={variant}
       aria-label="Run a pipeline"
-      className="nb-surface-card p-4 space-y-3"
+      className={`nb-surface-card space-y-3 ${isCompact ? "p-3 pipeline-launcher-compact" : "p-4"}`}
     >
       <header className="flex items-center gap-2">
         <div className="w-8 h-8 rounded-md bg-emerald-500/15 flex items-center justify-center">
@@ -200,14 +207,20 @@ export const PipelineLauncher: React.FC = () => {
         </div>
         <div>
           <h3 className="text-sm font-semibold text-content">Run a pipeline</h3>
-          <p className="text-[11px] text-content-muted">
-            Pick a kind, describe what you want, and submit. The run lands below in real time.
-          </p>
+          {isCompact ? (
+            <p className="text-[11px] text-content-muted">
+              Kind + spec. Full model and schedule controls remain on desktop.
+            </p>
+          ) : (
+            <p className="text-[11px] text-content-muted">
+              Pick a kind, describe what you want, and submit. The run lands below in real time.
+            </p>
+          )}
         </div>
       </header>
 
       <form onSubmit={handleSubmit} className="space-y-3" data-testid="pipeline-launcher-form">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <div className={`grid grid-cols-1 ${isCompact ? "gap-2" : "md:grid-cols-3 gap-3"}`}>
           <label className="flex flex-col gap-1 text-xs text-content-muted">
             <span>Kind</span>
             <select
@@ -226,6 +239,8 @@ export const PipelineLauncher: React.FC = () => {
               ))}
             </select>
           </label>
+          {!isCompact ? (
+            <>
           <label className="flex flex-col gap-1 text-xs text-content-muted">
             <span>Model</span>
             <select
@@ -255,9 +270,11 @@ export const PipelineLauncher: React.FC = () => {
               maxLength={120}
             />
           </label>
+            </>
+          ) : null}
         </div>
         {showLinkupDepth ? (
-          <div className="flex items-center gap-2 text-[11px] text-content-muted">
+          <div className="flex items-center gap-2 text-[11px] text-content-muted flex-wrap">
             <span>Web search depth:</span>
             <button
               type="button"
@@ -293,6 +310,7 @@ export const PipelineLauncher: React.FC = () => {
             <span>Composed run: two pipelineRuns rows will appear (stage 1 → stage 2).</span>
           </div>
         ) : null}
+        {!isCompact ? (
         <div className="flex items-center gap-3 flex-wrap text-[11px] text-content-muted">
           <label className="inline-flex items-center gap-1.5 cursor-pointer">
             <input
@@ -330,11 +348,12 @@ export const PipelineLauncher: React.FC = () => {
             </span>
           ) : null}
         </div>
+        ) : null}
         <label className="flex flex-col gap-1 text-xs text-content-muted">
           <span>Spec</span>
           <textarea
             data-testid="pipeline-launcher-spec"
-            className="bg-surface border border-edge rounded-md text-xs px-2 py-2 text-content font-mono resize-y min-h-[88px]"
+            className={`bg-surface border border-edge rounded-md text-xs px-2 py-2 text-content font-mono resize-y ${isCompact ? "min-h-[68px]" : "min-h-[88px]"}`}
             placeholder={PLACEHOLDER_BY_KIND[pipelineKind]}
             value={spec}
             onChange={(e) => setSpec(e.target.value)}
@@ -348,13 +367,13 @@ export const PipelineLauncher: React.FC = () => {
 
         <div className="flex items-center justify-between gap-3 flex-wrap">
           <div className="text-[11px] text-content-muted">
-            Runs durably via{" "}
+            {isCompact ? <>Durable workflow, idempotent resubmit.</> : <>Runs durably via{" "}
             <code className="text-[10px]">@convex-dev/workflow</code> — retries on transient
-            failure, idempotent on resubmit.
+            failure, idempotent on resubmit.</>}
             {loggedInUser?._id ? (
-              <span data-testid="pipeline-launcher-owner-signedin"> {ownerLabel}</span>
+              <span data-testid="pipeline-launcher-owner-signedin"> {isCompact ? "Signed in." : ownerLabel}</span>
             ) : (
-              <span data-testid="pipeline-launcher-owner-anon"> {ownerLabel}</span>
+              <span data-testid="pipeline-launcher-owner-anon"> {isCompact ? `Session ${anonymousSessionId?.slice(0, 8) ?? "?"}.` : ownerLabel}</span>
             )}
           </div>
           <button

--- a/src/lib/registry/viewRegistry.ts
+++ b/src/lib/registry/viewRegistry.ts
@@ -25,6 +25,7 @@ export type MainView =
   | "execution-trace"
   | "world-monitor"
   | "watchlists"
+  | "agents"
   | "receipts"
   | "delegation"
   | "mcp-ledger"
@@ -292,6 +293,19 @@ export const VIEW_REGISTRY: ViewRegistryEntry[] = [
     navVisible: false,
     parentId: "research",
     surfaceId: "ask",
+    commandPaletteVisible: true,
+  },
+  {
+    id: "agents",
+    title: "Agents",
+    subtitle: "AI assistants, autonomous operations, and run governance",
+    path: "/agents",
+    aliases: ["/operations", "/autonomous-operations", "/control-plane/agents"],
+    component: lazyView(() => import("@/features/agents/views/AgentsHub")),
+    group: "internal",
+    navVisible: false,
+    parentId: "control-plane",
+    surfaceId: "trace",
     commandPaletteVisible: true,
   },
   {

--- a/tests/e2e/live-smoke-mobile.spec.ts
+++ b/tests/e2e/live-smoke-mobile.spec.ts
@@ -65,7 +65,9 @@ test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
     // Top sources header
     await expect(page.getByText(/Top sources/i)).toBeVisible();
     // Follow-up chips
-    await expect(page.getByText(/Follow-up/i)).toBeVisible();
+    await expect(
+      page.locator('[data-testid="mobile-chat-surface"]').getByText(/^Follow-up$/),
+    ).toBeVisible();
     // Composer dock input
     await expect(page.getByPlaceholder(/Ask a follow-up/i)).toBeVisible();
   });
@@ -99,6 +101,31 @@ test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
     await expect(meSurface.getByText(/Quick settings/i)).toBeVisible();
     // Shortcuts CTA inside the mobile surface
     await expect(meSurface.getByRole("button", { name: /Starred threads/i })).toBeVisible();
+  });
+
+  test("Reports surface — mobile mounts live pipeline controls and report tabs", async ({ page }) => {
+    await page.goto(BASE_URL + "/?surface=reports");
+    const reportsSurface = page.locator('[data-testid="mobile-reports-surface"]');
+    const pipelineBlock = reportsSurface.locator('[data-testid="mobile-reports-pipeline-block"]');
+    await expect(reportsSurface).toBeVisible({ timeout: 20_000 });
+    await expect(pipelineBlock).toBeVisible();
+    await expect(pipelineBlock.locator('[data-testid="reports-pipeline-launcher-slot"]')).toBeVisible();
+    await expect(pipelineBlock.locator('[data-testid="pipeline-launcher"]')).toBeVisible();
+    await expect(pipelineBlock.locator('[data-testid="pipeline-launcher"]')).toHaveAttribute(
+      "data-pipeline-launcher-variant",
+      "compact",
+    );
+    await expect(pipelineBlock.locator('[data-testid="reports-pipelines-panel-slot"]')).toBeVisible();
+    await expect(pipelineBlock.locator('[data-testid="pipeline-runs-panel"]')).toBeVisible();
+    await expect(pipelineBlock.locator('[data-testid="reports-pipeline-eval-slot"]')).toBeVisible();
+    await expect(
+      pipelineBlock.locator(
+        '[data-testid="pipeline-eval-scorecard"], [data-testid="pipeline-eval-scorecard-empty"]',
+      ),
+    ).toBeVisible();
+    await expect(reportsSurface.getByRole("button", { name: /^Brief$/ })).toBeVisible();
+    await expect(reportsSurface.getByRole("button", { name: /^Sources$/ })).toBeVisible();
+    await expect(reportsSurface.getByRole("button", { name: /^Notebook$/ })).toBeVisible();
   });
 
   test("Report detail — MobileReportSurface mounts with Brief|Sources|Notebook sub-tabs", async ({ page }) => {


### PR DESCRIPTION
## Summary
- restore mobile Reports parity with a compact live pipeline block
- expose compact PipelineLauncher variant for mobile use
- restore hidden /agents route and surface Autonomous Operations by default
- add mobile smoke assertions for launcher, runs, and eval wiring

## Verification
- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
- npm run build
- BASE_URL=https://www.nodebenchai.com npx playwright test tests/e2e/live-smoke-mobile.spec.ts --project=chromium --workers=1
- BASE_URL=https://www.nodebenchai.com npx playwright test tests/e2e/autonomous-operations.spec.ts --project=chromium --workers=1

## Deploy
- Convex deployed to https://agile-caribou-964.convex.cloud
- Vercel production deployed and aliased to https://www.nodebenchai.com
- Vercel deployment: https://nodebench-qjivyu6i0-hshum2018-gmailcoms-projects.vercel.app
