### PR TITLE
fix(ci): restore CONVEX_URL fallback for notebook health workflows

### DIFF
--- a/.github/workflows/notebook-daily.yml
+++ b/.github/workflows/notebook-daily.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Run daily summary
         env:
-          VITE_CONVEX_URL: ${{ secrets.CONVEX_URL }}
-          CONVEX_URL: ${{ secrets.CONVEX_URL }}
+          VITE_CONVEX_URL: ${{ secrets.CONVEX_URL || vars.CONVEX_URL || 'https://agile-caribou-964.convex.cloud' }}
+          CONVEX_URL: ${{ secrets.CONVEX_URL || vars.CONVEX_URL || 'https://agile-caribou-964.convex.cloud' }}
           OPS_NTFY_URL: ${{ secrets.OPS_NTFY_URL }}
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
           NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}

--- a/.github/workflows/notebook-hourly.yml
+++ b/.github/workflows/notebook-hourly.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Run hourly health check
         env:
-          VITE_CONVEX_URL: ${{ secrets.CONVEX_URL }}
-          CONVEX_URL: ${{ secrets.CONVEX_URL }}
+          VITE_CONVEX_URL: ${{ secrets.CONVEX_URL || vars.CONVEX_URL || 'https://agile-caribou-964.convex.cloud' }}
+          CONVEX_URL: ${{ secrets.CONVEX_URL || vars.CONVEX_URL || 'https://agile-caribou-964.convex.cloud' }}
           OPS_NTFY_URL: ${{ secrets.OPS_NTFY_URL }}
           HEALTH_P95_MS_BUDGET: "500"
           HEALTH_ERROR_RATE_BUDGET: "0.01"


### PR DESCRIPTION
## Summary
- Hourly + daily Notebook health workflows have been failing every run since the `CONVEX_URL` secret was never created (only `CONVEX_DEPLOY_KEY` + `CONVEX_SITE_URL` exist on the repo).
- Mirror the fallback pattern already proven in [ci.yml](.github/workflows/ci.yml) and [dogfood-qa-gate.yml](.github/workflows/dogfood-qa-gate.yml): `secrets.CONVEX_URL || vars.CONVEX_URL || 'https://agile-caribou-964.convex.cloud'`.
- `OPS_NTFY_URL` left untouched — script fails-open when missing.

## Root cause (verified via `gh run view 25233834894 --log-failed`)
```
env:
  VITE_CONVEX_URL:    <- empty
  CONVEX_URL:         <- empty
[hourly-health] fatal: CONVEX_URL / VITE_CONVEX_URL not set
##[error]Process completed with exit code 2.
```

10 consecutive runs across the last 10 hours all crashed at the same line.

## Test plan
- [ ] PR turns green on required CI checks
- [ ] After merge, manually dispatch `Notebook hourly health` workflow → run reaches the actual Convex query path instead of crashing on env load
- [ ] Next scheduled hourly run (`:07`) is silent-on-green or posts a real degradation signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)