### PR TITLE
fix(mcp): allow and meter public research gateway calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,17 @@ GEMINI_API_KEY=
 VITE_CONVEX_URL=https://your-project.convex.cloud
 CONVEX_DEPLOY_KEY=
 
+# Hosted public research MCP (optional for external app integrations)
+# Public profiles can run anonymously. Use a stable non-sensitive client id for
+# usage attribution, budgets, and cost tracking before the user links/signs in.
+NODEBENCH_MCP_URL=https://nodebench-mcp-unified.onrender.com?profile=gmail-research
+NODEBENCH_MCP_PROFILE=gmail-research
+NODEBENCH_MCP_CLIENT=your-app-name
+NODEBENCH_MCP_CLIENT_VERSION=1.0.0
+NODEBENCH_MCP_CLIENT_ID=
+# Optional profile-scoped token for linked accounts, private profiles, or custom budgets.
+NODEBENCH_MCP_TOKEN=
+
 # ─── Search providers (at least one recommended) ────────────────────────────
 
 # Linkup (web search) — https://linkup.so

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ They need a system that can:
 - five-surface web app across `Home`, `Reports`, `Chat`, `Inbox`, and `Me`
 - separate deep-work Workspace shell at `nodebench.workspace`
 - typed search and reporting pipeline
+- hosted public research MCP for external apps and agents:
+  `https://nodebench-mcp-unified.onrender.com?profile=public-research`
 - Pi-AI pipeline lane on `Reports` with code-gen, design-gen, research,
   composed runs, schedules, streaming previews, eval scorecard, and MCP HTTP
   bridge
@@ -50,6 +52,63 @@ They need a system that can:
   distribution lanes
 - builder-facing Oracle, dogfood, eval, replay, and control-plane
   infrastructure
+
+## Hosted Public Research MCP
+
+NodeBench can be used as a public research memory and tool server from any
+agent or app without forcing signup before the first useful result.
+
+Use the hosted MCP endpoint:
+
+```txt
+https://nodebench-mcp-unified.onrender.com?profile=public-research
+```
+
+For Gmail/job-match style integrations, use the smaller profile:
+
+```txt
+https://nodebench-mcp-unified.onrender.com?profile=gmail-research
+```
+
+Public profiles are anonymous by default, but still metered. Responses include:
+
+```txt
+x-nodebench-request-id
+x-nodebench-profile
+x-nodebench-auth-mode
+x-nodebench-account-key
+```
+
+Apps should send stable, non-sensitive client headers:
+
+```http
+x-nodebench-client: your-app-name
+x-nodebench-client-version: 1.0.0
+x-nodebench-client-id: stable-install-or-workspace-id
+```
+
+`x-nodebench-client-id` lets NodeBench attribute anonymous usage and estimated
+costs without requiring a NodeBench token. Do not put private email text,
+resume text, API keys, or user secrets in this header.
+
+### Progressive Sign-In And Linking
+
+The intended user flow is:
+
+```text
+First public dossier works without signup
+  -> show sources, freshness, and confidence
+  -> offer "Link NodeBench" after value is visible
+  -> linked users get stable history, higher budgets, team usage, webhooks,
+     token management, billing controls, and reusable private workspace context
+```
+
+Do not block public-source research behind login. Promote sign-in when the user
+wants persistence, shared team memory, budget controls, private workspace
+linking, or API/MCP tokens.
+
+See [MCP_TOOL_PROFILES.md](./docs/guides/MCP_TOOL_PROFILES.md) for the full
+profile list, tool catalog, account attribution, and cost tracking contract.
 
 ## Product At A Glance
 

--- a/convex/domains/mcp/mcpGatewayDispatcher.ts
+++ b/convex/domains/mcp/mcpGatewayDispatcher.ts
@@ -563,6 +563,19 @@ const ALLOWLIST: Record<string, AllowlistEntry> = {
   },
 };
 
