### PR TITLE
feat(web): reduce first-run mobile clutter

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
          - object-src 'none': no Flash/Java applets
          - base-uri 'self': prevent base tag hijacking
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.convex.cloud wss://*.convex.cloud https://api.elevenlabs.io ws://localhost:* http://localhost:* ws://127.0.0.1:* http://127.0.0.1:*; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; frame-src 'none'; object-src 'none'; base-uri 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.convex.cloud wss://*.convex.cloud https://api.elevenlabs.io ws://localhost:* http://localhost:* ws://127.0.0.1:* http://127.0.0.1:*; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; worker-src 'self' blob:; manifest-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self';" />
 
     <!-- Resource hints for better performance -->
     <link rel="dns-prefetch" href="https://fonts.googleapis.com" />

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -84,13 +84,12 @@ type WebSurfaceProps = {
   onSurfaceChange?: (surface: CockpitSurfaceId) => void;
 };
 
-type LaneId = "answer" | "deep" | "admin";
+type LaneId = "answer" | "deep";
 type MobileSurface = "home" | "reports" | "chat" | "inbox" | "me";
 
 const LANES: Array<{ id: LaneId; label: string; note: string }> = [
-  { id: "answer", label: "Answer", note: "fast - default" },
-  { id: "deep", label: "Deep dive", note: "multi-agent - 3-5 min" },
-  { id: "admin", label: "Admin", note: "nodebench-mcp-admin" },
+  { id: "answer", label: "Quick answer", note: "fast read" },
+  { id: "deep", label: "Deep research", note: "more sources" },
 ];
 
 const PROMPT_CARDS: Array<{ icon: LucideIcon; prompt: string }> = [
@@ -412,28 +411,30 @@ function FirstImpressionBoard({
           ))}
         </div>
       </header>
