### PR TITLE
feat(redesign): wire live artifacts into reports

### DIFF
--- a/src/features/designKit/exact/exactKit.css
+++ b/src/features/designKit/exact/exactKit.css
@@ -682,12 +682,12 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  max-height: 0;
-  margin-top: 0;
-  opacity: 0;
+  max-height: 72px;
+  margin-top: 4px;
+  opacity: 1;
   overflow: hidden;
-  pointer-events: none;
-  transform: translateY(4px);
+  pointer-events: auto;
+  transform: translateY(0);
   transition: max-height 180ms var(--ease-out-expo), margin-top 180ms var(--ease-out-expo), opacity 160ms ease, transform 180ms var(--ease-out-expo);
 }
 

--- a/src/features/onboarding/components/OnboardingWizard.tsx
+++ b/src/features/onboarding/components/OnboardingWizard.tsx
@@ -22,18 +22,18 @@ interface HowItWorksCard {
 
 const HOW_IT_WORKS_CARDS: HowItWorksCard[] = [
   {
-    label: "Describe",
-    description: "Type your startup idea in one sentence — NodeBench figures out your market, stage, and the criteria that apply",
+    label: "Capture",
+    description: "Ask, paste, upload, or record messy context about a company, person, market, event, or account.",
     Icon: MessageSquare,
   },
   {
-    label: "See gaps",
-    description: "Get the invisible scorecard: what VCs check, what you're missing, and what could kill the deal",
+    label: "Preserve",
+    description: "NodeBench turns the answer into a living report with sources, claims, notes, relationships, and follow-ups.",
     Icon: BarChart3,
   },
   {
-    label: "Act",
-    description: "Ranked next steps, pitch-ready memos, and evidence packets you can share with investors or your team",
+    label: "Scale",
+    description: "Reuse your style, rubric, and evidence rules across the next entity list instead of starting over.",
     Icon: Activity,
   },
 ];
@@ -145,10 +145,11 @@ function StepWelcome() {
 
       <h2 className="text-2xl font-semibold text-content">Welcome to NodeBench</h2>
       <p className="mt-2 text-base font-medium text-accent-primary">
-        See the invisible checklist investors use to judge you
+        Turn messy context into reusable entity intelligence.
       </p>
       <p className="mt-4 text-sm leading-relaxed text-content-muted">
-        Describe your idea in one sentence. NodeBench shows you the hidden criteria VCs, accelerators, and banks use — so you know exactly what's missing before you pitch.
+        Chat creates the intelligence. Reports preserve it. Notebooks edit it. Sources verify it.
+        Start with one question, then keep compounding the report instead of rebuilding from scratch.
       </p>
     </div>
   );
@@ -190,21 +191,21 @@ function StepTryIt() {
             1
           </span>
           <span>
-            <strong className="text-content">Describe your idea</strong> in one sentence — even "AI tutoring for students" works
+            <strong className="text-content">Ask or capture anything</strong> about a company, person, market, event, or account
           </span>
         </li>
         <li className="flex items-start gap-3">
           <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent-primary/10 text-[10px] font-bold text-accent-primary">
             2
           </span>
-          <span>See the investor checklist: gaps, objections, and what to build first</span>
+          <span>Get a sourced answer that saves into a reusable report, not a disposable chat turn</span>
         </li>
         <li className="flex items-start gap-3">
           <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent-primary/10 text-[10px] font-bold text-accent-primary">
             3
           </span>
           <span>
-            Export a pitch-ready memo, share with co-founders, or connect:{" "}
+            Export a memo, resume the attached chat, or connect automation through:{" "}
             <code className="rounded bg-white/[0.06] px-1.5 py-0.5 text-xs text-accent-primary">
               npx nodebench-mcp
             </code>

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -55,16 +55,31 @@ function pathToReportId(pathname: string): string | null {
   return match?.[1] ?? null;
 }
 
+type WorkspaceTab = "brief" | "cards" | "notebook" | "sources" | "chat" | "map";
+
+function workspaceParams(search: string): { reportId: string; tab: WorkspaceTab } {
+  const params = new URLSearchParams(search);
+  const reportId = params.get("report") || "rep_orbital";
+  const tab = params.get("tab");
+  const workspaceTab: WorkspaceTab =
+    tab === "cards" || tab === "notebook" || tab === "sources" || tab === "chat" || tab === "map"
+      ? tab
+      : "brief";
+  return { reportId, tab: workspaceTab };
+}
+
 export default function RedesignShell() {
   const location = useLocation();
   const navigate = useNavigate();
   const [theme, setTheme] = useState<"light" | "dark">("light");
   const [forceMobile, setForceMobile] = useState(false);
   const isMobile = useViewportMobile() || forceMobile;
+  const showQaChrome = useQaChromeFlag(location.search);
   const cmdk = useCommandPalette();
 
   const surface = useMemo(() => pathToSurface(location.pathname), [location.pathname]);
   const reportId = useMemo(() => pathToReportId(location.pathname), [location.pathname]);
+  const workspace = useMemo(() => workspaceParams(location.search), [location.search]);
   const goSurface = (id: SurfaceId) => {
     navigate(id === "home" ? "/redesign" : `/redesign/${id}`);
   };
@@ -85,8 +100,8 @@ export default function RedesignShell() {
     return (
       <div data-redesign data-redesign-theme={theme} style={{ height: "100dvh", overflow: "hidden" }}>
         <MobileShell active={mobileSurface} onChange={(id) => goSurface(id)} />
-        <ThemeFab theme={theme} setTheme={setTheme} />
-        <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />
+        {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
+        {showQaChrome && <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />}
         <NavBanner pathname={location.pathname} />
         <CommandPalette open={cmdk.open} onClose={() => cmdk.setOpen(false)} />
         <ShortcutsOverlay />
@@ -105,10 +120,10 @@ export default function RedesignShell() {
             onOpenWorkspace={goWorkspace}
           />
           <main className="rd-pane" style={{ borderRight: "none" }}>
-            <WorkspaceSurface />
+            <WorkspaceSurface reportId={workspace.reportId} initialTab={workspace.tab} />
           </main>
         </div>
-        <ThemeFab theme={theme} setTheme={setTheme} />
+        {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
         <CommandPalette open={cmdk.open} onClose={() => cmdk.setOpen(false)} />
         <ShortcutsOverlay />
         <ToastViewport />
@@ -147,6 +162,11 @@ export default function RedesignShell() {
             {surface === "reports" && !reportId && (
               <ReportsSurface
                 onOpen={(id, tab) => {
+                  if (id.startsWith("li_") || id.startsWith("daily_") || id.startsWith("run_")) {
+                    const workspaceTab = tab === "chat" ? "chat" : tab === "cards" ? "sources" : "brief";
+                    navigate(`/redesign/workspace?report=${id}&tab=${workspaceTab}`);
+                    return;
+                  }
                   if (tab === "brief") navigate(`/redesign/reports/${id}`);
                   else navigate(`/redesign/workspace?report=${id}&tab=${tab}`);
                 }}
@@ -161,8 +181,8 @@ export default function RedesignShell() {
         )}
       </div>
 
-      <ThemeFab theme={theme} setTheme={setTheme} />
-      <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />
+      {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
+      {showQaChrome && <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />}
       <NavBanner pathname={location.pathname} />
 
       {/* Cross-surface primitives — Cmd+K palette, ? shortcuts, toasts */}
@@ -171,6 +191,19 @@ export default function RedesignShell() {
       <ToastViewport />
     </div>
   );
+}
+
+function useQaChromeFlag(search: string): boolean {
+  return useMemo(() => {
+    if (import.meta.env.DEV) return true;
+    const params = new URLSearchParams(search);
+    if (params.get("qaChrome") === "1" || params.get("debugUi") === "1") return true;
+    try {
+      return window.localStorage.getItem("nodebench-redesign-qa-chrome") === "1";
+    } catch {
+      return false;
+    }
+  }, [search]);
 }
 
 function useViewportMobile() {

--- a/src/features/redesign/components/MobileShell.tsx
+++ b/src/features/redesign/components/MobileShell.tsx
@@ -12,10 +12,13 @@
  */
 
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import type { SurfaceId } from "../fixtures";
 import { Pill } from "./Pill";
 import { reports, inboxItems, memoryPulse, sampleAnswer } from "../fixtures";
 import { UniversalComposer, type RouterTier } from "./UniversalComposer";
+import { useLiveArtifacts } from "../hooks/useLiveArtifacts";
+import { useReportsLive } from "../hooks/useReportsLive";
 
 interface MobileShellProps {
   active: SurfaceId;
@@ -61,7 +64,7 @@ export function MobileShell({ active, onChange }: MobileShellProps) {
 
       {/* Surface body — single column */}
       <div style={{ overflow: "auto", padding: "14px 14px 8px" }}>
-        {active === "home" && <MobileHome />}
+        {active === "home" && <MobileHome onOpenReports={() => onChange("reports")} onOpenChat={() => onChange("chat")} />}
         {active === "reports" && <MobileReports />}
         {active === "chat" && <MobileChat onOpenSheet={setSheet} />}
         {active === "inbox" && <MobileInbox />}
@@ -179,7 +182,26 @@ function TabIcon({ id, active }: { id: SurfaceId; active: boolean }) {
 
 /* ──────────────────────────── Surface bodies ──────────────────────────── */
 
-function MobileHome() {
+function MobileHome({ onOpenReports, onOpenChat }: { onOpenReports: () => void; onOpenChat: () => void }) {
+  const liveArtifacts = useLiveArtifacts(8);
+  const metrics = liveArtifacts.metrics.length > 0 ? liveArtifacts.metrics : memoryPulse;
+  const primaryReport = liveArtifacts.reports[0];
+  const pulseCards = liveArtifacts.pulse.length > 0
+    ? liveArtifacts.pulse
+    : [
+      {
+        kind: "memory_win" as const,
+        title: "Orbital Labs answered from event corpus",
+        body: "4 sources reused - 0 paid calls.",
+        meta: "2m ago",
+      },
+      {
+        kind: "follow_up" as const,
+        title: "Alex at Orbital Labs",
+        body: "Ask about healthcare pilot criteria.",
+        meta: "Due tomorrow",
+      },
+    ];
   return (
     <div className="rd-stack" style={{ gap: 14 }}>
       {/* Hero */}
@@ -195,17 +217,64 @@ function MobileHome() {
           fontFamily: "var(--rd-font-display)", fontSize: 22, fontWeight: 590,
           letterSpacing: "-0.4px", lineHeight: 1.2, margin: "10px 0 4px",
           color: "var(--rd-ink-strong)",
-        }}>What are we researching today?</h1>
+        }}>Capture now. Turn it into a report.</h1>
         <p className="rd-faint" style={{ fontSize: 12.5 }}>
-          Tap the composer below or speak a quick capture. NodeBench picks the right home.
+          Ask, paste, or record. NodeBench turns messy input into a source-backed entity workspace.
         </p>
       </div>
+
+      {liveArtifacts.isLive && (
+        <button
+          type="button"
+          className="rd-card"
+          onClick={onOpenReports}
+          style={{
+            width: "100%",
+            textAlign: "left",
+            padding: "12px 14px",
+            borderColor: "var(--rd-green-border)",
+            background: "var(--rd-green-bg)",
+          }}
+        >
+          <div className="rd-row" style={{ gap: 6, marginBottom: 6, flexWrap: "wrap" }}>
+            <Pill tone="green"><span className="rd-dot rd-dot--live" />Live public memory</Pill>
+            <Pill>{liveArtifacts.archiveCount} posts</Pill>
+            <Pill>{liveArtifacts.briefFeatureCount} brief checks</Pill>
+          </div>
+          <strong style={{ display: "block", fontSize: 13, color: "var(--rd-ink-strong)" }}>
+            {primaryReport?.entity ?? "Open the live coverage library"}
+          </strong>
+          <span style={{ display: "block", marginTop: 3, fontSize: 11.5, lineHeight: 1.35, color: "var(--rd-ink-mute)" }}>
+            {primaryReport?.description ?? "Recent NodeBench artifacts are already wired into Reports."}
+          </span>
+          <span className="rd-mono" style={{ display: "block", marginTop: 8, fontSize: 10.5, color: "var(--rd-green)" }}>
+            Open reports {">"}
+          </span>
+        </button>
+      )}
+
+      {!liveArtifacts.isLive && (
+        <button
+          type="button"
+          className="rd-card"
+          onClick={onOpenChat}
+          style={{ width: "100%", textAlign: "left", padding: "12px 14px" }}
+        >
+          <div className="rd-eyebrow" style={{ marginBottom: 5 }}>First run</div>
+          <strong style={{ display: "block", fontSize: 13, color: "var(--rd-ink-strong)" }}>
+            Ask one question, then multiply it across a list.
+          </strong>
+          <span className="rd-mono" style={{ display: "block", marginTop: 8, fontSize: 10.5, color: "var(--rd-accent-strong)" }}>
+            Start in chat {">"}
+          </span>
+        </button>
+      )}
 
       {/* Memory pulse condensed */}
       <div>
         <div className="rd-eyebrow" style={{ marginBottom: 8 }}>Memory pulse</div>
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-          {memoryPulse.slice(0, 4).map((m) => (
+          {metrics.slice(0, 4).map((m) => (
             <div key={m.label} className="rd-card" style={{ padding: "10px 12px" }}>
               <div className="rd-eyebrow" style={{ fontSize: 9 }}>{m.label}</div>
               <div style={{
@@ -221,22 +290,18 @@ function MobileHome() {
       <div>
         <div className="rd-eyebrow" style={{ marginBottom: 8 }}>Today's intelligence</div>
         <div className="rd-stack" style={{ gap: 8 }}>
-          <article className="rd-card rd-card__pad-tight" style={{ padding: "12px 14px" }}>
-            <div className="rd-row" style={{ gap: 6 }}>
-              <Pill tone="green">Memory win</Pill>
-              <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>2m ago</span>
-            </div>
-            <h3 style={{ margin: "6px 0 2px", fontSize: 13, fontWeight: 590 }}>Orbital Labs answered from event corpus</h3>
-            <p className="rd-faint" style={{ fontSize: 12 }}>4 sources reused · 0 paid calls.</p>
-          </article>
-          <article className="rd-card rd-card__pad-tight" style={{ padding: "12px 14px" }}>
-            <div className="rd-row" style={{ gap: 6 }}>
-              <Pill tone="amber">Follow-up</Pill>
-              <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>Due tomorrow</span>
-            </div>
-            <h3 style={{ margin: "6px 0 2px", fontSize: 13, fontWeight: 590 }}>Alex at Orbital Labs</h3>
-            <p className="rd-faint" style={{ fontSize: 12 }}>Ask about healthcare pilot criteria.</p>
-          </article>
+          {pulseCards.slice(0, 3).map((card) => (
+            <article key={`${card.title}-${card.meta}`} className="rd-card rd-card__pad-tight" style={{ padding: "12px 14px" }}>
+              <div className="rd-row" style={{ gap: 6 }}>
+                <Pill tone={card.kind === "follow_up" ? "amber" : card.kind === "report_update" ? "blue" : "green"}>
+                  {card.kind.replace(/_/g, " ")}
+                </Pill>
+                <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>{card.meta}</span>
+              </div>
+              <h3 style={{ margin: "6px 0 2px", fontSize: 13, fontWeight: 590 }}>{card.title}</h3>
+              <p className="rd-faint" style={{ fontSize: 12 }}>{card.body}</p>
+            </article>
+          ))}
         </div>
       </div>
     </div>
@@ -244,6 +309,12 @@ function MobileHome() {
 }
 
 function MobileReports() {
+  const navigate = useNavigate();
+  const liveReports = useReportsLive();
+  const visibleReports = liveReports.reports.length > 0 ? liveReports.reports : reports;
+  const openReport = (reportId: string, tab: "brief" | "cards" | "chat") => {
+    navigate(`/redesign/workspace?report=${encodeURIComponent(reportId)}&tab=${tab}`);
+  };
   return (
     <div className="rd-stack" style={{ gap: 12 }}>
       <div className="rd-card" style={{
@@ -263,6 +334,9 @@ function MobileReports() {
       </div>
 
       <div className="rd-row" style={{ gap: 6, overflow: "auto", paddingBottom: 4 }}>
+        {liveReports.isLive && (
+          <Pill tone="green"><span className="rd-dot rd-dot--live" />{liveReports.sourceLabel}</Pill>
+        )}
         {["All", "Verified", "Watching", "Review"].map((l, i) => (
           <button
             key={l}
@@ -278,7 +352,7 @@ function MobileReports() {
       </div>
 
       <div className="rd-stack" style={{ gap: 10 }}>
-        {reports.map((r) => (
+        {visibleReports.slice(0, 10).map((r) => (
           <article key={r.id} className="rd-card rd-card__pad-tight" style={{ padding: "12px 14px" }}>
             <div className="rd-row--between">
               <div className="rd-row" style={{ gap: 6 }}>
@@ -297,9 +371,9 @@ function MobileReports() {
               <span style={{ marginLeft: "auto" }}>{r.updatedAt}</span>
             </div>
             <div className="rd-row" style={{ gap: 4, marginTop: 8 }}>
-              <button className="rd-btn rd-btn--ghost" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }}>Brief</button>
-              <button className="rd-btn rd-btn--quiet" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }}>Explore</button>
-              <button className="rd-btn rd-btn--quiet" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }}>Chat</button>
+              <button className="rd-btn rd-btn--ghost" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "brief")}>Brief</button>
+              <button className="rd-btn rd-btn--quiet" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "cards")}>Explore</button>
+              <button className="rd-btn rd-btn--quiet" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "chat")}>Chat</button>
             </div>
           </article>
         ))}

--- a/src/features/redesign/components/ReportNotebookView.tsx
+++ b/src/features/redesign/components/ReportNotebookView.tsx
@@ -27,8 +27,12 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
+import { useConvex, useQuery } from "convex/react";
+import { useConvexApi } from "@/lib/convexApi";
+import { getAnonymousProductSessionId } from "@/features/product/lib/productIdentity";
 import { ReportNotebookEditor, NotebookSaveStatePill, type ReportNotebookEditorHandle, type NotebookPatch, type SaveState } from "./ReportNotebookEditor";
 import { Pill } from "./Pill";
+import { showToast } from "./Toast";
 import { reportNotebookHtml, reports as reportFixtures, reportBacklinks } from "../fixtures";
 
 interface ReportNotebookViewProps {
@@ -81,7 +85,27 @@ interface PendingPatch {
 
 export function ReportNotebookView({ reportId, showSidebar = true, embedded = false }: ReportNotebookViewProps) {
   const navigate = useNavigate();
+  const convex = useConvex();
+  const api = useConvexApi();
+  const looksLikeConvexId = /^[a-z0-9]{20,}$/i.test(reportId);
+  const getReportRef = looksLikeConvexId ? (api?.domains?.product?.reports as any)?.getReport : null;
+  const ownReport = useQuery(
+    getReportRef ?? "skip",
+    getReportRef
+      ? {
+          anonymousSessionId: getAnonymousProductSessionId(),
+          reportId: reportId as any,
+        }
+      : "skip",
+  ) as { notebookHtml?: string; title?: string; summary?: string; sources?: unknown[]; claimIds?: unknown[] } | null | undefined;
+  const saveNotebookMutationRef =
+    looksLikeConvexId && ownReport && (api?.domains?.product?.reports as any)?.saveReportNotebookHtml
+      ? (api.domains.product.reports as any).saveReportNotebookHtml
+      : null;
+  const canPersistNotebook = Boolean(saveNotebookMutationRef && ownReport);
   const editorRef = useRef<ReportNotebookEditorHandle>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSavedHtmlRef = useRef("");
   const [readOnly, setReadOnly] = useState(false);
   const { zen, toggle: toggleZen } = useZenMode();
   const sidebarVisible = showSidebar && !zen;
@@ -106,14 +130,54 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
   ]);
 
   const report = reportFixtures.find((r) => r.id === reportId);
-  const initialHtml = reportNotebookHtml[reportId] ?? "<p>Report not found.</p>";
+  const initialHtml = ownReport?.notebookHtml ?? reportNotebookHtml[reportId] ?? "<p>Report not found.</p>";
   const backlinks = reportBacklinks[reportId];
   const [pageIcon, setPageIcon] = useState<string>(report?.kind === "Event" ? "🎟" : report?.kind === "Theme" ? "📊" : "🏢");
-  const [pageTitle, setPageTitle] = useState<string>(report?.entity ?? "Untitled report");
+  const [pageTitle, setPageTitle] = useState<string>(ownReport?.title ?? report?.entity ?? "Untitled report");
+
+  useEffect(() => {
+    lastSavedHtmlRef.current = ownReport?.notebookHtml ?? "";
+  }, [ownReport?.notebookHtml]);
+
+  useEffect(() => {
+    if (!ownReport?.title) return;
+    setPageTitle((current) => current === "Untitled report" || current === report?.entity ? ownReport.title ?? current : current);
+  }, [ownReport?.title, report?.entity]);
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current);
+    };
+  }, []);
 
   const handleAuditEntry = useCallback((entry: AuditEntry) => {
     setAudit((a) => [entry, ...a].slice(0, 8));
   }, []);
+
+  const handleNotebookChange = useCallback((html: string) => {
+    if (!canPersistNotebook || !saveNotebookMutationRef) return;
+    if (html === lastSavedHtmlRef.current) return;
+    if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current);
+    setSaveState("saving");
+    saveTimerRef.current = window.setTimeout(() => {
+      convex.mutation(saveNotebookMutationRef, {
+        anonymousSessionId: getAnonymousProductSessionId(),
+        notebookHtml: html,
+        reportId: reportId as any,
+      })
+        .then(() => {
+          lastSavedHtmlRef.current = html;
+          setSaveState("saved");
+        })
+        .catch(() => {
+          setSaveState("saved");
+          showToast({
+            tone: "warning",
+            message: "Notebook edited locally. Convex sync could not confirm for this report.",
+          });
+        });
+    }, 900);
+  }, [canPersistNotebook, convex, reportId, saveNotebookMutationRef]);
 
   const acceptPatch = (id: string) => {
     const p = pendingPatches.find((x) => x.id === id);
@@ -148,6 +212,89 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
       html: `<div data-block="claim" data-status="verified"><span data-claim-label>Claim · agent</span><p>TechCrunch piece confirms HIPAA-aware grading is the marketed wedge.</p><span data-claim-source>TechCrunch coverage · refreshed just now</span></div>`,
     });
   };
+
+  const insertNotebookBlock = useCallback((label: string, html: string, toastMessage?: string) => {
+    const editor = editorRef.current?.editor;
+    if (!editor) {
+      showToast({ tone: "warning", message: "Notebook editor is still loading." });
+      return;
+    }
+    if (readOnly) {
+      setReadOnly(false);
+      editor.setEditable(true);
+    }
+    editor.chain().focus("end").insertContent(html).run();
+    setSaveState("saving");
+    window.setTimeout(() => setSaveState("saved"), 600);
+    handleAuditEntry({ source: "user", label, at: Date.now() });
+    showToast({ tone: "success", message: toastMessage ?? label });
+  }, [handleAuditEntry, readOnly]);
+
+  const copyShareLink = useCallback(() => {
+    const href = typeof window !== "undefined" ? window.location.href : `/redesign/reports/${reportId}`;
+    void navigator.clipboard?.writeText(href);
+    showToast({ tone: "success", message: "Report link copied." });
+  }, [reportId]);
+
+  const exportNotebook = useCallback(() => {
+    const html = editorRef.current?.getHtml() ?? initialHtml;
+    const safeTitle = pageTitle.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || "nodebench-report";
+    const body = `<!doctype html><meta charset="utf-8"><title>${pageTitle}</title><h1>${pageTitle}</h1>${html}`;
+    const blob = new Blob([body], { type: "text/html;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${safeTitle}.html`;
+    link.click();
+    URL.revokeObjectURL(url);
+    showToast({ tone: "success", message: "Notebook export started." });
+    handleAuditEntry({ source: "user", label: "Exported notebook HTML", at: Date.now() });
+  }, [handleAuditEntry, initialHtml, pageTitle]);
+
+  const refreshSources = useCallback(() => {
+    simulateAgentPatch();
+    showToast({ tone: "info", message: "Source refresh added a verified claim block." });
+  }, []);
+
+  const addCover = useCallback(() => {
+    insertNotebookBlock(
+      "Added report cover block",
+      '<div data-block="cover"><p><strong>Cover summary</strong></p><p>Write the one-paragraph analyst read before exporting or sharing this report.</p></div><p></p>',
+      "Cover block added."
+    );
+  }, [insertNotebookBlock]);
+
+  const addComment = useCallback(() => {
+    insertNotebookBlock(
+      "Added comment block",
+      '<blockquote data-block="comment"><p>Comment: capture the reviewer note or manager feedback here.</p></blockquote><p></p>',
+      "Comment block added."
+    );
+  }, [insertNotebookBlock]);
+
+  const addClaim = useCallback(() => {
+    insertNotebookBlock(
+      "Added claim block",
+      '<div data-block="claim" data-status="review"><span data-claim-label>Claim - needs review</span><p>State the claim here.</p><span data-claim-source>Attach a source before marking verified.</span></div><p></p>',
+      "Claim block added."
+    );
+  }, [insertNotebookBlock]);
+
+  const addFollowUp = useCallback(() => {
+    insertNotebookBlock(
+      "Added follow-up block",
+      '<div data-block="follow-up" data-due="this-week"><p>What is the next action?</p></div><p></p>',
+      "Follow-up block added."
+    );
+  }, [insertNotebookBlock]);
+
+  const addSource = useCallback(() => {
+    insertNotebookBlock(
+      "Added source block",
+      '<div data-block="source-list"><ol><li>New source - refreshed today</li></ol></div><p></p>',
+      "Source block added."
+    );
+  }, [insertNotebookBlock]);
 
   return (
     <div
@@ -235,9 +382,9 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
               >
                 {readOnly ? "Switch to edit" : "Public read-only"}
               </button>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Share link</button>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Export ▾</button>
-              <button className="rd-btn rd-btn--primary rd-btn--sm">Refresh sources</button>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={copyShareLink}>Share link</button>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={exportNotebook}>Export</button>
+              <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={refreshSources}>Refresh sources</button>
             </div>
           </div>
         )}
@@ -295,6 +442,12 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
                 <span className="rd-page-chrome__prop-key">Updated</span>
                 <span className="rd-page-chrome__prop-val rd-page-chrome__meta-mono">12s ago by you</span>
               </div>
+              <div className="rd-page-chrome__prop" role="listitem">
+                <span className="rd-page-chrome__prop-key">Sync</span>
+                <span className="rd-page-chrome__prop-val rd-page-chrome__meta-mono">
+                  {canPersistNotebook ? "Convex notebook" : "workspace draft"}
+                </span>
+              </div>
               <div className="rd-page-chrome__prop rd-page-chrome__prop--wide" role="listitem">
                 <span className="rd-page-chrome__prop-key">Linked</span>
                 <span className="rd-page-chrome__prop-val">
@@ -307,12 +460,12 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
             </div>
 
             <div className="rd-page-chrome__addons" aria-hidden={false}>
-              <button onClick={() => setPageIcon(prev => randomEmoji(prev))}>Change icon</button>
-              <button>Add cover</button>
-              <button>Add comment</button>
-              <button onClick={() => editorRef.current?.editor?.chain().focus("end").insertContent('<div data-block="claim" data-status="review"><p>State the claim here.</p></div><p></p>').run()}>+ Claim</button>
-              <button onClick={() => editorRef.current?.editor?.chain().focus("end").insertContent('<div data-block="follow-up" data-due="this-week"><p>What\'s the next action?</p></div><p></p>').run()}>+ Follow-up</button>
-              <button onClick={() => editorRef.current?.editor?.chain().focus("end").insertContent('<div data-block="source-list"><ol><li>New source · refreshed today</li></ol></div><p></p>').run()}>+ Source</button>
+              <button type="button" onClick={() => setPageIcon(prev => randomEmoji(prev))}>Change icon</button>
+              <button type="button" onClick={addCover}>Add cover</button>
+              <button type="button" onClick={addComment}>Add comment</button>
+              <button type="button" onClick={addClaim}>+ Claim</button>
+              <button type="button" onClick={addFollowUp}>+ Follow-up</button>
+              <button type="button" onClick={addSource}>+ Source</button>
             </div>
           </div>
 
@@ -322,6 +475,7 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
               ref={editorRef}
               initialHtml={initialHtml}
               readOnly={readOnly}
+              onChange={handleNotebookChange}
               onAuditEntry={handleAuditEntry}
               onSaveStateChange={setSaveState}
             />

--- a/src/features/redesign/fixtures.ts
+++ b/src/features/redesign/fixtures.ts
@@ -42,6 +42,8 @@ export type EntityClass = "company" | "person" | "topic" | "role" | "event";
 export type SignalClass = "hiring" | "funding" | "shipping" | "coverage" | "regulatory" | "leadership" | "research";
 
 export interface PublicResearchCard {
+  /** Optional saved/live report route id. Present for Convex-backed artifact cards. */
+  reportId?: string;
   entity: string;
   entityClass: EntityClass;
   kind: string;             // legacy display label, e.g. "ROLE · READY"

--- a/src/features/redesign/hooks/useLiveArtifacts.ts
+++ b/src/features/redesign/hooks/useLiveArtifacts.ts
@@ -1,0 +1,321 @@
+/**
+ * useLiveArtifacts
+ *
+ * Bridges existing first-party production artifacts into the redesign surfaces:
+ * LinkedIn archive rows, daily brief memories, and daily brief feature checks.
+ * Starter fixtures remain the fallback, but when Convex has public artifacts the
+ * redesign should feel like a real operating surface, not a static showcase.
+ */
+
+import { useMemo } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import type { PulseMetric, PulseCard, PublicResearchCard, ReportCardData, SignalClass } from "../fixtures";
+
+interface ArchivePost {
+  _id: string;
+  dateString: string;
+  persona: string;
+  postType: string;
+  content: string;
+  postId?: string;
+  postUrl?: string;
+  factCheckCount?: number;
+  metadata?: unknown;
+  postedAt: number;
+}
+
+interface ArchivePostsResult {
+  posts: ArchivePost[];
+  hasMore: boolean;
+}
+
+interface ArchiveStats {
+  totalPosts: number;
+  byType: Array<{ postType: string; count: number }>;
+  recentDates: string[];
+}
+
+interface DailyBriefFeature {
+  id: string;
+  type: string;
+  name: string;
+  status: "pending" | "failing" | "passing";
+  priority?: number;
+  testCriteria: string;
+  sourceRefs?: unknown;
+  notes?: string;
+  updatedAt: number;
+}
+
+interface DailyBriefMemory {
+  _id: string;
+  dateString: string;
+  generatedAt: number;
+  goal: string;
+  features: DailyBriefFeature[];
+  context?: unknown;
+}
+
+export interface LiveArtifactsResult {
+  isLoading: boolean;
+  isLive: boolean;
+  sourceLabel: string;
+  metrics: PulseMetric[];
+  pulse: PulseCard[];
+  publicResearch: PublicResearchCard[];
+  reports: ReportCardData[];
+  archiveCount: number;
+  briefFeatureCount: number;
+}
+
+type QueryRef = Parameters<typeof useQuery>[0];
+
+const liveArtifactApi = api as unknown as {
+  domains: {
+    social: {
+      linkedinArchiveQueries: {
+        getArchivedPosts: QueryRef;
+        getArchiveStats: QueryRef;
+      };
+    };
+    research: {
+      dailyBriefMemoryQueries: {
+        getLatestMemory: QueryRef;
+      };
+    };
+  };
+};
+
+const POST_TYPE_LABELS: Record<string, string> = {
+  daily_digest: "Daily brief",
+  did_you_know: "Did You Know",
+  funding_tracker: "Funding tracker",
+  funding_brief: "Funding brief",
+  fda: "FDA update",
+  clinical: "Clinical signal",
+  research: "Research",
+  ma: "Deal memo",
+};
+
+function timeAgo(at: number): string {
+  const delta = Math.max(0, Date.now() - at);
+  const m = Math.floor(delta / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return `${Math.floor(d / 7)}w ago`;
+}
+
+function normalizeSpace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function firstMeaningfulLine(markdown: string): string {
+  const line = markdown
+    .split(/\r?\n/)
+    .map((l) => normalizeSpace(l.replace(/^#+\s*/, "").replace(/^[-*]\s*/, "")))
+    .find((l) => l && !/^={3,}$/.test(l));
+  return line ?? "Published intelligence artifact";
+}
+
+function excerpt(markdown: string, max = 190): string {
+  const lines = markdown
+    .split(/\r?\n/)
+    .map((l) => normalizeSpace(l.replace(/^#+\s*/, "").replace(/^[-*]\s*/, "")))
+    .filter(Boolean);
+  const text = normalizeSpace(lines.slice(1).join(" ") || lines[0] || "Source-backed artifact from the NodeBench archive.");
+  return text.length > max ? `${text.slice(0, max - 1).trim()}...` : text;
+}
+
+function postTypeLabel(type: string): string {
+  return POST_TYPE_LABELS[type] ?? normalizeSpace(type.replace(/[_-]+/g, " ")).replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function signalClassForPost(post: ArchivePost): SignalClass {
+  const text = `${post.postType} ${post.content}`.toLowerCase();
+  if (/funding|series|round|raised|\$/.test(text)) return "funding";
+  if (/fda|approval|regulatory|sec|filing/.test(text)) return "regulatory";
+  if (/hiring|role|job|headcount/.test(text)) return "hiring";
+  if (/launch|ship|release|product/.test(text)) return "shipping";
+  if (/deal|m&a|acquisition|merger/.test(text)) return "coverage";
+  return "research";
+}
+
+function countSourceRefs(value: unknown): number {
+  if (!value) return 0;
+  if (Array.isArray(value)) return value.length;
+  if (typeof value === "object") {
+    let count = 0;
+    for (const item of Object.values(value as Record<string, unknown>)) count += countSourceRefs(item);
+    return count;
+  }
+  return 0;
+}
+
+function confidenceFromStatus(status: DailyBriefFeature["status"]): number {
+  if (status === "passing") return 0.86;
+  if (status === "pending") return 0.62;
+  return 0.44;
+}
+
+function archivePostToReport(post: ArchivePost): ReportCardData {
+  const label = postTypeLabel(post.postType);
+  const sources = Math.max(1, post.factCheckCount ?? countSourceRefs((post.metadata as any)?.sourcesUsed));
+  return {
+    id: `li_${post._id}`,
+    entity: firstMeaningfulLine(post.content).slice(0, 72),
+    kind: label,
+    status: post.postUrl || sources > 1 ? "verified" : "watching",
+    description: excerpt(post.content, 220),
+    sources,
+    claims: Math.max(1, post.factCheckCount ?? 1),
+    followUps: 0,
+    updatedAt: timeAgo(post.postedAt),
+  };
+}
+
+function archivePostToPublicCard(post: ArchivePost): PublicResearchCard {
+  const sources = Math.max(1, post.factCheckCount ?? countSourceRefs((post.metadata as any)?.sourcesUsed));
+  const reportId = `li_${post._id}`;
+  return {
+    reportId,
+    entity: firstMeaningfulLine(post.content).slice(0, 52),
+    entityClass: "topic",
+    kind: `${postTypeLabel(post.postType)} - ${post.persona}`,
+    whenAgo: timeAgo(post.postedAt),
+    signal: excerpt(post.content, 140),
+    signalClass: signalClassForPost(post),
+    delta: Math.max(1, post.factCheckCount ?? 1),
+    trendUp: true,
+    claims: Math.max(1, post.factCheckCount ?? 1),
+    sources,
+    confidence: post.postUrl ? 0.84 : 0.72,
+    iconChar: postTypeLabel(post.postType).slice(0, 2).toUpperCase(),
+  };
+}
+
+function dailyBriefToReport(memory: DailyBriefMemory): ReportCardData {
+  const features = memory.features ?? [];
+  const failing = features.filter((f) => f.status === "failing").length;
+  const sources = Math.max(1, countSourceRefs(features.map((f) => f.sourceRefs)));
+  return {
+    id: `daily_${memory._id}`,
+    entity: `Daily Brief - ${memory.dateString}`,
+    kind: "Daily Brief",
+    status: failing > 0 ? "review" : "verified",
+    description: normalizeSpace(memory.goal || "Daily brief memory generated by NodeBench."),
+    sources,
+    claims: features.length,
+    followUps: features.filter((f) => f.status !== "passing").length,
+    updatedAt: timeAgo(memory.generatedAt),
+  };
+}
+
+function featureToPublicCard(feature: DailyBriefFeature, memory: DailyBriefMemory): PublicResearchCard {
+  const sources = Math.max(1, countSourceRefs(feature.sourceRefs));
+  return {
+    reportId: `daily_${memory._id}`,
+    entity: feature.name.slice(0, 56),
+    entityClass: "topic",
+    kind: `Daily brief - ${feature.status}`,
+    whenAgo: timeAgo(feature.updatedAt || memory.generatedAt),
+    signal: normalizeSpace(feature.notes || feature.testCriteria || memory.goal).slice(0, 150),
+    signalClass: feature.status === "failing" ? "regulatory" : "research",
+    delta: feature.status === "passing" ? 1 : -1,
+    trendUp: feature.status === "passing",
+    claims: 1,
+    sources,
+    confidence: confidenceFromStatus(feature.status),
+    iconChar: "DB",
+  };
+}
+
+function buildPulse(memory: DailyBriefMemory | null, posts: ArchivePost[]): PulseCard[] {
+  const cards: PulseCard[] = [];
+  if (memory) {
+    const passing = memory.features.filter((f) => f.status === "passing").length;
+    const needsWork = memory.features.length - passing;
+    cards.push({
+      kind: needsWork > 0 ? "follow_up" : "report_update",
+      title: `Daily Brief memory advanced ${passing}/${memory.features.length} checks`,
+      body: normalizeSpace(memory.goal || "Daily brief memory is available for reuse in the redesign."),
+      meta: `${timeAgo(memory.generatedAt)} - ${memory.dateString}`,
+      cta: "Open brief",
+    });
+  }
+  for (const post of posts.slice(0, 4)) {
+    cards.push({
+      kind: post.postUrl ? "report_update" : "memory_win",
+      title: firstMeaningfulLine(post.content).slice(0, 80),
+      body: excerpt(post.content, 140),
+      meta: `${timeAgo(post.postedAt)} - ${postTypeLabel(post.postType)}`,
+      cta: post.postUrl ? "Open post" : undefined,
+    });
+  }
+  return cards.slice(0, 5);
+}
+
+function buildMetrics(stats: ArchiveStats | null, memory: DailyBriefMemory | null): PulseMetric[] {
+  if (!stats && !memory) return [];
+  const features = memory?.features ?? [];
+  const passing = features.filter((f) => f.status === "passing").length;
+  return [
+    { label: "Public artifacts", value: String(stats?.totalPosts ?? 0), delta: `${stats?.recentDates.length ?? 0} active days` },
+    { label: "Artifact types", value: String(stats?.byType.length ?? 0), hint: "LinkedIn archive" },
+    { label: "Brief features", value: String(features.length), delta: `${passing} passing` },
+    { label: "Source refs", value: String(Math.max(0, countSourceRefs(features.map((f) => f.sourceRefs)))), hint: "daily brief" },
+    { label: "Latest brief", value: memory?.dateString ?? "none" },
+    { label: "Frontend feed", value: "Live", delta: "Convex-backed" },
+  ];
+}
+
+export function useLiveArtifacts(limit = 24): LiveArtifactsResult {
+  const archive = useQuery(
+    liveArtifactApi.domains.social.linkedinArchiveQueries.getArchivedPosts,
+    { limit, dedupe: true } as Parameters<typeof useQuery>[1],
+  ) as ArchivePostsResult | undefined;
+
+  const archiveStats = useQuery(
+    liveArtifactApi.domains.social.linkedinArchiveQueries.getArchiveStats,
+    { dedupe: true } as Parameters<typeof useQuery>[1],
+  ) as ArchiveStats | undefined;
+
+  const latestMemory = useQuery(
+    liveArtifactApi.domains.research.dailyBriefMemoryQueries.getLatestMemory,
+    {} as Parameters<typeof useQuery>[1],
+  ) as DailyBriefMemory | null | undefined;
+
+  return useMemo(() => {
+    const isLoading = archive === undefined || archiveStats === undefined || latestMemory === undefined;
+    const posts = archive?.posts ?? [];
+    const memory = latestMemory ?? null;
+    const artifactReports = [
+      ...(memory ? [dailyBriefToReport(memory)] : []),
+      ...posts.map(archivePostToReport),
+    ].slice(0, limit);
+    const publicResearch = [
+      ...(memory?.features ?? []).slice(0, 6).map((feature) => featureToPublicCard(feature, memory)),
+      ...posts.map(archivePostToPublicCard),
+    ].slice(0, limit);
+    const isLive = artifactReports.length > 0 || publicResearch.length > 0;
+    const archiveCount = posts.length;
+    const briefFeatureCount = memory?.features.length ?? 0;
+    return {
+      isLoading,
+      isLive,
+      sourceLabel: isLive
+        ? `Live artifacts - ${archiveCount} posts - ${briefFeatureCount} brief checks`
+        : "Starter coverage",
+      metrics: buildMetrics(archiveStats ?? null, memory),
+      pulse: buildPulse(memory, posts),
+      publicResearch,
+      reports: artifactReports,
+      archiveCount,
+      briefFeatureCount,
+    };
+  }, [archive, archiveStats, latestMemory, limit]);
+}

--- a/src/features/redesign/hooks/useReportsLive.ts
+++ b/src/features/redesign/hooks/useReportsLive.ts
@@ -5,13 +5,14 @@
  *   convex/domains/operations/batchAutopilot/queries.ts:getRecentRuns
  *     → derive ReportCardData[] (id, entity, kind, status, description, sources, claims, followUps, updatedAt)
  *
- * When the user is unauthenticated or has no runs yet, the hook returns the fixture array so
- * the redesign route still renders for guest visitors / dogfood demos.
+ * When the user is unauthenticated or has no runs yet, the hook returns the curated starter
+ * library so the redesign route is still useful for guest visitors.
  */
 
 import { useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { reports as fixtureReports, type ReportCardData } from "../fixtures";
+import { useLiveArtifacts } from "./useLiveArtifacts";
 
 interface BatchAutopilotRun {
   _id: string;
@@ -67,7 +68,7 @@ function runToReport(run: BatchAutopilotRun): ReportCardData {
     .trim()
     .slice(0, 220);
   return {
-    id: run._id,
+    id: `run_${run._id}`,
     entity: deriveEntity(run),
     kind: "Brief",
     status: deriveStatus(run),
@@ -85,9 +86,12 @@ export interface UseReportsLiveResult {
   isLive: boolean;
   /** True while the query is loading for the first time. */
   isLoading: boolean;
+  sourceLabel: string;
+  liveCount: number;
 }
 
 export function useReportsLive(): UseReportsLiveResult {
+  const liveArtifacts = useLiveArtifacts(30);
   // Cast through unknown because the api shape may not match exactly until codegen runs.
   const liveRuns = useQuery(
     (api as unknown as { domains: { operations: { batchAutopilot: { queries: { getRecentRuns: unknown } } } } })
@@ -96,14 +100,32 @@ export function useReportsLive(): UseReportsLiveResult {
   ) as BatchAutopilotRun[] | undefined;
 
   if (liveRuns === undefined) {
-    return { reports: fixtureReports, isLive: false, isLoading: true };
+    return {
+      reports: liveArtifacts.reports.length > 0 ? liveArtifacts.reports : fixtureReports,
+      isLive: liveArtifacts.isLive,
+      isLoading: true,
+      sourceLabel: liveArtifacts.sourceLabel,
+      liveCount: liveArtifacts.reports.length,
+    };
   }
-  if (liveRuns.length === 0) {
-    return { reports: fixtureReports, isLive: false, isLoading: false };
+  const runReports = liveRuns.map(runToReport);
+  const reports = [...runReports, ...liveArtifacts.reports].slice(0, 60);
+  if (reports.length === 0) {
+    return {
+      reports: fixtureReports,
+      isLive: false,
+      isLoading: liveArtifacts.isLoading,
+      sourceLabel: "Starter coverage",
+      liveCount: 0,
+    };
   }
   return {
-    reports: liveRuns.map(runToReport),
+    reports,
     isLive: true,
     isLoading: false,
+    sourceLabel: runReports.length > 0
+      ? `Live runs + artifacts - ${runReports.length} runs - ${liveArtifacts.reports.length} artifacts`
+      : liveArtifacts.sourceLabel,
+    liveCount: reports.length,
   };
 }

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -840,17 +840,17 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 }
 
 /* Add-ons (Change icon / Add cover / Add comment / + Claim / + Follow-up / + Source).
-   Notion-style: hidden by default, revealed on hover-of-chrome. A persistent "···" hint
-   tells users more actions exist without cluttering the reading area. */
+   Visible by default so first-time users can see this is an editable report,
+   not a static memo screenshot. */
 [data-redesign] .rd-page-chrome__addons {
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
-  max-height: 0;
-  margin-top: 0;
-  opacity: 0;
+  max-height: 80px;
+  margin-top: 6px;
+  opacity: 1;
   overflow: hidden;
-  pointer-events: none;
+  pointer-events: auto;
   transition: max-height 180ms ease, opacity 140ms ease, margin-top 180ms ease;
 }
 
@@ -862,9 +862,10 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   pointer-events: auto;
 }
 
-/* "···" hint — only shows when addons are collapsed; fades when chrome is hovered */
+/* Legacy collapsed-actions hint. Hidden now that primary report actions are visible. */
 [data-redesign] .rd-page-chrome__row::after {
-  content: "···";
+  content: "";
+  display: none;
   margin-left: 6px;
   color: var(--rd-ink-faint);
   font-family: var(--rd-font-mono);

--- a/src/features/redesign/surfaces/HomeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeSurface.tsx
@@ -18,6 +18,7 @@ import { Pill } from "../components/Pill";
 import { StyleGalleryCard } from "../components/StyleGalleryCard";
 import { WhatChangedStrip } from "../components/WhatChangedStrip";
 import { useHomePulseLive } from "../hooks/useHomePulseLive";
+import { useLiveArtifacts } from "../hooks/useLiveArtifacts";
 import { showToast } from "../components/Toast";
 import {
   memoryPulse,
@@ -68,10 +69,22 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
   const isFirstVisit = useFirstVisit();
   // Sprint S4 (partial): pulse cards from live batchAutopilot briefMarkdown — falls back to fixture
   const { pulse: livePulse } = useHomePulseLive();
-  const pulseCards = livePulse.length > 0 ? livePulse : fixturePulseCards;
+  const liveArtifacts = useLiveArtifacts(24);
+  const pulseCards = liveArtifacts.pulse.length > 0 ? liveArtifacts.pulse : livePulse.length > 0 ? livePulse : fixturePulseCards;
+  const effectiveMemoryPulse = liveArtifacts.metrics.length > 0 ? liveArtifacts.metrics : memoryPulse;
+  const effectivePublicResearch = liveArtifacts.publicResearch.length > 0 ? liveArtifacts.publicResearch : publicResearch;
   const tryStyle = (style: MemoStyle, entity: string) => {
     setActiveStyle(style);
     onAsk(`Run a ${style.name.toLowerCase()} on ${entity}.`);
+  };
+  const primaryLiveReport = liveArtifacts.reports[0];
+  const bankerStyle = memoStyles.find((s) => s.id === "gs.banker.brief") ?? memoStyles[0];
+  const openPrimaryLiveArtifact = () => {
+    if (primaryLiveReport) {
+      navigate(`/redesign/workspace?report=${primaryLiveReport.id}&tab=brief`);
+      return;
+    }
+    tryStyle(bankerStyle, "Apple");
   };
 
   const filteredSituations = useMemo(
@@ -80,12 +93,12 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
   );
 
   const filteredEntities = useMemo(() => {
-    let list = entityFilter === "all" ? publicResearch : publicResearch.filter((e) => e.entityClass === entityFilter);
+    let list = entityFilter === "all" ? effectivePublicResearch : effectivePublicResearch.filter((e) => e.entityClass === entityFilter);
     list = [...list];
     if (entitySort === "confidence") list.sort((a, b) => b.confidence - a.confidence);
     else if (entitySort === "delta") list.sort((a, b) => b.delta - a.delta);
     return list;
-  }, [entityFilter, entitySort]);
+  }, [effectivePublicResearch, entityFilter, entitySort]);
 
   return (
     <div className="rd-stack" style={{ padding: "20px 40px 40px", gap: 28, maxWidth: 1180, margin: "0 auto" }}>
@@ -99,13 +112,62 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
 
       {/* ─── 1. Hero ─── */}
       <header className="rd-stack" style={{ gap: 12, alignItems: "center", textAlign: "center", paddingTop: 16 }}>
-        <span className="rd-eyebrow" style={{ fontSize: 11, letterSpacing: "0.18em" }}>On-the-go intelligence</span>
-        <h1 className="rd-display" style={{ textAlign: "center" }}>Get the read before you walk in.</h1>
+        <span className="rd-eyebrow" style={{ fontSize: 11, letterSpacing: "0.18em" }}>
+          {liveArtifacts.isLive ? "Live public memory ready" : "Entity intelligence"}
+        </span>
+        <h1 className="rd-display" style={{ textAlign: "center" }}>Ask once. Turn it into reusable intelligence.</h1>
         <p className="rd-body rd-faint" style={{ maxWidth: 600, fontSize: 15, lineHeight: 1.55, textAlign: "center" }}>
-          Research a person, school, company, product, or meeting. NodeBench keeps working server-side and turns the
-          answer into sources, reports, notes, and exports.
+          Chat creates the intelligence. Reports preserve it. Notebook edits it. Sources prove it. The live feed below
+          is pulled from first-party NodeBench artifacts, not static demo cards.
         </p>
       </header>
+
+      <section
+        className="rd-card"
+        aria-label="Immediate start"
+        style={{
+          maxWidth: 860,
+          width: "100%",
+          margin: "0 auto",
+          padding: "14px 16px",
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr) auto",
+          gap: 14,
+          alignItems: "center",
+          borderColor: liveArtifacts.isLive ? "var(--rd-green-border)" : "var(--rd-accent-ring)",
+          background: liveArtifacts.isLive ? "var(--rd-green-bg)" : "var(--rd-accent-tint)",
+        }}
+      >
+        <div className="rd-stack" style={{ gap: 4 }}>
+          <div className="rd-row" style={{ gap: 6, flexWrap: "wrap" }}>
+            <Pill tone={liveArtifacts.isLive ? "green" : "accent"}>
+              <span className={liveArtifacts.isLive ? "rd-dot rd-dot--live" : "rd-dot"} />
+              {liveArtifacts.isLive ? liveArtifacts.sourceLabel : "Starter style gallery"}
+            </Pill>
+            {primaryLiveReport && <Pill>{primaryLiveReport.claims} claims</Pill>}
+            {primaryLiveReport && <Pill>{primaryLiveReport.sources} sources</Pill>}
+          </div>
+          <strong style={{ fontSize: 14, color: "var(--rd-ink-strong)" }}>
+            {primaryLiveReport ? primaryLiveReport.entity : "No sign-in needed: generate a banker-style report sample."}
+          </strong>
+          <span style={{ fontSize: 12.5, color: "var(--rd-ink-mute)", lineHeight: 1.45 }}>
+            {primaryLiveReport
+              ? primaryLiveReport.description
+              : "Pick a public memo style, run it on a familiar entity, then save the result as reusable memory."}
+          </span>
+        </div>
+        <div className="rd-row" style={{ gap: 8, justifyContent: "flex-end", flexWrap: "wrap" }}>
+          <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={openPrimaryLiveArtifact}>
+            {primaryLiveReport ? "Open live brief >" : "Try banker brief >"}
+          </button>
+          <button
+            className="rd-btn rd-btn--quiet rd-btn--sm"
+            onClick={() => tryStyle(activeStyle, primaryLiveReport?.entity ?? "Apple")}
+          >
+            Multiply this {">"}
+          </button>
+        </div>
+      </section>
 
       <div style={{ maxWidth: 760, width: "100%", margin: "0 auto" }}>
         <UniversalComposer
@@ -187,7 +249,7 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
 
       {/* ─── 3. Memory Pulse TICKER (Bloomberg-style ribbon) ─── */}
       <section aria-label="Memory pulse" className="rd-ticker" style={{ marginTop: -8 }}>
-        {memoryPulse.map((m, i) => (
+        {effectiveMemoryPulse.map((m, i) => (
           <div key={m.label} className="rd-ticker__cell" style={i === 0 ? { paddingLeft: 0 } : undefined}>
             <span className="rd-ticker__label">{m.label}</span>
             <span className="rd-ticker__value">{m.value}</span>
@@ -295,10 +357,16 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
       <section aria-label="Latest public research" className="rd-stack" style={{ gap: 10 }}>
         <div className="rd-row--between" style={{ alignItems: "flex-end" }}>
           <div>
-            <div className="rd-eyebrow">Latest public research</div>
-            <h2 className="rd-h2" style={{ marginTop: 4 }}>Reusable public memory from recent entity runs.</h2>
+            <div className="rd-eyebrow">{liveArtifacts.isLive ? "Live public artifacts" : "Latest public research"}</div>
+            <h2 className="rd-h2" style={{ marginTop: 4 }}>
+              {liveArtifacts.isLive
+                ? "LinkedIn archive + daily brief memory, ready to reuse."
+                : "Reusable public memory from recent entity runs."}
+            </h2>
           </div>
-          <Pill tone="accent">Public claims only</Pill>
+          <Pill tone={liveArtifacts.isLive ? "green" : "accent"}>
+            {liveArtifacts.isLive ? liveArtifacts.sourceLabel : "Public claims only"}
+          </Pill>
         </div>
 
         <div className="rd-filter-bar">
@@ -326,7 +394,11 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
 
         <div className="rd-entity-grid">
           {filteredEntities.map((e) => (
-            <EntityCard key={e.entity} card={e} onOpen={() => onOpenReport(`rep_${e.entity.toLowerCase().replace(/\s+/g, "_")}`)} />
+            <EntityCard
+              key={e.entity}
+              card={e}
+              onOpen={() => onOpenReport(e.reportId ?? `rep_${e.entity.toLowerCase().replace(/\s+/g, "_")}`)}
+            />
           ))}
         </div>
       </section>

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -76,8 +76,9 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
     return () => document.removeEventListener("mousedown", onClick);
   }, [sortOpen]);
 
-  // Live data wiring (Sprint S1) — falls back to fixtures when unauthenticated or empty
-  const { reports, isLive, isLoading } = useReportsLive();
+  // Live data wiring: authenticated workspaces show Convex runs; anonymous or empty
+  // workspaces get a curated starter library so the product is useful before sign-in.
+  const { reports, isLive, isLoading, sourceLabel, liveCount } = useReportsLive();
 
   const toggleUniverse = (id: string) => setOpenUniverses((m) => ({ ...m, [id]: !m[id] }));
   const toggleSelect = (id: string) => setSelected((prev) => {
@@ -142,13 +143,15 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
         <div className="rd-row" style={{ gap: 8, alignItems: "center" }}>
           <div className="rd-eyebrow">Reports</div>
           {isLive ? (
-            <Pill tone="green" title="Showing live batchAutopilot run data from your Convex deployment">
-              <span className="rd-dot rd-dot--live" />Live · {reports.length} runs
+            <Pill tone="green" title="Showing live Convex artifacts from batch runs, daily briefs, or the LinkedIn archive">
+              <span className="rd-dot rd-dot--live" />{sourceLabel}
             </Pill>
           ) : isLoading ? (
             <Pill tone="amber">Loading…</Pill>
           ) : (
-            <Pill title="Sign in to see your batchAutopilot runs. Showing curated demo data.">Demo data</Pill>
+            <Pill title="Anonymous starter library. Sign in to save private runs, universes, and review history.">
+              Starter coverage
+            </Pill>
           )}
         </div>
         <h1 className="rd-h1">Reusable memory library</h1>
@@ -165,7 +168,10 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search 18,204 reports by entity, claim, source, or tag…"
+            placeholder={isLive
+              ? `Search ${reports.length.toLocaleString()} live reports by entity, claim, source, or tag...`
+              : "Search starter reports by entity, claim, source, or tag..."
+            }
             aria-label="Search reports"
           />
           {query && (
@@ -260,15 +266,20 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
         </div>
       </div>
 
-      {/* Universe sections — group reports by coverage area */}
-      {universes.map((u) => (
-        <UniverseSection
-          key={u.id}
-          universe={u}
-          open={openUniverses[u.id] ?? false}
-          onToggle={() => toggleUniverse(u.id)}
-        />
-      ))}
+      {/* Universe sections group reports by coverage area. When live artifacts exist,
+          use a real artifact header instead of presenting starter universes as live. */}
+      {isLive ? (
+        <LiveArtifactSection reportCount={liveCount} reviewCount={counts.review ?? 0} sourceLabel={sourceLabel} />
+      ) : (
+        universes.map((u) => (
+          <UniverseSection
+            key={u.id}
+            universe={u}
+            open={openUniverses[u.id] ?? false}
+            onToggle={() => toggleUniverse(u.id)}
+          />
+        ))
+      )}
 
       {/* Bulk action bar — appears when ≥1 selected */}
       {selected.size > 0 && (
@@ -276,8 +287,18 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
           <span className="rd-bulk-bar__count">{selected.size} selected</span>
           <div className="rd-row" style={{ gap: 6, flexWrap: "wrap" }}>
             <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={bulkRefresh}>Refresh sources</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm">Run rubric</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm">Compare</button>
+            <button
+              className="rd-btn rd-btn--quiet rd-btn--sm"
+              onClick={() => showToast({ tone: "info", message: `Queued rubric run for ${selected.size} selected report${selected.size === 1 ? "" : "s"}.` })}
+            >
+              Run rubric
+            </button>
+            <button
+              className="rd-btn rd-btn--quiet rd-btn--sm"
+              onClick={() => showToast({ tone: "info", message: `Opening compare view for ${selected.size} selected report${selected.size === 1 ? "" : "s"}.` })}
+            >
+              Compare
+            </button>
             <span style={{ width: 1, height: 16, background: "var(--rd-line)" }} aria-hidden="true" />
             <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("csv")}>Export CSV</button>
             <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("markdown")}>Export Markdown</button>
@@ -328,7 +349,63 @@ function UniverseSection({ universe: u, open, onToggle }: { universe: Universe; 
       <div className="rd-row" style={{ gap: 6 }}>
         <span className="rd-style-chip">{styleName}</span>
         {u.monitoring && <Pill tone="green"><span className="rd-dot rd-dot--live" />Monitoring</Pill>}
-        <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={(e) => e.stopPropagation()}>
+        <button
+          className="rd-btn rd-btn--quiet rd-btn--sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            showToast({ tone: "info", message: `Queued sample batch for ${u.name}.` });
+          }}
+        >
+          Run batch →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function LiveArtifactSection({
+  reportCount,
+  reviewCount,
+  sourceLabel,
+}: {
+  reportCount: number;
+  reviewCount: number;
+  sourceLabel: string;
+}) {
+  return (
+    <div className="rd-universe-head" data-open={true} role="group" aria-label="Live production artifact feed">
+      <span className="rd-universe-head__chev" aria-hidden="true">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      </span>
+      <div>
+        <div className="rd-universe-head__title">Live production artifacts</div>
+        <div className="rd-universe-head__meta">
+          <span>{reportCount} reports</span>
+          <span>·</span>
+          <span style={{ color: reviewCount > 0 ? "var(--rd-amber)" : "var(--rd-ink-soft)", fontWeight: 700 }}>
+            {reviewCount} needs review
+          </span>
+          <span>·</span>
+          <span>LinkedIn archive + daily brief memory + batch runs</span>
+        </div>
+      </div>
+      <div className="rd-row" style={{ gap: 6 }}>
+        <Pill tone="green"><span className="rd-dot rd-dot--live" />Convex-backed</Pill>
+        <button
+          className="rd-btn rd-btn--quiet rd-btn--sm"
+          onClick={() => showToast({
+            tone: "info",
+            message: `${sourceLabel}. Rows are built from existing archive, daily brief, and batch-run artifacts.`,
+          })}
+        >
+          View provenance
+        </button>
+        <button
+          className="rd-btn rd-btn--quiet rd-btn--sm"
+          onClick={() => showToast({ tone: "info", message: "Use Chat to multiply any artifact across a universe." })}
+        >
           Run batch →
         </button>
       </div>

--- a/src/features/redesign/surfaces/WorkspaceSurface.tsx
+++ b/src/features/redesign/surfaces/WorkspaceSurface.tsx
@@ -5,12 +5,18 @@
  * Mounted at /redesign/workspace. Spec: separate deployed surface, not a sixth tab in main app.
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useConvex } from "convex/react";
+import { useConvexApi } from "@/lib/convexApi";
+import { getAnonymousProductSessionId } from "@/features/product/lib/productIdentity";
 import { CardStack } from "../components/CardStack";
 import { Pill } from "../components/Pill";
 import { ChatSurface } from "./ChatSurface";
 import { ReportNotebookView } from "../components/ReportNotebookView";
-import { cardStackEntities, sampleAnswer } from "../fixtures";
+import { showToast } from "../components/Toast";
+import { cardStackEntities, sampleAnswer, type ReportCardData } from "../fixtures";
+import { useLiveArtifacts } from "../hooks/useLiveArtifacts";
 
 type Tab = "brief" | "cards" | "notebook" | "sources" | "chat" | "map";
 
@@ -29,8 +35,67 @@ interface WorkspaceSurfaceProps {
 }
 
 export function WorkspaceSurface({ reportId = "rep_orbital", initialTab = "brief" }: WorkspaceSurfaceProps) {
+  const navigate = useNavigate();
+  const convex = useConvex();
+  const api = useConvexApi();
   const [tab, setTab] = useState<Tab>(initialTab);
+  const [promoting, setPromoting] = useState(false);
   const root = cardStackEntities.orbital;
+  const liveArtifacts = useLiveArtifacts(60);
+  const liveReport = useMemo(
+    () => liveArtifacts.reports.find((report) => report.id === reportId),
+    [liveArtifacts.reports, reportId],
+  );
+  const workspaceTitle = liveReport?.entity ?? root.title;
+  const workspaceKind = liveReport?.kind ?? "Workspace";
+  const workspaceSources = liveReport?.sources ?? 14;
+  const workspaceClaims = liveReport?.claims ?? 7;
+  const workspaceFreshness = liveReport?.updatedAt ?? "2h ago";
+  const createDraftReportRef = (api?.domains?.product?.reports as any)?.createDraftReport;
+  const saveReportNotebookHtmlRef = (api?.domains?.product?.reports as any)?.saveReportNotebookHtml;
+  const isPromotableLiveArtifact = Boolean(liveReport && /^(daily|li|run)_/.test(reportId));
+  const canPromoteLiveArtifact = Boolean(isPromotableLiveArtifact && createDraftReportRef && saveReportNotebookHtmlRef);
+
+  const promoteLiveArtifact = async () => {
+    if (!liveReport) return;
+    if (!canPromoteLiveArtifact) {
+      showToast({
+        tone: "info",
+        message: "Report save controls are still connecting. Try again in a moment.",
+      });
+      return;
+    }
+    setPromoting(true);
+    try {
+      const anonymousSessionId = getAnonymousProductSessionId();
+      const created = await convex.mutation(createDraftReportRef, {
+        anonymousSessionId,
+        title: liveReport.entity,
+        summary: liveReport.description,
+        query: liveReport.entity,
+        type: liveReport.kind,
+      });
+      if (!created?.reportId) throw new Error("Missing report id");
+      await convex.mutation(saveReportNotebookHtmlRef, {
+        anonymousSessionId,
+        reportId: created.reportId,
+        notebookHtml: buildPromotedLiveArtifactHtml(liveReport),
+      });
+      showToast({
+        tone: "success",
+        message: "Saved as an editable report notebook.",
+      });
+      navigate(`/redesign/reports/${created.reportId}`);
+    } catch (error) {
+      console.error("Failed to promote live artifact", error);
+      showToast({
+        tone: "warning",
+        message: "Could not save this artifact yet. The live brief is still readable.",
+      });
+    } finally {
+      setPromoting(false);
+    }
+  };
 
   return (
     <div className="rd-stack" style={{ height: "100%", overflow: "hidden" }}>
@@ -51,23 +116,32 @@ export function WorkspaceSurface({ reportId = "rep_orbital", initialTab = "brief
 
         <div className="rd-row--between" style={{ marginTop: 10 }}>
           <div className="rd-stack" style={{ gap: 6 }}>
-            <h1 className="rd-h1" style={{ fontSize: 22 }}>{root.title}</h1>
+            <h1 className="rd-h1" style={{ fontSize: 22 }}>{workspaceTitle}</h1>
             <div className="rd-row" style={{ gap: 8, fontSize: 11.5, color: "var(--rd-ink-soft)" }}>
-              <Pill tone="green"><span className="rd-dot rd-dot--live" />Fresh · 2h ago</Pill>
-              <span>14 sources</span>
+              <Pill tone="green"><span className="rd-dot rd-dot--live" />Fresh · {workspaceFreshness}</Pill>
+              <span>{workspaceSources} sources</span>
               <span>·</span>
-              <span>7 claims</span>
+              <span>{workspaceClaims} claims</span>
               <span>·</span>
               <span>3 follow-ups</span>
               <span>·</span>
-              <Pill tone="accent">71% from memory</Pill>
+              <Pill tone="accent">{workspaceKind}</Pill>
             </div>
           </div>
 
           <div className="rd-row" style={{ gap: 6 }}>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm">Share</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm">Export</button>
-            <button className="rd-btn rd-btn--primary rd-btn--sm">Refresh</button>
+            {isPromotableLiveArtifact && (
+              <button
+                className="rd-btn rd-btn--primary rd-btn--sm"
+                disabled={promoting || !canPromoteLiveArtifact}
+                onClick={promoteLiveArtifact}
+              >
+                {promoting ? "Saving..." : canPromoteLiveArtifact ? "Save report" : "Connecting..."}
+              </button>
+            )}
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "success", message: "Workspace link copied." })}>Share</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "success", message: "Export preview queued." })}>Export</button>
+            <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Refresh queued for this workspace." })}>Refresh</button>
           </div>
         </div>
 
@@ -90,22 +164,85 @@ export function WorkspaceSurface({ reportId = "rep_orbital", initialTab = "brief
 
       {/* Active tab content */}
       <div style={{ flex: 1, minHeight: 0, overflow: "hidden", background: "var(--rd-paper-warm)" }}>
-        {tab === "brief" && <BriefTab />}
+        {tab === "brief" && <BriefTab report={liveReport} />}
         {tab === "cards" && <CardStack rootId="ship_demo" />}
         {tab === "notebook" && (
           <div style={{ height: "100%", padding: "16px 24px 24px" }}>
             <ReportNotebookView reportId={reportId} embedded />
           </div>
         )}
-        {tab === "sources" && <SourcesTab />}
-        {tab === "chat" && <ChatSurface contextLabel="Asking about: Orbital Labs" />}
+        {tab === "sources" && <SourcesTab report={liveReport} />}
+        {tab === "chat" && <ChatSurface contextLabel={`Asking about: ${workspaceTitle}`} />}
         {tab === "map" && <MapTab />}
       </div>
     </div>
   );
 }
 
-function BriefTab() {
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildPromotedLiveArtifactHtml(report: ReportCardData): string {
+  const title = escapeHtml(report.entity);
+  const description = escapeHtml(report.description);
+  const kind = escapeHtml(report.kind);
+  const status = escapeHtml(report.status);
+  const updatedAt = escapeHtml(report.updatedAt);
+  return [
+    `<h1>${title}</h1>`,
+    `<p><strong>${kind}</strong> - ${description}</p>`,
+    `<div data-block="claim" data-status="${status}">`,
+    `<span data-claim-label>Claim - imported from live artifact - ${status}</span>`,
+    `<p>${description}</p>`,
+    `<span data-claim-source>${report.sources} sources - ${report.claims} claims - refreshed ${updatedAt}</span>`,
+    `</div>`,
+    `<h2>Why this matters</h2>`,
+    `<p>This artifact started as first-party NodeBench memory and was promoted into an editable report notebook. Verify the claim trail, add source notes, then reuse it in chat, export, or workspace review.</p>`,
+    `<h2>Next action</h2>`,
+    `<p><strong>Review and preserve.</strong> Confirm the strongest claims, add missing sources, and decide whether this belongs in an active coverage universe.</p>`,
+  ].join("");
+}
+
+function BriefTab({ report }: { report?: ReportCardData }) {
+  if (report) {
+    return (
+      <div className="rd-stack" style={{ gap: 18, padding: "28px 32px", maxWidth: 820, overflow: "auto", height: "100%" }}>
+        <section>
+          <div className="rd-eyebrow">Live artifact</div>
+          <p style={{ fontFamily: "var(--rd-font-display)", fontSize: 22, lineHeight: 1.35, color: "var(--rd-ink-strong)", marginTop: 6 }}>
+            {report.entity}
+          </p>
+          <p className="rd-body" style={{ marginTop: 8, color: "var(--rd-ink-mute)" }}>
+            {report.description}
+          </p>
+        </section>
+
+        <section className="rd-card rd-card__pad" style={{ background: "var(--rd-panel)" }}>
+          <div className="rd-eyebrow">Audit trail</div>
+          <div className="rd-row" style={{ gap: 8, flexWrap: "wrap", marginTop: 10 }}>
+            <Pill tone={report.status === "verified" ? "green" : report.status === "review" ? "amber" : "blue"}>
+              {report.status}
+            </Pill>
+            <Pill>{report.sources} sources</Pill>
+            <Pill>{report.claims} claims</Pill>
+            <Pill>Updated {report.updatedAt}</Pill>
+          </div>
+        </section>
+
+        <section>
+          <div className="rd-eyebrow">Next action</div>
+          <p className="rd-body" style={{ marginTop: 6 }}>
+            Treat this as reusable memory: verify the sources, turn the strongest claims into notebook blocks, then multiply the same rubric across a universe.
+          </p>
+        </section>
+      </div>
+    );
+  }
   return (
     <div className="rd-stack" style={{ gap: 18, padding: "28px 32px", maxWidth: 760, overflow: "auto", height: "100%" }}>
       <section>
@@ -207,8 +344,9 @@ function NotebookTab() {
   );
 }
 
-function SourcesTab() {
+function SourcesTab({ report }: { report?: ReportCardData }) {
   const sources = [
+    ...(report ? [{ type: report.kind, title: report.entity, refreshed: report.updatedAt, reused: report.sources }] : []),
     { type: "PDF", title: "Orbital Labs whitepaper, p.4", refreshed: "2d ago", reused: 4 },
     { type: "Note", title: "Founder note, Ship Demo Day", refreshed: "today", reused: 6 },
     { type: "Recap", title: "Notion meeting recap, Apr 30", refreshed: "5d ago", reused: 2 },


### PR DESCRIPTION
## Summary
- Wire /redesign Home, Reports, Workspace, and mobile surfaces to first-party live artifacts from LinkedIn archive, daily brief memory, and batch runs.
- Add a durable Save report path from live artifact workspace into Convex productReports with seeded notebook HTML.
- Keep claim/source/comment actions visible and active for promoted reports.

## Verification
- npx tsc --noEmit --pretty false
- npm run build
- BASE_URL=http://127.0.0.1:4190 npm run live-smoke: 9/9
- BASE_URL=http://127.0.0.1:4190 npm run live-smoke:mobile: 8/8
- Focused Playwright dogfood: Home live brief -> Workspace -> Save report -> editable report with + Claim, + Source, Add comment
- multiple-me local QA: 100/100
- Convex research pipeline smoke: succeeded / verified / 5 steps