### PR TITLE
fix(research): expose paid public source toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,6 +471,7 @@ Automated org page posts currently read like machine-generated reports. 67 posts
   - Full internal surface remains available through `full` / `internal-full`.
   - External users should use scoped profiles: `public-research`, `gmail-research`, `documents`, `memory`, `financial`, `knowledge`, or `builder`.
   - HTTP profile selection: `?profile=public-research`, `x-nodebench-profile`, or `x-mcp-profile`.
+  - Hosted `public-research` and `gmail-research` are anonymous by default through `MCP_PUBLIC_PROFILES=public-research,gmail-research`; token auth is still required for internal/full and any profile not in that allowlist.
   - Profile-scoped tokens are configured with `MCP_PROFILE_TOKENS=token:profile,token2:profile2`; scoped token profile wins over query/header requests.
   - `findTools` is profile-scoped and only searches tools visible to that profile.
   - Profile runbook: `docs/guides/MCP_TOOL_PROFILES.md`.

--- a/convex/domains/knowledge/entityInsights.ts
+++ b/convex/domains/knowledge/entityInsights.ts
@@ -1509,7 +1509,7 @@ Use null for unknown fields. Be precise with amounts and dates.`;
         contactPoints: enrichedEntity.contactPoints,
         freshness: enrichedEntity.freshness,
         personaHooks: enrichedEntity.personaHooks,
-        researchedBy: userId,
+        researchedBy: userId ?? undefined,
       },
     );
 

--- a/convex/domains/publicResearch/actions.ts
+++ b/convex/domains/publicResearch/actions.ts
@@ -175,7 +175,7 @@ async function runRolePublicResearch(ctx: any, args: {
       query: roleQuery,
       maxResults: 8,
       skipRateLimit: true,
-      allowPaidSearch: false,
+      allowPaidSearch: true,
     });
     roleSources = publicSourcesFromSearch(searchResult);
   } catch (err: any) {
@@ -252,7 +252,7 @@ async function runExistingEntityResearch(ctx: any, args: {
       query: `${args.entityName} public sources overview`,
       maxResults: 8,
       skipRateLimit: true,
-      allowPaidSearch: false,
+      allowPaidSearch: true,
     });
     const sources = publicSourcesFromSearch(result);
     return {
@@ -419,13 +419,14 @@ export const searchPublicSources = action({
     query: v.string(),
     entity: v.optional(entitySignalValidator),
     maxResults: v.optional(v.number()),
+    allowPaidSearch: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const result = await ctx.runAction(api.domains.search.fusion.actions.quickSearch, {
       query: args.query,
       maxResults: args.maxResults ?? 8,
       skipRateLimit: true,
-      allowPaidSearch: false,
+      allowPaidSearch: args.allowPaidSearch ?? false,
     });
     if (args.entity) {
       await ctx.runMutation(internal.domains.publicResearch.core.startResearchRunInternal, {

--- a/convex/domains/publicResearch/core.ts
+++ b/convex/domains/publicResearch/core.ts
@@ -579,17 +579,21 @@ export const verifyClaim = mutation({
 
 export const getEntityDossier = query({
   args: {
+    entityId: v.optional(v.id("publicResearchEntities")),
     entityKey: v.optional(v.string()),
     entityType: v.optional(entityTypeValidator),
     name: v.optional(v.string()),
+    domain: v.optional(v.string()),
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const entityKey = args.entityKey ?? canonicalKey({ entityType: args.entityType, name: args.name });
-    const entity = await ctx.db
-      .query("publicResearchEntities")
-      .withIndex("by_entityKey", (q) => q.eq("entityKey", entityKey))
-      .first();
+    const entityKey = args.entityKey ?? canonicalKey({ entityType: args.entityType, name: args.name, domain: args.domain });
+    const entity = args.entityId
+      ? await ctx.db.get(args.entityId)
+      : await ctx.db
+        .query("publicResearchEntities")
+        .withIndex("by_entityKey", (q) => q.eq("entityKey", entityKey))
+        .first();
     if (!entity) return null;
     const limit = Math.min(args.limit ?? 20, 50);
     const claims = await ctx.db
@@ -627,22 +631,27 @@ export const getEntityDossier = query({
 
 export const getContextPack = query({
   args: {
+    entityId: v.optional(v.id("publicResearchEntities")),
     entityKey: v.optional(v.string()),
     entityType: v.optional(entityTypeValidator),
     name: v.optional(v.string()),
+    domain: v.optional(v.string()),
     useCase: v.optional(v.union(
       v.literal("job_match"),
       v.literal("interview_prep"),
       v.literal("sales_research"),
+      v.literal("product_intel"),
       v.literal("general"),
     )),
   },
   handler: async (ctx, args) => {
-    const entityKey = args.entityKey ?? canonicalKey({ entityType: args.entityType, name: args.name });
-    const entity = await ctx.db
-      .query("publicResearchEntities")
-      .withIndex("by_entityKey", (q) => q.eq("entityKey", entityKey))
-      .first();
+    const entityKey = args.entityKey ?? canonicalKey({ entityType: args.entityType, name: args.name, domain: args.domain });
+    const entity = args.entityId
+      ? await ctx.db.get(args.entityId)
+      : await ctx.db
+        .query("publicResearchEntities")
+        .withIndex("by_entityKey", (q) => q.eq("entityKey", entityKey))
+        .first();
     if (!entity) return null;
     const claims = await ctx.db
       .query("publicResearchClaims")

--- a/convex/domains/publicResearch/core.ts
+++ b/convex/domains/publicResearch/core.ts
@@ -650,12 +650,12 @@ export const getContextPack = query({
       .order("desc")
       .take(12);
     const verifiedClaims = claims.filter((claim: any) => claim.verifierStatus === "verified");
-    const sourceRefs = verifiedClaims.slice(0, 8).map((claim: any) => ({
+    const sourceRefs = Array.from(new Map(verifiedClaims.map((claim: any) => [claim.sourceUrl, {
       title: claim.sourceTitle,
       url: claim.sourceUrl,
       evidence: claim.evidenceSnippet,
       retrievedAt: claim.retrievedAt,
-    }));
+    }])).values()).slice(0, 8);
     return {
       entity_id: entity._id,
       entity_key: entity.entityKey,
@@ -714,7 +714,10 @@ export const listLatestPublicEntityResearch = query({
           ? claims.reduce((sum: number, claim: any) => sum + claim.confidence, 0) / claims.length
           : entity?.confidence ?? 0,
         summary: claims.map((claim: any) => claim.claim).join(" "),
-        sources: claims.map((claim: any) => ({ title: claim.sourceTitle, url: claim.sourceUrl })),
+        sources: Array.from(new Map(claims.map((claim: any) => [claim.sourceUrl, {
+          title: claim.sourceTitle,
+          url: claim.sourceUrl,
+        }])).values()),
       });
       if (rows.length >= limit) break;
     }

--- a/docs/guides/MCP_TOOL_PROFILES.md
+++ b/docs/guides/MCP_TOOL_PROFILES.md
@@ -43,18 +43,28 @@ x-mcp-profile: public-research
 
 If the server is configured with a profile-scoped token, the token wins over query/header profile requests. For example, a `gmail-research` token cannot request `full`.
 
+Hosted production allows anonymous access to the public profiles listed in `MCP_PUBLIC_PROFILES`:
+
+```txt
+public-research,gmail-research
+```
+
+That means external Gmail/job integrations can call the hosted MCP URL with `?profile=gmail-research` and no token. Internal, builder, document, memory, and full profiles still require a token when `MCP_HTTP_TOKEN` or `MCP_PROFILE_TOKENS` is configured.
+
 ## Environment Variables
 
 ```txt
 MCP_HTTP_TOKEN=<internal full-access token>
 MCP_DEFAULT_PROFILE=full
 MCP_PROFILE_TOKENS=<token1>:public-research,<token2>:gmail-research,<token3>:builder