-      <div className="nb-first-grid">
+      <div className="nb-first-list">
         {cards.map((card) => (
           <article key={card.id} className="nb-first-card" data-audience={card.audience.toLowerCase()}>
-            <div className="nb-first-card-top">
-              <span className="nb-badge nb-badge-accent">{card.audience}</span>
-              <span className="nb-first-card-horizon">{card.horizon}</span>
-            </div>
-            <h3>{card.title}</h3>
-            <p>{card.prompt}</p>
-            <div className="nb-first-proof">
-              {card.proofPoints.map((point) => (
-                <span key={point}><Check size={11} /> {point}</span>
-              ))}
-            </div>
-            <div className="nb-first-export">
-              {card.exportTargets.map((target) => (
-                <span key={target}>{target}</span>
-              ))}
+            <div className="nb-first-card-main">
+              <div className="nb-first-card-top">
+                <span className="nb-badge nb-badge-accent">{card.audience}</span>
+                <span className="nb-first-card-horizon">{card.horizon}</span>
+              </div>
+              <h3>{card.title}</h3>
+              <p>{card.prompt}</p>
+              <div className="nb-first-proof">
+                {card.proofPoints.slice(0, 3).map((point) => (
+                  <span key={point}><Check size={11} /> {point}</span>
+                ))}
+              </div>
             </div>
             <div className="nb-first-actions">
+              <div className="nb-first-export" aria-label="Export targets">
+                {card.exportTargets.slice(0, 3).map((target) => (
+                  <span key={target}>{target}</span>
+                ))}
+              </div>
               <button type="button" className="nb-btn nb-btn-secondary" onClick={() => onUsePrompt(card.prompt)}>
-                Use prompt
+                Fill prompt
               </button>
               <button
                 type="button"
@@ -442,7 +443,7 @@ function FirstImpressionBoard({
                 onClick={() => onRunCard(card)}
               >
                 <Clock3 size={13} />
-                Run async
+                Run research
               </button>
             </div>
           </article>
@@ -1054,10 +1055,10 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
     setBackgroundSubmitting(true);
     setBackgroundFeedback(null);
     try {
-      const result = await startPipelineRun(request);
+      await startPipelineRun(request);
       setBackgroundFeedback({
         kind: "ok",
-        message: `Background workflow ${result.workflowId} started. You can close this tab or lock your phone; the run continues server-side and will appear in Reports with sources and exports.`,
+        message: "Research started. Safe to close this tab or lock your phone. The report, sources, notes, and export options will be saved under Reports.",
       });
       setQuery(request.spec);
     } catch (error) {
@@ -1130,10 +1131,11 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
             <button
               type="button"
               className="nb-btn nb-btn-secondary"
+              aria-label="Open workspace"
               onClick={() => start()}
             >
               <MessageSquare size={14} />
-              Open workspace
+              Chat now
             </button>
             <button
               type="button"
@@ -1144,7 +1146,7 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
               onClick={() => void startBackgroundResearch()}
             >
               {backgroundSubmitting ? <Clock3 size={14} /> : <Send size={14} />}
-              Run in background
+              Run research
             </button>
           </div>
         </div>
@@ -1165,21 +1167,19 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
           </div>
         ) : null}
 
-        <div className="nb-prompt-grid">
+        <div className="nb-example-strip" aria-label="Example research prompts">
           {PROMPT_CARDS.map(({ icon: Icon, prompt }) => (
             <button
               key={prompt}
               type="button"
-              className="nb-prompt-card"
+              className="nb-example-chip"
               onClick={() => {
                 setQuery(prompt);
                 start(prompt);
               }}
             >
-              <span className="nb-prompt-icon"><Icon size={14} /></span>
-              <span style={{ display: "block", fontSize: 14, fontWeight: 800, lineHeight: 1.35 }}>
-                {prompt}
-              </span>
+              <span className="nb-prompt-icon"><Icon size={13} /></span>
+              <span>{prompt}</span>
             </button>
           ))}
         </div>
@@ -1196,12 +1196,20 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
 
       <NBPulseStrip liveEntities={liveEntities} />
 
-      <div className="nb-home-grid">
-        <NBTodayIntel liveEntities={liveEntities} />
-        <NBActiveEvent />
-      </div>
+      <details className="nb-home-more">
+        <summary>
+          <span>Recent intelligence and saved reports</span>
+          <small>Open when you want the dashboard view</small>
+        </summary>
+        <div className="nb-home-more-body">
+          <div className="nb-home-grid">
+            <NBTodayIntel liveEntities={liveEntities} />
+            <NBActiveEvent />
+          </div>
 
-      <NBRecentReports onOpenReport={openReport} liveEntities={liveEntities} />
+          <NBRecentReports onOpenReport={openReport} liveEntities={liveEntities} />
+        </div>
+      </details>
 
       <div className="nb-install-chip">
         <span style={{ textTransform: "uppercase", letterSpacing: ".14em" }}>Use from Claude or Cursor</span>
@@ -1594,6 +1602,7 @@ export function ExactReportsSurface() {
   const [view, setView] = useState<"grid" | "list">("grid");
   const [filter, setFilter] = useState("all");
   const [visibleReportCount, setVisibleReportCount] = useState(12);
+  const [reportsTool, setReportsTool] = useState<"start" | "runs" | "quality" | "refresh">("start");
   const backgroundReady = useIdleGate({ timeoutMs: 850 });
 
   useEffect(() => {
@@ -1672,7 +1681,7 @@ export function ExactReportsSurface() {
           <div>
             <h1 style={{ margin: 0, fontSize: 28, fontWeight: 760, letterSpacing: "-0.02em" }}>Reports</h1>
             <p style={{ margin: "4px 0 0", color: "var(--text-muted)", fontSize: 13 }}>
-              Reusable entity memory. Open serious work in workspace.nodebenchai.com.
+              Saved research reports with sources, review status, exports, and follow-up actions.
             </p>
           </div>
           <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
@@ -1693,29 +1702,65 @@ export function ExactReportsSurface() {
           </div>
         </div>
 
-        <div data-testid="reports-pipeline-launcher-slot" style={{ marginBottom: 16 }}>
-          <PipelineLauncher />
-        </div>
-
-        <div data-testid="reports-pipelines-panel-slot" style={{ marginBottom: 16 }}>
-          <PipelineRunsPanel initialVisibleCount={6} queryLimit={18} windowStep={6} />
-        </div>
-
-        <div data-testid="reports-pipeline-eval-slot" style={{ marginBottom: 16 }}>
-          {backgroundReady ? <PipelineEvalScorecard /> : <DeferredReportsPanel label="Eval scorecard" />}
-        </div>
-
-        <div data-testid="reports-pipeline-schedules-slot" style={{ marginBottom: 16 }}>
-          {backgroundReady ? (
-            <PipelineSchedulesPanel initialVisibleCount={4} queryLimit={12} windowStep={4} />
-          ) : (
-            <DeferredReportsPanel label="Pipeline schedules" />
-          )}
-        </div>
-
-        <div data-testid="reports-findings-panel-slot" style={{ marginBottom: 16 }}>
-          {backgroundReady ? <EntityFindingsPanel /> : <DeferredReportsPanel label="Entity findings" />}
-        </div>
+        <section className="nb-research-workbench" data-testid="reports-research-workbench">
+          <header className="nb-research-workbench-head">
+            <div>
+              <div className="nb-kicker">Research workspace</div>
+              <h2>Start one thing, then check status when you come back.</h2>
+            </div>
+            <span className="nb-badge nb-badge-success">phone-safe background runs</span>
+          </header>
+          <div className="nb-workbench-tabs" role="tablist" aria-label="Reports research tools">
+            {([
+              ["start", "Start"],
+              ["runs", "Runs"],
+              ["quality", "Quality"],
+              ["refresh", "Refreshes"],
+            ] as const).map(([id, label]) => (
+              <button
+                key={id}
+                type="button"
+                role="tab"
+                data-active={reportsTool === id}
+                aria-selected={reportsTool === id}
+                onClick={() => setReportsTool(id)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <div className="nb-workbench-panel">
+            {reportsTool === "start" ? (
+              <div data-testid="reports-pipeline-launcher-slot">
+                <PipelineLauncher />
+              </div>
+            ) : null}
+            {reportsTool === "runs" ? (
+              <div data-testid="reports-pipelines-panel-slot">
+                <PipelineRunsPanel initialVisibleCount={6} queryLimit={18} windowStep={6} />
+              </div>
+            ) : null}
+            {reportsTool === "quality" ? (
+              <div data-testid="reports-pipeline-eval-slot">
+                {backgroundReady ? <PipelineEvalScorecard /> : <DeferredReportsPanel label="Research quality" />}
+              </div>
+            ) : null}
+            {reportsTool === "refresh" ? (
+              <div className="nb-workbench-stack">
+                <div data-testid="reports-pipeline-schedules-slot">
+                  {backgroundReady ? (
+                    <PipelineSchedulesPanel initialVisibleCount={4} queryLimit={12} windowStep={4} />
+                  ) : (
+                    <DeferredReportsPanel label="Automatic refreshes" />
+                  )}
+                </div>
+                <div data-testid="reports-findings-panel-slot">
+                  {backgroundReady ? <EntityFindingsPanel /> : <DeferredReportsPanel label="Entity findings" />}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </section>
 
         <div className="nb-reports-grid" data-view={view}>
           {reportsReadModel.visibleReports.map((report) => (
@@ -3069,12 +3114,13 @@ export function ExactMeSurface() {
 
   const [section, setSection] = useState("notebook");
   const [entities, setEntities] = useState<ExactNotebookEntity[]>(() => [...ME_NOTEBOOK_SEED]);
+  const [pendingUnwatchId, setPendingUnwatchId] = useState<string | null>(null);
 
   useEffect(() => {
     if (liveNotebook) setEntities(liveNotebook);
   }, [liveNotebook]);
   const nav = [
-    { group: "Account", items: [{ id: "notebook", label: "Notebook", icon: BookOpen, count: entities.length }, { id: "profile", label: "Profile", icon: User }] },
+    { group: "Account", items: [{ id: "notebook", label: "Memory", icon: BookOpen, count: entities.length }, { id: "profile", label: "Profile", icon: User }] },
     { group: "Preferences", items: [{ id: "notifications", label: "Notifications", icon: Bell }, { id: "pace", label: "Pace & feel", icon: Zap }, { id: "data", label: "Data & memory", icon: FileText }] },
     { group: "Workspace", items: [{ id: "integrations", label: "Integrations", icon: Link2 }, { id: "usage", label: "Usage", icon: Sparkles }] },
   ];
@@ -3118,8 +3164,8 @@ export function ExactMeSurface() {
         <section>
           {section === "notebook" ? (
             <div>
-              <h1 className="nb-settings-h1">Notebook</h1>
-              <p className="nb-settings-sub">Entities you have taught NodeBench to watch. Reports and Inbox items anchor to these.</p>
+              <h1 className="nb-settings-h1">Memory</h1>
+              <p className="nb-settings-sub">Entities NodeBench watches for you. Reports, source updates, and Inbox nudges anchor here.</p>
               <div className="nb-settings-section" style={{ padding: 0, overflow: "hidden" }}>
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "1px solid var(--border-subtle)", padding: "14px 20px" }}>
                   <div>
@@ -3133,7 +3179,7 @@ export function ExactMeSurface() {
                     key={entity.id}
                     style={{
                       display: "grid",
-                      gridTemplateColumns: "36px 1fr auto auto",
+                      gridTemplateColumns: "36px minmax(0, 1fr) auto minmax(130px, auto)",
                       gap: 14,
                       alignItems: "center",
                       borderTop: index === 0 ? 0 : "1px solid var(--border-subtle)",
@@ -3151,7 +3197,33 @@ export function ExactMeSurface() {
                       </div>
                     </div>
                     <button type="button" className="nb-btn nb-btn-secondary"><FileText size={12} /> Reports</button>
-                    <button type="button" className="nb-btn" aria-label="Unwatch" onClick={() => setEntities((current) => current.filter((item) => item.id !== entity.id))}><X size={13} /></button>
+                    {pendingUnwatchId === entity.id ? (
+                      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
+                        <button type="button" className="nb-btn nb-btn-secondary" onClick={() => setPendingUnwatchId(null)}>
+                          Keep
+                        </button>
+                        <button
+                          type="button"
+                          className="nb-btn"
+                          aria-label={`Stop watching ${entity.name}`}
+                          onClick={() => {
+                            setEntities((current) => current.filter((item) => item.id !== entity.id));
+                            setPendingUnwatchId(null);
+                          }}
+                        >
+                          Stop watching
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        className="nb-btn"
+                        aria-label={`Stop watching ${entity.name}`}
+                        onClick={() => setPendingUnwatchId(entity.id)}
+                      >
+                        <X size={13} /> Stop watching
+                      </button>
+                    )}
                   </div>
                 ))}
               </div>
@@ -3354,43 +3426,71 @@ function ExactMobileSurface({ surface }: { surface: MobileSurface }) {
 
 function MobileReportsPipelineBlock() {
   const [schedulesOpen, setSchedulesOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<"start" | "runs" | "quality">("start");
   const evalReady = useIdleGate({ timeoutMs: 450 });
+  const tabs = [
+    { id: "start", label: "Start" },
+    { id: "runs", label: "Runs" },
+    { id: "quality", label: "Quality" },
+  ] as const;
 
   return (
     <section
       className="m-pipeline-block"
       data-testid="mobile-reports-pipeline-block"
-      aria-label="Mobile pipeline runtime"
+      aria-label="Mobile research runtime"
     >
       <header className="m-pipeline-block-head">
         <div>
-          <span className="kicker">Pipelines</span>
-          <h2>Run, review, and score</h2>
+          <span className="kicker">Research</span>
+          <h2>Start or check research</h2>
         </div>
-        <span className="pill pill-neutral">live runtime</span>
+        <span className="pill pill-neutral">phone-safe</span>
       </header>
+      <div className="m-pipeline-tabs" role="tablist" aria-label="Research tools">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            data-active={activeTab === tab.id}
+            aria-selected={activeTab === tab.id}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
       <div className="m-pipeline-stack">
-        <div data-testid="reports-pipeline-launcher-slot">
-          <PipelineLauncher variant="compact" />
-        </div>
-        <div data-testid="reports-pipelines-panel-slot">
-          <PipelineRunsPanel initialVisibleCount={4} queryLimit={12} windowStep={4} />
-        </div>
-        <div data-testid="reports-pipeline-eval-slot">
-          {evalReady ? <PipelineEvalScorecard /> : <DeferredReportsPanel label="Eval scorecard" />}
-        </div>
-        <details
-          className="m-pipeline-more"
-          open={schedulesOpen}
-          onToggle={(event) => setSchedulesOpen(event.currentTarget.open)}
-        >
-          <summary>Schedules</summary>
-          <div data-testid="reports-pipeline-schedules-slot">
-            {schedulesOpen ? (
-              <PipelineSchedulesPanel initialVisibleCount={3} queryLimit={10} windowStep={3} />
-            ) : null}
+        {activeTab === "start" ? (
+          <div data-testid="reports-pipeline-launcher-slot">
+            <PipelineLauncher variant="compact" />
           </div>
-        </details>
+        ) : null}
+        {activeTab === "runs" ? (
+          <div data-testid="reports-pipelines-panel-slot">
+            <PipelineRunsPanel initialVisibleCount={4} queryLimit={12} windowStep={4} />
+          </div>
+        ) : null}
+        {activeTab === "quality" ? (
+          <div data-testid="reports-pipeline-eval-slot">
+            {evalReady ? <PipelineEvalScorecard /> : <DeferredReportsPanel label="Research quality" />}
+          </div>
+        ) : null}
+        {activeTab === "quality" ? (
+          <details
+            className="m-pipeline-more"
+            open={schedulesOpen}
+            onToggle={(event) => setSchedulesOpen(event.currentTarget.open)}
+          >
+            <summary>Automatic refreshes</summary>
+            <div data-testid="reports-pipeline-schedules-slot">
+              {schedulesOpen ? (
+                <PipelineSchedulesPanel initialVisibleCount={3} queryLimit={10} windowStep={3} />
+              ) : null}
+            </div>
+          </details>
+        ) : null}
       </div>
     </section>
   );
@@ -3416,9 +3516,9 @@ function MobileHomeBody() {
     setSubmitting(true);
     setFeedback(null);
     try {
-      const result = await startPipelineRun(request);
+      await startPipelineRun(request);
       setMobileQuery(request.spec);
-      setFeedback(`Running in background: ${result.workflowId.slice(0, 10)}. Check Reports later.`);
+      setFeedback("Research started. Safe to lock your phone; the report will appear under Reports.");
     } catch (error) {
       setFeedback(error instanceof Error ? error.message : String(error));
     } finally {
@@ -3444,46 +3544,44 @@ function MobileHomeBody() {
         </button>
       </div>
       <div className="m-offline-proof">
-        <span>server-side</span>
-        <span>phone-safe</span>
+        <span>keeps working</span>
+        <span>safe to leave</span>
         <span>export-ready</span>
       </div>
       {feedback ? <div className="m-run-feedback" role="status">{feedback}</div> : null}
       <section className="m-section" data-testid="mobile-home-first-impression">
         <header className="m-section-head"><span className="kicker">Use cases today</span><a href="/?surface=reports">Reports</a></header>
         <div className="m-scenario-stack">
-          {mobileCards.map((card) => (
+          {mobileCards.slice(0, 1).map((card) => (
             <div key={card.id} className="m-scenario-card">
               <div className="m-scenario-top"><span>{card.audience}</span><span>{card.exportTargets[0]}</span></div>
               <div className="m-scenario-title">{card.title}</div>
               <p>{card.proofPoints.join(" - ")}</p>
               <button type="button" onClick={() => void runMobileBackground(card.prompt, card.title)} disabled={submitting}>
-                Run async
+                Run research
               </button>
             </div>
           ))}
+          <details className="m-scenario-more">
+            <summary>More example workflows</summary>
+            {mobileCards.slice(1).map((card) => (
+              <button
+                key={card.id}
+                type="button"
+                onClick={() => void runMobileBackground(card.prompt, card.title)}
+                disabled={submitting}
+              >
+                <span>{card.audience}</span>
+                {card.title}
+              </button>
+            ))}
+          </details>
         </div>
       </section>
       <section className="m-section">
-        <header className="m-section-head"><span className="kicker">Watchlist</span><a href="/?surface=reports">Manage</a></header>
-        <div className="m-watch">
-          {WATCHLIST.map((item) => (
-            <div key={item.id} className="m-watch-tile">
-              <div className="m-watch-tile-head">
-                <div className="m-watch-tile-avatar" style={{ background: item.avatar }}>{item.initials}</div>
-                <div className="m-watch-tile-name">{item.name}</div>
-                <div className="m-watch-tile-ticker">{item.ticker}</div>
-              </div>
-              <div className="m-watch-tile-val"><strong>{item.value}</strong><span className="delta" data-trend={item.trend}>{item.delta}</span></div>
-              <div className="m-watch-tile-meta">{item.meta}</div>
-            </div>
-          ))}
-        </div>
-      </section>
-      <section className="m-section">
-        <header className="m-section-head"><span className="kicker">Since you were last here</span><a href="/?surface=inbox" role="button">All 5</a></header>
+        <header className="m-section-head"><span className="kicker">Today</span><a href="/?surface=inbox" role="button">All 5</a></header>
         <div className="m-nudges">
-          {INBOX_SEED.slice(0, 3).map((item) => {
+          {INBOX_SEED.slice(0, 1).map((item) => {
             const Icon = item.icon;
             return (
               <div key={item.id} className="m-nudge">
@@ -3498,20 +3596,38 @@ function MobileHomeBody() {
           })}
         </div>
       </section>
-      <section className="m-section">
-        <header className="m-section-head"><span className="kicker">Recent threads</span><a href="/?surface=chat">View all</a></header>
-        <div className="m-threads">
-          {THREADS.map((thread) => (
-            <div key={thread.id} className="m-thread">
-              <div className="m-thread-icon"><MobileIcon name="chat" size={14} /></div>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div className="m-thread-title">{thread.title}</div>
-                <div className="m-thread-meta">{thread.meta}</div>
+      <details className="m-section m-mobile-more">
+        <summary><span>Watchlist</span><small>4 tracked</small></summary>
+        <div className="m-watch">
+          {WATCHLIST.map((item) => (
+            <div key={item.id} className="m-watch-tile">
+              <div className="m-watch-tile-head">
+                <div className="m-watch-tile-avatar" style={{ background: item.avatar }}>{item.initials}</div>
+                <div className="m-watch-tile-name">{item.name}</div>
+                <div className="m-watch-tile-ticker">{item.ticker}</div>
               </div>
-              <MobileIcon name="chevron" />
+              <div className="m-watch-tile-val"><strong>{item.value}</strong><span className="delta" data-trend={item.trend}>{item.delta}</span></div>
+              <div className="m-watch-tile-meta">{item.meta}</div>
             </div>
           ))}
         </div>
+      </details>
+      <section className="m-section">
+        <details className="m-mobile-more">
+          <summary><span>Recent threads</span><small>3 saved</small></summary>
+          <div className="m-threads">
+            {THREADS.map((thread) => (
+              <div key={thread.id} className="m-thread">
+                <div className="m-thread-icon"><MobileIcon name="chat" size={14} /></div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div className="m-thread-title">{thread.title}</div>
+                  <div className="m-thread-meta">{thread.meta}</div>
+                </div>
+                <MobileIcon name="chevron" />
+              </div>
+            ))}
+          </div>
+        </details>
       </section>
     </main>
   );
@@ -3535,33 +3651,39 @@ function MobileChatBody() {
         <div className="m-chat-callout-head"><Sparkles size={12} /> So what</div>
         <p>The next best action is not a generic intro. Verify the claim, then send a tight reply around regulated EU expansion.</p>
       </div>
-      <div className="m-strip-head"><span className="kicker">Entities</span><a href="/?surface=reports">Open cards</a></div>
-      <div className="m-strip">
-        {WATCHLIST.slice(0, 3).map((item) => (
-          <div key={item.id} className="m-card">
-            <div className="m-card-head">
-              <div className="m-card-avatar" style={{ background: item.avatar }}>{item.initials}</div>
-              <div><div className="m-card-name">{item.name}</div><div className="m-card-sub">{item.meta}</div></div>
+      <details className="m-chat-evidence">
+        <summary>
+          <span>Evidence</span>
+          <small>3 entities - 24 sources</small>
+        </summary>
+        <div className="m-strip-head"><span className="kicker">Entities</span><a href="/?surface=reports">Open entity cards</a></div>
+        <div className="m-strip">
+          {WATCHLIST.slice(0, 3).map((item) => (
+            <div key={item.id} className="m-card">
+              <div className="m-card-head">
+                <div className="m-card-avatar" style={{ background: item.avatar }}>{item.initials}</div>
+                <div><div className="m-card-name">{item.name}</div><div className="m-card-sub">{item.meta}</div></div>
+              </div>
+              <div className="m-card-metrics">
+                <div><div className="m-card-metric-l">Signal</div><div className="m-card-metric-v" data-trend={item.trend}>{item.value}</div></div>
+                <div><div className="m-card-metric-l">Delta</div><div className="m-card-metric-v" data-trend={item.trend}>{item.delta}</div></div>
+              </div>
             </div>
-            <div className="m-card-metrics">
-              <div><div className="m-card-metric-l">Signal</div><div className="m-card-metric-v" data-trend={item.trend}>{item.value}</div></div>
-              <div><div className="m-card-metric-l">Delta</div><div className="m-card-metric-v" data-trend={item.trend}>{item.delta}</div></div>
+          ))}
+        </div>
+        <div className="m-strip-head"><span className="kicker">Top sources</span><a href="/?surface=reports">View source list</a></div>
+        {["Security page", "Saved report", "Launch note"].map((source, index) => (
+          <div key={source} className="m-src-row">
+            <MobileIcon name="source" />
+            <div style={{ flex: 1 }}>
+              <div className="m-src-title">{source}</div>
+              <div className="m-src-meta"><span>source {index + 1}</span><span>medium confidence</span></div>
             </div>
           </div>
         ))}
-      </div>
-      <div className="m-strip-head"><span className="kicker">Top sources</span><a href="/?surface=reports">View all</a></div>
-      {["Security page", "Saved report", "Launch note"].map((source, index) => (
-        <div key={source} className="m-src-row">
-          <MobileIcon name="source" />
-          <div style={{ flex: 1 }}>
-            <div className="m-src-title">{source}</div>
-            <div className="m-src-meta"><span>source {index + 1}</span><span>medium confidence</span></div>
-          </div>
-        </div>
-      ))}
+      </details>
       <div className="m-followups">
-        <span className="kicker">Follow-up</span>
+        <span className="kicker">Next</span>
         {["Verify", "Open card", "Draft reply"].map((item) => <button key={item} className="m-followup">{item}</button>)}
       </div>
       <div className="m-composer-dock">

--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -716,6 +716,36 @@
   opacity: 0.72;
 }
 
+.nb-kit .pipeline-launcher-advanced,
+.nb-mobile-kit .pipeline-launcher-advanced {
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: var(--bg-muted);
+  padding: 8px 10px;
+}
+
+.nb-kit .pipeline-launcher-advanced summary,
+.nb-mobile-kit .pipeline-launcher-advanced summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 800;
+  list-style: none;
+}
+
+.nb-kit .pipeline-launcher-advanced summary::-webkit-details-marker,
+.nb-mobile-kit .pipeline-launcher-advanced summary::-webkit-details-marker {
+  display: none;
+}
+
+.nb-kit .pipeline-launcher-advanced-body,
+.nb-mobile-kit .pipeline-launcher-advanced-body {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding-top: 9px;
+}
+
 .nb-kit .nb-show-more-row {
   display: flex;
   justify-content: center;
@@ -1511,6 +1541,10 @@
   padding: 14px 16px 84px;
 }
 
+.nb-mobile-kit .m-chat-body {
+  padding-bottom: 126px;
+}
+
 .nb-mobile-kit .m-chat-title {
   margin: 10px 0;
   font-size: 20px;
@@ -1540,6 +1574,24 @@
   overflow-x: auto;
   margin: 0 -16px;
   padding: 0 16px 4px;
+}
+
+.nb-mobile-kit .m-strip-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 14px 0 8px;
+}
+
+.nb-mobile-kit .m-strip-head a {
+  flex: none;
+  color: var(--accent-ink);
+  font-size: 11.5px;
+  font-weight: 800;
+  line-height: 1.2;
+  text-decoration: none;
+  white-space: nowrap;
 }
 
 .nb-mobile-kit .m-card {
@@ -1705,6 +1757,14 @@
   background: var(--bg-surface);
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.1), 0 2px 6px rgba(15, 23, 42, 0.05);
   padding: 8px 10px;
+}
+
+.nb-mobile-kit .m-chat-body .m-composer-dock {
+  position: sticky;
+  left: auto;
+  right: auto;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 72px);
+  margin-top: 14px;
 }
 
 .nb-mobile-kit .m-composer-dock input {
@@ -5933,4 +5993,313 @@
   padding: 2px 6px;
   border-radius: 4px;
   border: 1px solid var(--border-subtle);
+}
+
+/* Clarity pass: keep first-run surfaces focused instead of dashboard-dense. */
+.nb-kit .nb-example-strip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.nb-kit .nb-example-chip {
+  display: inline-flex;
+  max-width: 260px;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  padding: 7px 10px;
+  font-size: 12px;
+  font-weight: 720;
+  line-height: 1.15;
+  text-align: left;
+  box-shadow: var(--shadow-sm);
+}
+
+.nb-kit .nb-example-chip span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nb-kit .nb-example-chip .nb-prompt-icon {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  margin-bottom: 0;
+}
+
+.nb-kit .nb-first-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.nb-kit .nb-first-list .nb-first-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: end;
+  min-height: 0;
+  padding: 13px 14px;
+}
+
+.nb-kit .nb-first-card-main {
+  min-width: 0;
+}
+
+.nb-kit .nb-first-list .nb-first-proof {
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-top: 9px;
+}
+
+.nb-kit .nb-first-list .nb-first-export {
+  justify-content: flex-end;
+  margin: 0;
+  padding: 0;
+}
+
+.nb-kit .nb-first-list .nb-first-actions {
+  min-width: 240px;
+  align-items: flex-end;
+  flex-direction: column;
+  margin: 0;
+}
+
+.nb-kit .nb-home-more {
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.nb-kit .nb-home-more > summary {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 16px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 800;
+  list-style: none;
+}
+
+.nb-kit .nb-home-more > summary::-webkit-details-marker {
+  display: none;
+}
+
+.nb-kit .nb-home-more > summary small {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 680;
+}
+
+.nb-kit .nb-home-more-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  border-top: 1px solid var(--border-subtle);
+  padding: 16px;
+}
+
+.nb-kit .nb-research-workbench {
+  margin: 16px 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-sm);
+  padding: 14px;
+}
+
+.nb-kit .nb-research-workbench-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.nb-kit .nb-research-workbench-head h2 {
+  margin: 3px 0 0;
+  color: var(--text-primary);
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.nb-kit .nb-workbench-tabs {
+  display: inline-flex;
+  gap: 3px;
+  margin-top: 12px;
+  border-radius: 10px;
+  background: var(--bg-secondary);
+  padding: 3px;
+}
+
+.nb-kit .nb-workbench-tabs button {
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.nb-kit .nb-workbench-tabs button[data-active="true"] {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.nb-kit .nb-workbench-panel {
+  margin-top: 12px;
+}
+
+.nb-kit .nb-workbench-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nb-mobile-kit .m-pipeline-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 3px;
+  margin-bottom: 10px;
+  border-radius: 10px;
+  background: var(--bg-muted);
+  padding: 3px;
+}
+
+.nb-mobile-kit .m-pipeline-tabs button {
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  padding: 7px 4px;
+  font-size: 11.5px;
+  font-weight: 820;
+}
+
+.nb-mobile-kit .m-pipeline-tabs button[data-active="true"] {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.nb-mobile-kit .m-scenario-more,
+.nb-mobile-kit .m-mobile-more,
+.nb-mobile-kit .m-chat-evidence {
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--bg-surface);
+}
+
+.nb-mobile-kit .m-scenario-more {
+  padding: 0;
+}
+
+.nb-mobile-kit .m-scenario-more summary,
+.nb-mobile-kit .m-mobile-more summary,
+.nb-mobile-kit .m-chat-evidence summary {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 820;
+  list-style: none;
+}
+
+.nb-mobile-kit .m-scenario-more summary::-webkit-details-marker,
+.nb-mobile-kit .m-mobile-more summary::-webkit-details-marker,
+.nb-mobile-kit .m-chat-evidence summary::-webkit-details-marker {
+  display: none;
+}
+
+.nb-mobile-kit .m-scenario-more summary::after,
+.nb-mobile-kit .m-mobile-more summary::after,
+.nb-mobile-kit .m-chat-evidence summary::after {
+  content: "+";
+  color: var(--text-muted);
+  font-weight: 900;
+}
+
+.nb-mobile-kit .m-scenario-more[open] summary::after,
+.nb-mobile-kit .m-mobile-more[open] summary::after,
+.nb-mobile-kit .m-chat-evidence[open] summary::after {
+  content: "-";
+}
+
+.nb-mobile-kit .m-mobile-more summary small,
+.nb-mobile-kit .m-chat-evidence summary small {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.nb-mobile-kit .m-scenario-more button {
+  display: block;
+  width: calc(100% - 16px);
+  margin: 0 8px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 9px;
+  background: var(--bg-muted);
+  color: var(--text-primary);
+  padding: 9px 10px;
+  text-align: left;
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.nb-mobile-kit .m-scenario-more button span {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.nb-mobile-kit .m-mobile-more .m-watch,
+.nb-mobile-kit .m-mobile-more .m-threads {
+  padding: 0 10px 10px;
+}
+
+.nb-mobile-kit .m-chat-evidence {
+  margin-top: 12px;
+}
+
+.nb-mobile-kit .m-chat-evidence .m-strip-head {
+  padding: 0 12px;
+}
+
+.nb-mobile-kit .m-chat-evidence .m-src-row {
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+@media (max-width: 760px) {
+  .nb-kit .nb-first-list .nb-first-card {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .nb-kit .nb-first-list .nb-first-actions {
+    min-width: 0;
+    align-items: stretch;
+  }
 }

--- a/src/features/home/views/HomeLanding.tsx
+++ b/src/features/home/views/HomeLanding.tsx
@@ -49,9 +49,8 @@ const WEB_KIT_PROMPT_CARDS = [
 ] as const;
 
 const WEB_KIT_RESEARCH_LANES = [
-  { id: "answer", label: "Answer", note: "fast - default" },
-  { id: "deep", label: "Deep dive", note: "multi-agent - 3-5 min" },
-  { id: "admin", label: "Admin", note: "nodebench-mcp-admin" },
+  { id: "answer", label: "Quick answer", note: "fast read" },
+  { id: "deep", label: "Deep research", note: "more sources" },
 ] as const satisfies readonly ProductResearchLane[];
 
 type WebKitResearchLaneId = (typeof WEB_KIT_RESEARCH_LANES)[number]["id"];
@@ -493,7 +492,7 @@ export function HomeLanding() {
             uploadingFiles={uploadingFiles}
             placeholder="Ask anything - a company, a market, a question..."
             helperText="Accepts URLs, PDFs, docs, and notes."
-            submitLabel="Start run"
+            submitLabel="Open workspace"
             showOperatorContextChip={false}
             showOperatorContextHint={false}
             showLensSelector={false}

--- a/src/features/me/views/MeHome.tsx
+++ b/src/features/me/views/MeHome.tsx
@@ -404,7 +404,7 @@ export function MeHome() {
         className="mt-5 -mx-2 flex flex-wrap gap-1 overflow-x-auto rounded-full border border-black/[0.06] bg-black/[0.03] p-1 text-xs dark:border-white/10 dark:bg-white/[0.03] sm:mx-0"
       >
         {[
-          ["me-notebook", "Notebook"],
+          ["me-notebook", "Memory"],
           ["me-profile", "Profile"],
           ["me-files", "Files"],
           ["me-plan", "Plan"],
@@ -436,13 +436,13 @@ export function MeHome() {
         </p>
       </section>
 
-      {/* Notebook section */}
+      {/* Memory section */}
       <section id="me-notebook" className="mt-6 scroll-mt-24 rounded-2xl border border-gray-200 bg-white p-5 dark:border-white/[0.08] dark:bg-white/[0.02]">
         <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
           <div>
             <div className="mb-2 inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--accent-primary)]">
               <BookOpen className="h-4 w-4" aria-hidden="true" />
-              Notebook
+              Memory
             </div>
             <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">Watched memory</h2>
             <p className="mt-1 text-sm leading-6 text-gray-500 dark:text-gray-400">

--- a/src/features/pipelines/views/PipelineEvalScorecard.tsx
+++ b/src/features/pipelines/views/PipelineEvalScorecard.tsx
@@ -1,14 +1,7 @@
 /**
  * PipelineEvalScorecard
  *
- * Surfaces aggregate eval metrics over the most recent pipelineRuns:
- *   - Verdict accuracy (% verified)
- *   - Brier score (forecast-vs-outcome calibration)
- *   - Avg duration / cost
- *   - Per-kind breakdown
- *
- * Pure-data view — no LLM calls. Uses the existing `pipelineRuns`
- * substrate to derive scores deterministically.
+ * User-facing quality summary for recent background research runs.
  */
 
 import React from "react";
@@ -21,34 +14,57 @@ function pct(n: number): string {
 }
 
 function ms(n?: number): string {
-  if (typeof n !== "number" || !Number.isFinite(n)) return "—";
+  if (typeof n !== "number" || !Number.isFinite(n)) return "-";
   if (n < 1000) return `${Math.round(n)}ms`;
   return `${(n / 1000).toFixed(1)}s`;
 }
 
 function usd(n?: number): string {
-  if (typeof n !== "number" || !Number.isFinite(n) || n <= 0) return "—";
+  if (typeof n !== "number" || !Number.isFinite(n) || n <= 0) return "-";
   if (n < 0.01) return "<$0.01";
   return `$${n.toFixed(3)}`;
 }
 
-function brierLabel(b?: number): { label: string; tone: string } {
-  if (typeof b !== "number") return { label: "—", tone: "text-content-muted" };
+function qualityLabel(b?: number): { label: string; tone: string } {
+  if (typeof b !== "number") return { label: "-", tone: "text-content-muted" };
   if (b < 0.15)
     return {
-      label: `${b.toFixed(3)} · well-calibrated`,
+      label: "well calibrated",
       tone: "text-emerald-700 dark:text-emerald-300",
     };
   if (b < 0.25)
     return {
-      label: `${b.toFixed(3)} · acceptable`,
+      label: "acceptable",
       tone: "text-amber-700 dark:text-amber-300",
     };
   return {
-    label: `${b.toFixed(3)} · poorly calibrated`,
+    label: "needs review",
     tone: "text-red-700 dark:text-red-300",
   };
 }
+
+function verdictLabel(key: string): string {
+  if (key === "verified") return "verified";
+  if (key === "provisionally_verified") return "partly verified";
+  if (key === "needs_review") return "needs review";
+  if (key === "failed") return "failed";
+  return "other";
+}
+
+function kindLabel(kind: string): string {
+  if (kind === "research") return "research";
+  if (kind === "code_gen") return "code starter";
+  if (kind === "design_gen") return "design brief";
+  return kind.replaceAll("_", " ");
+}
+
+const COUNT_TONE: Record<string, string> = {
+  verified: "text-emerald-700 dark:text-emerald-300",
+  provisionally_verified: "text-amber-700 dark:text-amber-300",
+  needs_review: "text-amber-700 dark:text-amber-300",
+  failed: "text-red-700 dark:text-red-300",
+  other: "text-content-muted",
+};
 
 export const PipelineEvalScorecard: React.FC = () => {
   const stats = useStableQuery(
@@ -62,7 +78,7 @@ export const PipelineEvalScorecard: React.FC = () => {
         data-testid="pipeline-eval-scorecard"
         className="nb-surface-card p-4 text-xs text-content-muted"
       >
-        Loading eval scorecard…
+        Loading research quality...
       </section>
     );
   }
@@ -77,9 +93,9 @@ export const PipelineEvalScorecard: React.FC = () => {
             <Gauge className="w-4 h-4 text-violet-600 dark:text-violet-300" />
           </div>
           <div>
-            <h3 className="text-sm font-semibold text-content">Eval scorecard</h3>
+            <h3 className="text-sm font-semibold text-content">Research quality</h3>
             <p className="text-[11px] text-content-muted">
-              Brier + verdict accuracy across recent runs · empty until runs land.
+              Quality and review counters appear after research runs finish.
             </p>
           </div>
         </header>
@@ -87,12 +103,12 @@ export const PipelineEvalScorecard: React.FC = () => {
     );
   }
 
-  const brier = brierLabel(stats.brier);
+  const quality = qualityLabel(stats.brier);
 
   return (
     <section
       data-testid="pipeline-eval-scorecard"
-      aria-label="Pipeline eval scorecard"
+      aria-label="Research quality"
       className="nb-surface-card p-4 space-y-3"
     >
       <header className="flex items-center justify-between gap-3 flex-wrap">
@@ -101,9 +117,9 @@ export const PipelineEvalScorecard: React.FC = () => {
             <Gauge className="w-4 h-4 text-violet-600 dark:text-violet-300" />
           </div>
           <div>
-            <h3 className="text-sm font-semibold text-content">Eval scorecard</h3>
+            <h3 className="text-sm font-semibold text-content">Research quality</h3>
             <p className="text-[11px] text-content-muted">
-              Aggregated over the last {stats.samples} run(s)
+              Based on the last {stats.samples} run(s)
             </p>
           </div>
         </div>
@@ -111,33 +127,33 @@ export const PipelineEvalScorecard: React.FC = () => {
           <span data-testid="pipeline-eval-accuracy">
             verified {pct(stats.verdictAccuracy)}
           </span>{" "}
-          ·{" "}
-          <span data-testid="pipeline-eval-brier" className={brier.tone}>
-            Brier {brier.label}
+          -{" "}
+          <span data-testid="pipeline-eval-brier" className={quality.tone}>
+            confidence {quality.label}
           </span>{" "}
-          · avg {ms(stats.avgDurationMs)} / {usd(stats.avgUsd)}
+          - avg {ms(stats.avgDurationMs)} / {usd(stats.avgUsd)}
         </div>
       </header>
 
       <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
         {(
           [
-            ["verified", "emerald"],
-            ["provisionally_verified", "amber"],
-            ["needs_review", "amber"],
-            ["failed", "red"],
-            ["other", "content-muted"],
+            "verified",
+            "provisionally_verified",
+            "needs_review",
+            "failed",
+            "other",
           ] as const
-        ).map(([key, tone]) => (
+        ).map((key) => (
           <div
             key={key}
             data-testid={`pipeline-eval-count-${key}`}
             className="rounded-md border border-edge/60 px-2 py-1.5"
           >
             <div className="text-[10px] uppercase tracking-wide text-content-muted">
-              {key.replace("_", " ")}
+              {verdictLabel(key)}
             </div>
-            <div className={`text-sm font-semibold text-${tone}-700 dark:text-${tone}-300`}>
+            <div className={`text-sm font-semibold ${COUNT_TONE[key]}`}>
               {(stats.verdictCounts as any)[key]}
             </div>
           </div>
@@ -147,22 +163,22 @@ export const PipelineEvalScorecard: React.FC = () => {
       {stats.byKind.length > 0 ? (
         <div data-testid="pipeline-eval-by-kind" className="text-[11px]">
           <div className="text-content-muted mb-1 inline-flex items-center gap-1">
-            <TrendingUp className="w-3 h-3" /> Per-kind breakdown
+            <TrendingUp className="w-3 h-3" /> By output type
           </div>
           <table className="w-full">
             <thead>
               <tr className="text-[10px] uppercase text-content-muted">
-                <th className="text-left py-0.5">Kind</th>
-                <th className="text-right py-0.5">Samples</th>
-                <th className="text-right py-0.5">Verified%</th>
-                <th className="text-right py-0.5">Avg duration</th>
+                <th className="text-left py-0.5">Type</th>
+                <th className="text-right py-0.5">Runs</th>
+                <th className="text-right py-0.5">Verified</th>
+                <th className="text-right py-0.5">Avg time</th>
                 <th className="text-right py-0.5">Avg cost</th>
               </tr>
             </thead>
             <tbody>
               {stats.byKind.map((k) => (
                 <tr key={k.pipelineKind} className="border-t border-edge/40">
-                  <td className="py-0.5 text-content">{k.pipelineKind.replace("_", " ")}</td>
+                  <td className="py-0.5 text-content">{kindLabel(k.pipelineKind)}</td>
                   <td className="py-0.5 text-right text-content-muted">{k.samples}</td>
                   <td className="py-0.5 text-right text-content-muted">
                     {pct(k.verifiedShare)}

--- a/src/features/pipelines/views/PipelineLauncher.tsx
+++ b/src/features/pipelines/views/PipelineLauncher.tsx
@@ -1,27 +1,24 @@
 /**
  * PipelineLauncher
  *
- * Inline form mounted above PipelineRunsPanel that lets users kick off
- * a pi-ai pipeline directly from the UI. On submit it calls the durable
- * `startPipelineRun` workflow mutation (so retries + scheduling are
- * handled by `@convex-dev/workflow`), then resets the form. The new
- * run appears in the panel via the existing reactive query — no manual
- * refresh required.
+ * User-facing launcher for server-side research runs. The backend still uses
+ * the pi-ai pipeline workflow, but this surface intentionally describes the
+ * experience as saved research that keeps running after the user leaves.
  */
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { Play, Loader2, Layers, Calendar } from "lucide-react";
 import { getAnonymousProductSessionId } from "@/features/product/lib/productIdentity";
 
 const PIPELINE_KINDS = [
-  { value: "research", label: "Research" },
-  { value: "code_gen", label: "Code generation" },
-  { value: "design_gen", label: "Design generation" },
-  { value: "research_then_code", label: "Research → Code (composed)" },
-  { value: "research_then_design", label: "Research → Design (composed)" },
-  { value: "code_then_design", label: "Code → Design (composed)" },
+  { value: "research", label: "Research report", advanced: false },
+  { value: "code_gen", label: "Code starter", advanced: false },
+  { value: "design_gen", label: "Design brief", advanced: false },
+  { value: "research_then_code", label: "Research, then code", advanced: true },
+  { value: "research_then_design", label: "Research, then design", advanced: true },
+  { value: "code_then_design", label: "Code, then design", advanced: true },
 ] as const;
 
 type PipelineKindValue = (typeof PIPELINE_KINDS)[number]["value"];
@@ -36,25 +33,19 @@ const COMPOSED_KINDS = new Set<PipelineKindValue>([
 ]);
 
 const MODEL_PRESETS = [
-  { value: "gpt-4o-mini", label: "GPT-4o mini · cheap + fast" },
-  { value: "openai:gpt-4o", label: "GPT-4o · higher quality" },
+  { value: "gpt-4o-mini", label: "Fast default" },
+  { value: "openai:gpt-4o", label: "Deeper read" },
   { value: "anthropic:claude-haiku-4.5", label: "Claude Haiku 4.5" },
   { value: "google:gemini-3-flash", label: "Gemini 3 Flash" },
 ];
 
 const PLACEHOLDER_BY_KIND: Record<string, string> = {
-  research:
-    "Ask a research question — e.g., What are the practical tradeoffs between pi-ai and Vercel AI SDK?",
-  code_gen:
-    "Describe what to scaffold — e.g., A TypeScript util that hashes strings with SHA-256, plus a Vitest test.",
-  design_gen:
-    "Describe the surface — e.g., A landing page for a coding-pipeline product. Hero, CTA, three feature cards, dark mode.",
-  research_then_code:
-    "Describe what to research and then build — e.g., Compare Tailwind v4 vs Panda CSS, then scaffold a starter using the winner.",
-  research_then_design:
-    "Describe what to research and then design — e.g., Survey premium SaaS landing pages, then design our hero + CTA.",
-  code_then_design:
-    "Describe what to scaffold and then design — e.g., A simple kanban board in React, then a polished design for it.",
+  research: "Example: Research Orbital Labs and tell me if I should follow up.",
+  code_gen: "Example: Create a small TypeScript helper and include a test.",
+  design_gen: "Example: Make a clean mobile-first landing page for a research tool.",
+  research_then_code: "Example: Compare two libraries, then scaffold a starter with the better fit.",
+  research_then_design: "Example: Research strong SaaS examples, then design the hero and CTA.",
+  code_then_design: "Example: Scaffold a small React board, then polish the design.",
 };
 
 export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
@@ -66,6 +57,7 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
   const [title, setTitle] = useState("");
   const [modelId, setModelId] = useState("gpt-4o-mini");
   const [linkupDepth, setLinkupDepth] = useState<"standard" | "deep">("standard");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<{
     kind: "ok" | "error";
@@ -82,12 +74,6 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
     api.domains.pipelines.pipelineSchedule.createSchedule,
   );
 
-  // Auth-aware ownerKey: when signed in, runs are attributed to the
-  // user (`user:<id>`) so the document handoff fires automatically and
-  // /reports filtering works. When anonymous, fall back to the persistent
-  // anonymous session id (`session:<id>`) so shareable run links resolve
-  // for the same browser session even before signup. Storage-bundle export
-  // is the only handoff path until they sign in (auth-gated).
   const loggedInUser = useQuery(
     (api as any)?.domains?.auth?.auth?.loggedInUser ?? "skip",
   );
@@ -98,31 +84,44 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
       ? `session:${anonymousSessionId}`
       : undefined;
   const ownerLabel = loggedInUser?._id
-    ? "Signed in — output also lands as a Workspace document."
-    : `Session ${anonymousSessionId?.slice(0, 8) ?? "?"} — bundle export only (sign in for document handoff).`;
-  // Schedule mode: when ON, submit creates a scheduledPipelineRuns row
-  // instead of firing the workflow immediately. Cron sweeps the row
-  // hourly and kicks off the run when nextRunAt elapses.
+    ? "Reports, sources, and notes are saved to your workspace."
+    : "This browser can reopen the report later. Sign in to keep it across devices.";
+
   const [scheduleMode, setScheduleMode] = useState(false);
   const [scheduleCadence, setScheduleCadence] = useState<
     "once" | "hourly" | "daily" | "weekly"
   >("daily");
+
   const isComposed = COMPOSED_KINDS.has(pipelineKind);
   const showLinkupDepth =
-    pipelineKind === "research" || pipelineKind === "research_then_code" ||
+    pipelineKind === "research" ||
+    pipelineKind === "research_then_code" ||
     pipelineKind === "research_then_design";
+  const visibleKinds = useMemo(
+    () =>
+      isCompact || advancedOpen
+        ? PIPELINE_KINDS
+        : PIPELINE_KINDS.filter((kind) => !kind.advanced),
+    [advancedOpen, isCompact],
+  );
+
+  useEffect(() => {
+    if (!advancedOpen && !isCompact && isComposed) {
+      setPipelineKind("research");
+    }
+  }, [advancedOpen, isCompact, isComposed]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (submitting) return;
     if (!spec.trim()) {
-      setFeedback({ kind: "error", message: "Spec required." });
+      setFeedback({ kind: "error", message: "Tell NodeBench what to research first." });
       return;
     }
     if (scheduleMode && isComposed) {
       setFeedback({
         kind: "error",
-        message: "Composed pipelines can't be scheduled yet. Pick a primitive kind.",
+        message: "Automatic refresh is available for single-step research right now.",
       });
       return;
     }
@@ -130,28 +129,27 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
     setFeedback(null);
     try {
       if (scheduleMode) {
-        const result = await createSchedule({
+        await createSchedule({
           ownerKey,
           pipelineKind: pipelineKind as "research" | "code_gen" | "design_gen",
           spec: spec.trim(),
           title: title.trim() || undefined,
           modelId,
           cadence: scheduleCadence,
-          nextRunAt: Date.now(), // fire immediately on next cron sweep
+          nextRunAt: Date.now(),
           options: showLinkupDepth ? { linkupDepth } : undefined,
         });
         setFeedback({
           kind: "ok",
-          message: `Schedule ${result.scheduleId} created — fires on next ${scheduleCadence} cron sweep.`,
+          message: "Automatic refresh saved. It will run on the selected cadence and appear below.",
         });
         setSpec("");
         setTitle("");
         setSubmitting(false);
         return;
       }
-      let workflowId: string;
       if (isComposed) {
-        const result = await startComposedPipelineRun({
+        await startComposedPipelineRun({
           composition: pipelineKind as
             | "research_then_code"
             | "research_then_design"
@@ -163,9 +161,8 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
           forceFresh: true,
           linkupDepth: showLinkupDepth ? linkupDepth : undefined,
         });
-        workflowId = result.workflowId;
       } else {
-        const result = await startPipelineRun({
+        await startPipelineRun({
           pipelineKind: pipelineKind as "research" | "code_gen" | "design_gen",
           spec: spec.trim(),
           title: title.trim() || undefined,
@@ -174,15 +171,10 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
           forceFresh: true,
           linkupDepth: showLinkupDepth ? linkupDepth : undefined,
         });
-        workflowId = result.workflowId;
       }
       setFeedback({
         kind: "ok",
-        message: `Workflow ${workflowId} started — ${
-          isComposed ? "two runs" : "run"
-        } will appear below.${
-          ownerKey ? "" : " (anonymous: bundle export only)"
-        }`,
+        message: "Research started. Safe to leave this page; progress and the final report will appear below.",
       });
       setSpec("");
       setTitle("");
@@ -198,7 +190,7 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
     <section
       data-testid="pipeline-launcher"
       data-pipeline-launcher-variant={variant}
-      aria-label="Run a pipeline"
+      aria-label="Start research"
       className={`nb-surface-card space-y-3 ${isCompact ? "p-3 pipeline-launcher-compact" : "p-4"}`}
     >
       <header className="flex items-center gap-2">
@@ -206,154 +198,213 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
           <Play className="w-4 h-4 text-emerald-600 dark:text-emerald-300" />
         </div>
         <div>
-          <h3 className="text-sm font-semibold text-content">Run a pipeline</h3>
+          <h3 className="text-sm font-semibold text-content">Start research</h3>
           {isCompact ? (
             <p className="text-[11px] text-content-muted">
-              Kind + spec. Full model and schedule controls remain on desktop.
+              Tell NodeBench what to find. It keeps running if you leave.
             </p>
           ) : (
             <p className="text-[11px] text-content-muted">
-              Pick a kind, describe what you want, and submit. The run lands below in real time.
+              Ask a question, start the run, then come back to sources, status, and exports.
             </p>
           )}
         </div>
       </header>
 
       <form onSubmit={handleSubmit} className="space-y-3" data-testid="pipeline-launcher-form">
-        <div className={`grid grid-cols-1 ${isCompact ? "gap-2" : "md:grid-cols-3 gap-3"}`}>
-          <label className="flex flex-col gap-1 text-xs text-content-muted">
-            <span>Kind</span>
-            <select
-              data-testid="pipeline-launcher-kind"
-              className="bg-surface border border-edge rounded-md text-xs px-2 py-1.5 text-content"
-              value={pipelineKind}
-              onChange={(e) =>
-                setPipelineKind(e.target.value as "research" | "code_gen" | "design_gen")
-              }
-              disabled={submitting}
-            >
-              {PIPELINE_KINDS.map((k) => (
-                <option key={k.value} value={k.value}>
-                  {k.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          {!isCompact ? (
+        {isCompact ? (
+          <details className="pipeline-launcher-advanced">
+            <summary>Options: {PIPELINE_KINDS.find((k) => k.value === pipelineKind)?.label ?? "Research"} - {linkupDepth === "deep" ? "Deep refresh" : "Standard sources"}</summary>
+            <div className="pipeline-launcher-advanced-body">
+              <label className="flex flex-col gap-1 text-xs text-content-muted">
+                <span>Output type</span>
+                <select
+                  data-testid="pipeline-launcher-kind"
+                  className="bg-surface border border-edge rounded-md text-xs px-2 py-1.5 text-content"
+                  value={pipelineKind}
+                  onChange={(e) => setPipelineKind(e.target.value as PipelineKindValue)}
+                  disabled={submitting}
+                >
+                  {visibleKinds.map((k) => (
+                    <option key={k.value} value={k.value}>
+                      {k.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {showLinkupDepth ? (
+                <div className="flex items-center gap-2 text-[11px] text-content-muted flex-wrap">
+                  <span>Search depth</span>
+                  <button
+                    type="button"
+                    data-testid="pipeline-launcher-depth-standard"
+                    onClick={() => setLinkupDepth("standard")}
+                    className={`px-2 py-0.5 rounded-full border ${
+                      linkupDepth === "standard"
+                        ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300"
+                        : "border-edge"
+                    }`}
+                    disabled={submitting}
+                  >
+                    Standard
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="pipeline-launcher-depth-deep"
+                    onClick={() => setLinkupDepth("deep")}
+                    className={`px-2 py-0.5 rounded-full border ${
+                      linkupDepth === "deep"
+                        ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300"
+                        : "border-edge"
+                    }`}
+                    disabled={submitting}
+                  >
+                    Deep
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </details>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <label className="flex flex-col gap-1 text-xs text-content-muted">
+              <span>Output type</span>
+              <select
+                data-testid="pipeline-launcher-kind"
+                className="bg-surface border border-edge rounded-md text-xs px-2 py-1.5 text-content"
+                value={pipelineKind}
+                onChange={(e) => setPipelineKind(e.target.value as PipelineKindValue)}
+                disabled={submitting}
+              >
+                {visibleKinds.map((k) => (
+                  <option key={k.value} value={k.value}>
+                    {k.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {advancedOpen ? (
             <>
-          <label className="flex flex-col gap-1 text-xs text-content-muted">
-            <span>Model</span>
-            <select
-              data-testid="pipeline-launcher-model"
-              className="bg-surface border border-edge rounded-md text-xs px-2 py-1.5 text-content"
-              value={modelId}
-              onChange={(e) => setModelId(e.target.value)}
-              disabled={submitting}
-            >
-              {MODEL_PRESETS.map((m) => (
-                <option key={m.value} value={m.value}>
-                  {m.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex flex-col gap-1 text-xs text-content-muted md:col-span-1">
-            <span>Title (optional)</span>
-            <input
-              data-testid="pipeline-launcher-title"
-              type="text"
-              placeholder="Auto-derived from spec if blank"
-              className="bg-surface border border-edge rounded-md text-xs px-2 py-1.5 text-content"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              disabled={submitting}
-              maxLength={120}
-            />
-          </label>
+              <label className="flex flex-col gap-1 text-xs text-content-muted">
+                <span>Model</span>
+                <select
+                  data-testid="pipeline-launcher-model"
+                  className="bg-surface border border-edge rounded-md text-xs px-2 py-1.5 text-content"
+                  value={modelId}
+                  onChange={(e) => setModelId(e.target.value)}
+                  disabled={submitting}
+                >
+                  {MODEL_PRESETS.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs text-content-muted md:col-span-1">
+                <span>Title (optional)</span>
+                <input
+                  data-testid="pipeline-launcher-title"
+                  type="text"
+                  placeholder="Auto-derived if blank"
+                  className="bg-surface border border-edge rounded-md text-xs px-2 py-1.5 text-content"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  disabled={submitting}
+                  maxLength={120}
+                />
+              </label>
             </>
-          ) : null}
-        </div>
-        {showLinkupDepth ? (
-          <div className="flex items-center gap-2 text-[11px] text-content-muted flex-wrap">
-            <span>Web search depth:</span>
-            <button
-              type="button"
-              data-testid="pipeline-launcher-depth-standard"
-              onClick={() => setLinkupDepth("standard")}
-              className={`px-2 py-0.5 rounded-full border ${
-                linkupDepth === "standard"
-                  ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300"
-                  : "border-edge"
-              }`}
-              disabled={submitting}
-            >
-              Standard (~€0.005/query)
-            </button>
-            <button
-              type="button"
-              data-testid="pipeline-launcher-depth-deep"
-              onClick={() => setLinkupDepth("deep")}
-              className={`px-2 py-0.5 rounded-full border ${
-                linkupDepth === "deep"
-                  ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300"
-                  : "border-edge"
-              }`}
-              disabled={submitting}
-            >
-              Deep (~€0.05/query, slower)
-            </button>
+            ) : null}
           </div>
-        ) : null}
-        {isComposed ? (
-          <div className="flex items-center gap-1.5 text-[11px] text-content-muted">
-            <Layers className="w-3 h-3" />
-            <span>Composed run: two pipelineRuns rows will appear (stage 1 → stage 2).</span>
-          </div>
-        ) : null}
+        )}
+
         {!isCompact ? (
-        <div className="flex items-center gap-3 flex-wrap text-[11px] text-content-muted">
-          <label className="inline-flex items-center gap-1.5 cursor-pointer">
-            <input
-              type="checkbox"
-              data-testid="pipeline-launcher-schedule-toggle"
-              checked={scheduleMode}
-              onChange={(e) => setScheduleMode(e.target.checked)}
-              disabled={submitting || isComposed}
-              className="h-3 w-3"
-            />
-            <Calendar className="w-3 h-3" />
-            <span>Schedule instead of run now</span>
-          </label>
-          {scheduleMode ? (
-            <select
-              data-testid="pipeline-launcher-schedule-cadence"
-              className="bg-surface border border-edge rounded-md text-xs px-2 py-0.5 text-content"
-              value={scheduleCadence}
-              onChange={(e) =>
-                setScheduleCadence(
-                  e.target.value as "once" | "hourly" | "daily" | "weekly",
-                )
-              }
-              disabled={submitting}
-            >
-              <option value="once">Once</option>
-              <option value="hourly">Hourly</option>
-              <option value="daily">Daily</option>
-              <option value="weekly">Weekly</option>
-            </select>
-          ) : null}
-          {scheduleMode && isComposed ? (
-            <span className="text-amber-700 dark:text-amber-300">
-              (composed schedules not supported)
-            </span>
-          ) : null}
-        </div>
+          <details
+            className="pipeline-launcher-advanced"
+            open={advancedOpen}
+            onToggle={(event) => setAdvancedOpen(event.currentTarget.open)}
+          >
+            <summary>Advanced controls</summary>
+            <div className="pipeline-launcher-advanced-body">
+              {showLinkupDepth ? (
+                <div className="flex items-center gap-2 text-[11px] text-content-muted flex-wrap">
+                  <span>Search depth</span>
+                  <button
+                    type="button"
+                    data-testid="pipeline-launcher-depth-standard"
+                    onClick={() => setLinkupDepth("standard")}
+                    className={`px-2 py-0.5 rounded-full border ${
+                      linkupDepth === "standard"
+                        ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300"
+                        : "border-edge"
+                    }`}
+                    disabled={submitting}
+                  >
+                    Standard sources
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="pipeline-launcher-depth-deep"
+                    onClick={() => setLinkupDepth("deep")}
+                    className={`px-2 py-0.5 rounded-full border ${
+                      linkupDepth === "deep"
+                        ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300"
+                        : "border-edge"
+                    }`}
+                    disabled={submitting}
+                  >
+                    Deep refresh
+                  </button>
+                </div>
+              ) : null}
+              {isComposed ? (
+                <div className="flex items-center gap-1.5 text-[11px] text-content-muted">
+                  <Layers className="w-3 h-3" />
+                  <span>Multi-step run: research and generation are saved as separate rows.</span>
+                </div>
+              ) : null}
+              <div className="flex items-center gap-3 flex-wrap text-[11px] text-content-muted">
+                <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    data-testid="pipeline-launcher-schedule-toggle"
+                    checked={scheduleMode}
+                    onChange={(e) => setScheduleMode(e.target.checked)}
+                    disabled={submitting || isComposed}
+                    className="h-3 w-3"
+                  />
+                  <Calendar className="w-3 h-3" />
+                  <span>Refresh automatically</span>
+                </label>
+                {scheduleMode ? (
+                  <select
+                    data-testid="pipeline-launcher-schedule-cadence"
+                    className="bg-surface border border-edge rounded-md text-xs px-2 py-0.5 text-content"
+                    value={scheduleCadence}
+                    onChange={(e) =>
+                      setScheduleCadence(
+                        e.target.value as "once" | "hourly" | "daily" | "weekly",
+                      )
+                    }
+                    disabled={submitting}
+                  >
+                    <option value="once">Once</option>
+                    <option value="hourly">Hourly</option>
+                    <option value="daily">Daily</option>
+                    <option value="weekly">Weekly</option>
+                  </select>
+                ) : null}
+              </div>
+            </div>
+          </details>
         ) : null}
+
         <label className="flex flex-col gap-1 text-xs text-content-muted">
-          <span>Spec</span>
+          <span>What should NodeBench find out?</span>
           <textarea
             data-testid="pipeline-launcher-spec"
-            className={`bg-surface border border-edge rounded-md text-xs px-2 py-2 text-content font-mono resize-y ${isCompact ? "min-h-[68px]" : "min-h-[88px]"}`}
+            className={`bg-surface border border-edge rounded-md text-xs px-2 py-2 text-content resize-y ${isCompact ? "min-h-[68px]" : "min-h-[88px]"}`}
             placeholder={PLACEHOLDER_BY_KIND[pipelineKind]}
             value={spec}
             onChange={(e) => setSpec(e.target.value)}
@@ -367,13 +418,11 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
 
         <div className="flex items-center justify-between gap-3 flex-wrap">
           <div className="text-[11px] text-content-muted">
-            {isCompact ? <>Durable workflow, idempotent resubmit.</> : <>Runs durably via{" "}
-            <code className="text-[10px]">@convex-dev/workflow</code> — retries on transient
-            failure, idempotent on resubmit.</>}
+            Runs in the background. Safe to leave this page.
             {loggedInUser?._id ? (
-              <span data-testid="pipeline-launcher-owner-signedin"> {isCompact ? "Signed in." : ownerLabel}</span>
+              <span data-testid="pipeline-launcher-owner-signedin"> {isCompact ? "Saved to workspace." : ownerLabel}</span>
             ) : (
-              <span data-testid="pipeline-launcher-owner-anon"> {isCompact ? `Session ${anonymousSessionId?.slice(0, 8) ?? "?"}.` : ownerLabel}</span>
+              <span data-testid="pipeline-launcher-owner-anon"> {isCompact ? "Saved in this browser." : ownerLabel}</span>
             )}
           </div>
           <button
@@ -387,7 +436,7 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
             ) : (
               <Play className="w-3.5 h-3.5" />
             )}
-            {submitting ? "Starting…" : "Run pipeline"}
+            {submitting ? "Starting..." : "Run research"}
           </button>
         </div>
 

--- a/src/features/pipelines/views/PipelineRunsPanel.tsx
+++ b/src/features/pipelines/views/PipelineRunsPanel.tsx
@@ -1,10 +1,8 @@
 /**
  * Pipeline Runs Panel
  *
- * Surfaces the most recent pi-ai pipeline runs on the Reports surface.
- * Each row shows status, verdict, model, tokens + estimated USD, and a
- * step count. Mirrors the look of EntityFindingsPanel — both are
- * cheap-retrieval substrates over Convex queries.
+ * Shows recent server-side research work on the Reports surface. Copy stays
+ * product-facing; implementation details remain in the backend and tests.
  */
 
 import React, { useMemo, useState } from "react";
@@ -36,12 +34,12 @@ const statusBadge: Record<string, { label: string; className: string; Icon: any 
     Icon: Loader2,
   },
   succeeded: {
-    label: "Succeeded",
+    label: "Ready",
     className: "text-emerald-700 dark:text-emerald-300 bg-emerald-500/10 border border-emerald-500/30",
     Icon: CheckCircle2,
   },
   failed: {
-    label: "Failed",
+    label: "Needs attention",
     className: "text-red-700 dark:text-red-300 bg-red-500/10 border border-red-500/30",
     Icon: AlertCircle,
   },
@@ -72,23 +70,40 @@ function formatRelative(ms: number): string {
 }
 
 function formatUsd(n: number | undefined): string {
-  if (typeof n !== "number" || !Number.isFinite(n) || n <= 0) return "—";
-  if (n < 0.01) return `<$0.01`;
+  if (typeof n !== "number" || !Number.isFinite(n) || n <= 0) return "-";
+  if (n < 0.01) return "<$0.01";
   return `$${n.toFixed(2)}`;
 }
 
 function formatDuration(ms: number | undefined): string {
-  if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) return "—";
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) return "-";
   if (ms < 1000) return `${ms}ms`;
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-/**
- * Live stream preview — subscribes to `getPipelineStream` for the run
- * and renders the partial text as it grows. Shown when a row is
- * expanded. Streaming state badge ("Live" / "Complete") reflects the
- * real-time mutation chain in `pipelineRunStreams`.
- */
+function formatKind(kind: string): string {
+  if (kind === "research") return "research report";
+  if (kind === "code_gen") return "code starter";
+  if (kind === "design_gen") return "design brief";
+  if (kind === "custom") return "custom run";
+  return kind.replaceAll("_", " ");
+}
+
+function formatVerdict(verdict: string): string {
+  if (verdict === "provisionally_verified") return "partly verified";
+  if (verdict === "needs_review") return "needs review";
+  if (verdict === "in_progress") return "in progress";
+  return verdict.replaceAll("_", " ");
+}
+
+function formatRunTitle(title: string): string {
+  const cleaned = title
+    .replace(/^original\s+spec:\s*/i, "")
+    .replace(/^spec:\s*/i, "")
+    .trim();
+  return cleaned || "Research run";
+}
+
 const PipelineRunStreamPreview: React.FC<{ runId: string }> = ({ runId }) => {
   const stream = useStableQuery(
     api.domains.pipelines.pipelineStreamMutations.getPipelineStream,
@@ -100,7 +115,7 @@ const PipelineRunStreamPreview: React.FC<{ runId: string }> = ({ runId }) => {
         data-testid="pipeline-run-stream-loading"
         className="text-[11px] text-content-muted"
       >
-        Loading stream…
+        Loading live output...
       </div>
     );
   }
@@ -128,8 +143,8 @@ const PipelineRunStreamPreview: React.FC<{ runId: string }> = ({ runId }) => {
               isLive ? "text-emerald-500 animate-pulse" : "text-content-muted"
             }`}
           />
-          {stream.stepName} · {stream.status}
-          {stream.errorMessage ? ` · ${stream.errorMessage}` : ""}
+          {stream.stepName} - {stream.status}
+          {stream.errorMessage ? ` - ${stream.errorMessage}` : ""}
         </span>
         <span className="text-[10px] text-content-muted">
           {stream.partialText.length.toLocaleString()} chars
@@ -141,8 +156,8 @@ const PipelineRunStreamPreview: React.FC<{ runId: string }> = ({ runId }) => {
       >
         {stream.partialText.length > 0
           ? stream.partialText.slice(0, 4000) +
-            (stream.partialText.length > 4000 ? "\n\n[…truncated]" : "")
-          : "(waiting for first delta)"}
+            (stream.partialText.length > 4000 ? "\n\n[truncated]" : "")
+          : "(waiting for first update)"}
       </pre>
     </div>
   );
@@ -182,7 +197,7 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
         data-testid="pipeline-runs-panel"
         className="nb-surface-card p-4 text-xs text-content-muted"
       >
-        Loading pipeline runs…
+        Loading research runs...
       </section>
     );
   }
@@ -198,19 +213,14 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
             <Cpu className="w-4 h-4 text-amber-600 dark:text-amber-300" />
           </div>
           <div>
-            <h3 className="text-sm font-semibold text-content">Pipeline runs</h3>
+            <h3 className="text-sm font-semibold text-content">Research runs</h3>
             <p className="text-[11px] text-content-muted">
-              Pi-AI code-gen / design-gen / research runs land here.
+              Your background research appears here with status, sources, review state, and exports.
             </p>
           </div>
         </header>
         <p className="text-xs text-content-muted">
-          No runs yet. Trigger one via{" "}
-          <code className="text-[11px]">
-            npx convex run domains/pipelines/codeGenPipeline:runCodeGenPipeline
-            '{"{\"spec\": \"...\"}"}'
-          </code>
-          .
+          No runs yet. Start one above; it will keep running if you leave this page.
         </p>
       </section>
     );
@@ -219,7 +229,7 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
   return (
     <section
       data-testid="pipeline-runs-panel"
-      aria-label="Pi-AI pipeline runs"
+      aria-label="Research runs"
       className="nb-surface-card p-4 space-y-3"
     >
       <header className="flex items-start justify-between gap-3 flex-wrap">
@@ -228,9 +238,9 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
             <Cpu className="w-4 h-4 text-amber-600 dark:text-amber-300" />
           </div>
           <div>
-            <h3 className="text-sm font-semibold text-content">Pipeline runs</h3>
+            <h3 className="text-sm font-semibold text-content">Research runs</h3>
             <p className="text-[11px] text-content-muted">
-              Pi-AI orchestrated runs · cost + verdict tracked
+              Background research with progress, review status, and export links.
             </p>
           </div>
         </div>
@@ -240,7 +250,7 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
               <span className="text-emerald-700 dark:text-emerald-300 font-medium">
                 {stats.succeeded}
               </span>{" "}
-              succeeded
+              ready
             </span>
             <span data-testid="pipeline-stat-failed">
               <span className="text-red-700 dark:text-red-300 font-medium">{stats.failed}</span>{" "}
@@ -271,7 +281,7 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
               <div className="flex items-center justify-between gap-2 flex-wrap">
                 <span className="inline-flex items-center gap-2 font-medium text-content truncate max-w-[55%]">
                   <FileText className="w-3.5 h-3.5 text-content-muted" />
-                  <span className="truncate">{run.title}</span>
+                  <span className="truncate">{formatRunTitle(run.title)}</span>
                 </span>
                 <span
                   className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] uppercase tracking-wide ${badge.className}`}
@@ -283,21 +293,19 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
                 </span>
               </div>
               <div className="flex items-center gap-3 text-[11px] text-content-muted flex-wrap">
-                <span>{run.pipelineKind.replace("_", " ")}</span>
-                <span>·</span>
-                <span>{run.modelId}</span>
-                <span>·</span>
-                <span>{run.stepCount} steps</span>
-                <span>·</span>
+                <span>{formatKind(run.pipelineKind)}</span>
+                <span>-</span>
+                <span>{run.stepCount} checks</span>
+                <span>-</span>
                 <span>{formatDuration(run.durationMs)}</span>
-                <span>·</span>
+                <span>-</span>
                 <span>{formatUsd(run.estimatedUsd)}</span>
-                <span>·</span>
+                <span>-</span>
                 <span>{formatRelative(run.createdAt)}</span>
                 {run.verdict ? (
                   <>
-                    <span>·</span>
-                    <span className={verdictBadge[run.verdict] ?? ""}>{run.verdict}</span>
+                    <span>-</span>
+                    <span className={verdictBadge[run.verdict] ?? ""}>{formatVerdict(run.verdict)}</span>
                   </>
                 ) : null}
               </div>
@@ -329,7 +337,7 @@ export const PipelineRunsPanel: React.FC<PipelineRunsPanelProps> = ({
                   {expandedRunId === run.runId ? "Hide live output" : "Show live output"}
                 </button>
               </div>
-              {(run.bundleUrl || run.imageUrl) ? (
+              {run.bundleUrl || run.imageUrl ? (
                 <div className="flex items-center gap-3 pt-1">
                   {run.imageUrl ? (
                     <a

--- a/src/features/pipelines/views/PipelineSchedulesPanel.tsx
+++ b/src/features/pipelines/views/PipelineSchedulesPanel.tsx
@@ -1,9 +1,8 @@
 /**
  * PipelineSchedulesPanel
  *
- * Lists `scheduledPipelineRuns` rows for the signed-in user (or session)
- * with toggle / delete affordances. Drives the cron sweep that fires
- * pipelines on cadence (once / hourly / daily / weekly).
+ * Lists saved automatic refreshes. These rows are backed by scheduled
+ * pipeline runs, but the UI describes the user-facing refresh workflow.
  */
 
 import React from "react";
@@ -48,6 +47,13 @@ function formatRelative(ms: number): string {
   return diff > 0 ? `in ${d}d` : `${d}d ago`;
 }
 
+function formatKind(kind: string): string {
+  if (kind === "research") return "research";
+  if (kind === "code_gen") return "code starter";
+  if (kind === "design_gen") return "design brief";
+  return kind.replaceAll("_", " ");
+}
+
 type PipelineSchedulesPanelProps = {
   ownerKey?: string;
   queryLimit?: number;
@@ -84,7 +90,7 @@ export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
         data-testid="pipeline-schedules-panel"
         className="nb-surface-card p-4 text-xs text-content-muted"
       >
-        Loading schedules…
+        Loading automatic refreshes...
       </section>
     );
   }
@@ -100,17 +106,14 @@ export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
             <Calendar className="w-4 h-4 text-blue-600 dark:text-blue-300" />
           </div>
           <div>
-            <h3 className="text-sm font-semibold text-content">Pipeline schedules</h3>
+            <h3 className="text-sm font-semibold text-content">Automatic refreshes</h3>
             <p className="text-[11px] text-content-muted">
-              Cron-fired pipeline runs land here. Empty — none scheduled yet.
+              Saved refreshes appear here. None are scheduled yet.
             </p>
           </div>
         </header>
         <p className="text-xs text-content-muted">
-          Create one via{" "}
-          <code className="text-[11px]">
-            npx convex run domains/pipelines/pipelineSchedule:createSchedule …
-          </code>
+          Create one from Advanced controls when you want NodeBench to re-check a topic.
         </p>
       </section>
     );
@@ -119,7 +122,7 @@ export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
   return (
     <section
       data-testid="pipeline-schedules-panel"
-      aria-label="Pipeline schedules"
+      aria-label="Automatic refreshes"
       className="nb-surface-card p-4 space-y-3"
     >
       <header className="flex items-center gap-2">
@@ -127,9 +130,9 @@ export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
           <Calendar className="w-4 h-4 text-blue-600 dark:text-blue-300" />
         </div>
         <div>
-          <h3 className="text-sm font-semibold text-content">Pipeline schedules</h3>
+          <h3 className="text-sm font-semibold text-content">Automatic refreshes</h3>
           <p className="text-[11px] text-content-muted">
-            Cron sweeps every hour · {schedules.filter((s) => s.enabled).length} enabled ·{" "}
+            Checks for changes every hour - {schedules.filter((s) => s.enabled).length} active -{" "}
             showing {visibleSchedules.length} / {schedules.length}
           </p>
         </div>
@@ -147,19 +150,19 @@ export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
                 {row.title ?? row.spec.slice(0, 60)}
               </span>
               <span className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-content-muted">
-                {row.pipelineKind.replace("_", " ")} · {row.cadence}
+                {formatKind(row.pipelineKind)} - {row.cadence}
                 {row.enabled ? (
-                  <span className="text-emerald-700 dark:text-emerald-300">enabled</span>
+                  <span className="text-emerald-700 dark:text-emerald-300">active</span>
                 ) : (
                   <span className="text-content-muted">paused</span>
                 )}
               </span>
             </div>
             <div className="text-[11px] text-content-muted">
-              Next run {formatRelative(row.nextRunAt)} · model {row.modelId}
+              Next check {formatRelative(row.nextRunAt)}
               {row.lastRunAt
-                ? ` · last fired ${formatRelative(row.lastRunAt)}${row.lastStatus ? ` (${row.lastStatus})` : ""}`
-                : " · never fired"}
+                ? ` - last checked ${formatRelative(row.lastRunAt)}${row.lastStatus ? ` (${row.lastStatus})` : ""}`
+                : " - not checked yet"}
             </div>
             <div className="flex items-center gap-2 pt-1">
               <button
@@ -189,7 +192,7 @@ export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
                   if (
                     typeof window !== "undefined" &&
                     !window.confirm(
-                      `Delete schedule "${row.title ?? row.spec.slice(0, 40)}"? This cannot be undone.`,
+                      `Delete automatic refresh "${row.title ?? row.spec.slice(0, 40)}"? This cannot be undone.`,
                     )
                   ) {
                     return;
@@ -202,7 +205,7 @@ export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
               </button>
               {row.lastStatus === "kicked" ? (
                 <span className="inline-flex items-center gap-1 text-[10px] text-emerald-700 dark:text-emerald-300">
-                  <CheckCircle2 className="w-3 h-3" /> last sweep ok
+                  <CheckCircle2 className="w-3 h-3" /> last check ok
                 </span>
               ) : null}
             </div>
@@ -216,8 +219,8 @@ export const PipelineSchedulesPanel: React.FC<PipelineSchedulesPanelProps> = ({
           onClick={showMore}
           className="inline-flex items-center justify-center rounded-md border border-edge px-3 py-1.5 text-[11px] font-medium text-content-muted hover:bg-surface-hover"
         >
-          Show {Math.min(windowStep, remainingCount)} more schedule
-          {remainingCount === 1 ? "" : "s"}
+          Show {Math.min(windowStep, remainingCount)} more refresh
+          {remainingCount === 1 ? "" : "es"}
         </button>
       ) : null}
     </section>

--- a/src/layouts/MobileCaptureFab.tsx
+++ b/src/layouts/MobileCaptureFab.tsx
@@ -9,11 +9,23 @@
  * Hidden above `md` viewport (desktop has rail + top nav already).
  */
 import { Plus } from "lucide-react";
+import { useLocation } from "react-router-dom";
 import { useFastAgent } from "@/features/agents/context/FastAgentContext";
 import "@/features/designKit/exact/exactKit.css";
 
 export function MobileCaptureFab() {
   const { open } = useFastAgent();
+  const location = useLocation();
+  const surface = new URLSearchParams(location.search).get("surface");
+  const hidesPrimaryContent =
+    surface === null ||
+    surface === "home" ||
+    surface === "chat" ||
+    surface === "reports" ||
+    surface === "packets" ||
+    location.pathname.startsWith("/reports/");
+  if (hidesPrimaryContent) return null;
+
   return (
     <button
       type="button"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -289,7 +289,7 @@ if ('serviceWorker' in navigator && import.meta.env.PROD && !isAutomatedBrowser)
     window.location.reload();
   });
 
-  import(/* @vite-ignore */ 'virtual:pwa-register' as any).then(({ registerSW }: any) => {
+  import("virtual:pwa-register").then(({ registerSW }) => {
     const updateSW = registerSW({
       immediate: true,
       onNeedRefresh() {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 declare module "*?raw" {
   const content: string;

--- a/tests/e2e/exact-kit-parity-prod.spec.ts
+++ b/tests/e2e/exact-kit-parity-prod.spec.ts
@@ -30,7 +30,7 @@ test("PR A4: Home renders ExactHomeSurface composer hero", async ({ page }) => {
   expect(result.composer).toBe(true);
   expect(result.kicker).toBe(true);
   expect(result.h1).toContain("Get the read before you walk in.");
-  expect(result.lanes.length).toBeGreaterThanOrEqual(3);
+  expect(result.lanes.length).toBeGreaterThanOrEqual(2);
   expect(result.asyncProof).toBe(true);
   expect(result.firstImpression).toBe(true);
 });

--- a/tests/e2e/live-smoke-mobile.spec.ts
+++ b/tests/e2e/live-smoke-mobile.spec.ts
@@ -41,17 +41,19 @@ test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
     await expect(page.getByText(/Need the read before you walk in/i)).toBeVisible();
     await expect(page.locator('[data-testid="mobile-home-async-run"]')).toBeVisible();
     await expect(page.locator('[data-testid="mobile-home-first-impression"]')).toBeVisible();
-    await expect(page.getByText(/phone-safe/i)).toBeVisible();
+    await expect(page.getByText(/safe to leave/i)).toBeVisible();
     // Watchlist kicker
     await expect(page.getByText(/Watchlist/i).first()).toBeVisible();
     // At least one watchlist tile — Disco is the DISCO scenario root
-    await expect(page.getByText(/Disco Corp/i).first()).toBeVisible();
+    await expect(page.getByText(/^Today$/).first()).toBeVisible();
+    await expect(page.getByText(/Announced GA/i).first()).toBeVisible();
+    await page.getByText(/Watchlist/i).first().click();
+    await expect(page.getByText(/^DISCO$/).first()).toBeVisible();
     // Nudges section
-    await expect(page.getByText(/Since you were last here/i)).toBeVisible();
+    await expect(page.getByText(/Recent threads/i).first()).toBeVisible();
     // Recent threads kicker
-    await expect(page.getByText(/Recent threads/i)).toBeVisible();
-    // Mobile capture FAB (PR #21)
-    await expect(page.locator('[data-testid="mobile-capture-fab"]')).toBeVisible();
+    // Home already has a primary research control; no floating button should cover cards.
+    await expect(page.locator('[data-testid="mobile-capture-fab"]')).toHaveCount(0);
   });
 
   test("Chat surface — MobileChatSurface mounts with answer + entities + sources", async ({ page }) => {
@@ -64,15 +66,32 @@ test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
     // "So what" callout (design-kit vocabulary)
     await expect(page.getByText(/So what/i)).toBeVisible();
     // Entities strip header
+    const chatSurface = page.locator('[data-testid="mobile-chat-surface"]');
+    await expect(chatSurface.getByText(/^Evidence$/i)).toBeVisible();
+    await expect(chatSurface.getByText(/3 entities - 24 sources/i)).toBeVisible();
+    await chatSurface.getByText(/^Evidence$/i).click();
     await expect(page.getByText(/Entities/i).first()).toBeVisible();
+    await expect(page.getByRole("link", { name: /Open entity cards/i })).toBeVisible();
     // Top sources header
     await expect(page.getByText(/Top sources/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /View source list/i })).toBeVisible();
     // Follow-up chips
     await expect(
-      page.locator('[data-testid="mobile-chat-surface"]').getByText(/^Follow-up$/),
+      page.locator('[data-testid="mobile-chat-surface"]').getByText(/^Next$/),
     ).toBeVisible();
     // Composer dock input
     await expect(page.getByPlaceholder(/Ask a follow-up/i)).toBeVisible();
+    const stripHeadersFit = await page.evaluate(() =>
+      Array.from(document.querySelectorAll(".m-strip-head")).every((header) => {
+        const rect = header.getBoundingClientRect();
+        return Array.from(header.children).every((child) => {
+          const childRect = child.getBoundingClientRect();
+          return childRect.left >= rect.left - 1 && childRect.right <= rect.right + 1;
+        });
+      }),
+    );
+    expect(stripHeadersFit, "mobile chat strip headers should not collide or overflow").toBe(true);
+    await expect(page.locator('[data-testid="mobile-capture-fab"]')).toHaveCount(0);
   });
 
   test("Inbox surface — MobileInboxSurface mounts with filter tabs", async ({ page }) => {
@@ -118,24 +137,37 @@ test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
     const pipelineBlock = reportsSurface.locator('[data-testid="mobile-reports-pipeline-block"]');
     await expect(reportsSurface).toBeVisible({ timeout: 20_000 });
     await expect(pipelineBlock).toBeVisible();
+    await expect(pipelineBlock.getByText(/Start or check research/i)).toBeVisible();
+    await expect(pipelineBlock.getByRole("tab", { name: /^Start$/ })).toHaveAttribute("data-active", "true");
+    await expect(pipelineBlock.getByRole("tab", { name: /^Runs$/ })).toBeVisible();
+    await expect(pipelineBlock.getByRole("tab", { name: /^Quality$/ })).toBeVisible();
+    await expect(pipelineBlock.getByText(/Start research/i).first()).toBeVisible();
+    await expect(pipelineBlock.getByText(/Run a pipeline/i)).toHaveCount(0);
+    await expect(pipelineBlock.getByText(/Run pipeline/i)).toHaveCount(0);
+    await expect(pipelineBlock.getByText(/idempotent|@convex-dev/i)).toHaveCount(0);
+    await expect(page.locator('[data-testid="mobile-capture-fab"]')).toHaveCount(0);
     await expect(pipelineBlock.locator('[data-testid="reports-pipeline-launcher-slot"]')).toBeVisible();
     await expect(pipelineBlock.locator('[data-testid="pipeline-launcher"]')).toBeVisible();
     await expect(pipelineBlock.locator('[data-testid="pipeline-launcher"]')).toHaveAttribute(
       "data-pipeline-launcher-variant",
       "compact",
     );
+    await expect(pipelineBlock.locator('[data-testid="reports-pipelines-panel-slot"]')).toHaveCount(0);
+    await expect(pipelineBlock.locator('[data-testid="reports-pipeline-eval-slot"]')).toHaveCount(0);
+    await pipelineBlock.getByRole("tab", { name: /^Runs$/ }).click();
     await expect(pipelineBlock.locator('[data-testid="reports-pipelines-panel-slot"]')).toBeVisible();
     await expect(pipelineBlock.locator('[data-testid="pipeline-runs-panel"], [data-testid="pipeline-runs-empty"]')).toBeVisible();
+    await expect(
+      pipelineBlock.locator(
+        '[data-testid="pipeline-stat-window"], [data-testid="pipeline-runs-empty"], [data-testid="pipeline-run-list"]',
+      ).first(),
+    ).toBeVisible();
+    await pipelineBlock.getByRole("tab", { name: /^Quality$/ }).click();
     await expect(pipelineBlock.locator('[data-testid="reports-pipeline-eval-slot"]')).toBeVisible();
     await expect(
       pipelineBlock.locator(
         '[data-testid="pipeline-eval-scorecard"], [data-testid="pipeline-eval-scorecard-empty"], .nb-deferred-panel',
       ),
-    ).toBeVisible();
-    await expect(
-      pipelineBlock.locator(
-        '[data-testid="pipeline-stat-window"], [data-testid="pipeline-runs-empty"], [data-testid="pipeline-run-list"]',
-      ).first(),
     ).toBeVisible();
     await expect(pipelineBlock.locator('[data-testid="pipeline-schedules-panel"]')).toHaveCount(0);
     await expect(reportsSurface.getByRole("button", { name: /^Brief$/ })).toBeVisible();

--- a/tests/e2e/pr77-me-anchor-nav.spec.ts
+++ b/tests/e2e/pr77-me-anchor-nav.spec.ts
@@ -46,7 +46,7 @@ test("PR #77: /?surface=me has 7 kit-aligned anchor IDs + jump nav", async ({ pa
 
   expect(result.hasJumpNav).toBe(true);
   expect(result.navLabels).toEqual([
-    "Notebook",
+    "Memory",
     "Profile",
     "Files",
     "Plan",

--- a/tests/e2e/product-shell-smoke.spec.ts
+++ b/tests/e2e/product-shell-smoke.spec.ts
@@ -92,7 +92,7 @@ test.describe("Product shell smoke", () => {
       // Home: actionable first-impression H1 + async background CTA.
       await page.goto("/?surface=home", { waitUntil: "networkidle" });
       await expect(page.getByRole("heading", { name: /Get the read before you walk in\./i })).toBeVisible();
-      await expect(page.getByRole("button", { name: /run in background/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /run research/i }).first()).toBeVisible();
       await expect(page.getByTestId("home-first-impression-board")).toBeVisible();
       await expect(page.getByText(/Continues if the phone locks/i)).toBeVisible();
 
@@ -120,10 +120,10 @@ test.describe("Product shell smoke", () => {
       await expect(page.getByText(/what shows up here/i)).toHaveCount(0);
       await expect(page.getByRole("heading", { name: /nothing urgent right now/i })).toHaveCount(0);
 
-      // Me: notebook-first personal context surface, not a generic Settings page.
+      // Me: memory-first personal context surface, not a generic Settings page.
       await page.goto("/?surface=me", { waitUntil: "networkidle" });
-      await expect(page.getByRole("heading", { level: 1, name: /^Notebook$/i })).toBeVisible();
-      await expect(page.getByText(/Entities you have taught NodeBench to watch/i)).toBeVisible();
+      await expect(page.getByRole("heading", { level: 1, name: /^Memory$/i })).toBeVisible();
+      await expect(page.getByText(/Entities NodeBench watches for you/i)).toBeVisible();
       await expect(page.getByRole("heading", { level: 1, name: /^settings$/i })).toHaveCount(0);
     } finally {
       await context.close().catch(() => undefined);
@@ -168,7 +168,7 @@ test.describe("Product shell smoke", () => {
       await expect(page).toHaveURL(/surface=me/);
       await expect(meButton).toHaveAttribute("data-active", "true");
       await expect(meButton).toHaveAttribute("aria-current", "page");
-      await expect(page.getByRole("heading", { level: 1, name: /your context/i })).toBeVisible();
+      await expect(page.getByRole("heading", { level: 1, name: /^Memory$/i })).toBeVisible();
       await expect(inboxButton).toHaveAttribute("data-active", "false");
     } finally {
       await context.close().catch(() => undefined);
@@ -188,7 +188,7 @@ test.describe("Product shell smoke", () => {
 
       await expect(page).toHaveURL(/surface=me/);
       await expect(meButton).toHaveAttribute("aria-current", "page");
-      await expect(page.getByRole("heading", { level: 1, name: /your context/i })).toBeVisible();
+      await expect(page.getByText(/^Me$/i).first()).toBeVisible();
     } finally {
       await context.close().catch(() => undefined);
     }


### PR DESCRIPTION
## Summary
- Simplifies Home into an ask-first first-run flow with compact examples and progressive disclosure.
- Makes Reports desktop/mobile use compact Start/Runs/Quality tabs instead of stacked pipeline panels.
- Makes Chat mobile answer-first with collapsed evidence and removes overlapping mobile FAB behavior on primary surfaces.

## Verification
- `npx tsc --noEmit --pretty false`
- `npx tsc -p convex --noEmit --pretty false`
- `npm run build`
- `npx vitest run src/features/home/lib/firstImpressionResearch.test.ts src/layouts/ActiveSurfaceHost.test.tsx --exclude ".worktrees/**"`
- `npx playwright test tests/e2e/live-smoke-mobile.spec.ts --project=chromium --grep "Home surface|Chat surface|Reports surface"`
- `npx playwright test tests/e2e/exact-kit-parity-prod.spec.ts --project=chromium --grep "PR A4|PR A6|PR A2"`
- `npx playwright test tests/e2e/pr79-memory-pulse-honest.spec.ts --project=chromium`