### PR TITLE
fix: clean up dogfood warnings and performance plan

### DIFF
--- a/docs/architecture/plans/2026-04-30-nodebench-performance-product-plan.md
+++ b/docs/architecture/plans/2026-04-30-nodebench-performance-product-plan.md
@@ -1,0 +1,149 @@
+# NodeBench Performance And Product Plan
+
+Last updated: April 30, 2026
+
+## Input
+
+This plan translates performance and product-shape ideas from two Gmail workspace notes into NodeBench terms:
+
+- `engineering-decision-log.md`
+- `performance-and-product-principles.md`
+
+Those notes are useful as reference material, not implementation instructions. NodeBench has different surfaces, a Convex-backed runtime, mobile Reports parity, live pipeline workflows, and a separate workspace product. The plan below keeps those constraints intact.
+
+## Working Principle
+
+Treat performance as four related systems:
+
+1. Data shape: what each surface asks Convex or HTTP routes to return.
+2. Render shape: how much DOM and editor state a route mounts at first paint.
+3. Background shape: what work runs during navigation versus idle time.
+4. Product shape: how many decisions the user must understand before acting.
+
+A route can have fast queries and still feel slow if it mounts too many panels, runs background work immediately, or splits one workflow across too many destinations.
+
+## NodeBench Budgets
+
+| Interaction | Target |
+| --- | ---: |
+| Mobile tab switch after initial load | under 100ms perceived |
+| Reports pipeline block first useful paint | under 1.5s on mobile |
+| Cached report or entity card open | under 500ms |
+| Notebook shell before editor hydration | under 1s |
+| Command palette open | under 75ms |
+| Source or evidence panel open from cached data | under 500ms |
+| Background pipeline refresh | never blocks route navigation |
+| Deep research or paid search | explicit background run with progress |
+
+These are product budgets. If a feature cannot meet them, it should be precomputed, deferred, hidden behind an explicit action, or removed from the default route.
+
+## Near-Term Plan
+
+### 1. Add Route-Level Performance Records
+
+Create a tiny client-side route timing buffer, modeled for NodeBench rather than Gmail:
+
+- route id
+- surface id
+- viewport class
+- time to root test id visible
+- time to first action visible
+- console or page error count
+- live Convex warning state
+
+Expose it as `window.__nodebenchPerf` in development and dogfood only. Do not add visible product UI yet.
+
+### 2. Shape Reports Around A Compact Read Model
+
+Reports now carry pipeline launcher, schedules, eval, runs, findings, report cards, notebook detail, and graph workspace paths. The default Reports surface should not recompute or mount all detail structures at once.
+
+Plan:
+
+- Define a compact Reports read model for the first viewport.
+- Keep pipeline run detail and stream expansion lazy.
+- Keep notebook/editor hydration behind the report detail or notebook tab.
+- Track whether each block came from live Convex data, cached Convex data, or local starter data.
+
+### 3. Window Long Lists Before Adding More Rows
+
+Candidate surfaces:
+
+- pipeline runs
+- report cards when there are many saved reports
+- sources and claims panels
+- execution trace ledgers
+- MCP ledger rows
+- entity graph edge lists
+
+Start with fixed-height windowing where row heights are stable. Use a mature virtualizer only when dynamic heights become necessary.
+
+### 4. Move Background Work To Idle Or Explicit Runs
+
+Pipeline schedules, eval aggregation, dogfood artifact checks, and agent suggestions should not compete with initial route interaction.
+
+Plan:
+
+- Make route entry render from existing data first.
+- Use idle callbacks or explicit refresh buttons for heavy recomputation.
+- Surface stale state honestly instead of silently blocking on refresh.
+- Keep paid or deep research behind approval and progress states.
+
+### 5. Keep The Main IA Constrained
+
+Locked web nav remains:
+
+```text
+Home - Reports - Chat - Inbox - Me
+```
+
+Workspace remains a separate deployed surface, not a sixth web tab.
+
+Performance work should reinforce that product shape. Add modes, display options, and drill-ins before adding top-level routes.
+
+### 6. Make Actions Contextual, Not Page-Heavy
+
+NodeBench should move repeated operations into a shared action model:
+
+- open sources
+- export CRM CSV
+- refresh stale sources
+- use memory only
+- run deep refresh with approval
+- attach source to claim
+- create follow-up
+- open notebook
+- resume source chat
+
+The same action should be available from buttons, command palette, graph cards, and notebook affordances when the context supports it.
+
+### 7. Add Measurement To Dogfood Gates
+
+Extend existing dogfood checks with lightweight product-performance assertions:
+
+- mobile Reports first useful block visible under budget
+- route has no horizontal overflow
+- console has no uncaught errors
+- no production fixture fallback warning
+- pipeline controls visible without desktop-only affordances
+- background work does not block first interaction
+
+Keep Gemini or LLM review optional. Boolean gates should decide pass/fail.
+
+## What Not To Copy
+
+Do not copy Gmail-specific routes, email caches, or Next.js APIs directly. NodeBench is not an inbox app and is not on the same runtime stack.
+
+Do not turn every performance idea into a new abstraction. Add read models and caches only where route timing or dogfood evidence shows repeated work.
+
+Do not create another top-level product surface to solve density. Prefer progressive disclosure inside the locked IA.
+
+## First Suggested Slice
+
+Implement route timing records for the five main web surfaces plus mobile Reports:
+
+1. Add a tiny recorder under `src/lib/performance`.
+2. Record route id, viewport class, and first visible root timing.
+3. Have dogfood smoke assert mobile Reports reaches the pipeline block under the budget.
+4. Document the current baseline before changing data fetching.
+
+This gives NodeBench its own measurement loop before heavier optimization work starts.