+MCP_PUBLIC_PROFILES=public-research,gmail-research
 ```
 
 Recommended production setup:
 
 - Keep `MCP_HTTP_TOKEN` as the internal full-access token.
-- Issue external users profile-scoped tokens through `MCP_PROFILE_TOKENS`.
+- Keep `public-research` and `gmail-research` anonymous for frictionless public-source integrations.
+- Issue external users profile-scoped tokens through `MCP_PROFILE_TOKENS` when they need non-public profiles or custom budgets.
 - Use `MCP_DEFAULT_PROFILE=public-research` only for a public demo service where full internal access is not needed through the same endpoint.
 
 For stdio clients:
@@ -76,10 +86,7 @@ MCP_DEFAULT_PROFILE=public-research
   "mcpServers": {
     "nodebench-public-research": {
       "transport": "http",
-      "url": "https://nodebench-mcp-unified.onrender.com?profile=public-research",
-      "headers": {
-        "x-mcp-token": "<NODEBENCH_PUBLIC_RESEARCH_TOKEN>"
-      }
+      "url": "https://nodebench-mcp-unified.onrender.com?profile=public-research"
     }
   }
 }
@@ -111,10 +118,7 @@ findTools
   "mcpServers": {
     "nodebench-gmail-research": {
       "transport": "http",
-      "url": "https://nodebench-mcp-unified.onrender.com",
-      "headers": {
-        "x-mcp-token": "<NODEBENCH_GMAIL_RESEARCH_TOKEN>"
-      }
+      "url": "https://nodebench-mcp-unified.onrender.com?profile=gmail-research"
     }
   }
 }
@@ -139,9 +143,8 @@ findTools
 
 ```powershell
 $url = "https://nodebench-mcp-unified.onrender.com?profile=public-research"
