### PR TITLE
feat(reports): implement performance product loop

### DIFF
--- a/docs/architecture/plans/2026-04-30-nodebench-performance-product-plan.md
+++ b/docs/architecture/plans/2026-04-30-nodebench-performance-product-plan.md
@@ -147,3 +147,21 @@ Implement route timing records for the five main web surfaces plus mobile Report
 4. Document the current baseline before changing data fetching.
 
 This gives NodeBench its own measurement loop before heavier optimization work starts.
+
+## Implementation Update
+
+April 30, 2026 slice:
+
+- Added `window.__nodebenchPerf` for dev and dogfood runs, with route id, surface id, viewport class, root/action visibility timing, and console/page warning counts.
+- Wired timing records into the five main web surfaces and mobile Reports without adding visible debug UI.
+- Added a compact Reports read model that prefers live memory and makes starter memory explicit.
+- Deferred non-critical Reports background panels behind idle readiness so launcher, runs, and report cards reach the first viewport first.
+- Windowed pipeline runs, pipeline schedules, and report cards with explicit show-more controls.
+- Added contextual report actions for Brief, Sources, Notebook, Chat, and CRM CSV export.
+- Extended mobile Reports smoke coverage with performance, overflow, production-warning, and compact pipeline assertions.
+
+Remaining follow-up:
+
+- Persist dogfood timing summaries into a Convex operator table after the local buffer proves stable.
+- Apply the same windowing and timing checks to sources, claims, MCP ledger, and execution trace ledgers where route evidence shows large lists.
+- Add command-palette bindings for the shared report actions so buttons and keyboard actions use the same contract.

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent, type ReactNode } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { useConvex, useMutation, useQuery } from "convex/react";
 import { useConvexApi } from "@/lib/convexApi";
@@ -61,6 +61,14 @@ import {
   buildWorkspaceUrl,
   type WorkspaceTab,
 } from "@/features/workspace/lib/workspaceRouting";
+import { buildCompactReportsReadModel } from "@/features/reports/lib/compactReportsReadModel";
+import {
+  REPORT_CONTEXTUAL_ACTIONS,
+  downloadReportCrmCsv,
+  type ReportActionId,
+} from "@/features/reports/lib/reportActions";
+import { useIdleGate } from "@/lib/performance/useIdleGate";
+import { useRoutePerformanceRecord } from "@/lib/performance/routeTiming";
 
 import "./exactKit.css";
 
