### PR TITLE
fix(product): wire reports model selector and MCP profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,9 +464,16 @@ Automated org page posts currently read like machine-generated reports. 67 posts
 - Scheduled enforcement: `domains/operations/privacyEnforcement:*`
 - Safety: dry-run where supported, never delete without audit trail
 
-### MCP Unified Server plane (Render) — 101 tools, 9 domains
-- Health: `curl https://nodebench-mcp-unified.onrender.com/health` (must return `{"status":"ok","tools":101}`)
-- Tools list: `tools/list` returns 101 tools across research, narrative, verification, knowledge, documents, planning, memory, search, financial + findTools meta-tool
+### MCP Unified Server plane (Render) — 114 tools, 9 domains
+- Health: `curl https://nodebench-mcp-unified.onrender.com/health` (must return `{"status":"ok","tools":114}`)
+- Full tools list: `tools/list` with `full` / `internal-full` returns 114 tools across research, narrative, verification, knowledge, documents, planning, memory, search, financial + findTools meta-tool
+- Tool profile layer:
+  - Full internal surface remains available through `full` / `internal-full`.
+  - External users should use scoped profiles: `public-research`, `gmail-research`, `documents`, `memory`, `financial`, `knowledge`, or `builder`.
+  - HTTP profile selection: `?profile=public-research`, `x-nodebench-profile`, or `x-mcp-profile`.
+  - Profile-scoped tokens are configured with `MCP_PROFILE_TOKENS=token:profile,token2:profile2`; scoped token profile wins over query/header requests.
+  - `findTools` is profile-scoped and only searches tools visible to that profile.
+  - Profile runbook: `docs/guides/MCP_TOOL_PROFILES.md`.
 - Architecture: Convex-side dispatcher at `/api/mcpGateway`
   - Gateway calls single endpoint with `x-mcp-secret` header (no admin key)
   - Convex httpAction validates secret, resolves function from static allowlist, injects userId server-side