--- a/src/features/entities/components/DiligenceSection.tsx
+++ b/src/features/entities/components/DiligenceSection.tsx
@@ -1,66 +1,27 @@
 /**
- * DiligenceSection — renders one diligence block's output on a company entity
- * page (Classic view).
- *
- * Pattern: one reusable section primitive per block; the 10 blocks all render
- *          through this component with a block-specific `renderer` callback.
- *          Avoids hand-built section code per block.
- *
- * Prior art:
- *   - Notion databases — render one layout, many content shapes
- *   - Linear custom views — block-typed section shell
- *   - Airtable record sections
- *
- * See: docs/architecture/DILIGENCE_BLOCKS.md
- *      docs/architecture/REPORTS_AND_ENTITIES.md
- *      docs/architecture/AGENT_PIPELINE.md
- *      .claude/rules/reference_attribution.md
- *
- * Invariants:
- *  - Every section header carries an EvidenceChip reflecting the block's
- *    overall confidence (computed from the candidates).
- *  - Empty-section copy is intentional — never "nothing here" (see dogfood rule).
- *  - The section is keyboard-accessible (collapse via Enter/Space on header).
+ * DiligenceSection renders one diligence block's output on a company entity
+ * page. Each block supplies its own candidate renderer while this shell keeps
+ * evidence status, collapse behavior, and empty-state handling consistent.
  */
 
 import { useState, type ReactNode } from "react";
