### PR TITLE
fix(home): surface live public research memory

### DIFF
--- a/convex/domains/publicResearch/core.ts
+++ b/convex/domains/publicResearch/core.ts
@@ -148,6 +148,25 @@ function privateBoundaryStatus(claim: string, evidence: string): "clean" | "priv
   return "clean";
 }
 
+function isPublicLatestSafeEntity(entityKey: string, entityName: string): boolean {
+  const normalizedName = normalizeName(entityName).replace(/\u2019/g, "'");
+  const normalizedKey = entityKey.toLowerCase();
+  if (!normalizedName || normalizedName === "unknown entity") return false;
+  if (/^(re|fw|fwd):\s/.test(normalizedName)) return false;
+  if (normalizedKey.startsWith("role:re-")) return false;
+  if (
+    /\b(gmail|inbox|email thread|recruiter email|pinned resume|private artifact|no-reply|noreply)\b/.test(normalizedName)
+  ) {
+    return false;
+  }
+  if (/\b(great opportunity|the posting here|a fantastic)\b/.test(normalizedName)) return false;
+  if (/\bfrom [a-z0-9 ._-]{2,80}'s\b/.test(normalizedName)) return false;
+  if (normalizedName.length > 96 && /\b(role|opportunity|engineer|recruiter|hiring)\b/.test(normalizedName)) {
+    return false;
+  }
+  return true;
+}
+
 function evaluateClaim(args: {
   claim: string;
   evidenceSnippet: string;
@@ -698,32 +717,44 @@ export const listLatestPublicEntityResearch = query({
       .query("publicResearchRuns")
       .withIndex("by_updated")
       .order("desc")
-      .take(limit * 2);
+      .take(limit * 8);
     const rows: any[] = [];
     const seen = new Set<string>();
     for (const run of runs) {
       if (seen.has(run.entityKey)) continue;
+      if (run.status !== "ready" && run.status !== "needs_review") continue;
       seen.add(run.entityKey);
       const entity = run.entityId ? await ctx.db.get(run.entityId) : null;
+      const entityName = entity?.canonicalName ?? run.entityName;
+      const entityType = entity?.entityType ?? run.kind;
+      if (!isPublicLatestSafeEntity(run.entityKey, entityName)) continue;
       const claims = await ctx.db
         .query("publicResearchClaims")
         .withIndex("by_entity_updated", (q) => q.eq("entityKey", run.entityKey))
         .order("desc")
-        .take(3);
+        .take(8);
+      const publicClaims = claims
+        .filter((claim: any) =>
+          claim.sourceIsPublic &&
+          claim.privateBoundaryStatus === "clean" &&
+          (claim.verifierStatus === "verified" || claim.verifierStatus === "needs_review")
+        )
+        .slice(0, 3);
+      if (publicClaims.length === 0) continue;
       rows.push({
         researchRunId: run.researchRunId,
         status: run.status,
         entityKey: run.entityKey,
-        entityName: entity?.canonicalName ?? run.entityName,
-        entityType: entity?.entityType ?? run.kind,
+        entityName,
+        entityType,
         updatedAt: run.updatedAt,
-        claimCount: run.claimCount,
-        sourceCount: run.sourceCount,
-        confidence: claims.length
-          ? claims.reduce((sum: number, claim: any) => sum + claim.confidence, 0) / claims.length
+        claimCount: publicClaims.length,
+        sourceCount: new Set(publicClaims.map((claim: any) => claim.sourceUrl)).size,
+        confidence: publicClaims.length
+          ? publicClaims.reduce((sum: number, claim: any) => sum + claim.confidence, 0) / publicClaims.length
           : entity?.confidence ?? 0,
-        summary: claims.map((claim: any) => claim.claim).join(" "),
-        sources: Array.from(new Map(claims.map((claim: any) => [claim.sourceUrl, {
+        summary: publicClaims.map((claim: any) => claim.claim).join(" "),
+        sources: Array.from(new Map(publicClaims.map((claim: any) => [claim.sourceUrl, {
           title: claim.sourceTitle,
           url: claim.sourceUrl,
         }])).values()),

--- a/convex/domains/publicResearch/core.ts
+++ b/convex/domains/publicResearch/core.ts
@@ -151,18 +151,45 @@ function privateBoundaryStatus(claim: string, evidence: string): "clean" | "priv
 function isPublicLatestSafeEntity(entityKey: string, entityName: string): boolean {
   const normalizedName = normalizeName(entityName).replace(/\u2019/g, "'");
   const normalizedKey = entityKey.toLowerCase();
+  const wordCount = normalizedName.split(/\s+/).filter(Boolean).length;
   if (!normalizedName || normalizedName === "unknown entity") return false;
   if (/^(re|fw|fwd):\s/.test(normalizedName)) return false;
-  if (normalizedKey.startsWith("role:re-")) return false;
+  if (/^(ver|voir|view|apply)\s/.test(normalizedName)) return false;
+  if (normalizedKey.startsWith("role:re-") || normalizedKey.startsWith("role:ver-")) return false;
   if (
-    /\b(gmail|inbox|email thread|recruiter email|pinned resume|private artifact|no-reply|noreply)\b/.test(normalizedName)
+    /\b(gmail|inbox|email thread|recruiter email|pinned resume|private artifact|no-reply|noreply|homen)\b/.test(normalizedName)
   ) {
     return false;
   }
-  if (/\b(great opportunity|the posting here|a fantastic)\b/.test(normalizedName)) return false;
+  if (/\b(great opportunity|the posting here|a fantastic|happy monday|apply to|with no fee|from march|master of financial)\b/.test(normalizedName)) return false;
   if (/\bfrom [a-z0-9 ._-]{2,80}'s\b/.test(normalizedName)) return false;
-  if (normalizedName.length > 96 && /\b(role|opportunity|engineer|recruiter|hiring)\b/.test(normalizedName)) {
+  if (normalizedName.length > 72 && /\b(role|opportunity|engineer|recruiter|hiring|founder|cto|apply)\b/.test(normalizedName)) {
     return false;
+  }
+  if (wordCount > 8 && /\b(at|from|for|with)\b/.test(normalizedName)) {
+    return false;
+  }
+  if (normalizedKey.startsWith("role:") && /\$|salary|\bbase\b|\bopportunity\b/.test(normalizedName)) {
+    return false;
+  }
+  if (normalizedKey.startsWith("company:") && normalizedName.includes("+")) return false;
+  return true;
+}
+
+function isPublicLatestSafeRow(args: {
+  entityType: string;
+  entityName: string;
+  claims: Array<{ claim: string; sourceTitle?: string; sourceUrl?: string }>;
+}): boolean {
+  const normalizedName = normalizeName(args.entityName);
+  const combinedClaims = args.claims.map((claim) => normalizeName(claim.claim)).join("\n");
+  if (/\b(could not be found|not identify a specific company|search did not return|does not identify a specific company)\b/.test(combinedClaims)) {
+    return false;
+  }
+  if (args.entityType === "company") {
+    const words = normalizedName.split(/\s+/).filter(Boolean);
+    const hasCompanySignal = /\b(ai|labs?|group|inc|llc|corp|corporation|company|ventures?|capital|systems?|technolog(?:y|ies)|software|health|bank|university|school)\b/.test(normalizedName);
+    if (words.length === 2 && !hasCompanySignal) return false;
   }
   return true;
 }
@@ -741,6 +768,7 @@ export const listLatestPublicEntityResearch = query({
         )
         .slice(0, 3);
       if (publicClaims.length === 0) continue;
+      if (!isPublicLatestSafeRow({ entityType, entityName, claims: publicClaims })) continue;
       rows.push({
         researchRunId: run.researchRunId,
         status: run.status,

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -94,6 +94,20 @@ type WebSurfaceProps = {
 type LaneId = "answer" | "deep";
 type MobileSurface = "home" | "reports" | "chat" | "inbox" | "me";
 
+type PublicResearchHomeRow = {
+  researchRunId: string;
+  status: string;
+  entityKey: string;
+  entityName: string;
+  entityType: string;
+  updatedAt: number;
+  claimCount: number;
+  sourceCount: number;
+  confidence: number;
+  summary?: string;
+  sources?: Array<{ title?: string; url: string }>;
+};
+
 const LANES: Array<{ id: LaneId; label: string; note: string }> = [
   { id: "answer", label: "Quick answer", note: "fast read" },
   { id: "deep", label: "Deep research", note: "more sources" },
@@ -1030,6 +1044,12 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
   const loggedInUser = useQuery(
     (api as any)?.domains?.auth?.auth?.loggedInUser ?? "skip",
   );
+  const latestPublicResearch = useQuery(
+    (api as any)?.domains?.publicResearch?.core?.listLatestPublicEntityResearch ?? "skip",
+    (api as any)?.domains?.publicResearch?.core?.listLatestPublicEntityResearch
+      ? { limit: 8 }
+      : "skip",
+  ) as PublicResearchHomeRow[] | undefined;
   const startPipelineRun = useMutation(
     generatedApi.domains.pipelines.pipelineWorkflow.startPipelineRun,
   );
@@ -1226,6 +1246,42 @@ export function ExactHomeSurface(_props: WebSurfaceProps) {
           ))}
         </div>
       </section>
+
+      {(latestPublicResearch?.length ?? 0) > 0 ? (
+        <section className="nb-public-memory" data-testid="exact-latest-public-research">
+          <div className="nb-public-memory-head">
+            <div>
+              <div className="nb-kicker">Latest public research</div>
+              <h2>Reusable public memory from recent entity runs.</h2>
+            </div>
+            <span>Public claims only</span>
+          </div>
+          <div className="nb-public-memory-grid">
+            {latestPublicResearch?.slice(0, 6).map((item) => (
+              <button
+                key={item.entityKey}
+                type="button"
+                className="nb-public-memory-card"
+                onClick={() => start(`Open public dossier for ${item.entityName}`)}
+              >
+                <div className="nb-public-memory-card-top">
+                  <div>
+                    <strong>{item.entityName}</strong>
+                    <small>{item.entityType} - {item.status.replace(/_/g, " ")} - {formatRelativeWhen(item.updatedAt)}</small>
+                  </div>
+                  <ArrowUpRight size={15} />
+                </div>
+                <p>{item.summary || "Research run recorded. Verified public claims appear as sources are extracted."}</p>
+                <div className="nb-public-memory-meta">
+                  <span>{item.claimCount} claim{item.claimCount === 1 ? "" : "s"}</span>
+                  <span>{item.sourceCount} source{item.sourceCount === 1 ? "" : "s"}</span>
+                  <span>{Math.round((item.confidence || 0) * 100)}% confidence</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       <FirstImpressionBoard
         horizon={horizon}
@@ -3499,6 +3555,7 @@ function MobileReportsPipelineBlock() {
 
 function MobileHomeBody() {
   const navigate = useNavigate();
+  const api = useConvexApi();
   const [mobileQuery, setMobileQuery] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -3506,6 +3563,12 @@ function MobileHomeBody() {
     generatedApi.domains.pipelines.pipelineWorkflow.startPipelineRun,
   );
   const anonymousSessionId = useMemo(() => getAnonymousProductSessionId(), []);
+  const latestPublicResearch = useQuery(
+    (api as any)?.domains?.publicResearch?.core?.listLatestPublicEntityResearch ?? "skip",
+    (api as any)?.domains?.publicResearch?.core?.listLatestPublicEntityResearch
+      ? { limit: 5 }
+      : "skip",
+  ) as PublicResearchHomeRow[] | undefined;
   const mobileCards = getFirstImpressionCards("today");
   const runMobileBackground = async (prompt = mobileQuery, title?: string) => {
     if (submitting) return;
@@ -3589,6 +3652,34 @@ function MobileHomeBody() {
         </button>
       </div>
       {feedback ? <div className="m-run-feedback" role="status">{feedback}</div> : null}
+      {(latestPublicResearch?.length ?? 0) > 0 ? (
+        <section className="m-section" data-testid="mobile-latest-public-research">
+          <header className="m-section-head">
+            <span className="kicker">Latest public research</span>
+            <a href="/?surface=reports">Public memory</a>
+          </header>
+          <div className="m-public-memory-stack">
+            {latestPublicResearch?.slice(0, 3).map((item) => (
+              <button
+                key={item.entityKey}
+                type="button"
+                className="m-public-memory-card"
+                onClick={() => navigate(buildCockpitPath({
+                  surfaceId: "workspace",
+                  extra: { q: `Open public dossier for ${item.entityName}`, lane: "answer" },
+                }))}
+              >
+                <div>
+                  <strong>{item.entityName}</strong>
+                  <small>{item.entityType} - {item.status.replace(/_/g, " ")} - {formatRelativeWhen(item.updatedAt)}</small>
+                </div>
+                <p>{item.summary || "Verified public claims appear as sources are extracted."}</p>
+                <span>{item.claimCount} claims - {item.sourceCount} sources</span>
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
       <section className="m-section" data-testid="mobile-home-first-impression">
         <header className="m-section-head"><span className="kicker">Use cases today</span><a href="/?surface=reports">Reports</a></header>
         <div className="m-scenario-stack">

--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -1753,6 +1753,54 @@
   opacity: 0.6;
 }
 
+.nb-mobile-kit .m-public-memory-stack {
+  display: grid;
+  gap: 9px;
+}
+
+.nb-mobile-kit .m-public-memory-card {
+  width: 100%;
+  border: 1px solid var(--border-subtle);
+  border-radius: 13px;
+  background: var(--bg-surface);
+  padding: 11px 12px;
+  text-align: left;
+  box-shadow: var(--shadow-sm);
+}
+
+.nb-mobile-kit .m-public-memory-card strong {
+  display: block;
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.nb-mobile-kit .m-public-memory-card small {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-faint);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.nb-mobile-kit .m-public-memory-card p {
+  margin: 8px 0;
+  color: var(--text-muted);
+  display: -webkit-box;
+  font-size: 11.5px;
+  line-height: 1.4;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.nb-mobile-kit .m-public-memory-card span {
+  color: var(--accent-ink);
+  font-size: 11px;
+  font-weight: 800;
+}
+
 .nb-mobile-kit .m-watch-tile,
 .nb-mobile-kit .m-nudge,
 .nb-mobile-kit .m-thread,
@@ -6528,6 +6576,140 @@
   width: 22px;
   height: 22px;
   margin-bottom: 0;
+}
+
+.nb-kit .nb-public-memory {
+  margin: 0 auto;
+  max-width: 960px;
+  width: 100%;
+}
+
+.nb-kit .nb-public-memory-head {
+  align-items: flex-end;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.nb-kit .nb-public-memory-head h2 {
+  color: var(--text-primary);
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  margin: 5px 0 0;
+}
+
+.nb-kit .nb-public-memory-head > span {
+  border: 1px solid var(--border-default);
+  border-radius: 999px;
+  color: var(--text-muted);
+  flex: none;
+  font-size: 11px;
+  font-weight: 760;
+  padding: 6px 10px;
+}
+
+.nb-kit .nb-public-memory-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.nb-kit .nb-public-memory-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  background: var(--bg-surface);
+  color: inherit;
+  min-height: 172px;
+  padding: 14px;
+  text-align: left;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.nb-kit .nb-public-memory-card:hover {
+  border-color: var(--accent-primary-border);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.nb-kit .nb-public-memory-card-top {
+  align-items: flex-start;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.nb-kit .nb-public-memory-card-top strong {
+  color: var(--text-primary);
+  display: block;
+  font-size: 14px;
+  line-height: 1.2;
+}
+
+.nb-kit .nb-public-memory-card-top small {
+  color: var(--text-faint);
+  display: block;
+  font-size: 10px;
+  font-weight: 820;
+  line-height: 1.4;
+  margin-top: 5px;
+  text-transform: uppercase;
+}
+
+.nb-kit .nb-public-memory-card-top svg {
+  color: var(--text-faint);
+  flex: none;
+  transition: color 160ms ease;
+}
+
+.nb-kit .nb-public-memory-card:hover .nb-public-memory-card-top svg {
+  color: var(--accent-primary);
+}
+
+.nb-kit .nb-public-memory-card p {
+  color: var(--text-muted);
+  display: -webkit-box;
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 12px 0 0;
+  min-height: 36px;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.nb-kit .nb-public-memory-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.nb-kit .nb-public-memory-meta span {
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 760;
+  padding: 4px 7px;
+}
+
+@media (max-width: 880px) {
+  .nb-kit .nb-public-memory-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .nb-kit .nb-public-memory-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nb-kit .nb-public-memory-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .nb-kit .nb-first-list {


### PR DESCRIPTION
## Summary

- Show recent claim-backed public research rows on desktop Home and mobile Home instead of leaving first-impression memory at zero.
- Filter latest public research to safe, public, claim-backed entities before rendering.
- Add compact public-memory card styling for desktop and mobile.

## Validation

- npx tsc -p convex --noEmit --pretty false
- npx tsc --noEmit --pretty false
- npm run build