--- a/docs/guides/MCP_TOOL_PROFILES.md
+++ b/docs/guides/MCP_TOOL_PROFILES.md
@@ -1,0 +1,175 @@
+# NodeBench MCP Tool Profiles
+
+The unified NodeBench MCP gateway keeps one deployable service, but clients should not receive the full internal tool catalog by default. Tool profiles provide small, task-specific catalogs for external builders while preserving the full 114-tool internal surface.
+
+## Production Endpoint
+
+```txt
+https://nodebench-mcp-unified.onrender.com
+```
+
+## Profiles
+
+| Profile | Intended client | Tool count |
+| --- | --- | ---: |
+| `public-research` | External apps that need public entity research memory | 14 |
+| `gmail-research` | Gmail/job-match integrations | 10 |
+| `documents` | Document and spreadsheet agents | 21 |
+| `memory` | Agent memory clients | 5 |
+| `financial` | Market, macro, crypto, and news lookups | 10 |
+| `knowledge` | Knowledge graph and source registry clients | 11 |
+| `builder` | Builder-facing agents that need research, docs, memory, planning, and search | 55 |
+| `internal-full` / `full` | Internal NodeBench operators and eval harnesses | 114 |
+
+Counts include the profile-scoped `findTools` meta-tool. In a profile, `findTools` only searches the visible tools for that profile.
+
+## Selecting A Profile
+
+HTTP MCP clients can request a profile with either a query parameter or header:
+
+```txt
+https://nodebench-mcp-unified.onrender.com?profile=public-research
+```
+
+```http
+x-nodebench-profile: public-research
+```
+
+or:
+
+```http
+x-mcp-profile: public-research
+```
+
+If the server is configured with a profile-scoped token, the token wins over query/header profile requests. For example, a `gmail-research` token cannot request `full`.
+
+## Environment Variables
+
+```txt
+MCP_HTTP_TOKEN=<internal full-access token>
+MCP_DEFAULT_PROFILE=full
+MCP_PROFILE_TOKENS=<token1>:public-research,<token2>:gmail-research,<token3>:builder
+```
+
+Recommended production setup:
+
+- Keep `MCP_HTTP_TOKEN` as the internal full-access token.
+- Issue external users profile-scoped tokens through `MCP_PROFILE_TOKENS`.
+- Use `MCP_DEFAULT_PROFILE=public-research` only for a public demo service where full internal access is not needed through the same endpoint.
+
+For stdio clients:
+
+```txt
+MCP_PROFILE=public-research
+```
+
+or:
+
+```txt
+MCP_DEFAULT_PROFILE=public-research
+```
+
+## Public Research Client Config
+
+```json
+{
+  "mcpServers": {
+    "nodebench-public-research": {
+      "transport": "http",
+      "url": "https://nodebench-mcp-unified.onrender.com?profile=public-research",
+      "headers": {
+        "x-mcp-token": "<NODEBENCH_PUBLIC_RESEARCH_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+Visible tools:
+
+```txt
+nodebench.entities.resolve
+nodebench.search_public_sources
+nodebench.research_company
+nodebench.research_person
+nodebench.research_role
+nodebench.dossiers.get
+nodebench.context.pack
+nodebench.get_matching_context
+nodebench.compile_interview_packet
+nodebench.claims.submit_public
+nodebench.claims.verify
+nodebench.watch_entity
+nodebench.link_private_signal_to_public_entity
+findTools
+```
+
+## Gmail Research Client Config
+
+```json
+{
+  "mcpServers": {
+    "nodebench-gmail-research": {
+      "transport": "http",
+      "url": "https://nodebench-mcp-unified.onrender.com",
+      "headers": {
+        "x-mcp-token": "<NODEBENCH_GMAIL_RESEARCH_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+Visible tools:
+
+```txt
+nodebench.entities.resolve
+nodebench.search_public_sources
+nodebench.research_company
+nodebench.research_person
+nodebench.research_role
+nodebench.dossiers.get
+nodebench.context.pack
+nodebench.get_matching_context
+nodebench.compile_interview_packet
+findTools
+```
+
+## Smoke Tests
+
+```powershell
+$url = "https://nodebench-mcp-unified.onrender.com?profile=public-research"
+$token = "<NODEBENCH_PUBLIC_RESEARCH_TOKEN>"
+
+Invoke-RestMethod "$url" -Method Post -Headers @{"x-mcp-token"=$token} -ContentType "application/json" -Body (@{
+  jsonrpc = "2.0"
+  id = 1
+  method = "tools/list"
+} | ConvertTo-Json)
+```
+
+Expected:
+
+- `result.profile` is `public-research`
+- `result.tools.length` is `14`
+- no document, planning, eval, or internal-only tools appear
+
+Blocked-call check:
+
+```powershell
+Invoke-RestMethod "$url" -Method Post -Headers @{"x-mcp-token"=$token} -ContentType "application/json" -Body (@{
+  jsonrpc = "2.0"
+  id = 2
+  method = "tools/call"
+  params = @{
+    name = "createDocument"
+    arguments = @{ title = "Should be blocked" }
+  }
+} | ConvertTo-Json -Depth 5)
+```
+
+Expected JSON-RPC error message:
+
+```txt
+Tool not found in profile "public-research": createDocument
+```

--- a/docs/guides/PUBLIC_RESEARCH_INTEGRATION.md
+++ b/docs/guides/PUBLIC_RESEARCH_INTEGRATION.md
@@ -370,7 +370,21 @@ export async function getNodeBenchJobContext(input: {
 
 ## MCP Usage
 
-Set:
+For hosted MCP, use the scoped public research profile so clients see only the research-memory tools:
+
+```txt
+https://nodebench-mcp-unified.onrender.com?profile=public-research
+```
+
+Use a profile-scoped token when available:
+
+```http
+x-mcp-token: <NODEBENCH_PUBLIC_RESEARCH_TOKEN>
+```
+
+See `docs/guides/MCP_TOOL_PROFILES.md` for token-scoped profiles and full gateway configuration.
+
+For local/package MCP, set:
 
 ```txt
 NODEBENCH_API_URL=https://<nodebench-api-host>

--- a/mcp-services/gateway_server/httpServer.ts
+++ b/mcp-services/gateway_server/httpServer.ts
@@ -25,6 +25,12 @@ import { missionTools } from "./tools/missionTools.js";
 import { intelligenceTools } from "./tools/intelligenceTools.js";
 import { evalTools } from "./tools/evalTools.js";
 import { createMetaTools } from "./tools/metaTools.js";
+import {
+  filterToolsForProfile,
+  listToolProfiles,
+  normalizeToolProfileName,
+  type ToolProfileName,
+} from "./tools/toolProfiles.js";
 import { callGateway } from "./convexClient.js";
 import { getRequestContext, runWithRequestContext } from "./requestContext.js";
 
@@ -49,6 +55,13 @@ const directToolNames = new Set(financialTools.map((t) => t.name));
 const HOST = process.env.MCP_HTTP_HOST || "0.0.0.0";
 const PORT = process.env.PORT ? Number(process.env.PORT) : 4002;
 const TOKEN = process.env.MCP_HTTP_TOKEN;
+const DEFAULT_PROFILE =
+  normalizeToolProfileName(process.env.MCP_DEFAULT_PROFILE) ?? "full";
+
+type TokenProfileConfig = {
+  tokens: Set<string>;
+  tokenProfiles: Map<string, ToolProfileName>;
+};
 
 type JsonRpcRequest = {
   jsonrpc?: string;
@@ -76,13 +89,92 @@ function getSuppliedToken(req: http.IncomingMessage): string | undefined {
   return authValue.slice("bearer ".length);
 }
 
+function parseTokenProfiles(value: string | undefined): Map<string, ToolProfileName> {
+  const tokenProfiles = new Map<string, ToolProfileName>();
+  if (!value) return tokenProfiles;
+
+  for (const entry of value.split(",")) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+
+    const separator = trimmed.includes("=") ? "=" : ":";
+    const [token, profile] = trimmed.split(separator).map((part) => part.trim());
+    const normalizedProfile = normalizeToolProfileName(profile);
+    if (!token || !normalizedProfile) continue;
+    tokenProfiles.set(token, normalizedProfile);
+  }
+
+  return tokenProfiles;
+}
+
+const tokenConfig: TokenProfileConfig = (() => {
+  const tokenProfiles = parseTokenProfiles(process.env.MCP_PROFILE_TOKENS);
+  const tokens = new Set<string>();
+  if (TOKEN) tokens.add(TOKEN);
+  for (const token of tokenProfiles.keys()) tokens.add(token);
+  return { tokens, tokenProfiles };
+})();
+
+function getRequestedProfile(req: http.IncomingMessage): ToolProfileName | undefined {
+  const headerProfile =
+    (req.headers["x-nodebench-profile"] as string | undefined) ??
+    (req.headers["x-mcp-profile"] as string | undefined);
+  const normalizedHeader = normalizeToolProfileName(headerProfile);
+  if (normalizedHeader) return normalizedHeader;
+
+  try {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    return normalizeToolProfileName(url.searchParams.get("profile") ?? undefined);
+  } catch {
+    return undefined;
+  }
+}
+
+function getProfileTools(profileName: ToolProfileName) {
+  const visibleDomainTools = filterToolsForProfile(domainTools, profileName);
+  return [...visibleDomainTools, ...createMetaTools(visibleDomainTools)];
+}
+
+function getAuthAndProfile(req: http.IncomingMessage): {
+  authorized: boolean;
+  profileName: ToolProfileName;
+} {
+  const suppliedToken = getSuppliedToken(req);
+
+  if (tokenConfig.tokens.size > 0) {
+    if (!suppliedToken || !tokenConfig.tokens.has(suppliedToken)) {
+      return { authorized: false, profileName: DEFAULT_PROFILE };
+    }
+
+    const scopedProfile = tokenConfig.tokenProfiles.get(suppliedToken);
+    if (scopedProfile) return { authorized: true, profileName: scopedProfile };
+  }
+
+  return {
+    authorized: true,
+    profileName: getRequestedProfile(req) ?? DEFAULT_PROFILE,
+  };
+}
+
 const server = http.createServer(async (req, res) => {
   // Health check
-  if (req.method === "GET" && (req.url === "/" || req.url === "/health")) {
+  const pathname = (() => {
+    try {
+      return new URL(req.url ?? "/", "http://localhost").pathname;
+    } catch {
+      return req.url;
+    }
+  })();
+  if (req.method === "GET" && (pathname === "/" || pathname === "/health")) {
     respond(res, 200, {
       status: "ok",
       service: "nodebench-mcp-unified",
       tools: allTools.length,
+      defaultProfile: DEFAULT_PROFILE,
+      profiles: listToolProfiles().map((profile) => ({
+        ...profile,
+        tools: getProfileTools(profile.name).length,
+      })),
       categories: ["research", "narrative", "verification", "knowledge", "documents", "planning", "memory", "search", "financial"],
     });
     return;
@@ -94,7 +186,7 @@ const server = http.createServer(async (req, res) => {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
       "Access-Control-Allow-Headers":
-        "Content-Type, Accept, Authorization, x-mcp-token",
+        "Content-Type, Accept, Authorization, x-mcp-token, x-mcp-profile, x-nodebench-profile",
     });
     res.end();
     return;
@@ -122,18 +214,17 @@ const server = http.createServer(async (req, res) => {
         return;
       }
 
-      // Token auth
-      if (TOKEN) {
-        const supplied = getSuppliedToken(req);
-        if (!supplied || supplied !== TOKEN) {
-          respond(res, 401, {
-            jsonrpc: "2.0",
-            id,
-            error: { code: -32001, message: "Unauthorized" },
-          });
-          return;
-        }
+      const authAndProfile = getAuthAndProfile(req);
+      if (!authAndProfile.authorized) {
+        respond(res, 401, {
+          jsonrpc: "2.0",
+          id,
+          error: { code: -32001, message: "Unauthorized" },
+        });
+        return;
       }
+      const profileName = authAndProfile.profileName;
+      const profileTools = getProfileTools(profileName);
 
       // MCP initialize
       if (method === "initialize") {
@@ -146,6 +237,7 @@ const server = http.createServer(async (req, res) => {
             serverInfo: {
               name: "nodebench-mcp-unified",
               version: "1.0.0",
+              profile: profileName,
             },
           },
         });
@@ -158,11 +250,13 @@ const server = http.createServer(async (req, res) => {
           jsonrpc: "2.0",
           id,
           result: {
-            tools: allTools.map((t) => ({
+            tools: profileTools.map((t) => ({
               name: t.name,
               description: t.description,
               inputSchema: t.inputSchema,
             })),
+            profile: profileName,
+            profiles: listToolProfiles(),
           },
         });
         return;
@@ -172,14 +266,14 @@ const server = http.createServer(async (req, res) => {
       if (method === "tools/call") {
         const toolName = params?.name;
         const args = params?.arguments ?? {};
-        const tool = allTools.find((t) => t.name === toolName);
+        const tool = profileTools.find((t) => t.name === toolName);
         if (!tool) {
           respond(res, 200, {
             jsonrpc: "2.0",
             id,
             error: {
               code: -32602,
-              message: `Tool not found: ${toolName}`,
+              message: `Tool not found in profile "${profileName}": ${toolName}`,
             },
           });
           return;
@@ -196,7 +290,7 @@ const server = http.createServer(async (req, res) => {
               jsonrpcId: id,
               method,
               toolName,
-              tokenAuthEnabled: Boolean(TOKEN),
+              tokenAuthEnabled: tokenConfig.tokens.size > 0,
               tokenPresent: Boolean(suppliedToken),
               remoteIp,
               forwardedFor,

--- a/mcp-services/gateway_server/stdioServer.ts
+++ b/mcp-services/gateway_server/stdioServer.ts
@@ -25,6 +25,10 @@ import { missionTools } from "./tools/missionTools.js";
 import { intelligenceTools } from "./tools/intelligenceTools.js";
 import { evalTools } from "./tools/evalTools.js";
 import { createMetaTools } from "./tools/metaTools.js";
+import {
+  filterToolsForProfile,
+  normalizeToolProfileName,
+} from "./tools/toolProfiles.js";
 import { callGateway } from "./convexClient.js";
 
 const domainTools = [
@@ -41,7 +45,12 @@ const domainTools = [
   ...intelligenceTools,
   ...evalTools,
 ];
-const allTools = [...domainTools, ...createMetaTools(domainTools)];
+const profileName =
+  normalizeToolProfileName(process.env.MCP_PROFILE) ??
+  normalizeToolProfileName(process.env.MCP_DEFAULT_PROFILE) ??
+  "full";
+const profileDomainTools = filterToolsForProfile(domainTools, profileName);
+const allTools = [...profileDomainTools, ...createMetaTools(profileDomainTools)];
 const directToolNames = new Set(financialTools.map((t) => t.name));
 
 const server = new McpServer({
@@ -143,4 +152,6 @@ const transport = new StdioServerTransport();
 await server.connect(transport);
 
 // Log to stderr (stdout is reserved for MCP protocol)
-console.error(`nodebench-mcp-unified stdio server ready (${allTools.length} tools)`);
+console.error(
+  `nodebench-mcp-unified stdio server ready (${allTools.length} tools, profile=${profileName})`
+);

--- a/mcp-services/gateway_server/tools/researchTools.ts
+++ b/mcp-services/gateway_server/tools/researchTools.ts
@@ -3,7 +3,7 @@
  * Proxies Convex queries/actions from research, forYouFeed, dashboard, and dossier domains.
  */
 
-import { convexQuery, convexAction } from "../convexClient.js";
+import { convexQuery, convexMutation, convexAction } from "../convexClient.js";
 
 export type McpTool = {
   name: string;
@@ -13,6 +13,280 @@ export type McpTool = {
 };
 
 export const researchTools: McpTool[] = [
+  {
+    name: "nodebench.entities.resolve",
+    description:
+      "Resolve a public company, person, role, product, investor, school, or source into a stable NodeBench entity ID with aliases and confidence.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Entity name, such as OpenAI or Sam Altman." },
+        kind: {
+          type: "string",
+          enum: ["Company", "Person", "Role", "Product", "Investor", "School", "Source"],
+          description: "Optional entity kind hint.",
+        },
+        domain: { type: "string", description: "Optional website or email domain hint." },
+        url: { type: "string", description: "Optional public URL hint." },
+        aliases: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional known aliases.",
+        },
+      },
+      required: ["name"],
+    },
+    handler: async (args) => {
+      return await convexMutation("domains/publicResearch/core:resolveEntity", args);
+    },
+  },
+  {
+    name: "nodebench.search_public_sources",
+    description:
+      "Search NodeBench public research memory and source cache for public facts about an entity. Private email, resume, and inbox text must not be sent here.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Public research query." },
+        kind: {
+          type: "string",
+          enum: ["Company", "Person", "Role", "Product", "Investor", "School", "Source"],
+        },
+        limit: { type: "number", description: "Maximum results to return." },
+      },
+      required: ["query"],
+    },
+    handler: async (args) => {
+      return await convexAction("domains/publicResearch/actions:searchPublicSources", args);
+    },
+  },
+  {
+    name: "nodebench.research_company",
+    description:
+      "Run or reuse public-source company research, store verified public claims, and return a compact company dossier.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        companyName: { type: "string", description: "Company name to research." },
+        domain: { type: "string", description: "Optional company domain." },
+        goal: { type: "string", description: "Research goal, such as job_match or interview_prep." },
+        visibility: {
+          type: "string",
+          enum: ["public", "private_guided"],
+          description: "Use private_guided only when private signals guide research without entering public storage.",
+        },
+        forceRefresh: { type: "boolean", description: "Force a fresh run." },
+      },
+      required: ["companyName"],
+    },
+    handler: async (args) => {
+      return await convexAction("domains/publicResearch/actions:researchCompany", args);
+    },
+  },
+  {
+    name: "nodebench.research_person",
+    description:
+      "Run or reuse public-source person research, store verified public claims, and return a compact person dossier.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        personName: { type: "string", description: "Person name to research." },
+        domain: { type: "string", description: "Optional related domain." },
+        goal: { type: "string", description: "Research goal." },
+        visibility: {
+          type: "string",
+          enum: ["public", "private_guided"],
+        },
+        forceRefresh: { type: "boolean" },
+      },
+      required: ["personName"],
+    },
+    handler: async (args) => {
+      return await convexAction("domains/publicResearch/actions:researchPerson", args);
+    },
+  },
+  {
+    name: "nodebench.research_role",
+    description:
+      "Run or reuse public role research, store public hiring or market claims, and return a compact role dossier.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        roleTitle: { type: "string", description: "Role title to research." },
+        companyName: { type: "string", description: "Optional company context." },
+        goal: { type: "string", description: "Research goal." },
+        visibility: {
+          type: "string",
+          enum: ["public", "private_guided"],
+        },
+        forceRefresh: { type: "boolean" },
+      },
+      required: ["roleTitle"],
+    },
+    handler: async (args) => {
+      return await convexAction("domains/publicResearch/actions:researchRole", args);
+    },
+  },
+  {
+    name: "nodebench.dossiers.get",
+    description:
+      "Get a sourced public dossier for an entity by entity ID, key, name, or domain.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string" },
+        entityKey: { type: "string" },
+        name: { type: "string" },
+        domain: { type: "string" },
+      },
+    },
+    handler: async (args) => {
+      return await convexQuery("domains/publicResearch/core:getEntityDossier", args);
+    },
+  },
+  {
+    name: "nodebench.context.pack",
+    description:
+      "Return a compact context pack for a use case like job_match, interview_prep, sales_research, or product_intel. Apps should do private scoring locally.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string" },
+        entityKey: { type: "string" },
+        name: { type: "string" },
+        domain: { type: "string" },
+        useCase: {
+          type: "string",
+          enum: ["job_match", "interview_prep", "sales_research", "product_intel", "general"],
+        },
+      },
+      required: ["useCase"],
+    },
+    handler: async (args) => {
+      return await convexQuery("domains/publicResearch/core:getContextPack", args);
+    },
+  },
+  {
+    name: "nodebench.get_matching_context",
+    description:
+      "Alias for nodebench.context.pack optimized for app-local matching and scoring flows.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string" },
+        entityKey: { type: "string" },
+        name: { type: "string" },
+        domain: { type: "string" },
+        useCase: { type: "string" },
+      },
+      required: ["useCase"],
+    },
+    handler: async (args) => {
+      return await convexQuery("domains/publicResearch/core:getContextPack", args);
+    },
+  },
+  {
+    name: "nodebench.compile_interview_packet",
+    description:
+      "Compile a public interview-prep context pack for a company or person. Resume-specific fit scoring must happen in the calling app.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string" },
+        entityKey: { type: "string" },
+        name: { type: "string" },
+        domain: { type: "string" },
+      },
+    },
+    handler: async (args) => {
+      return await convexQuery("domains/publicResearch/core:getContextPack", {
+        ...args,
+        useCase: "interview_prep",
+      });
+    },
+  },
+  {
+    name: "nodebench.claims.submit_public",
+    description:
+      "Submit a sourced public claim. The verifier rejects private sources, raw email/resume/private artifact text, and uncited claims.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string" },
+        claim: { type: "string" },
+        claimType: { type: "string" },
+        sourceUrl: { type: "string" },
+        sourceTitle: { type: "string" },
+        evidenceSnippet: { type: "string" },
+        confidence: { type: "number" },
+        freshnessTtlDays: { type: "number" },
+      },
+      required: ["entityId", "claim", "claimType", "sourceUrl", "evidenceSnippet"],
+    },
+    handler: async (args) => {
+      return await convexMutation("domains/publicResearch/core:submitPublicClaim", args);
+    },
+  },
+  {
+    name: "nodebench.claims.verify",
+    description:
+      "Re-run deterministic public/private boundary and source-evidence verification for a stored public claim.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        claimId: { type: "string" },
+      },
+      required: ["claimId"],
+    },
+    handler: async (args) => {
+      return await convexMutation("domains/publicResearch/core:verifyClaim", args);
+    },
+  },
+  {
+    name: "nodebench.watch_entity",
+    description:
+      "Create a watch request for an entity. Current MVP returns the entity and recommended refresh cadence.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string" },
+        entityKey: { type: "string" },
+        name: { type: "string" },
+        domain: { type: "string" },
+        cadence: {
+          type: "string",
+          enum: ["daily", "weekly", "monthly"],
+        },
+      },
+    },
+    handler: async (args) => {
+      const dossier = await convexQuery("domains/publicResearch/core:getEntityDossier", args);
+      return {
+        ok: true,
+        cadence: args.cadence ?? "weekly",
+        dossier,
+      };
+    },
+  },
+  {
+    name: "nodebench.link_private_signal_to_public_entity",
+    description:
+      "Link an app-private signal to a public entity by hash only. Raw Gmail, resume, inbox, and private artifact text must not be sent.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entityId: { type: "string" },
+        app: { type: "string" },
+        privateSignalHash: { type: "string" },
+        signalType: { type: "string" },
+        expiresAt: { type: "number" },
+      },
+      required: ["entityId", "app", "privateSignalHash", "signalType"],
+    },
+    handler: async (args) => {
+      return await convexMutation("domains/publicResearch/core:linkPrivateSignalToPublicEntity", args);
+    },
+  },
   {
     name: "getForYouFeed",
     description:

--- a/mcp-services/gateway_server/tools/toolProfiles.ts
+++ b/mcp-services/gateway_server/tools/toolProfiles.ts
@@ -1,0 +1,204 @@
+import type { McpTool } from "./researchTools.js";
+
+export const TOOL_PROFILE_NAMES = [
+  "public-research",
+  "gmail-research",
+  "documents",
+  "memory",
+  "financial",
+  "knowledge",
+  "builder",
+  "internal-full",
+  "full",
+] as const;
+
+export type ToolProfileName = (typeof TOOL_PROFILE_NAMES)[number];
+
+type ToolProfileDefinition = {
+  name: ToolProfileName;
+  description: string;
+  toolNames?: readonly string[];
+  prefixes?: readonly string[];
+  all?: boolean;
+};
+
+const publicResearchTools = [
+  "nodebench.entities.resolve",
+  "nodebench.search_public_sources",
+  "nodebench.research_company",
+  "nodebench.research_person",
+  "nodebench.research_role",
+  "nodebench.dossiers.get",
+  "nodebench.context.pack",
+  "nodebench.get_matching_context",
+  "nodebench.compile_interview_packet",
+  "nodebench.claims.submit_public",
+  "nodebench.claims.verify",
+  "nodebench.watch_entity",
+  "nodebench.link_private_signal_to_public_entity",
+] as const;
+
+const documentTools = [
+  "createDocument",
+  "createDocumentWithContent",
+  "getDocument",
+  "updateDocument",
+  "archiveDocument",
+  "restoreDocument",
+  "searchDocuments",
+  "listDocuments",
+  "exportDocumentToMarkdown",
+  "duplicateDocument",
+  "createFolder",
+  "listFolders",
+  "getFolderWithDocuments",
+  "addDocumentToFolder",
+  "removeDocumentFromFolder",
+  "createSpreadsheet",
+  "listSpreadsheets",
+  "getSpreadsheetRange",
+  "applySpreadsheetOperations",
+  "listFiles",
+] as const;
+
+const memoryTools = [
+  "writeAgentMemory",
+  "readAgentMemory",
+  "listAgentMemory",
+  "deleteAgentMemory",
+] as const;
+
+const financialTools = [
+  "equity_price_quote",
+  "equity_price_historical",
+  "equity_fundamental_overview",
+  "crypto_price_quote",
+  "crypto_price_historical",
+  "economy_gdp",
+  "economy_inflation",
+  "news_company",
+  "news_world",
+] as const;
+
+const knowledgeTools = [
+  "searchEntityContexts",
+  "getEntityContext",
+  "getEntityContextByName",
+  "listEntityContexts",
+  "getEntityContextStats",
+  "getKnowledgeGraph",
+  "getKnowledgeGraphClaims",
+  "getSourceRegistry",
+] as const;
+
+const searchTools = ["quickSearch", "fusionSearch"] as const;
+
+export const TOOL_PROFILES: Record<ToolProfileName, ToolProfileDefinition> = {
+  "public-research": {
+    name: "public-research",
+    description:
+      "Public entity research memory: entity resolution, sourced research, dossiers, context packs, claims, and watches.",
+    toolNames: publicResearchTools,
+  },
+  "gmail-research": {
+    name: "gmail-research",
+    description:
+      "Smallest profile for inbox/job integrations. Private scoring remains in the calling app.",
+    toolNames: [
+      "nodebench.entities.resolve",
+      "nodebench.search_public_sources",
+      "nodebench.research_company",
+      "nodebench.research_person",
+      "nodebench.research_role",
+      "nodebench.dossiers.get",
+      "nodebench.context.pack",
+      "nodebench.get_matching_context",
+      "nodebench.compile_interview_packet",
+    ],
+  },
+  documents: {
+    name: "documents",
+    description: "Document, folder, spreadsheet, and file operations.",
+    toolNames: documentTools,
+  },
+  memory: {
+    name: "memory",
+    description: "Agent memory key-value operations.",
+    toolNames: memoryTools,
+  },
+  financial: {
+    name: "financial",
+    description: "Market, crypto, macroeconomic, and news lookup tools.",
+    toolNames: financialTools,
+  },
+  knowledge: {
+    name: "knowledge",
+    description: "Knowledge graph, entity context, source registry, and search tools.",
+    toolNames: [...knowledgeTools, ...searchTools],
+  },
+  builder: {
+    name: "builder",
+    description:
+      "Builder-facing profile combining public research, knowledge context, document tools, memory, planning, and search.",
+    toolNames: [
+      ...publicResearchTools,
+      ...knowledgeTools,
+      ...searchTools,
+      ...documentTools,
+      ...memoryTools,
+      "createPlan",
+      "updatePlanStep",
+      "getPlan",
+      "getMissionDashboard",
+      "getMission",
+      "getMissionByKey",
+      "getTasksForMission",
+      "getPendingSniffChecks",
+      "createMission",
+      "claimTask",
+      "resolveSniffCheck",
+    ],
+  },
+  "internal-full": {
+    name: "internal-full",
+    description: "Full internal NodeBench MCP tool surface.",
+    all: true,
+  },
+  full: {
+    name: "full",
+    description: "Alias for internal-full.",
+    all: true,
+  },
+};
+
+export function isToolProfileName(value: string | undefined): value is ToolProfileName {
+  return Boolean(value && Object.prototype.hasOwnProperty.call(TOOL_PROFILES, value));
+}
+
+export function normalizeToolProfileName(value: string | undefined): ToolProfileName | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  return isToolProfileName(normalized) ? normalized : undefined;
+}
+
+export function listToolProfiles() {
+  return TOOL_PROFILE_NAMES.map((name) => ({
+    name,
+    description: TOOL_PROFILES[name].description,
+  }));
+}
+
+export function filterToolsForProfile(
+  tools: McpTool[],
+  profileName: ToolProfileName
+): McpTool[] {
+  const profile = TOOL_PROFILES[profileName];
+  if (profile.all) return tools;
+
+  const names = new Set(profile.toolNames ?? []);
+  const prefixes = profile.prefixes ?? [];
+  return tools.filter((tool) => {
+    if (names.has(tool.name)) return true;
+    return prefixes.some((prefix) => tool.name.startsWith(prefix));
+  });
+}

--- a/src/features/designKit/exact/ExactComposer.tsx
+++ b/src/features/designKit/exact/ExactComposer.tsx
@@ -18,6 +18,12 @@ export type ExactComposerTool = {
   disabled?: boolean;
 };
 
+export type ExactComposerModelOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
 type ExactComposerProps = {
   as?: "div" | "form";
   className?: string;
@@ -48,6 +54,10 @@ type ExactComposerProps = {
   modelTitle?: string;
   modelProvider?: string;
   onModelClick?: () => void;
+  modelValue?: string;
+  modelOptions?: ExactComposerModelOption[];
+  onModelValueChange?: (value: string) => void;
+  modelSelectTestId?: string;
   footerMeta?: string;
   suggestions?: string[];
   onSuggestion?: (suggestion: string) => void;
@@ -83,11 +93,16 @@ export function ExactComposer({
   modelTitle = "Model",
   modelProvider = "anthropic",
   onModelClick,
+  modelValue,
+  modelOptions,
+  onModelValueChange,
+  modelSelectTestId,
   footerMeta,
   suggestions = [],
   onSuggestion,
 }: ExactComposerProps) {
   const disabledSubmit = Boolean(submitDisabled || submitting || disabled);
+  const hasModelSelect = Boolean(modelOptions?.length && modelValue && onModelValueChange);
   const handleSubmit = (event?: React.FormEvent) => {
     event?.preventDefault();
     if (disabledSubmit) return;
@@ -177,7 +192,25 @@ export function ExactComposer({
           {modelLabel ? (
             <>
               <span className="nb-composer-divider" />
-              {onModelClick ? (
+              {hasModelSelect ? (
+                <label className="nb-model-trigger nb-model-select-trigger" title={modelTitle}>
+                  <span className="dot" data-provider={modelProvider} />
+                  <select
+                    data-testid={modelSelectTestId}
+                    className="nb-model-select"
+                    aria-label={modelTitle}
+                    value={modelValue}
+                    disabled={disabled}
+                    onChange={(event) => onModelValueChange?.(event.target.value)}
+                  >
+                    {modelOptions?.map((option) => (
+                      <option key={option.value} value={option.value} disabled={option.disabled}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : onModelClick ? (
                 <button
                   type="button"
                   className="nb-model-trigger"

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -78,6 +78,12 @@ import {
   type FirstImpressionCard,
   type FirstImpressionHorizon,
 } from "@/features/home/lib/firstImpressionResearch";
+import {
+  DEFAULT_PIPELINE_MODEL_SELECTION,
+  PIPELINE_MODEL_OPTIONS,
+  getPipelineModelOption,
+  type PipelineModelSelection,
+} from "@/shared/llm/pipelineModelRoutes";
 
 import "./exactKit.css";
 
@@ -2608,6 +2614,10 @@ export function ExactChatSurface() {
   const [pins, setPins] = useState<{ kind: string; label: string }[]>([
     { kind: "event", label: "Ship Demo Day" },
   ]);
+  const [chatModelId, setChatModelId] = useState<PipelineModelSelection>(
+    DEFAULT_PIPELINE_MODEL_SELECTION,
+  );
+  const chatModelOption = getPipelineModelOption(chatModelId);
 
   // Tier D — when authenticated user has a live chat thread, prefer it
   // over the seed ORBITAL_THREAD_TURNS demo.  Anonymous → seed.
@@ -2734,10 +2744,18 @@ export function ExactChatSurface() {
                   { key: "url", label: "Add URL", icon: <Link2 size={14} /> },
                   { key: "voice", label: "Voice note", icon: <Mic size={14} /> },
                 ]}
-                modelLabel="Auto balanced"
+                modelLabel={chatModelOption.shortLabel}
                 modelTitle="Model"
-                modelProvider="openrouter"
-                footerMeta="Memory-first - auto route"
+                modelProvider={chatModelOption.provider}
+                modelValue={chatModelId}
+                modelOptions={PIPELINE_MODEL_OPTIONS.map((model) => ({
+                  value: model.value,
+                  label: model.label,
+                }))}
+                onModelValueChange={(value) => setChatModelId(value as PipelineModelSelection)}
+                footerMeta={
+                  chatModelOption.isFree ? "Memory-first - free route" : "Memory-first - auto route"
+                }
                 submitPerfAction="chat-send"
                 submitDisabled={!composer.trim()}
                 suggestions={STREAM_PROMPTS}

--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -6041,6 +6041,50 @@
   border-color: var(--accent-primary-border);
   outline: none;
 }
+.nb-composer-tools .nb-model-select-trigger {
+  position: relative;
+  padding-right: 7px;
+  color: var(--text-primary);
+}
+.nb-composer-tools .nb-model-select {
+  min-width: 112px;
+  max-width: min(34vw, 190px);
+  border: 0;
+  outline: none;
+  appearance: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 13px 0 0;
+}
+.nb-composer-tools .nb-model-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.nb-composer-tools .nb-model-select option {
+  background: #111318;
+  color: #f7f8fb;
+}
+.nb-composer-tools .nb-model-select-trigger::after {
+  content: "";
+  position: absolute;
+  right: 7px;
+  top: 50%;
+  width: 5px;
+  height: 5px;
+  border-right: 1px solid currentColor;
+  border-bottom: 1px solid currentColor;
+  transform: translateY(-65%) rotate(45deg);
+  opacity: 0.7;
+  pointer-events: none;
+}
+.nb-composer-tools .nb-model-select-trigger:hover,
+.nb-composer-tools .nb-model-select-trigger:focus-within {
+  color: var(--text-primary);
+  border-color: var(--accent-primary-border);
+}
 .nb-composer-tools .nb-model-trigger .dot {
   width: 7px; height: 7px; border-radius: 50%;
   background: var(--text-muted);

--- a/src/features/pipelines/views/PipelineLauncher.tsx
+++ b/src/features/pipelines/views/PipelineLauncher.tsx
@@ -216,21 +216,6 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
         </select>
       </label>
       <label className="pipeline-launcher-option-field">
-        <span>Route</span>
-        <select
-          data-testid="pipeline-launcher-model"
-          value={modelId}
-          onChange={(e) => setModelId(e.target.value as PipelineModelSelection)}
-          disabled={submitting}
-        >
-          {PIPELINE_MODEL_OPTIONS.map((model) => (
-            <option key={model.value} value={model.value}>
-              {model.label}
-            </option>
-          ))}
-        </select>
-      </label>
-      <label className="pipeline-launcher-option-field">
         <span>Title</span>
         <input
           data-testid="pipeline-launcher-title"
@@ -352,7 +337,13 @@ export const PipelineLauncher: React.FC<PipelineLauncherProps> = ({
         modelLabel={selectedModelLabel}
         modelTitle="Model"
         modelProvider={selectedModelProvider}
-        onModelClick={() => setAdvancedOpen(true)}
+        modelValue={modelId}
+        modelOptions={PIPELINE_MODEL_OPTIONS.map((model) => ({
+          value: model.value,
+          label: model.label,
+        }))}
+        onModelValueChange={(value) => setModelId(value as PipelineModelSelection)}
+        modelSelectTestId="pipeline-launcher-model"
         footerMeta={
           selectedModelOption.isFree
             ? "Memory-first - free route"

--- a/tests/e2e/exact-kit-parity-prod.spec.ts
+++ b/tests/e2e/exact-kit-parity-prod.spec.ts
@@ -151,10 +151,15 @@ test("PR A2: Reports renders ExactReportsSurface card grid", async ({ page }) =>
   );
   expect(result.launcherTopModelPins, "Reports does not add a top-row model settings pin").toBe(0);
   expect(result.launcherSuggestChips, "Reports keeps golden suggestion chips").toBeGreaterThanOrEqual(3);
-  await page.locator('[data-testid="pipeline-launcher"] .nb-model-trigger').filter({ visible: true }).click();
+  const launcherModelSelect = page
+    .locator('[data-testid="pipeline-launcher-model"]')
+    .filter({ visible: true });
+  await expect(launcherModelSelect).toContainText("Auto free");
+  await launcherModelSelect.selectOption("nodebench:auto-free");
+  await expect(launcherModelSelect).toHaveValue("nodebench:auto-free");
   await expect(
-    page.locator('[data-testid="pipeline-launcher-model"]').filter({ visible: true }),
-  ).toContainText("Auto free");
+    page.locator('[data-testid="pipeline-launcher"]:visible .nb-composer-meta'),
+  ).toContainText("Memory-first - free route");
 });
 
 test("PR A1: Inbox renders ExactInboxSurface single-column rows", async ({ page }) => {

--- a/tests/e2e/live-smoke-mobile.spec.ts
+++ b/tests/e2e/live-smoke-mobile.spec.ts
@@ -149,6 +149,15 @@ test.describe("live-smoke-mobile — Tier B (iPhone 14 viewport)", () => {
     ).toHaveAttribute("placeholder", "Ask, capture, paste, upload, or record...");
     await expect(pipelineBlock.locator('[data-testid="pipeline-launcher"] .nb-model-trigger')).toBeVisible();
     await expect(pipelineBlock.locator('[data-testid="pipeline-launcher"] .nb-model-trigger')).toContainText("Auto balanced");
+    const mobileModelSelect = pipelineBlock
+      .locator('[data-testid="pipeline-launcher-model"]')
+      .filter({ visible: true });
+    await expect(mobileModelSelect).toContainText("Auto free");
+    await mobileModelSelect.selectOption("nodebench:auto-free");
+    await expect(mobileModelSelect).toHaveValue("nodebench:auto-free");
+    await expect(
+      pipelineBlock.locator('[data-testid="pipeline-launcher"] .nb-composer-meta'),
+    ).toContainText("Memory-first - free route");
     await expect(pipelineBlock.locator('[data-testid="pipeline-launcher"] .nb-prompt-chip')).toHaveCount(3);
     await expect(pipelineBlock.getByText(/What should NodeBench find out/i)).toHaveCount(0);
     await expect(pipelineBlock.getByText(/Options:/i)).toHaveCount(0);


### PR DESCRIPTION
## Summary

Follow-up to the production release:

- makes the shared Exact composer model control a real selectable route dropdown
- wires Reports and Chat composer model state to the shared pipeline model bank
- updates desktop and mobile Reports smoke tests to select `Auto free` and verify the footer changes
- includes the missed public-research MCP gateway tools and scoped MCP tool profiles/docs

## Validation

- `npx tsc --noEmit --pretty false`
- `npx vitest run src/shared/llm/pipelineModelRoutes.test.ts src/features/home/lib/firstImpressionResearch.test.ts convex/domains/agents/mcp_tools/models/modelResolver.test.ts`
- `npm run build`
- `BASE_URL=http://127.0.0.1:4186 npx playwright test tests/e2e/exact-kit-parity-prod.spec.ts --project=chromium --grep "Reports renders"`
- `BASE_URL=http://127.0.0.1:4186 npx playwright test tests/e2e/live-smoke-mobile.spec.ts --project=chromium --grep "Reports surface"`

## Notes

Local browser verification confirmed the visible Reports launcher changes from `nodebench:auto-balanced` to `nodebench:auto-free` and its footer changes to `Memory-first - free route`.