### PR TITLE
fix(research): route public role research

### DIFF
--- a/convex/domains/agents/mcp_tools/models/modelResolver.test.ts
+++ b/convex/domains/agents/mcp_tools/models/modelResolver.test.ts
@@ -24,6 +24,11 @@ describe("pipeline model route resolution", () => {
     expect(resolvePipelineModelSelection("kilo-auto/free").resolvedModelId).toBe(
       "qwen3-coder-free",
     );
+    expect(resolvePipelineModelSelection("kilo-auto/public-research")).toMatchObject({
+      resolvedModelId: "glm-4.7-flash",
+      routeTier: "balanced",
+      isFreeRoute: false,
+    });
     expect(resolvePipelineModelSelection("anthropic:claude-haiku-4.5").resolvedModelId).toBe(
       "claude-haiku-4.5",
     );

--- a/convex/domains/agents/mcp_tools/models/modelResolver.ts
+++ b/convex/domains/agents/mcp_tools/models/modelResolver.ts
@@ -264,6 +264,10 @@ function routeAliasToModel(input: string): {
     case "nodebench:auto-balanced":
     case "kilo-auto/balanced":
       return { routeTier: "balanced", modelId: DEFAULT_MODEL };
+    case "public-research":
+    case "nodebench:auto-public-research":
+    case "kilo-auto/public-research":
+      return { routeTier: "balanced", modelId: "glm-4.7-flash" };
     case "free":
     case "auto-free":
     case "nodebench:auto-free":

--- a/convex/domains/knowledge/entityInsights.ts
+++ b/convex/domains/knowledge/entityInsights.ts
@@ -13,6 +13,7 @@ import {
   resolveModelAlias,
   getModelWithFailover,
 } from "../../../shared/llm/modelCatalog";
+import { runPiOrAiSdkCompletion } from "../pipelines/piRuntime";
 import { linkupSearch } from "../../tools/media/linkupSearch";
 import { getStockPrice } from "../../domains/agents/core/subagents/openbb_subagent/tools/equityTools";
 
@@ -596,6 +597,29 @@ async function generateWithProvider(
   userPrompt: string,
   maxTokens: number = 500,
 ): Promise<string> {
+  const route =
+    process.env.NODEBENCH_PUBLIC_RESEARCH_MODEL_ROUTE ||
+    process.env.NODEBENCH_PUBLIC_RESEARCH_MODEL ||
+    "kilo-auto/public-research";
+  try {
+    const result = await runPiOrAiSdkCompletion({
+      model: route,
+      system: systemPrompt,
+      prompt: userPrompt,
+      maxOutputTokens: maxTokens,
+      timeoutMs: 60_000,
+      temperature: 0.2,
+    });
+    if (result.text.trim()) {
+      return result.text;
+    }
+  } catch (err: any) {
+    console.warn(
+      `[entityInsights] pi-ai autorouter failed for ${route}; falling back to legacy provider path:`,
+      err?.message || err,
+    );
+  }
+
   const { model: modelName, provider } = getModelWithFailover(
     resolveModelAlias(modelInput),
   );
@@ -622,6 +646,30 @@ async function generateWithProvider(
       maxOutputTokens: maxTokens,
     });
     return result.text;
+  }
+
+  if (provider === "openrouter") {
+    const openrouter = new OpenAI({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      baseURL: process.env.OPENROUTER_BASE_URL || "https://openrouter.ai/api/v1",
+      defaultHeaders: {
+        ...(process.env.OPENROUTER_HTTP_REFERER
+          ? { "HTTP-Referer": process.env.OPENROUTER_HTTP_REFERER }
+          : {}),
+        ...(process.env.OPENROUTER_X_TITLE
+          ? { "X-Title": process.env.OPENROUTER_X_TITLE }
+          : {}),
+      },
+    });
+    const response = await openrouter.chat.completions.create({
+      model: modelName,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      max_tokens: maxTokens,
+    });
+    return response.choices[0]?.message?.content || "";
   }
 
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });

--- a/convex/domains/pipelines/piRuntime.ts
+++ b/convex/domains/pipelines/piRuntime.ts
@@ -403,7 +403,7 @@ export async function runPiOrAiSdkCompletion(args: PiRunArgs): Promise<PiRunResu
       // running on AI-SDK-only env (Convex without pi-ai keys) succeed.
       (code === "pi_ai_error" &&
         typeof (e as any).message === "string" &&
-        /api[_ ]?key|unauthorized|401|rate.?limit|429|502|503|504|temporar/i.test((e as any).message));
+        /api[_ ]?key|unauthorized|401|404|model .*does not exist|do not have access|rate.?limit|429|502|503|504|temporar/i.test((e as any).message));
     if (!isFallback) throw e;
 
     // Fallback: AI SDK path.

--- a/convex/domains/publicResearch/actions.ts
+++ b/convex/domains/publicResearch/actions.ts
@@ -65,6 +65,20 @@ function firstPublicSource(insights: any): { url: string; title?: string; snippe
   return null;
 }
 