-import { cn } from "@/lib/utils";
 import { ChevronDown, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
 import { EvidenceChip, type EvidenceTier } from "./EvidenceChip";
 
 export type DiligenceSectionProps<TCandidate> = {
-  /** Block type — drives icon + color accents; string for flexibility. */
   block: string;
-  /** Section header title — e.g., "Founders", "Products", "Funding". */
   title: string;
-  /** Short explanation shown under the title when expanded. */
   description?: string;
-  /** Overall confidence for this block's output — aggregate of candidate tiers. */
   overallTier: EvidenceTier;
-  /** Candidates for the block. May be empty (section still renders, with empty copy). */
   candidates: TCandidate[];
-  /** How many sources total informed this section. */
   sourceCount?: number;
-  /** Relative "last updated" label, e.g. "2h ago". */
   updatedLabel?: string;
-  /**
-   * Render function for a single candidate. Each block type supplies its
-   * own renderer — FounderRenderer, ProductRenderer, FundingRenderer, etc.
-   */
   renderer: (candidate: TCandidate, index: number) => ReactNode;
-  /**
-   * Action slot — optional buttons rendered in the header right side
-   * (e.g., "Refresh", "Watch", "View in chat").
-   */
   actions?: ReactNode;
-  /**
-   * Copy for the empty state. Must be actionable ("Upload a deck" etc.),
-   * never "nothing here". See .claude/rules/dogfood_verification.md.
-   */
   emptyLabel?: string;
-  /** Default-collapsed state. Defaults to expanded. */
   defaultCollapsed?: boolean;
-  /** Extra classes on the outer wrapper. */
   className?: string;
 };
 
@@ -74,12 +35,13 @@ export function DiligenceSection<TCandidate>({
   updatedLabel,
   renderer,
   actions,
-  emptyLabel = "Unable to identify — try uploading a deck or bio.",
+  emptyLabel = "Unable to identify - try uploading a deck or bio.",
   defaultCollapsed = false,
   className,
 }: DiligenceSectionProps<TCandidate>) {
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
-  const headerId = `diligence-${block}-header`;
+  const headerId = `diligence-${block}-heading`;
+  const toggleId = `diligence-${block}-toggle`;
   const panelId = `diligence-${block}-panel`;
 
   return (
@@ -90,24 +52,30 @@ export function DiligenceSection<TCandidate>({
       )}
       aria-labelledby={headerId}
     >
-      {/* Header — collapsible, keyboard-accessible */}
-      <button
-        id={headerId}
-        type="button"
-        onClick={() => setCollapsed((c) => !c)}
-        aria-expanded={!collapsed}
-        aria-controls={panelId}
-        className="flex w-full items-center justify-between gap-3 rounded-t-lg px-4 py-3 text-left transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757] dark:hover:bg-white/[0.04]"
-      >
-        <span className="flex items-center gap-2.5 min-w-0 flex-1">
+      <div className="flex items-center justify-between gap-3 rounded-t-lg px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-white/[0.04]">
+        <h2 id={headerId} className="sr-only">
+          {title}
+        </h2>
+        <button
+          id={toggleId}
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-labelledby={headerId}
+          aria-expanded={!collapsed}
+          aria-controls={panelId}
+          className="flex min-w-0 flex-1 items-center gap-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]"
+        >
           {collapsed ? (
             <ChevronRight className="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
           ) : (
             <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
           )}
-          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+          <span
+            className="truncate text-sm font-semibold text-gray-900 dark:text-gray-100"
+            aria-hidden="true"
+          >
             {title}
-          </h2>
+          </span>
           <EvidenceChip
             tier={overallTier}
             sourceCount={sourceCount}
@@ -115,34 +83,18 @@ export function DiligenceSection<TCandidate>({
             className="shrink-0"
           />
           {updatedLabel ? (
-            <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
-              · updated {updatedLabel}
+            <span className="truncate text-xs text-gray-500 dark:text-gray-400">
+              - updated {updatedLabel}
             </span>
           ) : null}
-        </span>
-        {actions ? (
-          <span
-            className="flex shrink-0 items-center gap-1"
-            // Stop propagation so action clicks don't also toggle the section
-            onClick={(e) => e.stopPropagation()}
-          >
-            {actions}
-          </span>
-        ) : null}
-      </button>
+        </button>
+        {actions ? <div className="flex shrink-0 items-center gap-1">{actions}</div> : null}
+      </div>
 
-      {/* Body — candidates or empty state.
-          No explicit role — the outer <section aria-labelledby> already
-          exposes a single labeled region to screen readers. A nested
-          role="region" here would create a second landmark for the same
-          heading (a11y warning). */}
       {!collapsed ? (
-        <div
-          id={panelId}
-          className="border-t border-gray-100 px-4 py-3 dark:border-white/[0.06]"
-        >
+        <div id={panelId} className="border-t border-gray-100 px-4 py-3 dark:border-white/[0.06]">
           {description ? (
-            <p className="mb-3 text-xs text-gray-500 dark:text-gray-400 leading-5">
+            <p className="mb-3 text-xs leading-5 text-gray-500 dark:text-gray-400">
               {description}
             </p>
           ) : null}
@@ -156,8 +108,8 @@ export function DiligenceSection<TCandidate>({
             </div>
           ) : (
             <ul className="flex flex-col gap-2">
-              {candidates.map((c, idx) => (
-                <li key={idx}>{renderer(c, idx)}</li>
+              {candidates.map((candidate, index) => (
+                <li key={index}>{renderer(candidate, index)}</li>
               ))}
             </ul>
           )}

--- a/src/features/notebook/components/RichNotebookEditor.onChange.test.tsx
+++ b/src/features/notebook/components/RichNotebookEditor.onChange.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { RichNotebookEditor } from "./RichNotebookEditor";
@@ -60,7 +60,9 @@ describe("RichNotebookEditor — onChange callback (Convex persistence hook)", (
       ).not.toBeNull();
     });
     // Allow a frame to ensure no async transactions land.
-    await new Promise((r) => setTimeout(r, 50));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
     expect(onChange).not.toHaveBeenCalled();
   });
 
@@ -89,7 +91,9 @@ describe("RichNotebookEditor — onChange callback (Convex persistence hook)", (
     await user.keyboard(" persisted");
 
     // Wait a beat for the debounced save.
-    await new Promise((r) => setTimeout(r, 1000));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    });
     const stored = window.localStorage.getItem(storageKey);
     expect(stored).toContain("persisted");
 

--- a/src/features/reports/views/ReportNotebookDetail.persistence.test.tsx
+++ b/src/features/reports/views/ReportNotebookDetail.persistence.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 
@@ -174,7 +174,9 @@ describe("ReportNotebookDetail — Convex persistence round-trip", () => {
 
     for (let i = 0; i < 5; i++) {
       await user.keyboard(` t${i}`);
-      await new Promise((r) => setTimeout(r, 120));
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 120));
+      });
     }
 
     await waitFor(
@@ -220,7 +222,9 @@ describe("ReportNotebookDetail — Convex persistence round-trip", () => {
 
     // Wait an extra beat to confirm we don't auto-retry without new input.
     const before = mocks.saveCalls.length;
-    await new Promise((r) => setTimeout(r, 1500));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1500));
+    });
     expect(mocks.saveCalls.length).toBe(before);
   });
 
@@ -289,7 +293,9 @@ describe("ReportNotebookDetail — Convex persistence round-trip", () => {
     await user.keyboard(" attempted-edit");
 
     // Even after debounce window, no save fires for public-shared reports.
-    await new Promise((r) => setTimeout(r, 1500));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1500));
+    });
     expect(mocks.saveCalls.length).toBe(0);
   });
 
