### PR TITLE
fix(home): import public memory card icon

### DIFF
--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -6,6 +6,7 @@ import { useConvexApi } from "@/lib/convexApi";
 import { getAnonymousProductSessionId } from "@/features/product/lib/productIdentity";
 import {
   Archive,
+  ArrowUpRight,
   Bell,
   BookOpen,
   Bot,


### PR DESCRIPTION
## Summary

- Add the missing ArrowUpRight import used by the Home public-memory card.
- Use this tiny PR as a post-workflow-cleanup check that fresh PR events attach required checks.

## Validation

- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