+function publicSourcesFromSearch(result: any): Array<{ url: string; title?: string; snippet?: string }> {
+  const results = asArray(result?.payload?.results).length
+    ? asArray(result?.payload?.results)
+    : asArray(result?.results);
+  return results
+    .map((item) => ({
+      url: asString(item?.url),
+      title: asString(item?.title) || undefined,
+      snippet: asString(item?.snippet) || asString(item?.highlights?.[0]) || undefined,
+    }))
+    .filter((source) => /^https?:\/\//i.test(source.url))
+    .slice(0, 8);
+}
+
 function sourceForClaim(insights: any, fallback: { url: string; title?: string; snippet?: string } | null, fact: string) {
   const source = firstPublicSource(insights) ?? fallback;
   if (source) {
@@ -137,16 +151,117 @@ function extractClaimsFromInsights(entityName: string, kind: string, insights: a
   return claims;
 }
 
+function parseRoleEntityName(entityName: string): { roleTitle: string; companyName?: string } {
+  const match = entityName.match(/^(.+?)\s+at\s+(.+)$/i);
+  if (!match) return { roleTitle: entityName.trim() };
+  return {
+    roleTitle: match[1].trim(),
+    companyName: match[2].trim(),
+  };
+}
+
+async function runRolePublicResearch(ctx: any, args: {
+  entityName: string;
+  forceRefresh?: boolean;
+}) {
+  const { roleTitle, companyName } = parseRoleEntityName(args.entityName);
+  const roleQuery = companyName
+    ? `${companyName} ${roleTitle} careers job requirements`
+    : `${roleTitle} role responsibilities market hiring requirements`;
+
+  let roleSources: Array<{ url: string; title?: string; snippet?: string }> = [];
+  try {
+    const searchResult = await ctx.runAction(api.domains.search.fusion.actions.quickSearch, {
+      query: roleQuery,
+      maxResults: 8,
+      skipRateLimit: true,
+      allowPaidSearch: false,
+    });
+    roleSources = publicSourcesFromSearch(searchResult);
+  } catch (err: any) {
+    console.warn("[publicResearch] Role source search failed:", err?.message || err);
+  }
+
+  let companyInsights: any = null;
+  if (companyName) {
+    try {
+      companyInsights = await ctx.runAction(api.domains.knowledge.entityInsights.getEntityInsights, {
+        entityName: companyName,
+        entityType: "company",
+        forceRefresh: args.forceRefresh ?? false,
+      });
+    } catch (err: any) {
+      console.warn("[publicResearch] Company fallback for role failed:", err?.message || err);
+    }
+  }
+
+  const sources = roleSources.length
+    ? roleSources
+    : asArray(companyInsights?.sources).map((source) => ({
+        url: asString(source?.url),
+        title: asString(source?.name) || asString(source?.title) || undefined,
+        snippet: asString(source?.snippet) || asString(source?.summary) || undefined,
+      })).filter((source) => /^https?:\/\//i.test(source.url)).slice(0, 8);
+
+  const companySummary = asString(companyInsights?.summary);
+  const sourceSummary = sources
+    .map((source) => source.snippet || source.title || source.url)
+    .filter(Boolean)
+    .slice(0, 3)
+    .join(" ");
+  const summary = companyName
+    ? `${roleTitle} at ${companyName}: public role context is grounded in ${sources.length} public source${sources.length === 1 ? "" : "s"}.${companySummary ? ` Company context: ${companySummary}` : ""}`
+    : `${roleTitle}: public role context is grounded in ${sources.length} public source${sources.length === 1 ? "" : "s"}.`;
+
+  const keyFacts = [
+    companyName
+      ? `${companyName} is the company context for the ${roleTitle} role.`
+      : `${roleTitle} is the role target for this public research run.`,
+    sourceSummary
+      ? `Relevant public role/source signal: ${clip(sourceSummary, 260)}`
+      : "",
+    companySummary
+      ? `Company background relevant to the role: ${clip(companySummary, 260)}`
+      : "",
+  ].filter(Boolean);
+
+  return {
+    summary,
+    keyFacts,
+    sources,
+    crmFields: {
+      roleTitle,
+      companyName: companyName || "",
+      product: asString(companyInsights?.crmFields?.product),
+      industry: asString(companyInsights?.crmFields?.industry),
+      website: asString(companyInsights?.crmFields?.website),
+    },
+  };
+}
+
 async function runExistingEntityResearch(ctx: any, args: {
   entityName: string;
   kind: string;
   forceRefresh?: boolean;
 }) {
+  if (args.kind === "role") {
+    return await runRolePublicResearch(ctx, args);
+  }
   if (args.kind !== "company" && args.kind !== "person") {
+    const result = await ctx.runAction(api.domains.search.fusion.actions.quickSearch, {
+      query: `${args.entityName} public sources overview`,
+      maxResults: 8,
+      skipRateLimit: true,
+      allowPaidSearch: false,
+    });
+    const sources = publicSourcesFromSearch(result);
     return {
-      summary: `${args.entityName} is queued in the public research registry. No specialized ${args.kind} extractor is enabled yet.`,
-      keyFacts: [],
-      sources: [],
+      summary: `${args.entityName} public research is grounded in ${sources.length} public source${sources.length === 1 ? "" : "s"}.`,
+      keyFacts: sources
+        .map((source) => source.snippet || source.title || source.url)
+        .filter(Boolean)
+        .slice(0, 5),
+      sources,
     };
   }
   return await ctx.runAction(api.domains.knowledge.entityInsights.getEntityInsights, {


### PR DESCRIPTION
## Summary

Ships the remaining public-research backend routing fixes:

- adds `kilo-auto/public-research` and `nodebench:auto-public-research` route aliases to GLM 4.7 Flash
- runs entity insights through the pi-ai/AI-SDK runtime first, then falls back to the legacy provider path
- broadens pi-ai fallback detection for missing/unavailable model responses
- adds role-specific public research using public source search plus company context fallback
- lets non-company/person public research use public source search instead of empty placeholder dossiers

## Validation

- `npx tsc -p convex --noEmit --pretty false`
- `npx tsc --noEmit --pretty false`
- `npx vitest run convex/domains/agents/mcp_tools/models/modelResolver.test.ts`
- `npm run build`