### PR TITLE
ci: streamline required checks and release runbook

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+-
+
+## Validation
+
+- [ ] `npx tsc -p convex --noEmit --pretty false`
+- [ ] `npx tsc --noEmit --pretty false`
+- [ ] `npm run build`
+- [ ] Browser or API smoke for changed surface:
+
+## Release Notes
+
+- Required checks expected: `Typecheck`, `Runtime smoke`, `Build`, `Tier B vs preview URL`
+- If checks do not attach, follow `docs/runbooks/GITHUB_ACTIONS_OPERATIONS.md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,24 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
+  merge_group:
   workflow_dispatch:
+    inputs:
+      reason:
+        description: "Optional reason for manually running the required CI gates"
+        required: false
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/tier-b-preview.yml
+++ b/.github/workflows/tier-b-preview.yml
@@ -28,8 +28,19 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
   workflow_dispatch:
     inputs:
+      pr_number:
+        description: "PR number to inspect for changed files when running manually"
+        required: false
+      head_ref:
+        description: "Head branch to poll in Vercel when running manually"
+        required: false
+      head_sha:
+        description: "Head SHA to prefer when running manually"
+        required: false
       preview_url:
         description: "Override preview URL (skip Vercel polling)"
         required: false
@@ -39,7 +50,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: tier-b-preview-${{ github.ref }}
+  group: tier-b-preview-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -65,8 +76,18 @@ jobs:
           # touch any path Vercel actually serves, no preview will ever exist.
           # Don't block such PRs (docs-only, .github/-only, etc.).
           BUILD_RELEVANT=(src convex packages apps public server shared api scripts/vercel-build.sh vercel.json package.json package-lock.json tsconfig.json tsconfig.node.json vite.config.ts vite.config.mjs index.html)
+          if [ -n "${OVERRIDE_URL:-}" ]; then
+            echo "has_relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Manual preview URL supplied; running Tier B against it."
+            exit 0
+          fi
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "has_relevant=true" >> "$GITHUB_OUTPUT"
+            echo "No PR number available for changed-file detection; assuming relevant."
+            exit 0
+          fi
           # Get changed files for this PR
-          CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only 2>/dev/null || echo "")
+          CHANGED=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || echo "")
           if [ -z "$CHANGED" ]; then
             # Fallback: if we can't get the diff, assume relevant
             echo "has_relevant=true" >> "$GITHUB_OUTPUT"
@@ -84,6 +105,8 @@ jobs:
           echo "::notice::PR touches no build-relevant paths — Vercel will not build a preview, Tier B skipped."
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          OVERRIDE_URL: ${{ github.event.inputs.preview_url }}
 
       - name: Resolve Vercel preview URL
         id: preview
@@ -92,8 +115,8 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
-          GITHUB_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.event.inputs.head_sha || github.sha }}
+          GITHUB_REF: ${{ github.event.pull_request.head.ref || github.event.inputs.head_ref || github.ref_name }}
           OVERRIDE_URL: ${{ github.event.inputs.preview_url }}
         run: |
           if [ -n "$OVERRIDE_URL" ]; then
@@ -149,13 +172,28 @@ jobs:
                   // Prefer the deployment whose meta.githubCommitSha matches.
                   // Otherwise pick the most-recent terminal deployment for the branch
                   // (Vercel may have rebuilt with a different SHA after rebase/merge).
-                  const exactMatch = deployments.find(d => {
+                  const state = (d) => d.readyState || d.state;
+                  const exactReady = deployments.find(d => {
                     const m = d.meta || {};
-                    return (m.githubCommitSha === sha || m.commitSha === sha) && isTerminal(d);
+                    return (m.githubCommitSha === sha || m.commitSha === sha) && state(d) === 'READY';
                   });
-                  const dep = exactMatch || deployments.find(isTerminal);
+                  const exactError = deployments.find(d => {
+                    const m = d.meta || {};
+                    return (m.githubCommitSha === sha || m.commitSha === sha) && state(d) === 'ERROR';
+                  });
+                  // If the latest exact SHA was ignored because it is docs-only
+                  // but the branch already has a READY preview from the previous
+                  // app commit, run against that preview instead of skipping.
+                  const branchReady = deployments.find(d => state(d) === 'READY');
+                  const exactCanceled = deployments.find(d => {
+                    const m = d.meta || {};
+                    return (m.githubCommitSha === sha || m.commitSha === sha) && state(d) === 'CANCELED';
+                  });
+                  const branchError = deployments.find(d => state(d) === 'ERROR');
+                  const branchCanceled = deployments.find(d => state(d) === 'CANCELED');
+                  const dep = exactReady || exactError || branchReady || exactCanceled || branchError || branchCanceled;
                   if (dep) {
-                    const st = dep.readyState || dep.state;
+                    const st = state(dep);
                     if (st === 'READY') console.log('READY:https://' + dep.url);
                     else if (st === 'CANCELED') console.log('CANCELED:vercel-marked-ignored');
                     else if (st === 'ERROR') console.log('ERROR:vercel-build-failed');
@@ -192,6 +230,12 @@ jobs:
       - name: Install Playwright browsers
         if: steps.preview.outputs.preview_status == 'ready'
         run: npx playwright install --with-deps chromium
+
+      - name: Tier B summary
+        if: always()
+        run: |
+          echo "preview_status=${{ steps.preview.outputs.preview_status || 'not_resolved' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "preview_url=${{ steps.preview.outputs.url || 'none' }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Tier B regression + one-flow regression against preview
         if: steps.preview.outputs.preview_status == 'ready'

--- a/.github/workflows/vercel-preflight.yml
+++ b/.github/workflows/vercel-preflight.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
   workflow_dispatch:
     inputs:
       target:
@@ -20,7 +22,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: vercel-preflight-${{ github.ref }}
+  group: vercel-preflight-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/runbooks/GITHUB_ACTIONS_OPERATIONS.md
+++ b/docs/runbooks/GITHUB_ACTIONS_OPERATIONS.md
@@ -1,0 +1,138 @@
+# GitHub Actions Operations Runbook
+
+This repo protects `main` with four required checks:
+
+- `Typecheck`
+- `Runtime smoke`
+- `Build`
+- `Tier B vs preview URL`
+
+The expected path is:
+
+```text
+branch -> PR -> required checks -> squash merge -> Convex deploy -> Vercel prod -> smoke verify
+```
+
+## Required Gates
+
+`CI` owns the first three required checks:
+
+- `Typecheck`: Convex codegen, app typecheck, Convex typecheck.
+- `Runtime smoke`: focused Vitest coverage for server parsing, agent harness,
+  capture routing, workspace persistence, event memory, and search route.
+- `Build`: production Vite build after the first two gates pass.
+
+`Tier B regression (preview)` owns the preview smoke:
+
+- It runs Playwright against the Vercel preview when a preview exists.
+- It skips green for docs-only or otherwise non-servable PRs.
+- If the latest SHA is Vercel-ignored but an earlier ready preview exists for
+  the same branch, it tests that ready preview instead of waiting forever.
+
+## Manual Recovery
+
+If a PR shows "required checks expected" but no runs attach:
+
+1. Confirm workflows are active.
+
+```powershell
+gh workflow list --repo HomenShum/nodebench-ai --all
+```
+
+2. Inspect branch runs.
+
+```powershell
+gh run list --repo HomenShum/nodebench-ai --branch <branch> --limit 20
+gh pr checks <pr> --repo HomenShum/nodebench-ai
+```
+
+3. Dispatch CI if the account can run workflow dispatch.
+
+```powershell
+gh workflow run ci.yml --repo HomenShum/nodebench-ai --ref <branch> -f reason="rerun required gates"
+```
+
+4. Dispatch Tier B with a known preview URL when Vercel already produced one.
+
+```powershell
+gh workflow run tier-b-preview.yml --repo HomenShum/nodebench-ai --ref <branch> `
+  -f pr_number=<pr> `
+  -f head_ref=<branch> `
+  -f head_sha=<sha> `
+  -f preview_url=https://<preview>.vercel.app
+```
+
+5. If GitHub Actions cannot be dispatched from the current account, do not
+   silently bypass branch protection. Run local gates, get explicit approval, then
+   temporarily clear only `required_status_checks`, merge, and immediately restore
+   the exact four checks.
+
+Capture current required checks:
+
+```powershell
+gh api repos/HomenShum/nodebench-ai/branches/main/protection/required_status_checks
+```
+
+Clear checks only after explicit approval:
+
+```powershell
+@'
+{"strict":true,"contexts":[],"checks":[]}
+'@ | Set-Content -Encoding utf8 .tmp/required-status-checks-empty.json
+
+gh api repos/HomenShum/nodebench-ai/branches/main/protection/required_status_checks `
+  --method PATCH `
+  --input .tmp/required-status-checks-empty.json
+```
+
+Restore immediately:
+
+```powershell
+@'
+{
+  "strict": true,
+  "checks": [
+    {"context":"Typecheck","app_id":15368},
+    {"context":"Runtime smoke","app_id":15368},
+    {"context":"Build","app_id":15368},
+    {"context":"Tier B vs preview URL","app_id":15368}
+  ]
+}
+'@ | Set-Content -Encoding utf8 .tmp/required-status-checks-restore.json
+
+gh api repos/HomenShum/nodebench-ai/branches/main/protection/required_status_checks `
+  --method PATCH `
+  --input .tmp/required-status-checks-restore.json
+
+gh api repos/HomenShum/nodebench-ai/branches/main/protection/required_status_checks
+```
+
+## Release Checklist
+
+Before merge:
+
+```powershell
+npx tsc -p convex --noEmit --pretty false
+npx tsc --noEmit --pretty false
+npm run build
+```
+
+After merge:
+
+```powershell
+git fetch origin main
+npm run deploy:convex
+```
+
+Verify production:
+
+```powershell
+node -e "fetch('https://www.nodebenchai.com/?surface=reports').then(r=>console.log(r.status,r.headers.get('x-vercel-id')))"
+node -e "fetch('https://nodebench-mcp-unified.onrender.com/health').then(r=>r.json()).then(j=>console.log(j.status,j.tools,j.anonymousProfiles))"
+```
+
+For public MCP profile verification:
+
+```powershell
+node -e "fetch('https://nodebench-mcp-unified.onrender.com?profile=gmail-research',{method:'POST',headers:{'content-type':'application/json','x-nodebench-client':'release-verify','x-nodebench-client-id':'release-verify'},body:JSON.stringify({jsonrpc:'2.0',id:1,method:'tools/list'})}).then(async r=>console.log(r.status,r.headers.get('x-nodebench-auth-mode'),r.headers.get('x-nodebench-account-key'),(await r.json()).result.tools.length))"
+```


### PR DESCRIPTION
## Summary

- Make required CI workflows trigger predictably on PR open/sync/reopen/ready and merge queue events.
- Make Tier B preview checks easier to recover manually and smarter when Vercel ignores a docs-only latest SHA but an earlier ready preview exists.
- Add a PR template and GitHub Actions operations runbook for required-check recovery, release, Convex deploy, and production verification.

## Validation

- npx prettier --check .github/workflows/ci.yml .github/workflows/tier-b-preview.yml .github/workflows/vercel-preflight.yml .github/pull_request_template.md docs/runbooks/GITHUB_ACTIONS_OPERATIONS.md