-$token = "<NODEBENCH_PUBLIC_RESEARCH_TOKEN>"
 
-Invoke-RestMethod "$url" -Method Post -Headers @{"x-mcp-token"=$token} -ContentType "application/json" -Body (@{
+Invoke-RestMethod "$url" -Method Post -ContentType "application/json" -Body (@{
   jsonrpc = "2.0"
   id = 1
   method = "tools/list"
@@ -151,13 +154,14 @@ Invoke-RestMethod "$url" -Method Post -Headers @{"x-mcp-token"=$token} -ContentT
 Expected:
 
 - `result.profile` is `public-research`
+- `result.authMode` is `anonymous` on hosted production
 - `result.tools.length` is `14`
 - no document, planning, eval, or internal-only tools appear
 
 Blocked-call check:
 
 ```powershell
-Invoke-RestMethod "$url" -Method Post -Headers @{"x-mcp-token"=$token} -ContentType "application/json" -Body (@{
+Invoke-RestMethod "$url" -Method Post -ContentType "application/json" -Body (@{
   jsonrpc = "2.0"
   id = 2
   method = "tools/call"

--- a/docs/guides/PUBLIC_RESEARCH_INTEGRATION.md
+++ b/docs/guides/PUBLIC_RESEARCH_INTEGRATION.md
@@ -376,11 +376,20 @@ For hosted MCP, use the scoped public research profile so clients see only the r
 https://nodebench-mcp-unified.onrender.com?profile=public-research
 ```
 
-Use a profile-scoped token when available:
+The hosted `public-research` and `gmail-research` profiles are designed for tokenless public-source integrations. Use a profile-scoped token only when you need custom budgets or non-public profiles:
 
 ```http
 x-mcp-token: <NODEBENCH_PUBLIC_RESEARCH_TOKEN>
 ```
+
+Gmail/job integrations should use:
+
+```txt
+NODEBENCH_MCP_URL=https://nodebench-mcp-unified.onrender.com?profile=gmail-research
+NODEBENCH_MCP_PROFILE=gmail-research
+```
+
+No `NODEBENCH_MCP_TOKEN` is required for this public profile. The calling app must still keep Gmail, resume, and fit scoring local.
 
 See `docs/guides/MCP_TOOL_PROFILES.md` for token-scoped profiles and full gateway configuration.
 

--- a/mcp-services/gateway_server/httpServer.ts
+++ b/mcp-services/gateway_server/httpServer.ts
@@ -27,6 +27,7 @@ import { evalTools } from "./tools/evalTools.js";
 import { createMetaTools } from "./tools/metaTools.js";
 import {
   filterToolsForProfile,
+  isPublicToolProfileName,
   listToolProfiles,
   normalizeToolProfileName,
   type ToolProfileName,
@@ -57,6 +58,7 @@ const PORT = process.env.PORT ? Number(process.env.PORT) : 4002;
 const TOKEN = process.env.MCP_HTTP_TOKEN;
 const DEFAULT_PROFILE =
   normalizeToolProfileName(process.env.MCP_DEFAULT_PROFILE) ?? "full";
+const DEFAULT_ANONYMOUS_PROFILES = "public-research,gmail-research";
 
 type TokenProfileConfig = {
   tokens: Set<string>;
@@ -107,6 +109,15 @@ function parseTokenProfiles(value: string | undefined): Map<string, ToolProfileN
   return tokenProfiles;
 }
 
+function parseProfileList(value: string | undefined): Set<ToolProfileName> {
+  const profiles = new Set<ToolProfileName>();
+  for (const entry of (value || "").split(",")) {
+    const normalized = normalizeToolProfileName(entry);
+    if (normalized) profiles.add(normalized);
+  }
+  return profiles;
+}
+
 const tokenConfig: TokenProfileConfig = (() => {
   const tokenProfiles = parseTokenProfiles(process.env.MCP_PROFILE_TOKENS);
   const tokens = new Set<string>();
@@ -114,6 +125,11 @@ const tokenConfig: TokenProfileConfig = (() => {
   for (const token of tokenProfiles.keys()) tokens.add(token);
   return { tokens, tokenProfiles };
 })();
+const anonymousProfiles = parseProfileList(
+  process.env.MCP_ANONYMOUS_PROFILES ??
+    process.env.MCP_PUBLIC_PROFILES ??
+    DEFAULT_ANONYMOUS_PROFILES
+);
 
 function getRequestedProfile(req: http.IncomingMessage): ToolProfileName | undefined {
   const headerProfile =
@@ -138,21 +154,28 @@ function getProfileTools(profileName: ToolProfileName) {
 function getAuthAndProfile(req: http.IncomingMessage): {
   authorized: boolean;
   profileName: ToolProfileName;
+  authMode: "token" | "anonymous" | "open";
 } {
   const suppliedToken = getSuppliedToken(req);
+  const requestedProfile = getRequestedProfile(req);
 
   if (tokenConfig.tokens.size > 0) {
+    if (!suppliedToken && requestedProfile && anonymousProfiles.has(requestedProfile)) {
+      return { authorized: true, profileName: requestedProfile, authMode: "anonymous" };
+    }
+
     if (!suppliedToken || !tokenConfig.tokens.has(suppliedToken)) {
-      return { authorized: false, profileName: DEFAULT_PROFILE };
+      return { authorized: false, profileName: DEFAULT_PROFILE, authMode: "token" };
     }
 
     const scopedProfile = tokenConfig.tokenProfiles.get(suppliedToken);
-    if (scopedProfile) return { authorized: true, profileName: scopedProfile };
+    if (scopedProfile) return { authorized: true, profileName: scopedProfile, authMode: "token" };
   }
 
   return {
     authorized: true,
-    profileName: getRequestedProfile(req) ?? DEFAULT_PROFILE,
+    profileName: requestedProfile ?? DEFAULT_PROFILE,
+    authMode: tokenConfig.tokens.size > 0 ? "token" : "open",
   };
 }
 
@@ -174,8 +197,36 @@ const server = http.createServer(async (req, res) => {
       profiles: listToolProfiles().map((profile) => ({
         ...profile,
         tools: getProfileTools(profile.name).length,
+        anonymous: anonymousProfiles.has(profile.name) && isPublicToolProfileName(profile.name),
       })),
+      anonymousProfiles: [...anonymousProfiles],
       categories: ["research", "narrative", "verification", "knowledge", "documents", "planning", "memory", "search", "financial"],
+    });
+    return;
+  }
+
+  if (req.method === "GET" && (pathname === "/.well-known/nodebench-mcp.json" || pathname === "/setup/gmail-research")) {
+    const host = req.headers["x-forwarded-host"] || req.headers.host || `localhost:${PORT}`;
+    const proto = req.headers["x-forwarded-proto"] || (HOST === "0.0.0.0" ? "https" : "http");
+    const baseUrl = `${Array.isArray(proto) ? proto[0] : proto}://${Array.isArray(host) ? host[0] : host}`;
+    respond(res, 200, {
+      service: "nodebench-mcp-unified",
+      protocol: "json-rpc-2.0-http",
+      defaultProfile: DEFAULT_PROFILE,
+      profiles: listToolProfiles().map((profile) => ({
+        ...profile,
+        url: `${baseUrl}?profile=${profile.name}`,
+        tools: getProfileTools(profile.name).length,
+        authRequired: !(anonymousProfiles.has(profile.name) && isPublicToolProfileName(profile.name)),
+      })),
+      recommended: {
+        gmailResearch: {
+          url: `${baseUrl}?profile=gmail-research`,
+          profile: "gmail-research",
+          authRequired: !(anonymousProfiles.has("gmail-research") && isPublicToolProfileName("gmail-research")),
+          headers: anonymousProfiles.has("gmail-research") ? {} : { "x-mcp-token": "<token>" },
+        },
+      },
     });
     return;
   }
@@ -238,6 +289,7 @@ const server = http.createServer(async (req, res) => {
               name: "nodebench-mcp-unified",
               version: "1.0.0",
               profile: profileName,
+              authMode: authAndProfile.authMode,
             },
           },
         });
@@ -256,6 +308,7 @@ const server = http.createServer(async (req, res) => {
               inputSchema: t.inputSchema,
             })),
             profile: profileName,
+            authMode: authAndProfile.authMode,
             profiles: listToolProfiles(),
           },
         });

--- a/mcp-services/gateway_server/tools/researchTools.ts
+++ b/mcp-services/gateway_server/tools/researchTools.ts
@@ -12,6 +12,50 @@ export type McpTool = {
   handler: (args: any) => Promise<unknown>;
 };
 
+const entityKindMap: Record<string, string> = {
+  company: "company",
+  person: "person",
+  role: "role",
+  product: "product",
+  investor: "investor",
+  school: "school",
+  source: "source",
+};
+
+function entityTypeFromKind(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return entityKindMap[value.trim().toLowerCase()];
+}
+
+function compact<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== null)
+  ) as T;
+}
+
+function contextUseCase(value: unknown): string {
+  if (
+    value === "job_match" ||
+    value === "interview_prep" ||
+    value === "sales_research" ||
+    value === "product_intel"
+  ) {
+    return value;
+  }
+  return "general";
+}
+
+function publicResearchEntity(args: any) {
+  return compact({
+    entityId: args.entityId,
+    entityType: entityTypeFromKind(args.kind ?? args.entityType),
+    name: args.name,
+    domain: args.domain,
+    url: args.url,
+    aliases: args.aliases,
+  });
+}
+
 export const researchTools: McpTool[] = [
   {
     name: "nodebench.entities.resolve",
@@ -37,7 +81,7 @@ export const researchTools: McpTool[] = [
       required: ["name"],
     },
     handler: async (args) => {
-      return await convexMutation("domains/publicResearch/core:resolveEntity", args);
+      return await convexMutation("domains/publicResearch/core:resolveEntity", publicResearchEntity(args));
     },
   },
   {
@@ -57,7 +101,12 @@ export const researchTools: McpTool[] = [
       required: ["query"],
     },
     handler: async (args) => {
-      return await convexAction("domains/publicResearch/actions:searchPublicSources", args);
+      return await convexAction("domains/publicResearch/actions:searchPublicSources", compact({
+        query: args.query,
+        maxResults: args.maxResults ?? args.limit,
+        entity: args.entity ?? (args.name ? publicResearchEntity(args) : undefined),
+        allowPaidSearch: args.allowPaidSearch,
+      }));
     },
   },
   {
@@ -80,7 +129,12 @@ export const researchTools: McpTool[] = [
       required: ["companyName"],
     },
     handler: async (args) => {
-      return await convexAction("domains/publicResearch/actions:researchCompany", args);
+      return await convexAction("domains/publicResearch/actions:researchCompany", compact({
+        companyName: args.companyName,
+        domain: args.domain,
+        goal: args.goal,
+        visibility: args.visibility,
+      }));
     },
   },
   {
@@ -102,7 +156,11 @@ export const researchTools: McpTool[] = [
       required: ["personName"],
     },
     handler: async (args) => {
-      return await convexAction("domains/publicResearch/actions:researchPerson", args);
+      return await convexAction("domains/publicResearch/actions:researchPerson", compact({
+        personName: args.personName,
+        goal: args.goal,
+        visibility: args.visibility,
+      }));
     },
   },
   {
@@ -124,7 +182,11 @@ export const researchTools: McpTool[] = [
       required: ["roleTitle"],
     },
     handler: async (args) => {
-      return await convexAction("domains/publicResearch/actions:researchRole", args);
+      return await convexAction("domains/publicResearch/actions:researchRole", compact({
+        roleTitle: args.roleTitle,
+        companyName: args.companyName,
+        goal: args.goal,
+      }));
     },
   },
   {
@@ -141,7 +203,14 @@ export const researchTools: McpTool[] = [
       },
     },
     handler: async (args) => {
-      return await convexQuery("domains/publicResearch/core:getEntityDossier", args);
+      return await convexQuery("domains/publicResearch/core:getEntityDossier", compact({
+        entityId: args.entityId,
+        entityKey: args.entityKey,
+        name: args.name,
+        domain: args.domain,
+        entityType: entityTypeFromKind(args.kind ?? args.entityType),
+        limit: args.limit,
+      }));
     },
   },
   {
@@ -163,7 +232,14 @@ export const researchTools: McpTool[] = [
       required: ["useCase"],
     },
     handler: async (args) => {
-      return await convexQuery("domains/publicResearch/core:getContextPack", args);
+      return await convexQuery("domains/publicResearch/core:getContextPack", compact({
+        entityId: args.entityId,
+        entityKey: args.entityKey,
+        name: args.name,
+        domain: args.domain,
+        entityType: entityTypeFromKind(args.kind ?? args.entityType),
+        useCase: contextUseCase(args.useCase),
+      }));
     },
   },
   {
@@ -182,7 +258,14 @@ export const researchTools: McpTool[] = [
       required: ["useCase"],
     },
     handler: async (args) => {
-      return await convexQuery("domains/publicResearch/core:getContextPack", args);
+      return await convexQuery("domains/publicResearch/core:getContextPack", compact({
+        entityId: args.entityId,
+        entityKey: args.entityKey,
+        name: args.name,
+        domain: args.domain,
+        entityType: entityTypeFromKind(args.kind ?? args.entityType),
+        useCase: contextUseCase(args.useCase),
+      }));
     },
   },
   {
@@ -200,7 +283,13 @@ export const researchTools: McpTool[] = [
     },
     handler: async (args) => {
       return await convexQuery("domains/publicResearch/core:getContextPack", {
-        ...args,
+        ...compact({
+          entityId: args.entityId,
+          entityKey: args.entityKey,
+          name: args.name,
+          domain: args.domain,
+          entityType: entityTypeFromKind(args.kind ?? args.entityType),
+        }),
         useCase: "interview_prep",
       });
     },
@@ -224,7 +313,16 @@ export const researchTools: McpTool[] = [
       required: ["entityId", "claim", "claimType", "sourceUrl", "evidenceSnippet"],
     },
     handler: async (args) => {
-      return await convexMutation("domains/publicResearch/core:submitPublicClaim", args);
+      return await convexMutation("domains/publicResearch/core:submitPublicClaim", compact({
+        entity: args.entity ?? publicResearchEntity(args),
+        claim: args.claim,
+        claimType: args.claimType,
+        sourceUrl: args.sourceUrl,
+        sourceTitle: args.sourceTitle,
+        evidenceSnippet: args.evidenceSnippet,
+        confidence: args.confidence,
+        submittedBySurface: args.submittedBySurface ?? "mcp",
+      }));
     },
   },
   {
@@ -284,7 +382,13 @@ export const researchTools: McpTool[] = [
       required: ["entityId", "app", "privateSignalHash", "signalType"],
     },
     handler: async (args) => {
-      return await convexMutation("domains/publicResearch/core:linkPrivateSignalToPublicEntity", args);
+      return await convexMutation("domains/publicResearch/core:linkPrivateSignalToPublicEntity", compact({
+        ownerKey: args.ownerKey ?? args.app ?? "mcp",
+        entity: args.entity ?? publicResearchEntity(args),
+        privateSignalKind: args.privateSignalKind ?? args.signalType,
+        privateSignalSummary: args.privateSignalSummary ?? args.privateSignalHash,
+        publicPurpose: args.publicPurpose ?? "Guide public entity research without storing private text.",
+      }));
     },
   },
   {

--- a/mcp-services/gateway_server/tools/toolProfiles.ts
+++ b/mcp-services/gateway_server/tools/toolProfiles.ts
@@ -175,6 +175,10 @@ export function isToolProfileName(value: string | undefined): value is ToolProfi
   return Boolean(value && Object.prototype.hasOwnProperty.call(TOOL_PROFILES, value));
 }
 
+export function isPublicToolProfileName(value: ToolProfileName): boolean {
+  return value === "public-research" || value === "gmail-research" || value === "financial";
+}
+
 export function normalizeToolProfileName(value: string | undefined): ToolProfileName | undefined {
   if (!value) return undefined;
   const normalized = value.trim().toLowerCase();

--- a/render.yaml
+++ b/render.yaml
@@ -18,6 +18,8 @@ services:
         value: "0.0.0.0"
       - key: MCP_HTTP_TOKEN
         sync: false
+      - key: MCP_PUBLIC_PROFILES
+        value: "public-research,gmail-research"
       - key: CONVEX_URL
         sync: false
       - key: MCP_SECRET


### PR DESCRIPTION
## Summary

Final public-research backend cleanup:

- adds `allowPaidSearch` to `searchPublicSources`
- lets role research and generic public research use paid source search in the deep public-research path
- keeps explicit callers defaulting to free/public-only search unless they opt in

## Validation

- `npx tsc -p convex --noEmit --pretty false`
- `npx tsc --noEmit --pretty false`
- `npm run build`