@@ -348,6 +356,15 @@ function ResponsiveSurface({
    it via props in a follow-up — we keep the kit's exact JSX + class names so
    visual parity is verifiable in raw HTML.
    ────────────────────────────────────────────────────────────────────────── */
+
+function DeferredReportsPanel({ label }: { label: string }) {
+  return (
+    <section className="nb-deferred-panel" aria-label={`${label} loading`}>
+      <span className="nb-deferred-panel-dot" aria-hidden />
+      <span>{label} loading after the first reports view.</span>
+    </section>
+  );
+}
 
 type PulseMetric = {
   id: string;
@@ -914,9 +931,22 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
     navigate(buildCockpitPath({ surfaceId: "packets", extra: { report: id } }));
   };
 
+  useRoutePerformanceRecord({
+    routeId: "home",
+    surfaceId: "home",
+    rootSelector: '[data-testid="exact-web-home-surface"]',
+    firstActionSelector: '[data-nb-perf-action="home-primary"]',
+    dataSource: liveEntities && liveEntities.length > 0 ? "live_convex" : "starter",
+  });
+
   return (
     <ResponsiveSurface mobile="home">
-      <div className="nb-home-pulse" style={{ display: "flex", flexDirection: "column", gap: 28 }}>
+      <div
+        className="nb-home-pulse"
+        data-testid="exact-web-home-surface"
+        data-nb-perf-root="home"
+        style={{ display: "flex", flexDirection: "column", gap: 28 }}
+      >
       <section className="nb-composer-hero">
         <div className="nb-kicker">Entity intelligence</div>
         <h1>What are we researching today?</h1>
@@ -954,7 +984,12 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
             <span style={{ color: "var(--text-faint)", fontFamily: "var(--font-mono)", fontSize: 11 }}>
               <Command size={12} style={{ display: "inline", verticalAlign: "-2px" }} /> Enter
             </span>
-            <button type="button" className="nb-btn nb-btn-primary" onClick={() => start()}>
+            <button
+              type="button"
+              className="nb-btn nb-btn-primary"
+              data-nb-perf-action="home-primary"
+              onClick={() => start()}
+            >
               <Send size={14} />
               Start run
             </button>
@@ -1232,8 +1267,15 @@ export function ExactReportDetailSurface({ reportId, onBack }: { reportId: strin
   if (!detail) {
     return (
       <ResponsiveSurface mobile="reports">
-        <section style={{ padding: 24 }}>
-          <button type="button" className="nb-btn nb-btn-secondary" onClick={onBack}>← Back to reports</button>
+        <section style={{ padding: 24 }} data-testid="exact-web-report-detail">
+          <button
+            type="button"
+            className="nb-btn nb-btn-secondary"
+            data-testid="report-detail-back"
+            onClick={onBack}
+          >
+            ← Back to reports
+          </button>
           <p style={{ marginTop: 12, color: "var(--text-muted)" }}>Report not found.</p>
         </section>
       </ResponsiveSurface>
@@ -1251,6 +1293,7 @@ export function ExactReportDetailSurface({ reportId, onBack }: { reportId: strin
             <button
               type="button"
               className="nb-rdetail-back"
+              data-testid="report-detail-back"
               onClick={onBack}
               aria-label="Back to reports"
             >
@@ -1370,10 +1413,33 @@ export function ExactReportsSurface() {
     });
   }, [entities]);
 
-  const reportsSource = liveReports ?? REPORTS;
   const [view, setView] = useState<"grid" | "list">("grid");
   const [filter, setFilter] = useState("all");
-  const filteredReports = filter === "all" ? reportsSource : reportsSource.filter((report) => report.state.includes(filter));
+  const [visibleReportCount, setVisibleReportCount] = useState(12);
+  const backgroundReady = useIdleGate({ timeoutMs: 850 });
+
+  useEffect(() => {
+    setVisibleReportCount(12);
+  }, [filter, liveReports]);
+
+  const reportsReadModel = useMemo(
+    () =>
+      buildCompactReportsReadModel({
+        liveReports,
+        fallbackReports: REPORTS,
+        filter,
+        visibleCount: visibleReportCount,
+      }),
+    [filter, liveReports, visibleReportCount],
+  );
+
+  useRoutePerformanceRecord({
+    routeId: reportParam ? "reports-detail" : "reports",
+    surfaceId: "reports",
+    rootSelector: reportParam ? '[data-testid="exact-web-report-detail"]' : '[data-testid="reports-performance-root"]',
+    firstActionSelector: reportParam ? '[data-testid="report-detail-back"]' : '[data-testid="pipeline-launcher-submit"], [data-testid="report-card"]',
+    dataSource: reportsReadModel.sourceKind,
+  });
 
   const goBackToGrid = () => {
     const next = new URLSearchParams(searchParams);
@@ -1388,6 +1454,33 @@ export function ExactReportsSurface() {
     setSearchParams(next, { replace: false });
   };
 
+  const handleReportAction = (
+    report: ExactReportCard,
+    actionId: ReportActionId,
+    event: MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.stopPropagation();
+    if (actionId === "open_brief") {
+      openInlineReport(report.id);
+      return;
+    }
+    if (actionId === "open_sources") {
+      openWorkspace(report.id, "sources");
+      return;
+    }
+    if (actionId === "open_notebook") {
+      openWorkspace(report.id, "notebook");
+      return;
+    }
+    if (actionId === "resume_chat") {
+      navigate(buildCockpitPath({ surfaceId: "workspace", extra: { q: report.title, report: report.id } }));
+      return;
+    }
+    if (actionId === "export_crm_csv") {
+      downloadReportCrmCsv(report);
+    }
+  };
+
   // Inline detail view: ?surface=packets&report=<id> renders within the
   // cockpit shell instead of redirecting to the workspace subdomain.
   if (reportParam) {
@@ -1396,7 +1489,7 @@ export function ExactReportsSurface() {
 
   return (
     <ResponsiveSurface mobile="reports">
-      <section>
+      <section data-testid="reports-performance-root" data-reports-source={reportsReadModel.sourceKind}>
         <div className="nb-reports-toolbar">
           <div>
             <h1 style={{ margin: 0, fontSize: 28, fontWeight: 760, letterSpacing: "-0.02em" }}>Reports</h1>
@@ -1405,6 +1498,9 @@ export function ExactReportsSurface() {
             </p>
           </div>
           <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <span className="nb-reports-source-pill" data-source={reportsReadModel.sourceKind}>
+              {reportsReadModel.sourceLabel} - {reportsReadModel.filteredReports.length} reports
+            </span>
             <div className="nb-view-toggle" aria-label="Report filter">
               {["all", "verified", "review", "watching"].map((item) => (
                 <button key={item} type="button" data-active={filter === item} onClick={() => setFilter(item)}>
@@ -1419,28 +1515,32 @@ export function ExactReportsSurface() {
           </div>
         </div>
 
-        <div data-testid="reports-findings-panel-slot" style={{ marginBottom: 16 }}>
-          <EntityFindingsPanel />
-        </div>
-
         <div data-testid="reports-pipeline-launcher-slot" style={{ marginBottom: 16 }}>
           <PipelineLauncher />
         </div>
 
-        <div data-testid="reports-pipeline-schedules-slot" style={{ marginBottom: 16 }}>
-          <PipelineSchedulesPanel />
+        <div data-testid="reports-pipelines-panel-slot" style={{ marginBottom: 16 }}>
+          <PipelineRunsPanel initialVisibleCount={6} queryLimit={18} windowStep={6} />
         </div>
 
         <div data-testid="reports-pipeline-eval-slot" style={{ marginBottom: 16 }}>
-          <PipelineEvalScorecard />
+          {backgroundReady ? <PipelineEvalScorecard /> : <DeferredReportsPanel label="Eval scorecard" />}
         </div>
 
-        <div data-testid="reports-pipelines-panel-slot" style={{ marginBottom: 16 }}>
-          <PipelineRunsPanel />
+        <div data-testid="reports-pipeline-schedules-slot" style={{ marginBottom: 16 }}>
+          {backgroundReady ? (
+            <PipelineSchedulesPanel initialVisibleCount={4} queryLimit={12} windowStep={4} />
+          ) : (
+            <DeferredReportsPanel label="Pipeline schedules" />
+          )}
+        </div>
+
+        <div data-testid="reports-findings-panel-slot" style={{ marginBottom: 16 }}>
+          {backgroundReady ? <EntityFindingsPanel /> : <DeferredReportsPanel label="Entity findings" />}
         </div>
 
         <div className="nb-reports-grid" data-view={view}>
-          {filteredReports.map((report) => (
+          {reportsReadModel.visibleReports.map((report) => (
             <article
               key={report.id}
               className="nb-rcard"
@@ -1460,10 +1560,19 @@ export function ExactReportsSurface() {
               <div className="nb-rcard-body">
                 <div className="nb-rcard-title">{report.title}</div>
                 <div className="nb-rcard-sub">{report.summary}</div>
-                <div data-testid="report-card-actions" style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 4 }}>
-                  <button type="button" className="nb-btn nb-btn-secondary" onClick={(event) => { event.stopPropagation(); openInlineReport(report.id); }}>Brief</button>
-                  <button type="button" className="nb-btn nb-btn-secondary" aria-label="Explore workspace cards" onClick={(event) => { event.stopPropagation(); openWorkspace(report.id, "cards"); }}>Explore</button>
-                  <button type="button" className="nb-btn nb-btn-secondary" aria-label="Ask NodeBench" onClick={(event) => { event.stopPropagation(); navigate(buildCockpitPath({ surfaceId: "workspace", extra: { q: report.title, report: report.id } })); }}>Chat</button>
+                <div data-testid="report-card-actions" className="nb-rcard-actions">
+                  {REPORT_CONTEXTUAL_ACTIONS.map((action) => (
+                    <button
+                      key={action.id}
+                      type="button"
+                      className="nb-btn nb-btn-secondary"
+                      data-nb-action={action.id}
+                      aria-label={action.ariaLabel}
+                      onClick={(event) => handleReportAction(report, action.id, event)}
+                    >
+                      {action.label}
+                    </button>
+                  ))}
                 </div>
                 <div className="nb-rcard-foot">
                   <span>{report.sources} sources</span>
@@ -1477,6 +1586,18 @@ export function ExactReportsSurface() {
             </article>
           ))}
         </div>
+        {reportsReadModel.hasMore ? (
+          <div className="nb-show-more-row">
+            <button
+              type="button"
+              className="nb-btn nb-btn-secondary"
+              data-testid="reports-show-more"
+              onClick={() => setVisibleReportCount((count) => count + 12)}
+            >
+              Show {Math.min(12, reportsReadModel.hiddenCount)} more reports
+            </button>
+          </div>
+        ) : null}
       </section>
     </ResponsiveSurface>
   );
@@ -2322,6 +2443,14 @@ export function ExactChatSurface() {
     setComposer("");
   };
 
+  useRoutePerformanceRecord({
+    routeId: "chat",
+    surfaceId: "chat",
+    rootSelector: '[data-testid="exact-web-chat-stream"]',
+    firstActionSelector: '[data-nb-perf-action="chat-send"]',
+    dataSource: liveThreadTurns ? "live_convex" : "starter",
+  });
+
   return (
     <ResponsiveSurface mobile="chat">
       <section data-testid="exact-web-chat-stream" style={{ display: "flex", flexDirection: "column", gap: 14 }}>
@@ -2442,6 +2571,7 @@ export function ExactChatSurface() {
                       <button
                         type="button"
                         className="nb-composer-send"
+                        data-nb-perf-action="chat-send"
                         aria-label="Send"
                         disabled={!composer.trim()}
                         onClick={() => sendTurn(composer)}
@@ -2617,9 +2747,17 @@ export function ExactInboxSurface() {
     }
   };
 
+  useRoutePerformanceRecord({
+    routeId: "inbox",
+    surfaceId: "inbox",
+    rootSelector: '[data-testid="exact-web-inbox-surface"]',
+    firstActionSelector: '[data-nb-perf-action="inbox-filter"]',
+    dataSource: liveItems ? "live_convex" : "starter",
+  });
+
   return (
     <ResponsiveSurface mobile="inbox">
-      <section>
+      <section data-testid="exact-web-inbox-surface">
         <div className="nb-inbox-head">
           <div>
             <h1 style={{ margin: 0, fontSize: 28, fontWeight: 760, letterSpacing: "-0.02em" }}>Inbox</h1>
@@ -2634,7 +2772,13 @@ export function ExactInboxSurface() {
               ["auto", "Auto", counts.auto],
               ["watch", "Watching", counts.watch],
             ].map(([key, label, count]) => (
-              <button key={key} type="button" data-active={filter === key} onClick={() => setFilter(key as typeof filter)}>
+              <button
+                key={key}
+                type="button"
+                data-active={filter === key}
+                data-nb-perf-action={key === "all" ? "inbox-filter" : undefined}
+                onClick={() => setFilter(key as typeof filter)}
+              >
                 {label} <span style={{ marginLeft: 5, color: "var(--text-faint)", fontFamily: "var(--font-mono)" }}>{count}</span>
               </button>
             ))}
@@ -2757,9 +2901,17 @@ export function ExactMeSurface() {
     { group: "Workspace", items: [{ id: "integrations", label: "Integrations", icon: Link2 }, { id: "usage", label: "Usage", icon: Sparkles }] },
   ];
 
+  useRoutePerformanceRecord({
+    routeId: "me",
+    surfaceId: "me",
+    rootSelector: '[data-testid="exact-web-me-surface"]',
+    firstActionSelector: '[data-nb-perf-action="me-add-entity"]',
+    dataSource: liveNotebook ? "live_convex" : "starter",
+  });
+
   return (
     <ResponsiveSurface mobile="me">
-      <section className="nb-me-grid">
+      <section className="nb-me-grid" data-testid="exact-web-me-surface">
         <aside className="nb-me-sidenav">
           <div className="hd">
             <div className="av">HS</div>
@@ -2796,7 +2948,7 @@ export function ExactMeSurface() {
                     <div style={{ fontSize: 13.5, fontWeight: 800 }}>{entities.length} watched entities</div>
                     <div style={{ color: "var(--text-muted)", fontSize: 11.5 }}>New reports automatically link to entities they mention.</div>
                   </div>
-                  <button className="nb-btn nb-btn-secondary" type="button"><Plus size={13} /> Add entity</button>
+                  <button className="nb-btn nb-btn-secondary" type="button" data-nb-perf-action="me-add-entity"><Plus size={13} /> Add entity</button>
                 </div>
                 {entities.map((entity, index) => (
                   <div
@@ -2976,9 +3128,19 @@ function ExactMobileSurface({ surface }: { surface: MobileSurface }) {
     inbox: "Inbox",
     me: "Me",
   };
+  const mobileRootTestId = surfaceTestIds[surface] ?? "mobile-home-surface";
+
+  useRoutePerformanceRecord({
+    routeId: `mobile-${surface}`,
+    surfaceId: surface,
+    rootSelector: `[data-testid="${mobileRootTestId}"]`,
+    firstActionSelector: surface === "reports" ? '[data-testid="pipeline-launcher-submit"]' : undefined,
+    dataSource: surface === "reports" ? "live_convex" : "starter",
+  });
+
   return (
     <div className="nb-mobile-kit">
-      <div className="m-screen" data-testid={surfaceTestIds[surface]}>
+      <div className="m-screen" data-testid={mobileRootTestId}>
         <header className="m-top">
           <button className="m-icon-btn" aria-label="Menu"><MobileIcon name="thread" /></button>
           <div style={{ minWidth: 0, flex: 1 }}>
@@ -3013,6 +3175,9 @@ function ExactMobileSurface({ surface }: { surface: MobileSurface }) {
 }
 
 function MobileReportsPipelineBlock() {
+  const [schedulesOpen, setSchedulesOpen] = useState(false);
+  const evalReady = useIdleGate({ timeoutMs: 450 });
+
   return (
     <section
       className="m-pipeline-block"
@@ -3024,22 +3189,28 @@ function MobileReportsPipelineBlock() {
           <span className="kicker">Pipelines</span>
           <h2>Run, review, and score</h2>
         </div>
-        <span className="pill pill-neutral">live Convex</span>
+        <span className="pill pill-neutral">live runtime</span>
       </header>
       <div className="m-pipeline-stack">
         <div data-testid="reports-pipeline-launcher-slot">
           <PipelineLauncher variant="compact" />
         </div>
         <div data-testid="reports-pipelines-panel-slot">
-          <PipelineRunsPanel />
+          <PipelineRunsPanel initialVisibleCount={4} queryLimit={12} windowStep={4} />
         </div>
         <div data-testid="reports-pipeline-eval-slot">
-          <PipelineEvalScorecard />
+          {evalReady ? <PipelineEvalScorecard /> : <DeferredReportsPanel label="Eval scorecard" />}
         </div>
-        <details className="m-pipeline-more">
+        <details
+          className="m-pipeline-more"
+          open={schedulesOpen}
+          onToggle={(event) => setSchedulesOpen(event.currentTarget.open)}
+        >
           <summary>Schedules</summary>
           <div data-testid="reports-pipeline-schedules-slot">
-            <PipelineSchedulesPanel />
+            {schedulesOpen ? (
+              <PipelineSchedulesPanel initialVisibleCount={3} queryLimit={10} windowStep={3} />
+            ) : null}
           </div>
         </details>
       </div>

--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -325,6 +325,26 @@
   flex-wrap: wrap;
 }
 
+.nb-kit .nb-reports-source-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  padding: 0 10px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.nb-kit .nb-reports-source-pill[data-source="live_convex"] {
+  border-color: rgba(16, 185, 129, 0.28);
+  background: rgba(16, 185, 129, 0.08);
+  color: #047857;
+}
+
 .nb-kit .nb-view-toggle,
 .nb-kit .nb-inbox-filter {
   display: inline-flex;
@@ -431,6 +451,19 @@
   -webkit-line-clamp: 2;
 }
 
+.nb-kit .nb-rcard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.nb-kit .nb-rcard-actions .nb-btn {
+  min-height: 28px;
+  padding: 5px 9px;
+  font-size: 11px;
+}
+
 .nb-kit .nb-rcard-foot {
   display: flex;
   align-items: center;
@@ -461,6 +494,37 @@
   border-color: var(--accent-primary-border);
   background: var(--accent-primary-tint);
   color: var(--accent-ink);
+}
+
+.nb-kit .nb-deferred-panel,
+.nb-mobile-kit .nb-deferred-panel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 46px;
+  border: 1px dashed var(--border-subtle);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-surface) 72%, transparent);
+  color: var(--text-muted);
+  padding: 11px 13px;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.nb-kit .nb-deferred-panel-dot,
+.nb-mobile-kit .nb-deferred-panel-dot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 999px;
+  background: var(--accent-primary);
+  opacity: 0.72;
+}
+
+.nb-kit .nb-show-more-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
 }
 
 .nb-kit .nb-ibx-row {

--- a/src/features/pipelines/views/PipelineRunsPanel.tsx
+++ b/src/features/pipelines/views/PipelineRunsPanel.tsx
@@ -10,6 +10,7 @@
 import React, { useMemo, useState } from "react";
 import { api } from "../../../../convex/_generated/api";
 import { useStableQuery } from "@/hooks/useStableQuery";
+import { useWindowedList } from "@/lib/performance/useWindowedList";
 import {
   Cpu,
   AlertCircle,
@@ -147,11 +148,21 @@ const PipelineRunStreamPreview: React.FC<{ runId: string }> = ({ runId }) => {
   );
 };
 
-export const PipelineRunsPanel: React.FC = () => {
+type PipelineRunsPanelProps = {
+  queryLimit?: number;
+  initialVisibleCount?: number;
+  windowStep?: number;
+};
+
+export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
+  queryLimit = 24,
+  initialVisibleCount = 8,
+  windowStep = 8,
+}) => {
   const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
   const runs = useStableQuery(
     api.domains.pipelines.pipelineRunsQueries.listRecentRuns,
-    { limit: 8 },
+    { limit: queryLimit },
   );
   const stats = useStableQuery(
     api.domains.pipelines.pipelineRunsQueries.getRunSummaryStats,
@@ -159,6 +170,11 @@ export const PipelineRunsPanel: React.FC = () => {
   );
 
   const safeRuns = useMemo(() => runs ?? [], [runs]);
+  const { visibleItems: visibleRuns, remainingCount, hasMore, showMore } = useWindowedList({
+    items: safeRuns,
+    initialCount: initialVisibleCount,
+    step: windowStep,
+  });
 
   if (runs === undefined) {
     return (
@@ -233,12 +249,15 @@ export const PipelineRunsPanel: React.FC = () => {
             <span data-testid="pipeline-stat-cost">
               {formatUsd(stats.totalEstimatedUsd)} spent
             </span>
+            <span data-testid="pipeline-stat-window">
+              showing {visibleRuns.length} / {safeRuns.length}
+            </span>
           </div>
         ) : null}
       </header>
 
       <ul data-testid="pipeline-run-list" className="space-y-2">
-        {safeRuns.map((run) => {
+        {visibleRuns.map((run) => {
           const badge = statusBadge[run.status] ?? statusBadge.queued;
           const Icon = badge.Icon;
           return (
@@ -343,6 +362,16 @@ export const PipelineRunsPanel: React.FC = () => {
           );
         })}
       </ul>
+      {hasMore ? (
+        <button
+          type="button"
+          data-testid="pipeline-run-show-more"
+          onClick={showMore}
+          className="inline-flex items-center justify-center rounded-md border border-edge px-3 py-1.5 text-[11px] font-medium text-content-muted hover:bg-surface-hover"
+        >
+          Show {Math.min(windowStep, remainingCount)} more run{remainingCount === 1 ? "" : "s"}
+        </button>
+      ) : null}
     </section>
   );
 };

--- a/src/features/pipelines/views/PipelineSchedulesPanel.tsx
+++ b/src/features/pipelines/views/PipelineSchedulesPanel.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import type { Id } from "../../../../convex/_generated/dataModel";
+import { useWindowedList } from "@/lib/performance/useWindowedList";
 import {
   Calendar,
   CheckCircle2,
@@ -47,10 +48,22 @@ function formatRelative(ms: number): string {
   return diff > 0 ? `in ${d}d` : `${d}d ago`;
 }
 
-export const PipelineSchedulesPanel: React.FC<{ ownerKey?: string }> = ({ ownerKey }) => {
+type PipelineSchedulesPanelProps = {
+  ownerKey?: string;
+  queryLimit?: number;
+  initialVisibleCount?: number;
+  windowStep?: number;
+};
+
+export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
+  ownerKey,
+  queryLimit = 25,
+  initialVisibleCount = 6,
+  windowStep = 6,
+}) => {
   const schedules = useQuery(
     api.domains.pipelines.pipelineSchedule.listSchedules,
-    { ownerKey, limit: 25 },
+    { ownerKey, limit: queryLimit },
   ) as ScheduleRow[] | undefined;
   const setEnabled = useMutation(
     api.domains.pipelines.pipelineSchedule.setScheduleEnabled,
@@ -58,6 +71,12 @@ export const PipelineSchedulesPanel: React.FC<{ ownerKey?: string }> = ({ ownerK
   const deleteSchedule = useMutation(
     api.domains.pipelines.pipelineSchedule.deleteSchedule,
   );
+  const safeSchedules = schedules ?? [];
+  const { visibleItems: visibleSchedules, remainingCount, hasMore, showMore } = useWindowedList({
+    items: safeSchedules,
+    initialCount: initialVisibleCount,
+    step: windowStep,
+  });
 
   if (schedules === undefined) {
     return (
@@ -111,12 +130,12 @@ export const PipelineSchedulesPanel: React.FC<{ ownerKey?: string }> = ({ ownerK
           <h3 className="text-sm font-semibold text-content">Pipeline schedules</h3>
           <p className="text-[11px] text-content-muted">
             Cron sweeps every hour · {schedules.filter((s) => s.enabled).length} enabled ·{" "}
-            {schedules.length} total
+            showing {visibleSchedules.length} / {schedules.length}
           </p>
         </div>
       </header>
       <ul data-testid="pipeline-schedule-list" className="space-y-2">
-        {schedules.map((row) => (
+        {visibleSchedules.map((row) => (
           <li
             key={row._id}
             data-testid="pipeline-schedule-row"
@@ -190,6 +209,17 @@ export const PipelineSchedulesPanel: React.FC<{ ownerKey?: string }> = ({ ownerK
           </li>
         ))}
       </ul>
+      {hasMore ? (
+        <button
+          type="button"
+          data-testid="pipeline-schedule-show-more"
+          onClick={showMore}
+          className="inline-flex items-center justify-center rounded-md border border-edge px-3 py-1.5 text-[11px] font-medium text-content-muted hover:bg-surface-hover"
+        >
+          Show {Math.min(windowStep, remainingCount)} more schedule
+          {remainingCount === 1 ? "" : "s"}
+        </button>
+      ) : null}
     </section>
   );
 };

--- a/src/features/reports/lib/compactReportsReadModel.test.ts
+++ b/src/features/reports/lib/compactReportsReadModel.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCompactReportsReadModel } from "./compactReportsReadModel";
+
+describe("buildCompactReportsReadModel", () => {
+  const fallback = [
+    { id: "a", state: "verified" },
+    { id: "b", state: "needs review" },
+    { id: "c", state: "verified" },
+  ];
+
+  it("uses starter data only when live reports are absent", () => {
+    const model = buildCompactReportsReadModel({
+      liveReports: null,
+      fallbackReports: fallback,
+      filter: "all",
+      visibleCount: 2,
+    });
+    expect(model.sourceKind).toBe("starter");
+    expect(model.visibleReports.map((report) => report.id)).toEqual(["a", "b"]);
+    expect(model.hiddenCount).toBe(1);
+  });
+
+  it("prefers live reports and applies filters before windowing", () => {
+    const model = buildCompactReportsReadModel({
+      liveReports: [
+        { id: "live-a", state: "verified" },
+        { id: "live-b", state: "watching" },
+      ],
+      fallbackReports: fallback,
+      filter: "verified",
+      visibleCount: 8,
+    });
+    expect(model.sourceKind).toBe("live_convex");
+    expect(model.visibleReports.map((report) => report.id)).toEqual(["live-a"]);
+  });
+});

--- a/src/features/reports/lib/compactReportsReadModel.ts
+++ b/src/features/reports/lib/compactReportsReadModel.ts
@@ -1,0 +1,42 @@
+export type CompactReportSourceKind = "live_convex" | "starter";
+
+export type CompactReportsReadModel<TReport> = {
+  sourceKind: CompactReportSourceKind;
+  sourceLabel: string;
+  allReports: TReport[];
+  filteredReports: TReport[];
+  visibleReports: TReport[];
+  hiddenCount: number;
+  hasMore: boolean;
+};
+
+export function buildCompactReportsReadModel<TReport extends { state: string }>({
+  liveReports,
+  fallbackReports,
+  filter,
+  visibleCount,
+}: {
+  liveReports: TReport[] | null;
+  fallbackReports: readonly TReport[];
+  filter: string;
+  visibleCount: number;
+}): CompactReportsReadModel<TReport> {
+  const allReports = liveReports && liveReports.length > 0 ? liveReports : [...fallbackReports];
+  const sourceKind: CompactReportSourceKind =
+    liveReports && liveReports.length > 0 ? "live_convex" : "starter";
+  const filteredReports =
+    filter === "all" ? allReports : allReports.filter((report) => report.state.includes(filter));
+  const safeVisibleCount = Math.max(0, Math.min(filteredReports.length, visibleCount));
+  const visibleReports = filteredReports.slice(0, safeVisibleCount);
+  const hiddenCount = Math.max(0, filteredReports.length - visibleReports.length);
+
+  return {
+    sourceKind,
+    sourceLabel: sourceKind === "live_convex" ? "live memory" : "starter memory",
+    allReports,
+    filteredReports,
+    visibleReports,
+    hiddenCount,
+    hasMore: hiddenCount > 0,
+  };
+}

--- a/src/features/reports/lib/reportActions.test.ts
+++ b/src/features/reports/lib/reportActions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { createReportCrmCsv } from "./reportActions";
+
+describe("createReportCrmCsv", () => {
+  it("exports report identity and CRM-ready fields with escaped values", () => {
+    const csv = createReportCrmCsv({
+      id: "orbital",
+      kind: "Company",
+      title: 'Orbital "Labs"',
+      summary: "Voice-agent eval infra",
+      state: "verified",
+      sources: 14,
+      updated: "2h ago",
+      watched: true,
+    });
+
+    expect(csv).toContain('"record_type","name","category","status"');
+    expect(csv).toContain('"Orbital ""Labs"""');
+    expect(csv).toContain('"14"');
+    expect(csv).toContain('"true"');
+  });
+});

--- a/src/features/reports/lib/reportActions.ts
+++ b/src/features/reports/lib/reportActions.ts
@@ -1,0 +1,105 @@
+export type ReportActionId =
+  | "open_brief"
+  | "open_sources"
+  | "open_notebook"
+  | "resume_chat"
+  | "export_crm_csv";
+
+export type ReportActionTarget = "button" | "download";
+
+export type ReportActionItem = {
+  id: ReportActionId;
+  label: string;
+  ariaLabel: string;
+  target: ReportActionTarget;
+};
+
+export type ReportActionCard = {
+  id: string;
+  kind: string;
+  title: string;
+  summary: string;
+  state: string;
+  sources: number;
+  updated: string;
+  watched: boolean;
+};
+
+export const REPORT_CONTEXTUAL_ACTIONS: ReportActionItem[] = [
+  {
+    id: "open_brief",
+    label: "Brief",
+    ariaLabel: "Open report brief",
+    target: "button",
+  },
+  {
+    id: "open_sources",
+    label: "Sources",
+    ariaLabel: "Open report sources",
+    target: "button",
+  },
+  {
+    id: "open_notebook",
+    label: "Notebook",
+    ariaLabel: "Open report notebook",
+    target: "button",
+  },
+  {
+    id: "resume_chat",
+    label: "Chat",
+    ariaLabel: "Resume report chat",
+    target: "button",
+  },
+  {
+    id: "export_crm_csv",
+    label: "Export",
+    ariaLabel: "Export report to CRM CSV",
+    target: "download",
+  },
+];
+
+function csvCell(value: unknown) {
+  const text = String(value ?? "");
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export function createReportCrmCsv(report: ReportActionCard) {
+  const headers = [
+    "record_type",
+    "name",
+    "category",
+    "status",
+    "summary",
+    "source_count",
+    "updated",
+    "nodebench_report_id",
+    "watched",
+  ];
+  const values = [
+    "company",
+    report.title,
+    report.kind,
+    report.state,
+    report.summary,
+    report.sources,
+    report.updated,
+    report.id,
+    report.watched ? "true" : "false",
+  ];
+  return `${headers.map(csvCell).join(",")}\n${values.map(csvCell).join(",")}\n`;
+}
+
+export function downloadReportCrmCsv(report: ReportActionCard) {
+  if (typeof window === "undefined") return;
+  const csv = createReportCrmCsv(report);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `${report.id || "nodebench-report"}-crm.csv`;
+  anchor.rel = "noopener";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/src/lib/performance/routeTiming.test.ts
+++ b/src/lib/performance/routeTiming.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { getViewportClass } from "./routeTiming";
+
+describe("getViewportClass", () => {
+  it("classifies mobile, tablet, and desktop widths", () => {
+    expect(getViewportClass(390)).toBe("mobile");
+    expect(getViewportClass(900)).toBe("tablet");
+    expect(getViewportClass(1440)).toBe("desktop");
+  });
+});

--- a/src/lib/performance/routeTiming.ts
+++ b/src/lib/performance/routeTiming.ts
@@ -1,0 +1,256 @@
+import { useEffect, useRef } from "react";
+
+export type NodeBenchViewportClass = "mobile" | "tablet" | "desktop";
+
+export type NodeBenchPerfRecord = {
+  id: number;
+  routeId: string;
+  surfaceId: string;
+  viewportClass: NodeBenchViewportClass;
+  startedAt: number;
+  createdAtIso: string;
+  rootSelector: string;
+  firstActionSelector?: string;
+  rootVisibleMs?: number;
+  firstActionVisibleMs?: number;
+  completedMs?: number;
+  consoleErrorCount: number;
+  consoleWarningCount: number;
+  pageErrorCount: number;
+  convexWarningCount: number;
+  dataSource?: string;
+};
+
+type IssueCounts = {
+  consoleError: number;
+  consoleWarning: number;
+  pageError: number;
+  convexWarning: number;
+};
+
+type RecordInput = {
+  routeId: string;
+  surfaceId: string;
+  viewportClass: NodeBenchViewportClass;
+  rootSelector: string;
+  firstActionSelector?: string;
+  dataSource?: string;
+};
+
+export type NodeBenchPerfBuffer = {
+  records: NodeBenchPerfRecord[];
+  issueCounts: IssueCounts;
+  startRecord: (input: RecordInput) => number;
+  mark: (id: number, patch: Partial<NodeBenchPerfRecord>) => void;
+  getLatest: (routeId?: string) => NodeBenchPerfRecord | undefined;
+  getRecords: () => NodeBenchPerfRecord[];
+  reset: () => void;
+};
+
+declare global {
+  interface Window {
+    __nodebenchPerf?: NodeBenchPerfBuffer;
+  }
+}
+
+const MAX_RECORDS = 80;
+const CONVEX_WARNING_RE = /convex backend not configured|fixture fallback|starter data|fallback data/i;
+
+let consolePatched = false;
+let errorListenersInstalled = false;
+
+export function getViewportClass(width = window.innerWidth): NodeBenchViewportClass {
+  if (width < 768) return "mobile";
+  if (width < 1024) return "tablet";
+  return "desktop";
+}
+
+export function isNodeBenchPerfEnabled() {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  return (
+    import.meta.env.DEV ||
+    params.has("nbPerf") ||
+    params.get("dogfoodPerf") === "1" ||
+    window.localStorage.getItem("nodebench.dogfoodPerf") === "1"
+  );
+}
+
+export function ensureNodeBenchPerfBuffer(): NodeBenchPerfBuffer | null {
+  if (typeof window === "undefined" || !isNodeBenchPerfEnabled()) return null;
+  if (window.__nodebenchPerf) return window.__nodebenchPerf;
+
+  const buffer: NodeBenchPerfBuffer = {
+    records: [],
+    issueCounts: {
+      consoleError: 0,
+      consoleWarning: 0,
+      pageError: 0,
+      convexWarning: 0,
+    },
+    startRecord(input) {
+      const id = Math.floor(performance.timeOrigin + performance.now() + Math.random() * 1000);
+      const record: NodeBenchPerfRecord = {
+        id,
+        routeId: input.routeId,
+        surfaceId: input.surfaceId,
+        viewportClass: input.viewportClass,
+        startedAt: performance.now(),
+        createdAtIso: new Date().toISOString(),
+        rootSelector: input.rootSelector,
+        firstActionSelector: input.firstActionSelector,
+        consoleErrorCount: this.issueCounts.consoleError,
+        consoleWarningCount: this.issueCounts.consoleWarning,
+        pageErrorCount: this.issueCounts.pageError,
+        convexWarningCount: this.issueCounts.convexWarning,
+        dataSource: input.dataSource,
+      };
+      this.records.push(record);
+      if (this.records.length > MAX_RECORDS) this.records.splice(0, this.records.length - MAX_RECORDS);
+      return id;
+    },
+    mark(id, patch) {
+      const record = this.records.find((item) => item.id === id);
+      if (!record) return;
+      Object.assign(record, patch);
+    },
+    getLatest(routeId) {
+      const records = routeId
+        ? this.records.filter((record) => record.routeId === routeId)
+        : this.records;
+      return records[records.length - 1];
+    },
+    getRecords() {
+      return [...this.records];
+    },
+    reset() {
+      this.records = [];
+      this.issueCounts = {
+        consoleError: 0,
+        consoleWarning: 0,
+        pageError: 0,
+        convexWarning: 0,
+      };
+    },
+  };
+
+  window.__nodebenchPerf = buffer;
+  installIssueCollectors(buffer);
+  return buffer;
+}
+
+function installIssueCollectors(buffer: NodeBenchPerfBuffer) {
+  if (!consolePatched) {
+    consolePatched = true;
+    const originalError = console.error.bind(console);
+    const originalWarn = console.warn.bind(console);
+    console.error = (...args: unknown[]) => {
+      buffer.issueCounts.consoleError += 1;
+      const text = args.map(String).join(" ");
+      if (CONVEX_WARNING_RE.test(text)) buffer.issueCounts.convexWarning += 1;
+      originalError(...args);
+    };
+    console.warn = (...args: unknown[]) => {
+      buffer.issueCounts.consoleWarning += 1;
+      const text = args.map(String).join(" ");
+      if (CONVEX_WARNING_RE.test(text)) buffer.issueCounts.convexWarning += 1;
+      originalWarn(...args);
+    };
+  }
+
+  if (!errorListenersInstalled) {
+    errorListenersInstalled = true;
+    window.addEventListener("error", () => {
+      buffer.issueCounts.pageError += 1;
+    });
+    window.addEventListener("unhandledrejection", () => {
+      buffer.issueCounts.pageError += 1;
+    });
+  }
+}
+
+function isVisible(selector: string) {
+  const element = document.querySelector<HTMLElement>(selector);
+  if (!element) return false;
+  const rect = element.getBoundingClientRect();
+  const style = window.getComputedStyle(element);
+  return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+}
+
+export function useRoutePerformanceRecord({
+  routeId,
+  surfaceId,
+  rootSelector,
+  firstActionSelector,
+  dataSource,
+  timeoutMs = 5000,
+}: RecordInput & { timeoutMs?: number }) {
+  const lastKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const buffer = ensureNodeBenchPerfBuffer();
+    if (!buffer) return;
+
+    const key = `${routeId}:${surfaceId}:${rootSelector}:${firstActionSelector ?? ""}:${dataSource ?? ""}`;
+    if (lastKeyRef.current === key) return;
+    lastKeyRef.current = key;
+
+    const id = buffer.startRecord({
+      routeId,
+      surfaceId,
+      viewportClass: getViewportClass(),
+      rootSelector,
+      firstActionSelector,
+      dataSource,
+    });
+    const startedAt = performance.now();
+    const startCounts = { ...buffer.issueCounts };
+    let frame = 0;
+    let complete = false;
+
+    const tick = () => {
+      const elapsed = performance.now() - startedAt;
+      const record = buffer.records.find((item) => item.id === id);
+      if (!record) return;
+
+      const patch: Partial<NodeBenchPerfRecord> = {
+        consoleErrorCount: buffer.issueCounts.consoleError - startCounts.consoleError,
+        consoleWarningCount: buffer.issueCounts.consoleWarning - startCounts.consoleWarning,
+        pageErrorCount: buffer.issueCounts.pageError - startCounts.pageError,
+        convexWarningCount: buffer.issueCounts.convexWarning - startCounts.convexWarning,
+      };
+
+      if (record.rootVisibleMs == null && isVisible(rootSelector)) {
+        patch.rootVisibleMs = Math.round(elapsed);
+      }
+      if (
+        firstActionSelector &&
+        record.firstActionVisibleMs == null &&
+        isVisible(firstActionSelector)
+      ) {
+        patch.firstActionVisibleMs = Math.round(elapsed);
+      }
+
+      const nextRootVisible = patch.rootVisibleMs ?? record.rootVisibleMs;
+      const nextActionVisible = firstActionSelector
+        ? patch.firstActionVisibleMs ?? record.firstActionVisibleMs
+        : true;
+
+      if (nextRootVisible != null && nextActionVisible != null && !complete) {
+        complete = true;
+        patch.completedMs = Math.round(elapsed);
+      }
+
+      buffer.mark(id, patch);
+
+      if (!complete && elapsed < timeoutMs) {
+        frame = window.requestAnimationFrame(tick);
+      }
+    };
+
+    frame = window.requestAnimationFrame(tick);
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+  }, [routeId, surfaceId, rootSelector, firstActionSelector, dataSource, timeoutMs]);
+}

--- a/src/lib/performance/useIdleGate.ts
+++ b/src/lib/performance/useIdleGate.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+
+type IdleGateOptions = {
+  timeoutMs?: number;
+  disabled?: boolean;
+};
+
+type IdleDeadlineLike = {
+  didTimeout: boolean;
+  timeRemaining: () => number;
+};
+
+type WindowWithIdle = Window &
+  typeof globalThis & {
+    requestIdleCallback?: (
+      callback: (deadline: IdleDeadlineLike) => void,
+      options?: { timeout?: number },
+    ) => number;
+    cancelIdleCallback?: (id: number) => void;
+  };
+
+export function useIdleGate({ timeoutMs = 700, disabled = false }: IdleGateOptions = {}) {
+  const [ready, setReady] = useState(disabled);
+
+  useEffect(() => {
+    if (disabled) {
+      setReady(true);
+      return;
+    }
+
+    const win = window as WindowWithIdle;
+    let timeoutId = 0;
+    let idleId = 0;
+    let settled = false;
+    const markReady = () => {
+      if (settled) return;
+      settled = true;
+      setReady(true);
+    };
+
+    if (typeof win.requestIdleCallback === "function") {
+      idleId = win.requestIdleCallback(markReady, { timeout: timeoutMs });
+    } else {
+      timeoutId = window.setTimeout(markReady, Math.min(timeoutMs, 300));
+    }
+
+    timeoutId = window.setTimeout(markReady, timeoutMs);
+
+    return () => {
+      settled = true;
+      if (idleId && typeof win.cancelIdleCallback === "function") {
+        win.cancelIdleCallback(idleId);
+      }
+      if (timeoutId) window.clearTimeout(timeoutId);
+    };
+  }, [disabled, timeoutMs]);
+
+  return ready;
+}

--- a/src/lib/performance/useWindowedList.test.ts
+++ b/src/lib/performance/useWindowedList.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { getWindowedItems } from "./useWindowedList";
+
+describe("getWindowedItems", () => {
+  it("returns a stable first window and remaining count", () => {
+    const result = getWindowedItems([1, 2, 3, 4, 5], 3);
+    expect(result.visibleItems).toEqual([1, 2, 3]);
+    expect(result.remainingCount).toBe(2);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it("clamps the requested size to the list length", () => {
+    const result = getWindowedItems(["a", "b"], 10);
+    expect(result.visibleItems).toEqual(["a", "b"]);
+    expect(result.remainingCount).toBe(0);
+    expect(result.hasMore).toBe(false);
+  });
+});

--- a/src/lib/performance/useWindowedList.ts
+++ b/src/lib/performance/useWindowedList.ts
@@ -1,0 +1,44 @@
+import { useMemo, useState } from "react";
+
+export function clampWindowSize(total: number, requested: number) {
+  if (!Number.isFinite(total) || total <= 0) return 0;
+  if (!Number.isFinite(requested) || requested <= 0) return 0;
+  return Math.min(total, Math.max(0, Math.floor(requested)));
+}
+
+export function getWindowedItems<T>(items: readonly T[], visibleCount: number) {
+  const count = clampWindowSize(items.length, visibleCount);
+  return {
+    visibleItems: items.slice(0, count),
+    visibleCount: count,
+    remainingCount: Math.max(0, items.length - count),
+    hasMore: count < items.length,
+  };
+}
+
+export function useWindowedList<T>({
+  items,
+  initialCount,
+  step = initialCount,
+}: {
+  items: readonly T[];
+  initialCount: number;
+  step?: number;
+}) {
+  const [visibleCount, setVisibleCount] = useState(initialCount);
+  const windowed = useMemo(() => getWindowedItems(items, visibleCount), [items, visibleCount]);
+
+  const showMore = () => {
+    setVisibleCount((current) => clampWindowSize(items.length, current + step));
+  };
+
+  const resetWindow = () => {
+    setVisibleCount(initialCount);
+  };
+
+  return {
+    ...windowed,
+    showMore,
+    resetWindow,
+  };
+}

--- a/tests/e2e/live-smoke-mobile.spec.ts
+++ b/tests/e2e/live-smoke-mobile.spec.ts
@@ -104,7 +104,13 @@ test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
   });
 
   test("Reports surface — mobile mounts live pipeline controls and report tabs", async ({ page }) => {
-    await page.goto(BASE_URL + "/?surface=reports");
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+
+    await page.goto(BASE_URL + "/?surface=reports&nbPerf=1");
     const reportsSurface = page.locator('[data-testid="mobile-reports-surface"]');
     const pipelineBlock = reportsSurface.locator('[data-testid="mobile-reports-pipeline-block"]');
     await expect(reportsSurface).toBeVisible({ timeout: 20_000 });
@@ -116,16 +122,69 @@ test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
       "compact",
     );
     await expect(pipelineBlock.locator('[data-testid="reports-pipelines-panel-slot"]')).toBeVisible();
-    await expect(pipelineBlock.locator('[data-testid="pipeline-runs-panel"]')).toBeVisible();
+    await expect(pipelineBlock.locator('[data-testid="pipeline-runs-panel"], [data-testid="pipeline-runs-empty"]')).toBeVisible();
     await expect(pipelineBlock.locator('[data-testid="reports-pipeline-eval-slot"]')).toBeVisible();
     await expect(
       pipelineBlock.locator(
-        '[data-testid="pipeline-eval-scorecard"], [data-testid="pipeline-eval-scorecard-empty"]',
+        '[data-testid="pipeline-eval-scorecard"], [data-testid="pipeline-eval-scorecard-empty"], .nb-deferred-panel',
       ),
     ).toBeVisible();
+    await expect(
+      pipelineBlock.locator(
+        '[data-testid="pipeline-stat-window"], [data-testid="pipeline-runs-empty"], [data-testid="pipeline-run-list"]',
+      ).first(),
+    ).toBeVisible();
+    await expect(pipelineBlock.locator('[data-testid="pipeline-schedules-panel"]')).toHaveCount(0);
     await expect(reportsSurface.getByRole("button", { name: /^Brief$/ })).toBeVisible();
     await expect(reportsSurface.getByRole("button", { name: /^Sources$/ })).toBeVisible();
     await expect(reportsSurface.getByRole("button", { name: /^Notebook$/ })).toBeVisible();
+
+    const noHorizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    );
+    expect(noHorizontalOverflow, "mobile reports should not create document-level horizontal overflow").toBe(true);
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const perfApi = window as Window & {
+              __nodebenchPerf?: {
+                getLatest: (routeId?: string) => { rootVisibleMs?: number; firstActionVisibleMs?: number } | undefined;
+              };
+            };
+            const record = perfApi.__nodebenchPerf?.getLatest("mobile-reports");
+            return Boolean(record?.rootVisibleMs != null && record?.firstActionVisibleMs != null);
+          }),
+        { timeout: 5_000 },
+      )
+      .toBe(true);
+    const perf = await page.evaluate(() => {
+      const perfApi = window as Window & {
+        __nodebenchPerf?: {
+          getLatest: (routeId?: string) =>
+            | {
+                rootVisibleMs?: number;
+                firstActionVisibleMs?: number;
+                convexWarningCount?: number;
+              }
+            | undefined;
+        };
+      };
+      return perfApi.__nodebenchPerf?.getLatest("mobile-reports");
+    });
+    expect(perf?.rootVisibleMs ?? Infinity).toBeLessThanOrEqual(1_500);
+    expect(perf?.firstActionVisibleMs ?? Infinity).toBeLessThanOrEqual(2_000);
+    expect(perf?.convexWarningCount ?? 0, "mobile reports should not emit Convex fallback warnings").toBe(0);
+
+    const real = errors.filter(
+      (e) =>
+        !/favicon/i.test(e) &&
+        !/CSP/i.test(e) &&
+        !/Third-party cookie/i.test(e) &&
+        !/extension/i.test(e),
+    );
+    expect(real, "mobile reports console/page errors:\n" + real.map((e) => "  - " + e).join("\n")).toEqual([]);
   });
 
   test("Report detail — MobileReportSurface mounts with Brief|Sources|Notebook sub-tabs", async ({ page }) => {

--- a/tests/e2e/live-smoke.spec.ts
+++ b/tests/e2e/live-smoke.spec.ts
@@ -101,7 +101,7 @@ test.describe("live-smoke — Tier B hydrated-DOM verification", () => {
     await expect(page.locator('[aria-label="Breadcrumb"]')).toBeVisible();
   });
 
-  test("/?surface=reports shows Brief|Explore|Chat action row on cards", async ({ page }) => {
+  test("/?surface=reports shows contextual report action row on cards", async ({ page }) => {
     const response = await page.goto(BASE_URL + "/?surface=reports");
     expect(response?.status()).toBe(200);
     // Wait for report cards to hydrate.
@@ -114,12 +114,10 @@ test.describe("live-smoke — Tier B hydrated-DOM verification", () => {
     const actionRow = page.locator('[data-testid="report-card-actions"]').first();
     await expect(actionRow).toBeVisible();
     await expect(actionRow.getByRole("button", { name: "Brief" })).toBeVisible();
-    await expect(
-      actionRow.getByRole("button", { name: /Explore workspace cards/i }),
-    ).toBeVisible();
-    await expect(
-      actionRow.getByRole("button", { name: /Ask NodeBench/i }),
-    ).toBeVisible();
+    await expect(actionRow.getByRole("button", { name: /Open report sources/i })).toBeVisible();
+    await expect(actionRow.getByRole("button", { name: /Open report notebook/i })).toBeVisible();
+    await expect(actionRow.getByRole("button", { name: /Resume report chat/i })).toBeVisible();
+    await expect(actionRow.getByRole("button", { name: /Export report to CRM CSV/i })).toBeVisible();
   });
 
   test("/workspace/w/:id mounts UniversalWorkspacePage chromelessly", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add NodeBench route performance records for web surfaces and mobile Reports
- compact Reports read model, idle-gated background blocks, and windowed pipeline/report lists
- add contextual report actions for Brief, Sources, Notebook, Chat, and CRM CSV export
- extend mobile and desktop smoke coverage for Reports parity and performance

## Verification
- `npx vitest run src/lib/performance/useWindowedList.test.ts src/lib/performance/routeTiming.test.ts src/features/reports/lib/compactReportsReadModel.test.ts src/features/reports/lib/reportActions.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx tsc -p convex --noEmit --pretty false`
- `npm run build`
- `BASE_URL=http://127.0.0.1:4182 npx playwright test tests/e2e/live-smoke-mobile.spec.ts --project=chromium --grep "Reports surface"`
- `BASE_URL=http://127.0.0.1:4182 npx playwright test tests/e2e/live-smoke.spec.ts --project=chromium --grep "contextual report action"`

## Screenshots
- `.tmp/mobile-reports-performance.png`
- `.tmp/desktop-reports-performance.png`