@@ -340,7 +346,9 @@ describe("ReportNotebookDetail — Convex persistence round-trip", () => {
     );
     editor.focus();
     await user.keyboard(" starter-edit");
-    await new Promise((r) => setTimeout(r, 1500));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1500));
+    });
     expect(mocks.saveCalls.length).toBe(0);
   });
 });

--- a/src/layouts/cockpitRails.test.tsx
+++ b/src/layouts/cockpitRails.test.tsx
@@ -28,6 +28,7 @@ describe("cockpit rails", () => {
     mockUseQuery.mockReset();
     mockSignIn.mockReset();
     mockConvexMutation.mockReset();
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
     mockUseConvexAuth.mockReturnValue({ isAuthenticated: true });
     mockConvexMutation.mockResolvedValue(undefined);
     mockUseConvex.mockReturnValue({ mutation: mockConvexMutation });
@@ -35,6 +36,7 @@ describe("cockpit rails", () => {
 
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary

- Fix the `DiligenceSection` header so header actions are no longer nested inside the collapse button.
- Wrap delayed React test assertions in `act` and stub the cockpit rail latency fetch so warning noise does not mask real regressions.
- Add a NodeBench-specific performance and product plan based on the referenced Gmail docs, translating the ideas into our Convex-backed Reports, mobile, notebook, and dogfood constraints rather than copying implementation details.

## Validation

- `npx vitest run src/features/entities/components/DiligenceSection.test.tsx src/layouts/cockpitRails.test.tsx src/features/notebook/components/RichNotebookEditor.onChange.test.tsx src/features/reports/views/ReportNotebookDetail.persistence.test.tsx --reporter=dot`
- `npx tsc --noEmit --pretty false`
- `npx tsc -p convex --noEmit --pretty false`
- `npm run build`
- `npm run dogfood:verify:smoke`

## Notes

The dogfood smoke regenerated screenshot and walkthrough artifacts locally; those generated outputs were restored and are not part of this PR.

Supersedes #222, which used a branch name and title that failed the repository style gate.