+const PUBLIC_RESEARCH_GATEWAY_FNS = new Set([
+  "resolveEntity",
+  "startResearchRun",
+  "getResearchStatus",
+  "getEntityDossier",
+  "getContextPack",
+  "listLatestPublicEntityResearch",
+  "researchCompany",
+  "researchPerson",
+  "researchRole",
+  "searchPublicSources",
+]);
+
 // ── Dispatcher httpAction ──────────────────────────────────────────────────
 
 function inferRiskTier(fn: string, type: FnType): string {
@@ -580,11 +593,8 @@ function inferRiskTier(fn: string, type: FnType): string {
 }
 
 export const mcpGatewayHandler = httpAction(async (ctx, request) => {
-  // 1. Auth — validate x-mcp-secret
-  const authErr = requireMcpSecret(request);
-  if (authErr) return authErr;
-
-  // 2. Parse request body
+  // 1. Parse request body. Public research functions are intentionally
+  // available to anonymous MCP profiles, so auth depends on the requested fn.
   const body = await readJson(request);
   if (!body || typeof body.fn !== "string") {
     return badRequest(
@@ -597,13 +607,21 @@ export const mcpGatewayHandler = httpAction(async (ctx, request) => {
   const meta: Record<string, unknown> =
     body && typeof body.meta === "object" && body.meta ? body.meta : {};
 
-  // 3. Lookup in allowlist
+  // 2. Lookup in allowlist
   const entry = ALLOWLIST[fn];
   if (!entry) {
     const available = Object.keys(ALLOWLIST).sort().join(", ");
     return badRequest(
       `Unknown function: "${fn}". ${Object.keys(ALLOWLIST).length} available: ${available}`
     );
+  }
+
+  // 3. Auth. Internal, document, memory, builder, and control functions remain
+  // secret-gated. Only source-traceable public research primitives can be
+  // dispatched without a shared service secret.
+  if (!PUBLIC_RESEARCH_GATEWAY_FNS.has(fn)) {
+    const authErr = requireMcpSecret(request);
+    if (authErr) return authErr;
   }
 
   // 4. Policy + ledger (trusted access layer)

--- a/convex/domains/mcp/mcpToolLedger.ts
+++ b/convex/domains/mcp/mcpToolLedger.ts
@@ -254,6 +254,17 @@ function estimateToolCost(input: {
     "nodebench.claims.verify": 3,
     "nodebench.watch_entity": 1,
     "nodebench.link_private_signal_to_public_entity": 1,
+    resolveEntity: 1,
+    searchPublicSources: 5,
+    researchCompany: 12,
+    researchPerson: 12,
+    researchRole: 14,
+    getEntityDossier: 1,
+    getContextPack: 2,
+    submitPublicClaim: 2,
+    verifyPublicClaims: 3,
+    watchEntity: 1,
+    linkPrivateSignalToPublicEntity: 1,
   };
 
   const defaultUnitsByRisk: Record<RiskTier, number> = {

--- a/convex/domains/mcp/mcpToolLedger.ts
+++ b/convex/domains/mcp/mcpToolLedger.ts
@@ -37,6 +37,16 @@ type PolicyConfig = {
   updatedAt?: number;
 };
 
+type UsageScope =
+  | "tier"
+  | "tool"
+  | "profile"
+  | "account"
+  | "account_tool"
+  | "account_profile";
+
+const PRICING_VERSION = "mcp-cost-v1-2026-05";
+
 function stableStringify(value: unknown): string {
   const seen = new WeakSet<object>();
   return JSON.stringify(value, (_key, v) => {
@@ -144,7 +154,7 @@ async function getOrCreatePolicyConfig(
 async function getUsageCount(
   ctx: { db: any },
   dateKey: string,
-  scope: "tier" | "tool",
+  scope: UsageScope,
   key: string,
 ): Promise<{ row: Doc<"mcpToolUsageDaily"> | null; count: number }> {
   const row = await ctx.db
@@ -159,13 +169,19 @@ async function getUsageCount(
 async function incrementUsage(
   ctx: { db: any },
   dateKey: string,
-  scope: "tier" | "tool",
+  scope: UsageScope,
   key: string,
+  accounting: { costUnits: number; estimatedCostUsd: number },
 ): Promise<void> {
   const now = Date.now();
   const { row } = await getUsageCount(ctx, dateKey, scope, key);
   if (row) {
-    await ctx.db.patch(row._id, { count: row.count + 1, updatedAt: now });
+    await ctx.db.patch(row._id, {
+      count: row.count + 1,
+      costUnits: (row.costUnits ?? 0) + accounting.costUnits,
+      estimatedCostUsd: (row.estimatedCostUsd ?? 0) + accounting.estimatedCostUsd,
+      updatedAt: now,
+    });
     return;
   }
   await ctx.db.insert("mcpToolUsageDaily", {
@@ -173,6 +189,8 @@ async function incrementUsage(
     scope,
     key,
     count: 1,
+    costUnits: accounting.costUnits,
+    estimatedCostUsd: accounting.estimatedCostUsd,
     updatedAt: now,
   });
 }
@@ -188,6 +206,75 @@ function toRiskTier(input?: string): RiskTier {
     default:
       return "unknown";
   }
+}
+
+function stringFromMeta(value: unknown, maxLength = 160): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > maxLength ? trimmed.slice(0, maxLength) : trimmed;
+}
+
+function extractRequestAccountingMeta(requestMeta: unknown): {
+  requestId?: string;
+  accountKey?: string;
+  profileName?: string;
+  authMode?: string;
+  clientName?: string;
+} {
+  const meta = requestMeta && typeof requestMeta === "object"
+    ? (requestMeta as Record<string, unknown>)
+    : {};
+
+  return {
+    requestId: stringFromMeta(meta.requestId, 120),
+    accountKey: stringFromMeta(meta.accountKey, 180),
+    profileName: stringFromMeta(meta.profileName, 80),
+    authMode: stringFromMeta(meta.authMode, 40),
+    clientName: stringFromMeta(meta.clientName, 160),
+  };
+}
+
+function estimateToolCost(input: {
+  toolName: string;
+  toolType: string;
+  riskTier: RiskTier;
+}): { costUnits: number; estimatedCostUsd: number; pricingVersion: string } {
+  const explicitUnitsByTool: Record<string, number> = {
+    "nodebench.research_company": 12,
+    "nodebench.research_person": 12,
+    "nodebench.research_role": 14,
+    "nodebench.search_public_sources": 5,
+    "nodebench.compile_interview_packet": 4,
+    "nodebench.get_matching_context": 2,
+    "nodebench.context.pack": 2,
+    "nodebench.dossiers.get": 1,
+    "nodebench.entities.resolve": 1,
+    "nodebench.claims.submit_public": 2,
+    "nodebench.claims.verify": 3,
+    "nodebench.watch_entity": 1,
+    "nodebench.link_private_signal_to_public_entity": 1,
+  };
+
+  const defaultUnitsByRisk: Record<RiskTier, number> = {
+    read_only: 1,
+    external_read: 4,
+    write_internal: 3,
+    external_side_effect: 8,
+    destructive: 12,
+    unknown: 2,
+  };
+
+  const directToolPremium = input.toolType === "direct" ? 1 : 0;
+  const costUnits =
+    (explicitUnitsByTool[input.toolName] ?? defaultUnitsByRisk[input.riskTier]) +
+    directToolPremium;
+
+  // Unit pricing is deliberately conservative and estimated. Actual provider
+  // invoices can be reconciled separately when API/search providers expose usage.
+  const estimatedCostUsd = Number((costUnits * 0.001).toFixed(6));
+
+  return { costUnits, estimatedCostUsd, pricingVersion: PRICING_VERSION };
 }
 
 export const startToolCallInternal = internalMutation({
@@ -214,6 +301,8 @@ export const startToolCallInternal = internalMutation({
     const toolName = input.toolName;
     const toolType = input.toolType ?? "unknown";
     const riskTier = toRiskTier(input.riskTier);
+    const requestAccountingMeta = extractRequestAccountingMeta(input.requestMeta);
+    const toolAccounting = estimateToolCost({ toolName, toolType, riskTier });
 
     const argsValue = input.args ?? {};
     const argsString = stableStringify(argsValue);
@@ -274,6 +363,14 @@ export const startToolCallInternal = internalMutation({
         tool: { toolKey, count: toolCount, limit: toolLimit ?? null },
         wouldExceed: budgetWouldExceed,
       },
+      accounting: {
+        accountKey: requestAccountingMeta.accountKey ?? null,
+        profileName: requestAccountingMeta.profileName ?? null,
+        authMode: requestAccountingMeta.authMode ?? null,
+        costUnits: toolAccounting.costUnits,
+        estimatedCostUsd: toolAccounting.estimatedCostUsd,
+        pricingVersion: toolAccounting.pricingVersion,
+      },
     };
 
     const callId = await ctx.db.insert("mcpToolCallLedger", {
@@ -287,12 +384,42 @@ export const startToolCallInternal = internalMutation({
       argsPreview,
       idempotencyKey: input.idempotencyKey,
       requestMeta: input.requestMeta,
+      requestId: requestAccountingMeta.requestId,
+      accountKey: requestAccountingMeta.accountKey,
+      profileName: requestAccountingMeta.profileName,
+      authMode: requestAccountingMeta.authMode,
+      clientName: requestAccountingMeta.clientName,
       startedAt: now,
+      costUnits: toolAccounting.costUnits,
+      estimatedCostUsd: toolAccounting.estimatedCostUsd,
+      pricingVersion: toolAccounting.pricingVersion,
     });
 
     if (allowed) {
-      await incrementUsage(ctx, dateKey, "tier", tierKey);
-      await incrementUsage(ctx, dateKey, "tool", toolKey);
+      await incrementUsage(ctx, dateKey, "tier", tierKey, toolAccounting);
+      await incrementUsage(ctx, dateKey, "tool", toolKey, toolAccounting);
+      if (requestAccountingMeta.profileName) {
+        await incrementUsage(ctx, dateKey, "profile", requestAccountingMeta.profileName, toolAccounting);
+      }
+      if (requestAccountingMeta.accountKey) {
+        await incrementUsage(ctx, dateKey, "account", requestAccountingMeta.accountKey, toolAccounting);
+        await incrementUsage(
+          ctx,
+          dateKey,
+          "account_tool",
+          `${requestAccountingMeta.accountKey}:${toolKey}`,
+          toolAccounting,
+        );
+      }
+      if (requestAccountingMeta.accountKey && requestAccountingMeta.profileName) {
+        await incrementUsage(
+          ctx,
+          dateKey,
+          "account_profile",
+          `${requestAccountingMeta.accountKey}:${requestAccountingMeta.profileName}`,
+          toolAccounting,
+        );
+      }
     }
 
     return { allowed, callId, argsHash, policy };
@@ -372,6 +499,11 @@ export const listToolCalls = query({
       argsPreview: v.optional(v.string()),
       idempotencyKey: v.optional(v.string()),
       requestMeta: v.optional(v.any()),
+      requestId: v.optional(v.string()),
+      accountKey: v.optional(v.string()),
+      profileName: v.optional(v.string()),
+      authMode: v.optional(v.string()),
+      clientName: v.optional(v.string()),
       startedAt: v.number(),
       finishedAt: v.optional(v.number()),
       durationMs: v.optional(v.number()),
@@ -379,6 +511,9 @@ export const listToolCalls = query({
       errorMessage: v.optional(v.string()),
       resultPreview: v.optional(v.string()),
       resultBytes: v.optional(v.number()),
+      costUnits: v.optional(v.number()),
+      estimatedCostUsd: v.optional(v.number()),
+      pricingVersion: v.optional(v.string()),
     })),
     nextCursor: v.optional(v.string()),
     hasMore: v.boolean(),
@@ -454,6 +589,11 @@ export const listToolCalls = query({
       argsPreview: r.argsPreview,
       idempotencyKey: r.idempotencyKey,
       requestMeta: r.requestMeta,
+      requestId: r.requestId,
+      accountKey: r.accountKey,
+      profileName: r.profileName,
+      authMode: r.authMode,
+      clientName: r.clientName,
       startedAt: r.startedAt,
       finishedAt: r.finishedAt,
       durationMs: r.durationMs,
@@ -461,6 +601,9 @@ export const listToolCalls = query({
       errorMessage: r.errorMessage,
       resultPreview: r.resultPreview,
       resultBytes: r.resultBytes,
+      costUnits: r.costUnits,
+      estimatedCostUsd: r.estimatedCostUsd,
+      pricingVersion: r.pricingVersion,
     }));
 
     return {
@@ -538,6 +681,128 @@ export const getPolicyAndUsage = query({
         updatedAt: cfg.updatedAt,
       },
       usageByTier,
+    };
+  },
+});
+
+export const getUsageAndCostSnapshot = query({
+  args: {
+    dateKey: v.optional(v.string()),
+    accountKey: v.optional(v.string()),
+    profileName: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({
+    dateKey: v.string(),
+    pricingVersion: v.string(),
+    filters: v.object({
+      accountKey: v.optional(v.string()),
+      profileName: v.optional(v.string()),
+    }),
+    totals: v.object({
+      calls: v.number(),
+      costUnits: v.number(),
+      estimatedCostUsd: v.number(),
+    }),
+    usageByProfile: v.array(v.object({
+      profileName: v.string(),
+      calls: v.number(),
+      costUnits: v.number(),
+      estimatedCostUsd: v.number(),
+    })),
+    usageByTool: v.array(v.object({
+      toolName: v.string(),
+      calls: v.number(),
+      costUnits: v.number(),
+      estimatedCostUsd: v.number(),
+    })),
+    usageByAccount: v.array(v.object({
+      accountKey: v.string(),
+      calls: v.number(),
+      costUnits: v.number(),
+      estimatedCostUsd: v.number(),
+    })),
+  }),
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const requested = typeof args.dateKey === "string" ? args.dateKey.trim() : "";
+    const dateKey = /^\d{4}-\d{2}-\d{2}$/.test(requested) ? requested : todayDateKeyUtc(now);
+    const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
+
+    const normalizeRow = (row: Doc<"mcpToolUsageDaily">) => ({
+      key: row.key,
+      calls: row.count,
+      costUnits: row.costUnits ?? row.count,
+      estimatedCostUsd: row.estimatedCostUsd ?? 0,
+    });
+
+    const collectScopeRows = async (scope: UsageScope) => {
+      const rows = await ctx.db
+        .query("mcpToolUsageDaily")
+        .withIndex("by_date_scope", (q) => q.eq("dateKey", dateKey).eq("scope", scope))
+        .collect();
+      return rows.map(normalizeRow);
+    };
+
+    const rankRows = (rows: Awaited<ReturnType<typeof collectScopeRows>>) =>
+      rows
+        .sort((a, b) => b.estimatedCostUsd - a.estimatedCostUsd || b.calls - a.calls)
+        .slice(0, limit);
+
+    const profileRows = rankRows(await collectScopeRows("profile"));
+    const accountRows = rankRows(await collectScopeRows("account"));
+    const allToolRows = rankRows(await collectScopeRows("tool"));
+
+    let scopedToolRows = allToolRows;
+    if (args.accountKey) {
+      const accountToolRows = await collectScopeRows("account_tool");
+      const prefix = `${args.accountKey}:`;
+      scopedToolRows = rankRows(accountToolRows
+        .filter((row) => row.key.startsWith(prefix))
+        .map((row) => ({ ...row, key: row.key.slice(prefix.length) })));
+    }
+
+    const totalSource = args.accountKey
+      ? accountRows.filter((row) => row.key === args.accountKey)
+      : args.profileName
+        ? profileRows.filter((row) => row.key === args.profileName)
+        : accountRows;
+
+    const totals = totalSource.reduce(
+      (acc, row) => ({
+        calls: acc.calls + row.calls,
+        costUnits: acc.costUnits + row.costUnits,
+        estimatedCostUsd: Number((acc.estimatedCostUsd + row.estimatedCostUsd).toFixed(6)),
+      }),
+      { calls: 0, costUnits: 0, estimatedCostUsd: 0 },
+    );
+
+    return {
+      dateKey,
+      pricingVersion: PRICING_VERSION,
+      filters: {
+        accountKey: args.accountKey,
+        profileName: args.profileName,
+      },
+      totals,
+      usageByProfile: profileRows.map((row) => ({
+        profileName: row.key,
+        calls: row.calls,
+        costUnits: row.costUnits,
+        estimatedCostUsd: row.estimatedCostUsd,
+      })),
+      usageByTool: scopedToolRows.map((row) => ({
+        toolName: row.key,
+        calls: row.calls,
+        costUnits: row.costUnits,
+        estimatedCostUsd: row.estimatedCostUsd,
+      })),
+      usageByAccount: accountRows.map((row) => ({
+        accountKey: row.key,
+        calls: row.calls,
+        costUnits: row.costUnits,
+        estimatedCostUsd: row.estimatedCostUsd,
+      })),
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2642,9 +2642,18 @@ const mcpPolicyConfigs = defineTable({
 
 const mcpToolUsageDaily = defineTable({
   dateKey: v.string(), // YYYY-MM-DD (UTC)
-  scope: v.union(v.literal("tier"), v.literal("tool")),
-  key: v.string(), // riskTier or toolName depending on scope
+  scope: v.union(
+    v.literal("tier"),
+    v.literal("tool"),
+    v.literal("profile"),
+    v.literal("account"),
+    v.literal("account_tool"),
+    v.literal("account_profile"),
+  ),
+  key: v.string(), // riskTier, toolName, profile, accountKey, or composite account key
   count: v.number(),
+  costUnits: v.optional(v.number()),
+  estimatedCostUsd: v.optional(v.number()),
   updatedAt: v.number(),
 })
   .index("by_date_scope_key", ["dateKey", "scope", "key"])
@@ -2664,6 +2673,11 @@ const mcpToolCallLedger = defineTable({
 
   idempotencyKey: v.optional(v.string()),
   requestMeta: v.optional(v.any()), // upstream request context (gateway request id, etc.)
+  requestId: v.optional(v.string()),
+  accountKey: v.optional(v.string()),
+  profileName: v.optional(v.string()),
+  authMode: v.optional(v.string()),
+  clientName: v.optional(v.string()),
 
   startedAt: v.number(),
   finishedAt: v.optional(v.number()),
@@ -2674,6 +2688,9 @@ const mcpToolCallLedger = defineTable({
 
   resultPreview: v.optional(v.string()), // redacted + truncated for UI
   resultBytes: v.optional(v.number()),
+  costUnits: v.optional(v.number()),
+  estimatedCostUsd: v.optional(v.number()),
+  pricingVersion: v.optional(v.string()),
 })
   .index("by_startedAt", ["startedAt"])
   .index("by_tool_startedAt", ["toolName", "startedAt"])

--- a/docs/guides/API_INTEGRATION_GUIDE.md
+++ b/docs/guides/API_INTEGRATION_GUIDE.md
@@ -1,5 +1,92 @@
 # API Integration Guide - Cursor, Windsurf, Claude Code
 
+## Public Research MCP For Apps And Agents
+
+For company, person, role, and public-source context, prefer the hosted
+NodeBench MCP profile instead of building an app-specific research backend.
+
+Gmail/job-match integrations:
+
+```json
+{
+  "mcpServers": {
+    "nodebench-gmail-research": {
+      "transport": "http",
+      "url": "https://nodebench-mcp-unified.onrender.com?profile=gmail-research",
+      "headers": {
+        "x-nodebench-client": "your-app-name",
+        "x-nodebench-client-version": "1.0.0",
+        "x-nodebench-client-id": "stable-install-or-workspace-id"
+      }
+    }
+  }
+}
+```
+
+General public research integrations:
+
+```json
+{
+  "mcpServers": {
+    "nodebench-public-research": {
+      "transport": "http",
+      "url": "https://nodebench-mcp-unified.onrender.com?profile=public-research",
+      "headers": {
+        "x-nodebench-client": "your-app-name",
+        "x-nodebench-client-version": "1.0.0",
+        "x-nodebench-client-id": "stable-install-or-workspace-id"
+      }
+    }
+  }
+}
+```
+
+Start anonymous. NodeBench returns public dossiers and context packs without a
+token for `public-research` and `gmail-research`. Every response includes
+request/account/cost metadata in `result._meta.nodebench` and these headers:
+
+```txt
+x-nodebench-request-id
+x-nodebench-profile
+x-nodebench-auth-mode
+x-nodebench-account-key
+```
+
+Recommended product flow:
+
+```text
+Use public research anonymously
+  -> show sourced facts, freshness, confidence, and missing info
+  -> prompt "Link NodeBench" after the first useful dossier
+  -> linked users get persistent history, higher budgets, team usage,
+     API/MCP tokens, webhooks, billing controls, and workspace handoff
+```
+
+Privacy boundary:
+
+- Send public entity signals only: company name/domain, person name, role title,
+  job URL, source URL, and public goal.
+- Do not send raw Gmail text, resume text, private notes, API keys, or private
+  fit scores to public research tools.
+- Keep private scoring in the calling app.
+
+Core public tools:
+
+```txt
+nodebench.entities.resolve
+nodebench.search_public_sources
+nodebench.research_company
+nodebench.research_person
+nodebench.research_role
+nodebench.dossiers.get
+nodebench.context.pack
+nodebench.get_matching_context
+nodebench.compile_interview_packet
+```
+
+Full profile and metering contract:
+[MCP_TOOL_PROFILES.md](./MCP_TOOL_PROFILES.md).
+
 ## 🎯 Complete API for Agent-Driven DCF Editing
 
 This guide shows how to integrate the Interactive DCF system with Cursor, Windsurf, Claude Code, or any other agentic tool.

--- a/docs/guides/MCP_TOOL_PROFILES.md
+++ b/docs/guides/MCP_TOOL_PROFILES.md
@@ -51,6 +51,67 @@ public-research,gmail-research
 
 That means external Gmail/job integrations can call the hosted MCP URL with `?profile=gmail-research` and no token. Internal, builder, document, memory, and full profiles still require a token when `MCP_HTTP_TOKEN` or `MCP_PROFILE_TOKENS` is configured.
 
+## Accounts, Metering, And Cost Tracking
+
+The hosted MCP gateway is frictionless for public research, but still account-aware:
+
+- Token calls are attributed to a stable `token:<hash>` account key.
+- Anonymous public calls are attributed to a stable `anon:<profile>:<hash>` account key derived from request metadata without storing raw tokens.
+- Every tool call writes to the MCP ledger with profile, auth mode, client name, request id, estimated cost units, and estimated USD.
+- Daily rollups are stored by tier, tool, profile, account, account/tool, and account/profile.
+
+Every JSON-RPC response includes the same accounting metadata:
+
+```json
+{
+  "result": {
+    "_meta": {
+      "nodebench": {
+        "requestId": "uuid",
+        "profile": "gmail-research",
+        "authMode": "anonymous",
+        "accountKey": "anon:gmail-research:...",
+        "accounting": {
+          "ledger": "mcpToolCallLedger",
+          "costModel": "mcp-cost-v1-2026-05",
+          "costType": "estimated"
+        }
+      }
+    }
+  }
+}
+```
+
+The gateway also sends these HTTP headers so apps and agents can log them without parsing the MCP result:
+
+```txt
+x-nodebench-request-id
+x-nodebench-profile
+x-nodebench-auth-mode
+x-nodebench-account-key
+```
+
+Recommended client headers:
+
+```http
+x-nodebench-client: gmail-dashboard
+x-nodebench-client-version: 1.0.0
+```
+
+For operations views, use Convex:
+
+```powershell
+npx convex run --push "domains/mcp/mcpToolLedger:getUsageAndCostSnapshot" "{dateKey:'2026-05-03',limit:20}"
+```
+
+For one requester:
+
+```powershell
+npx convex run --push "domains/mcp/mcpToolLedger:getUsageAndCostSnapshot" "{accountKey:'anon:gmail-research:<hash>',limit:20}"
+```
+
+Cost values are estimates for product control and abuse detection. Provider invoices remain the source of truth for final billing reconciliation.
+
 ## Environment Variables
 
 ```txt

--- a/docs/guides/MCP_TOOL_PROFILES.md
+++ b/docs/guides/MCP_TOOL_PROFILES.md
@@ -114,6 +114,7 @@ npx convex run --push "domains/mcp/mcpToolLedger:getUsageAndCostSnapshot" "{acco
 ```
 
 Cost values are estimates for product control and abuse detection. Provider invoices remain the source of truth for final billing reconciliation.
+Anonymous public-profile accounting is intentionally stable per client id so apps can show usage before account linking without sending private user data.
 
 ## Environment Variables
 

--- a/docs/guides/MCP_TOOL_PROFILES.md
+++ b/docs/guides/MCP_TOOL_PROFILES.md
@@ -96,7 +96,10 @@ Recommended client headers:
 ```http
 x-nodebench-client: gmail-dashboard
 x-nodebench-client-version: 1.0.0
+x-nodebench-client-id: stable-install-or-workspace-id
 ```
+
+`x-nodebench-client-id` is optional but recommended. It gives anonymous public-profile clients stable usage attribution without requiring a NodeBench login or token. Do not put private email text, resume text, API keys, or other sensitive data in this header.
 
 For operations views, use Convex:
 

--- a/docs/guides/MCP_TOOL_PROFILES.md
+++ b/docs/guides/MCP_TOOL_PROFILES.md
@@ -99,7 +99,7 @@ x-nodebench-client-version: 1.0.0
 x-nodebench-client-id: stable-install-or-workspace-id
 ```
 
-`x-nodebench-client-id` is optional but recommended. It gives anonymous public-profile clients stable usage attribution without requiring a NodeBench login or token. Do not put private email text, resume text, API keys, or other sensitive data in this header.
+`x-nodebench-client-id` is optional but recommended. It gives anonymous public-profile clients stable usage attribution without requiring a NodeBench login or token. Do not put private email text, resume text, API keys, or other sensitive data in this header. Rotate this value only when you intentionally want a new anonymous accounting bucket.
 
 For operations views, use Convex:
 

--- a/mcp-services/README.md
+++ b/mcp-services/README.md
@@ -2,6 +2,48 @@
 
 This directory contains **Model Context Protocol (MCP) servers** that expose shared tools for NodeBench AI agents.
 
+## Hosted Public Research MCP
+
+Production endpoint:
+
+```txt
+https://nodebench-mcp-unified.onrender.com
+```
+
+Use profiles instead of giving every user the full internal tool catalog:
+
+```txt
+https://nodebench-mcp-unified.onrender.com?profile=public-research
+https://nodebench-mcp-unified.onrender.com?profile=gmail-research
+```
+
+Public profiles are anonymous and frictionless by default. They are still
+metered through the MCP ledger, with response headers:
+
+```txt
+x-nodebench-request-id
+x-nodebench-profile
+x-nodebench-auth-mode
+x-nodebench-account-key
+```
+
+Recommended app headers:
+
+```http
+x-nodebench-client: your-app-name
+x-nodebench-client-version: 1.0.0
+x-nodebench-client-id: stable-install-or-workspace-id
+```
+
+Progressive account model:
+
+- Do not require sign-in for the first public research dossier.
+- Prompt users to link/sign in after they see sourced value.
+- Link/sign-in should unlock persistent history, higher budgets, team usage,
+  API/MCP tokens, billing controls, webhooks, and private workspace context.
+
+Full contract: [../docs/guides/MCP_TOOL_PROFILES.md](../docs/guides/MCP_TOOL_PROFILES.md).
+
 ## 🏗️ Architecture
 
 MCP servers provide a standardized way for AI agents to access tools and data sources. Each server:

--- a/mcp-services/gateway_server/httpServer.ts
+++ b/mcp-services/gateway_server/httpServer.ts
@@ -146,6 +146,10 @@ function inferClientVersion(req: http.IncomingMessage): string | undefined {
   return firstHeader(req.headers["x-nodebench-client-version"])?.slice(0, 80);
 }
 
+function inferClientInstanceId(req: http.IncomingMessage): string | undefined {
+  return firstHeader(req.headers["x-nodebench-client-id"])?.slice(0, 160);
+}
+
 function buildAccountKey(input: {
   req: http.IncomingMessage;
   profileName: ToolProfileName;
@@ -159,10 +163,14 @@ function buildAccountKey(input: {
   }
 
   if (input.authMode === "anonymous") {
+    const clientInstanceId = inferClientInstanceId(input.req);
+    if (clientInstanceId) {
+      return `anon-client:${input.profileName}:${shortHash(clientInstanceId)}`;
+    }
+
     const publicRequesterBasis = [
       input.profileName,
-      input.forwardedFor?.split(",")[0]?.trim() ?? "",
-      input.remoteIp ?? "",
+      inferClientName(input.req) ?? "",
       firstHeader(input.req.headers["origin"]) ?? "",
       firstHeader(input.req.headers["user-agent"]) ?? "",
     ].join("|");
@@ -344,7 +352,7 @@ const server = http.createServer(async (req, res) => {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
       "Access-Control-Allow-Headers":
-        "Content-Type, Accept, Authorization, x-mcp-token, x-mcp-profile, x-nodebench-profile, x-nodebench-client, x-nodebench-client-version, x-request-id",
+        "Content-Type, Accept, Authorization, x-mcp-token, x-mcp-profile, x-nodebench-profile, x-nodebench-client, x-nodebench-client-version, x-nodebench-client-id, x-request-id",
     });
     res.end();
     return;
@@ -481,6 +489,7 @@ const server = http.createServer(async (req, res) => {
               accountKey,
               clientName: inferClientName(req),
               clientVersion: inferClientVersion(req),
+              clientInstanceId: inferClientInstanceId(req),
               origin: firstHeader(req.headers["origin"]),
               externalUserAgent: firstHeader(req.headers["user-agent"]),
               tokenAuthEnabled: tokenConfig.tokens.size > 0,

--- a/mcp-services/gateway_server/httpServer.ts
+++ b/mcp-services/gateway_server/httpServer.ts
@@ -12,6 +12,7 @@
  */
 
 import http from "http";
+import { createHash, randomUUID } from "node:crypto";
 import { researchTools } from "./tools/researchTools.js";
 import { narrativeTools } from "./tools/narrativeTools.js";
 import { verificationTools } from "./tools/verificationTools.js";
@@ -72,10 +73,16 @@ type JsonRpcRequest = {
   params?: { name?: string; arguments?: any };
 };
 
-function respond(res: http.ServerResponse, status: number, payload: any) {
+function respond(
+  res: http.ServerResponse,
+  status: number,
+  payload: any,
+  headers: Record<string, string> = {}
+) {
   res.writeHead(status, {
     "Content-Type": "application/json",
     "Access-Control-Allow-Origin": "*",
+    ...headers,
   });
   res.end(JSON.stringify(payload));
 }
@@ -116,6 +123,89 @@ function parseProfileList(value: string | undefined): Set<ToolProfileName> {
     if (normalized) profiles.add(normalized);
   }
   return profiles;
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 20);
+}
+
+function inferClientName(req: http.IncomingMessage): string | undefined {
+  return (
+    firstHeader(req.headers["x-nodebench-client"]) ??
+    firstHeader(req.headers["x-mcp-client"]) ??
+    firstHeader(req.headers["user-agent"])?.slice(0, 120)
+  );
+}
+
+function inferClientVersion(req: http.IncomingMessage): string | undefined {
+  return firstHeader(req.headers["x-nodebench-client-version"])?.slice(0, 80);
+}
+
+function buildAccountKey(input: {
+  req: http.IncomingMessage;
+  profileName: ToolProfileName;
+  authMode: "token" | "anonymous" | "open";
+  suppliedToken?: string;
+  forwardedFor?: string;
+  remoteIp?: string;
+}): string {
+  if (input.authMode === "token" && input.suppliedToken) {
+    return `token:${shortHash(input.suppliedToken)}`;
+  }
+
+  if (input.authMode === "anonymous") {
+    const publicRequesterBasis = [
+      input.profileName,
+      input.forwardedFor?.split(",")[0]?.trim() ?? "",
+      input.remoteIp ?? "",
+      firstHeader(input.req.headers["origin"]) ?? "",
+      firstHeader(input.req.headers["user-agent"]) ?? "",
+    ].join("|");
+    return `anon:${input.profileName}:${shortHash(publicRequesterBasis)}`;
+  }
+
+  return `open:${input.profileName}`;
+}
+
+function nodebenchMeta(ctx: {
+  requestId: string;
+  profileName: ToolProfileName;
+  authMode: "token" | "anonymous" | "open";
+  accountKey: string;
+}) {
+  return {
+    nodebench: {
+      requestId: ctx.requestId,
+      profile: ctx.profileName,
+      authMode: ctx.authMode,
+      accountKey: ctx.accountKey,
+      accounting: {
+        ledger: "mcpToolCallLedger",
+        costModel: "mcp-cost-v1-2026-05",
+        costType: "estimated",
+      },
+    },
+  };
+}
+
+function nodebenchHeaders(ctx?: {
+  requestId?: string;
+  profileName?: string;
+  authMode?: string;
+  accountKey?: string;
+}): Record<string, string> {
+  if (!ctx) return {};
+  const headers: Record<string, string> = {};
+  if (ctx.requestId) headers["x-nodebench-request-id"] = ctx.requestId;
+  if (ctx.profileName) headers["x-nodebench-profile"] = ctx.profileName;
+  if (ctx.authMode) headers["x-nodebench-auth-mode"] = ctx.authMode;
+  if (ctx.accountKey) headers["x-nodebench-account-key"] = ctx.accountKey;
+  return headers;
 }
 
 const tokenConfig: TokenProfileConfig = (() => {
@@ -200,6 +290,12 @@ const server = http.createServer(async (req, res) => {
         anonymous: anonymousProfiles.has(profile.name) && isPublicToolProfileName(profile.name),
       })),
       anonymousProfiles: [...anonymousProfiles],
+      accounting: {
+        anonymousProfilesAreMetered: true,
+        accountKeyHeader: "x-nodebench-account-key",
+        requestIdHeader: "x-nodebench-request-id",
+        costModel: "mcp-cost-v1-2026-05",
+      },
       categories: ["research", "narrative", "verification", "knowledge", "documents", "planning", "memory", "search", "financial"],
     });
     return;
@@ -227,6 +323,17 @@ const server = http.createServer(async (req, res) => {
           headers: anonymousProfiles.has("gmail-research") ? {} : { "x-mcp-token": "<token>" },
         },
       },
+      accounting: {
+        frictionlessPublicProfiles: [...anonymousProfiles].filter(isPublicToolProfileName),
+        responseHeaders: [
+          "x-nodebench-request-id",
+          "x-nodebench-profile",
+          "x-nodebench-auth-mode",
+          "x-nodebench-account-key",
+        ],
+        responseMetaPath: "result._meta.nodebench",
+        costModel: "mcp-cost-v1-2026-05",
+      },
     });
     return;
   }
@@ -237,7 +344,7 @@ const server = http.createServer(async (req, res) => {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
       "Access-Control-Allow-Headers":
-        "Content-Type, Accept, Authorization, x-mcp-token, x-mcp-profile, x-nodebench-profile",
+        "Content-Type, Accept, Authorization, x-mcp-token, x-mcp-profile, x-nodebench-profile, x-nodebench-client, x-nodebench-client-version, x-request-id",
     });
     res.end();
     return;
@@ -276,6 +383,30 @@ const server = http.createServer(async (req, res) => {
       }
       const profileName = authAndProfile.profileName;
       const profileTools = getProfileTools(profileName);
+      const suppliedToken = getSuppliedToken(req);
+      const forwardedFor = firstHeader(req.headers["x-forwarded-for"]);
+      const remoteIp = (req.socket as any)?.remoteAddress as string | undefined;
+      const requestId = firstHeader(req.headers["x-request-id"]) ?? randomUUID();
+      const accountKey = buildAccountKey({
+        req,
+        profileName,
+        authMode: authAndProfile.authMode,
+        suppliedToken,
+        forwardedFor,
+        remoteIp,
+      });
+      const responseHeaders = nodebenchHeaders({
+        requestId,
+        profileName,
+        authMode: authAndProfile.authMode,
+        accountKey,
+      });
+      const meta = nodebenchMeta({
+        requestId,
+        profileName,
+        authMode: authAndProfile.authMode,
+        accountKey,
+      });
 
       // MCP initialize
       if (method === "initialize") {
@@ -291,8 +422,9 @@ const server = http.createServer(async (req, res) => {
               profile: profileName,
               authMode: authAndProfile.authMode,
             },
+            _meta: meta,
           },
-        });
+        }, responseHeaders);
         return;
       }
 
@@ -309,9 +441,12 @@ const server = http.createServer(async (req, res) => {
             })),
             profile: profileName,
             authMode: authAndProfile.authMode,
+            accountKey,
+            accounting: meta.nodebench.accounting,
             profiles: listToolProfiles(),
+            _meta: meta,
           },
-        });
+        }, responseHeaders);
         return;
       }
 
@@ -328,21 +463,26 @@ const server = http.createServer(async (req, res) => {
               code: -32602,
               message: `Tool not found in profile "${profileName}": ${toolName}`,
             },
-          });
+          }, responseHeaders);
           return;
         }
 
-        const suppliedToken = getSuppliedToken(req);
-        const forwardedFor = (req.headers["x-forwarded-for"] as string | undefined) ?? undefined;
-        const remoteIp = (req.socket as any)?.remoteAddress as string | undefined;
         const receivedAtIso = new Date().toISOString();
 
         try {
           const result = await runWithRequestContext(
             {
+              requestId,
               jsonrpcId: id,
               method,
               toolName,
+              profileName,
+              authMode: authAndProfile.authMode,
+              accountKey,
+              clientName: inferClientName(req),
+              clientVersion: inferClientVersion(req),
+              origin: firstHeader(req.headers["origin"]),
+              externalUserAgent: firstHeader(req.headers["user-agent"]),
               tokenAuthEnabled: tokenConfig.tokens.size > 0,
               tokenPresent: Boolean(suppliedToken),
               remoteIp,
@@ -431,8 +571,9 @@ const server = http.createServer(async (req, res) => {
             result: {
               content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
               isError: false,
+              _meta: meta,
             },
-          });
+          }, responseHeaders);
         } catch (err: any) {
           // Tool execution errors are returned as results with isError, NOT as JSON-RPC errors.
           // JSON-RPC errors are reserved for protocol-level failures.
@@ -442,8 +583,9 @@ const server = http.createServer(async (req, res) => {
             result: {
               content: [{ type: "text", text: err?.message || "Internal error" }],
               isError: true,
+              _meta: meta,
             },
-          });
+          }, responseHeaders);
         }
         return;
       }
@@ -452,7 +594,7 @@ const server = http.createServer(async (req, res) => {
         jsonrpc: "2.0",
         id,
         error: { code: -32601, message: `Method not found: ${method}` },
-      });
+      }, responseHeaders);
     } catch {
       respond(res, 400, {
         jsonrpc: "2.0",

--- a/mcp-services/gateway_server/requestContext.ts
+++ b/mcp-services/gateway_server/requestContext.ts
@@ -1,9 +1,17 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 export type GatewayRequestContext = {
+  requestId?: string;
   jsonrpcId?: string | number | null;
   method?: string;
   toolName?: string;
+  profileName?: string;
+  authMode?: "token" | "anonymous" | "open";
+  accountKey?: string;
+  clientName?: string;
+  clientVersion?: string;
+  origin?: string;
+  externalUserAgent?: string;
   tokenAuthEnabled?: boolean;
   tokenPresent?: boolean;
   remoteIp?: string;
@@ -23,4 +31,3 @@ export function runWithRequestContext<T>(
 export function getRequestContext(): GatewayRequestContext | undefined {
   return storage.getStore();
 }
-

--- a/mcp-services/gateway_server/requestContext.ts
+++ b/mcp-services/gateway_server/requestContext.ts
@@ -10,6 +10,7 @@ export type GatewayRequestContext = {
   accountKey?: string;
   clientName?: string;
   clientVersion?: string;
+  clientInstanceId?: string;
   origin?: string;
   externalUserAgent?: string;
   tokenAuthEnabled?: boolean;

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -1164,6 +1164,41 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
           <span><Share2 size={12} /> Export to Notes, Notion, Linear, CSV</span>
         </div>
 
+        <div
+          style={{
+            alignItems: "center",
+            background: "rgba(255,255,255,0.76)",
+            border: "1px solid var(--border-default)",
+            borderRadius: 18,
+            boxShadow: "0 18px 42px -34px rgba(15,23,42,0.38)",
+            display: "flex",
+            gap: 12,
+            justifyContent: "space-between",
+            margin: "14px auto 0",
+            maxWidth: 680,
+            padding: "12px 14px",
+            width: "100%",
+          }}
+        >
+          <div style={{ minWidth: 0, textAlign: "left" }}>
+            <div style={{ alignItems: "center", color: "var(--text-primary)", display: "flex", fontSize: 13, fontWeight: 800, gap: 7 }}>
+              <Link2 size={14} />
+              <span>First public dossier works without sign-in.</span>
+            </div>
+            <p style={{ color: "var(--text-muted)", fontSize: 12, lineHeight: 1.55, margin: "4px 0 0" }}>
+              Link NodeBench after the first sourced result to keep memory, raise limits, and add team controls.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="nb-btn nb-btn-secondary"
+            onClick={() => navigate("/settings?tab=connections")}
+            style={{ flexShrink: 0 }}
+          >
+            Link when ready
+          </button>
+        </div>
+
         {backgroundFeedback ? (
           <div
             className="nb-background-feedback"
@@ -3463,6 +3498,7 @@ function MobileReportsPipelineBlock() {
 }
 
 function MobileHomeBody() {
+  const navigate = useNavigate();
   const [mobileQuery, setMobileQuery] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -3513,6 +3549,44 @@ function MobileHomeBody() {
         <span>keeps working</span>
         <span>safe to leave</span>
         <span>export-ready</span>
+      </div>
+      <div
+        style={{
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-default)",
+          borderRadius: 18,
+          boxShadow: "var(--shadow-sm)",
+          display: "grid",
+          gap: 10,
+          padding: 14,
+        }}
+      >
+        <div style={{ alignItems: "center", display: "flex", gap: 8 }}>
+          <Link2 size={15} />
+          <strong style={{ color: "var(--text-primary)", fontSize: 14 }}>Research first, link after value.</strong>
+        </div>
+        <p style={{ color: "var(--text-muted)", fontSize: 13, lineHeight: 1.5, margin: 0 }}>
+          Public dossiers work without sign-in. Link NodeBench when you want saved history, higher limits, and team controls.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/settings?tab=connections")}
+          style={{
+            alignItems: "center",
+            background: "var(--accent-primary)",
+            border: 0,
+            borderRadius: 14,
+            color: "#fff",
+            display: "inline-flex",
+            fontSize: 13,
+            fontWeight: 800,
+            justifyContent: "center",
+            minHeight: 42,
+            padding: "0 14px",
+          }}
+        >
+          Link when ready
+        </button>
       </div>
       {feedback ? <div className="m-run-feedback" role="status">{feedback}</div> : null}
       <section className="m-section" data-testid="mobile-home-first-impression">
@@ -4877,11 +4951,19 @@ function WorkspaceMapNode({ x, y, entity, large = false }: { x: number; y: numbe
 
 export function ExactMcpTerminalPage() {
   const copyCommand = "claude mcp add nodebench -- npx -y nodebench-mcp";
+  const hostedPublicUrl = "https://nodebench-mcp-unified.onrender.com?profile=public-research";
   const [copied, setCopied] = useState(false);
+  const [copiedHosted, setCopiedHosted] = useState(false);
   const copy = () => {
     void navigator.clipboard.writeText(copyCommand).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
+    });
+  };
+  const copyHosted = () => {
+    void navigator.clipboard.writeText(hostedPublicUrl).then(() => {
+      setCopiedHosted(true);
+      setTimeout(() => setCopiedHosted(false), 1500);
     });
   };
   return (
@@ -4892,31 +4974,41 @@ export function ExactMcpTerminalPage() {
           <section>
             <div className="nb-kicker" style={{ color: "#d97757" }}>CLI / MCP</div>
             <h1 style={{ margin: "8px 0", color: "#fff", fontSize: 42, lineHeight: 1.05, letterSpacing: "-.04em" }}>Bring NodeBench into Claude, Cursor, and agent workflows.</h1>
-            <p style={{ color: "#a1a1aa", fontSize: 16, lineHeight: 1.7, maxWidth: 620 }}>The CLI/MCP kit is the distribution lane: plan, streamed checkpoints, answer packet, resource URIs, verification summary, and saved workspace links.</p>
-            <button className="nb-btn nb-btn-primary" type="button" onClick={copy} style={{ marginTop: 18 }}>
-              {copied ? <Check size={15} /> : <Copy size={15} />}
-              {copied ? "Copied" : "Copy install command"}
-            </button>
+            <p style={{ color: "#a1a1aa", fontSize: 16, lineHeight: 1.7, maxWidth: 620 }}>Start with a public dossier from the hosted MCP endpoint, no sign-in required. Link NodeBench after the first useful result to keep memory, raise limits, and manage teams.</p>
+            <div style={{ marginTop: 18, display: "flex", flexWrap: "wrap", gap: 10 }}>
+              <button className="nb-btn nb-btn-primary" type="button" onClick={copy}>
+                {copied ? <Check size={15} /> : <Copy size={15} />}
+                {copied ? "Copied" : "Copy install command"}
+              </button>
+              <button className="nb-btn" type="button" onClick={copyHosted} style={{ border: "1px solid rgba(255,255,255,.12)", background: "rgba(255,255,255,.04)", color: "#e5e7eb" }}>
+                {copiedHosted ? <Check size={15} /> : <Link2 size={15} />}
+                {copiedHosted ? "Copied" : "Copy hosted public URL"}
+              </button>
+            </div>
           </section>
           <TerminalCard title="~/diligence - zsh - 120x32" badge="core lane">
-            <TerminalLine>homen@mac &gt; claude mcp add nodebench -- npx -y nodebench-mcp</TerminalLine>
-            <TerminalLine tone="ok">registered with Claude Code - nodebench-mcp</TerminalLine>
-            <TerminalLine tone="ok">loaded tools - nodebench.research_run, nodebench.expand_resource</TerminalLine>
+            <TerminalLine>client &gt; tools/list profile=gmail-research</TerminalLine>
+            <TerminalLine tone="ok">anonymous - 10 public research tools loaded</TerminalLine>
+            <TerminalLine tone="ok">account key - anon-client:gmail-research:...</TerminalLine>
             <TerminalDivider />
-            <TerminalLine>agent &gt; nodebench.research_run({"{"} objective: "Fast debrief on DISCO" {"}"})</TerminalLine>
-            <TerminalLine tone="accent">plan - resolve entity, search, synthesize, verify</TerminalLine>
-            <TerminalLine tone="ok">24 sources captured - answer packet streaming</TerminalLine>
+            <TerminalLine>agent &gt; nodebench.research_company({"{"} companyName: "DISCO" {"}"})</TerminalLine>
+            <TerminalLine tone="accent">public-source research - sources, claims, freshness</TerminalLine>
+            <TerminalLine tone="ok">first dossier returned - no signup gate</TerminalLine>
             <div style={{ border: "1px solid rgba(217,119,87,.26)", borderRadius: 8, background: "rgba(217,119,87,.10)", padding: 12, color: "#f8fafc", fontFamily: "var(--font-mono)", fontSize: 12, lineHeight: 1.7 }}>
-              Worth reaching out. Save the report, verify the claim, then open Workspace for cards and sources.
+              Link NodeBench to save this run, raise daily limits, create API keys, and share team usage controls.
             </div>
-            <TerminalLine tone="ok">verified - saved report URI nodebench://report/disco-diligence</TerminalLine>
+            <TerminalLine tone="ok">upgrade prompt shown after value - not before</TerminalLine>
           </TerminalCard>
         </div>
-        <div style={{ marginTop: 18, display: "grid", gridTemplateColumns: "repeat(2,minmax(0,1fr))", gap: 14 }}>
-          {["nodebench.research_run", "nodebench.expand_resource"].map((tool) => (
-            <section key={tool} style={{ border: "1px solid rgba(255,255,255,.08)", borderRadius: 14, background: "rgba(255,255,255,.03)", padding: 18 }}>
-              <div style={{ color: "#e59579", fontFamily: "var(--font-mono)", fontSize: 13 }}>{tool}</div>
-              <p style={{ color: "#a1a1aa", fontSize: 13, lineHeight: 1.7 }}>Outputs plan, checkpoints, answer packet, resource URIs, verification summary, and saved report link.</p>
+        <div style={{ marginTop: 18, display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(220px,1fr))", gap: 14 }}>
+          {[
+            { title: "Use anonymously", body: "Public research and Gmail profiles return sourced dossiers without a token." },
+            { title: "Link after value", body: "Prompt sign-in once the user sees sources, freshness, confidence, and missing info." },
+            { title: "Unlock controls", body: "Linked accounts get history, higher budgets, API keys, team usage, webhooks, and billing." },
+          ].map((item) => (
+            <section key={item.title} style={{ border: "1px solid rgba(255,255,255,.08)", borderRadius: 14, background: "rgba(255,255,255,.03)", padding: 18 }}>
+              <div style={{ color: "#e59579", fontFamily: "var(--font-mono)", fontSize: 13 }}>{item.title}</div>
+              <p style={{ color: "#a1a1aa", fontSize: 13, lineHeight: 1.7 }}>{item.body}</p>
             </section>
           ))}
         </div>

--- a/src/features/home/views/HomeLanding.tsx
+++ b/src/features/home/views/HomeLanding.tsx
@@ -556,6 +556,22 @@ export function HomeLanding() {
               CLI instructions -&gt;
             </a>
           </div>
+          <div className="mx-auto mt-3 flex max-w-[680px] flex-col gap-2 rounded-2xl border border-gray-200 bg-white/80 p-3 text-left shadow-[0_18px_44px_-38px_rgba(15,23,42,0.28)] dark:border-white/[0.08] dark:bg-white/[0.03] sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="text-[12px] font-semibold text-gray-900 dark:text-gray-100">
+                First public dossier works without sign-in.
+              </div>
+              <p className="mt-0.5 text-[12px] leading-5 text-gray-500 dark:text-gray-400">
+                Link NodeBench after the first sourced result to keep history, raise limits, and add team controls.
+              </p>
+            </div>
+            <a
+              href="/settings?tab=connections"
+              className="inline-flex shrink-0 items-center justify-center rounded-full border border-gray-200 px-3 py-1.5 text-[12px] font-medium text-gray-700 transition hover:border-[var(--accent-primary)]/35 hover:text-gray-900 dark:border-white/[0.10] dark:text-gray-200 dark:hover:border-[var(--accent-primary)]/35"
+            >
+              Link when ready
+            </a>
+          </div>
           <div className="mt-5 grid gap-2.5 sm:grid-cols-3">
             {WEB_KIT_PROMPT_CARDS.map(({ icon: Icon, prompt }, index) => (
               <button

--- a/src/features/home/views/MobileHomeSurface.tsx
+++ b/src/features/home/views/MobileHomeSurface.tsx
@@ -11,7 +11,7 @@
  * watchlist + nudges + thread history are wired through Convex.
  */
 import { useNavigate } from "react-router-dom";
-import { Bell, ChevronRight, FileText, MessageSquare, Search, UserPlus, AlertTriangle } from "lucide-react";
+import { Bell, ChevronRight, FileText, Link2, MessageSquare, Search, UserPlus, AlertTriangle } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useFastAgent } from "@/features/agents/context/FastAgentContext";
 
@@ -196,6 +196,29 @@ export function MobileHomeSurface() {
           ⌘K
         </kbd>
       </button>
+
+      <section className="rounded-[16px] border border-gray-200 bg-white px-3.5 py-3 shadow-sm dark:border-white/[0.08] dark:bg-white/[0.02]">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#d97757]/10 text-[#d97757]">
+            <Link2 size={15} aria-hidden />
+          </span>
+          <div className="min-w-0">
+            <div className="text-[13px] font-semibold text-gray-900 dark:text-white">
+              Research first, link after value.
+            </div>
+            <p className="mt-1 text-[12px] leading-5 text-gray-500 dark:text-gray-400">
+              Public dossiers work without sign-in. Link NodeBench when you want saved history, higher limits, and team controls.
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate("/settings?tab=connections")}
+              className="mt-2 text-[12px] font-semibold text-[#d97757]"
+            >
+              Link when ready
+            </button>
+          </div>
+        </div>
+      </section>
 
       {/* Watchlist */}
       <section>

--- a/src/features/mcp/views/ApiKeyManagementPage.tsx
+++ b/src/features/mcp/views/ApiKeyManagementPage.tsx
@@ -11,6 +11,7 @@ import {
   Activity,
   ClipboardCopy,
   Key,
+  Link2,
   Plus,
   ShieldCheck,
   ShieldOff,
@@ -581,6 +582,29 @@ function ApiKeyManagementPageInner() {
         >
           <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
           <span>Default limits: 100 calls/min, 10,000 calls/day per key</span>
+        </div>
+
+        <div
+          style={stagger("0.08s")}
+          className="mt-6 rounded-xl border border-[#d97757]/30 bg-[#d97757]/[0.06] p-4"
+        >
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 text-sm font-semibold text-content">
+                <Link2 className="h-4 w-4 text-[#d97757]" aria-hidden="true" />
+                Public research starts without a key
+              </div>
+              <p className="mt-2 max-w-2xl text-sm leading-relaxed text-content-secondary">
+                External apps can call the hosted `public-research` and `gmail-research`
+                MCP profiles anonymously for the first sourced dossier. Create a key when
+                the user links NodeBench for saved history, higher limits, team usage,
+                webhooks, and billing controls.
+              </p>
+            </div>
+            <code className="shrink-0 rounded-lg border border-white/[0.08] bg-black/20 px-3 py-2 font-mono text-[11px] leading-relaxed text-content">
+              ?profile=gmail-research
+            </code>
+          </div>
         </div>
 
         {/* New key banner */}

--- a/src/layouts/CockpitLayout.tsx
+++ b/src/layouts/CockpitLayout.tsx
@@ -301,6 +301,14 @@ export function CockpitLayout({
     setShowSettingsModal(true);
   }, []);
 
+  useEffect(() => {
+    if (location.pathname === "/settings" || location.pathname.startsWith("/settings/")) {
+      const params = new URLSearchParams(location.search);
+      const pathTab = location.pathname.split("/")[2];
+      openSettings(params.get("tab") ?? pathTab ?? undefined);
+    }
+  }, [location.pathname, location.search, openSettings]);
+
   // Command palette
   const commandPalette = useCommandPalette();
   const paletteWasOpenRef = useRef(false);

--- a/src/layouts/settings/SettingsModal.tsx
+++ b/src/layouts/settings/SettingsModal.tsx
@@ -1422,6 +1422,27 @@ export function SettingsModal({ isOpen, onClose, initialTab }: Props) {
               </div>
             ) : active === "connections" ? (
               <div className="space-y-6">
+                <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-950 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-100">
+                  <div className="flex items-start gap-3">
+                    <Link className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                    <div className="space-y-2">
+                      <div className="font-semibold">Start with public research, then link for memory.</div>
+                      <p className="text-xs leading-relaxed text-blue-900/80 dark:text-blue-100/80">
+                        A first company, person, or role dossier can run without sign-in. Link NodeBench when you want saved research history,
+                        higher limits, shared team usage, API keys, webhooks, and billing controls.
+                      </p>
+                      <div className="flex flex-wrap gap-2 text-[11px] font-medium">
+                        <span className="rounded-full bg-white/80 px-2 py-1 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100">
+                          first dossier: anonymous
+                        </span>
+                        <span className="rounded-full bg-white/80 px-2 py-1 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100">
+                          memory and limits: linked
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 {/* AI Services */}
                 <div className="space-y-4">
                   <h3 className="text-sm font-semibold text-content">AI Services</h3>


### PR DESCRIPTION
## Summary

- Allow only public-research MCP gateway functions to execute without `MCP_SECRET`.
- Keep internal/document/memory/builder/control-plane gateway functions secret-gated.
- Add account/profile/request-id metadata and estimated cost units to the MCP ledger for anonymous and token-backed profile calls.
- Add stable anonymous attribution via optional `x-nodebench-client-id` and document the public-profile accounting contract.

## Validation

- `npx tsc -p convex --noEmit --pretty false`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- GitHub CI: Typecheck, Runtime smoke, Build, Vercel preflight, PR style, tag chronology green

## Notes

Tier B preview smoke can cancel while waiting for a preview URL on backend/MCP-only changes. The production Vercel status for the head commit is green.