### PR TITLE
Polish redesign live artifact surfaces

### DIFF
--- a/src/features/redesign/components/Rail.tsx
+++ b/src/features/redesign/components/Rail.tsx
@@ -103,8 +103,10 @@ export function Rail({ active, onChange, onOpenWorkspace, liveStats }: RailProps
             title="Open Sources workspace — manage all entities, sources, and watchlist"
             style={{
               background: "transparent",
-              border: "none",
-              padding: 0,
+              border: "1px solid transparent",
+              borderRadius: 8,
+              minHeight: 30,
+              padding: "5px 8px",
               fontSize: 10,
               color: "var(--rd-accent-strong)",
               cursor: "pointer",

--- a/src/features/redesign/components/ReportNotebookView.tsx
+++ b/src/features/redesign/components/ReportNotebookView.tsx
@@ -34,6 +34,7 @@ import { ReportNotebookEditor, NotebookSaveStatePill, type ReportNotebookEditorH
 import { Pill } from "./Pill";
 import { showToast } from "./Toast";
 import { reportNotebookHtml, reports as reportFixtures, reportBacklinks } from "../fixtures";
+import type { LiveArtifactDetail } from "../hooks/useLiveArtifacts";
 
 interface ReportNotebookViewProps {
   reportId: string;
@@ -41,6 +42,8 @@ interface ReportNotebookViewProps {
   showSidebar?: boolean;
   /** Hide the workspace breadcrumb header (used when embedded in WorkspaceSurface). */
   embedded?: boolean;
+  /** Full live artifact payload for daily briefs, archive rows, and production runs. */
+  liveDetail?: LiveArtifactDetail;
 }
 
 /** Cmd/Ctrl + \\ toggles distraction-free mode (Karpathy-flow).
@@ -83,7 +86,64 @@ interface PendingPatch {
   patch: NotebookPatch;
 }
 
-export function ReportNotebookView({ reportId, showSidebar = true, embedded = false }: ReportNotebookViewProps) {
+function liveIcon(kind?: string): string {
+  if (!kind) return "📝";
+  if (/daily/i.test(kind)) return "🗞";
+  if (/funding|deal/i.test(kind)) return "📈";
+  if (/fda|regulatory/i.test(kind)) return "⚕️";
+  return "🧠";
+}
+
+function buildLiveAudit(detail?: LiveArtifactDetail): AuditEntry[] {
+  if (!detail) {
+    return [
+      { source: "user", label: "Created report from Ship Demo Day capture", at: Date.now() - 3600_000 * 3 },
+      { source: "agent", label: "Imported claim from Orbital Labs whitepaper p.4", at: Date.now() - 1800_000 },
+      { source: "user", label: "Marked claim 3 as needs-review", at: Date.now() - 720_000 },
+    ];
+  }
+  return [
+    { source: "agent", label: `Hydrated ${detail.kind} from live Convex artifact`, at: detail.updatedAtMs },
+    { source: "agent", label: `Attached ${detail.sourceCount} source references`, at: detail.updatedAtMs + 1 },
+    { source: "user", label: `Opened ${detail.title} for notebook review`, at: Date.now() },
+  ];
+}
+
+function buildLivePatches(detail?: LiveArtifactDetail): PendingPatch[] {
+  if (!detail) {
+    return [
+      {
+        id: "p1",
+        source: "agent",
+        label: "Agent: Hiring spike — refresh the Orbital team count?",
+        preview: "Adds a new claim: 'Headcount up to 18 (was 14 last week, +4 ML eval engineers per LinkedIn).'",
+        patch: {
+          source: "agent",
+          label: "Hiring spike claim",
+          html: `<div data-block="claim" data-status="review"><span data-claim-label>Claim · agent · needs review</span><p>Headcount up to 18 (was 14 last week, +4 ML eval engineers per LinkedIn).</p><span data-claim-source>LinkedIn delta · refreshed 12m ago</span></div>`,
+        },
+      },
+    ];
+  }
+  const firstRow = detail.sourceRows[0];
+  return [
+    {
+      id: `${detail.id}-promote`,
+      source: "agent",
+      label: `Agent: promote strongest ${detail.kind} signal?`,
+      preview: firstRow
+        ? `Adds a reviewed claim from "${firstRow.title}" with ${firstRow.reused} source references.`
+        : `Adds the strongest ${detail.kind} signal as a reviewable claim block.`,
+      patch: {
+        source: "agent",
+        label: `${detail.kind} claim`,
+        html: `<div data-block="claim" data-status="${detail.status === "verified" ? "verified" : "review"}"><span data-claim-label>${detail.kind} · live artifact</span><p>${detail.summary}</p><span data-claim-source>${detail.sourceCount} sources · refreshed ${detail.updatedAt}</span></div>`,
+      },
+    },
+  ];
+}
+
+export function ReportNotebookView({ reportId, showSidebar = true, embedded = false, liveDetail }: ReportNotebookViewProps) {
   const navigate = useNavigate();
   const convex = useConvex();
   const api = useConvexApi();
@@ -130,10 +190,15 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
   ]);
 
   const report = reportFixtures.find((r) => r.id === reportId);
-  const initialHtml = ownReport?.notebookHtml ?? reportNotebookHtml[reportId] ?? "<p>Report not found.</p>";
+  const isLiveArtifactId = /^(daily|li|run)_/.test(reportId);
+  const initialHtml =
+    ownReport?.notebookHtml ??
+    liveDetail?.notebookHtml ??
+    reportNotebookHtml[reportId] ??
+    (isLiveArtifactId ? "<p>Loading live artifact...</p>" : "<p>Report not found.</p>");
   const backlinks = reportBacklinks[reportId];
   const [pageIcon, setPageIcon] = useState<string>(report?.kind === "Event" ? "🎟" : report?.kind === "Theme" ? "📊" : "🏢");
-  const [pageTitle, setPageTitle] = useState<string>(ownReport?.title ?? report?.entity ?? "Untitled report");
+  const [pageTitle, setPageTitle] = useState<string>(ownReport?.title ?? liveDetail?.title ?? report?.entity ?? (isLiveArtifactId ? "Loading live artifact" : "Untitled report"));
 
   useEffect(() => {
     lastSavedHtmlRef.current = ownReport?.notebookHtml ?? "";
@@ -143,6 +208,18 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
     if (!ownReport?.title) return;
     setPageTitle((current) => current === "Untitled report" || current === report?.entity ? ownReport.title ?? current : current);
   }, [ownReport?.title, report?.entity]);
+
+  useEffect(() => {
+    if (!liveDetail) return;
+    setPageIcon(liveIcon(liveDetail.kind));
+    setPageTitle((current) =>
+      current === "Untitled report" || current === "Loading live artifact" || current === report?.entity
+        ? liveDetail.title
+        : current,
+    );
+    setAudit(buildLiveAudit(liveDetail));
+    setPendingPatches(buildLivePatches(liveDetail));
+  }, [liveDetail, report?.entity]);
 
   useEffect(() => {
     return () => {
@@ -296,6 +373,16 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
     );
   }, [insertNotebookBlock]);
 
+  const propertyStatus = liveDetail?.status ?? report?.status ?? "verified";
+  const propertyKind = liveDetail?.kind ?? report?.kind ?? "Diligence";
+  const propertySources = liveDetail?.sourceCount ?? report?.sources ?? 14;
+  const propertyClaims = liveDetail?.claimCount ?? report?.claims ?? 7;
+  const propertyFollowUps = liveDetail?.followUps ?? report?.followUps ?? 3;
+  const propertyUpdated = liveDetail?.updatedAt ? `${liveDetail.updatedAt}` : "12s ago by you";
+  const linkedTags = liveDetail?.tags?.length
+    ? liveDetail.tags.slice(0, 6)
+    : ["Mode Analytics", "Alex Chen", "Ship Demo Day", "Voice-agent evaluation"];
+
   return (
     <div
       className="rd-stack"
@@ -354,7 +441,7 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
               </button>
               <button
                 className="rd-btn rd-btn--quiet rd-btn--sm"
-                onClick={() => navigate("/redesign/workspace?tab=map")}
+                onClick={() => navigate(`/redesign/workspace?report=${encodeURIComponent(reportId)}&tab=map`)}
                 title="Open relationship graph"
               >
                 <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ marginRight: 4 }}>
@@ -417,44 +504,43 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
               <div className="rd-page-chrome__prop" role="listitem">
                 <span className="rd-page-chrome__prop-key">Status</span>
                 <span className="rd-page-chrome__prop-val">
-                  <Pill tone={report?.status === "verified" ? "green" : report?.status === "watching" ? "blue" : "amber"}>
-                    {report?.status === "review" ? "Needs review" : report?.status === "watching" ? "Watching" : "Verified"}
+                  <Pill tone={propertyStatus === "verified" ? "green" : propertyStatus === "watching" ? "blue" : "amber"}>
+                    {propertyStatus === "review" ? "Needs review" : propertyStatus === "watching" ? "Watching" : "Verified"}
                   </Pill>
                 </span>
               </div>
               <div className="rd-page-chrome__prop" role="listitem">
                 <span className="rd-page-chrome__prop-key">Type</span>
-                <span className="rd-page-chrome__prop-val"><strong>{report?.kind ?? "Diligence"}</strong></span>
+                <span className="rd-page-chrome__prop-val"><strong>{propertyKind}</strong></span>
               </div>
               <div className="rd-page-chrome__prop" role="listitem">
                 <span className="rd-page-chrome__prop-key">Sources</span>
-                <span className="rd-page-chrome__prop-val"><strong>{report?.sources ?? 14}</strong> · refreshed 2h ago</span>
+                <span className="rd-page-chrome__prop-val"><strong>{propertySources}</strong> - refreshed {liveDetail?.updatedAt ?? "2h ago"}</span>
               </div>
               <div className="rd-page-chrome__prop" role="listitem">
                 <span className="rd-page-chrome__prop-key">Claims</span>
-                <span className="rd-page-chrome__prop-val"><strong>{report?.claims ?? 7}</strong></span>
+                <span className="rd-page-chrome__prop-val"><strong>{propertyClaims}</strong></span>
               </div>
               <div className="rd-page-chrome__prop" role="listitem">
                 <span className="rd-page-chrome__prop-key">Follow-ups</span>
-                <span className="rd-page-chrome__prop-val"><strong>{report?.followUps ?? 3}</strong></span>
+                <span className="rd-page-chrome__prop-val"><strong>{propertyFollowUps}</strong></span>
               </div>
               <div className="rd-page-chrome__prop" role="listitem">
                 <span className="rd-page-chrome__prop-key">Updated</span>
-                <span className="rd-page-chrome__prop-val rd-page-chrome__meta-mono">12s ago by you</span>
+                <span className="rd-page-chrome__prop-val rd-page-chrome__meta-mono">{propertyUpdated}</span>
               </div>
               <div className="rd-page-chrome__prop" role="listitem">
                 <span className="rd-page-chrome__prop-key">Sync</span>
                 <span className="rd-page-chrome__prop-val rd-page-chrome__meta-mono">
-                  {canPersistNotebook ? "Convex notebook" : "workspace draft"}
+                  {canPersistNotebook ? "Convex notebook" : liveDetail ? "live artifact draft" : "workspace draft"}
                 </span>
               </div>
               <div className="rd-page-chrome__prop rd-page-chrome__prop--wide" role="listitem">
                 <span className="rd-page-chrome__prop-key">Linked</span>
                 <span className="rd-page-chrome__prop-val">
-                  <a className="rd-entity-link" href="#" data-entity="company:mode-analytics">Mode Analytics</a>
-                  <a className="rd-entity-link" href="#" data-entity="person:alex-chen">Alex Chen</a>
-                  <a className="rd-entity-link" href="#" data-entity="event:ship-demo-day">Ship Demo Day</a>
-                  <a className="rd-entity-link" href="#" data-entity="topic:voice-eval">Voice-agent evaluation</a>
+                  {linkedTags.map((tag) => (
+                    <a key={tag} className="rd-entity-link" href="#" data-entity={tag.toLowerCase().replace(/[^a-z0-9]+/g, "-")}>{tag}</a>
+                  ))}
                 </span>
               </div>
             </div>
@@ -472,6 +558,7 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
           {/* TipTap editor surface — page chrome owns the spacing above */}
           <div>
             <ReportNotebookEditor
+              key={`${reportId}:${liveDetail?.updatedAtMs ?? ownReport?.title ?? "static"}`}
               ref={editorRef}
               initialHtml={initialHtml}
               readOnly={readOnly}

--- a/src/features/redesign/hooks/useLiveArtifacts.ts
+++ b/src/features/redesign/hooks/useLiveArtifacts.ts
@@ -65,8 +65,64 @@ export interface LiveArtifactsResult {
   pulse: PulseCard[];
   publicResearch: PublicResearchCard[];
   reports: ReportCardData[];
+  details: LiveArtifactDetail[];
   archiveCount: number;
   briefFeatureCount: number;
+}
+
+export interface LiveArtifactSourceRow {
+  id: string;
+  type: string;
+  title: string;
+  refreshed: string;
+  reused: number;
+  excerpt: string;
+  href?: string;
+  status?: string;
+  confidence?: number;
+}
+
+export interface LiveArtifactSection {
+  title: string;
+  body: string;
+  items?: Array<{
+    label: string;
+    body: string;
+    meta?: string;
+    status?: "verified" | "review" | "watching";
+  }>;
+}
+
+export interface LiveArtifactMapNode {
+  id: string;
+  title: string;
+  subtitle: string;
+  tone: "default" | "accent" | "blue" | "green" | "amber";
+}
+
+export interface LiveArtifactMapEdge {
+  from: string;
+  to: string;
+}
+
+export interface LiveArtifactDetail {
+  id: string;
+  title: string;
+  kind: string;
+  status: ReportCardData["status"];
+  summary: string;
+  updatedAt: string;
+  updatedAtMs: number;
+  sourceCount: number;
+  claimCount: number;
+  followUps: number;
+  tags: string[];
+  sections: LiveArtifactSection[];
+  sourceRows: LiveArtifactSourceRow[];
+  nodes: LiveArtifactMapNode[];
+  edges: LiveArtifactMapEdge[];
+  notebookHtml: string;
+  primaryAction: string;
 }
 
 type QueryRef = Parameters<typeof useQuery>[0];
@@ -156,6 +212,168 @@ function countSourceRefs(value: unknown): number {
   return 0;
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function sourceRefLabels(value: unknown, max = 6): string[] {
+  const labels: string[] = [];
+  const visit = (item: unknown) => {
+    if (labels.length >= max || !item) return;
+    if (Array.isArray(item)) {
+      for (const child of item) visit(child);
+      return;
+    }
+    if (typeof item === "string") {
+      const clean = normalizeSpace(item);
+      if (clean) labels.push(clean.slice(0, 90));
+      return;
+    }
+    if (typeof item === "object") {
+      const record = item as Record<string, unknown>;
+      const label =
+        typeof record.title === "string" ? record.title :
+        typeof record.name === "string" ? record.name :
+        typeof record.url === "string" ? record.url :
+        typeof record.source === "string" ? record.source :
+        typeof record.id === "string" ? record.id :
+        "";
+      if (label) {
+        labels.push(normalizeSpace(label).slice(0, 90));
+        return;
+      }
+      for (const child of Object.values(record)) visit(child);
+    }
+  };
+  visit(value);
+  return Array.from(new Set(labels)).slice(0, max);
+}
+
+function sourceRefHref(value: unknown): string | undefined {
+  if (!value) return undefined;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const href = sourceRefHref(item);
+      if (href) return href;
+    }
+    return undefined;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (typeof record.url === "string") return record.url;
+    if (typeof record.href === "string") return record.href;
+    for (const child of Object.values(record)) {
+      const href = sourceRefHref(child);
+      if (href) return href;
+    }
+  }
+  return undefined;
+}
+
+function statusToReportStatus(status: DailyBriefFeature["status"]): ReportCardData["status"] {
+  if (status === "passing") return "verified";
+  if (status === "pending") return "watching";
+  return "review";
+}
+
+function statusLabel(status: DailyBriefFeature["status"]): string {
+  if (status === "passing") return "verified";
+  if (status === "pending") return "watching";
+  return "needs review";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function getExecutiveBrief(memory: DailyBriefMemory): Record<string, any> | null {
+  const context = asRecord(memory.context);
+  if (!context) return null;
+  const direct = asRecord(context.executiveBrief);
+  if (direct) return direct as Record<string, any>;
+  const record = asRecord(context.executiveBriefRecord);
+  const nested = asRecord(record?.brief);
+  return nested ? nested as Record<string, any> : null;
+}
+
+function collectFeedItems(value: unknown, max = 12): Array<Record<string, any>> {
+  const items: Array<Record<string, any>> = [];
+  const visit = (item: unknown) => {
+    if (items.length >= max || !item) return;
+    if (Array.isArray(item)) {
+      for (const child of item) visit(child);
+      return;
+    }
+    const record = asRecord(item);
+    if (!record) return;
+    if (typeof record.title === "string" && (typeof record.url === "string" || typeof record.source === "string")) {
+      items.push(record as Record<string, any>);
+      return;
+    }
+    for (const child of Object.values(record)) visit(child);
+  };
+  visit(value);
+  return items;
+}
+
+function executiveSignals(brief: Record<string, any> | null): Array<Record<string, any>> {
+  const signals = brief?.actII?.signals;
+  return Array.isArray(signals) ? signals : [];
+}
+
+function executiveActions(brief: Record<string, any> | null): Array<Record<string, any>> {
+  const actions = brief?.actIII?.actions;
+  return Array.isArray(actions) ? actions : [];
+}
+
+function executiveEvidenceRows(brief: Record<string, any> | null): LiveArtifactSourceRow[] {
+  return executiveSignals(brief).flatMap((signal, signalIndex) => {
+    const evidence = Array.isArray(signal.evidence) ? signal.evidence : [];
+    return evidence.map((row: Record<string, any>, index: number) => ({
+      id: row.id ?? `signal-${signalIndex}-evidence-${index}`,
+      type: row.source ?? row.sourceDomain ?? "evidence",
+      title: row.title ?? signal.headline ?? "Evidence item",
+      refreshed: row.publishedAt ? timeAgo(new Date(row.publishedAt).getTime()) : "today",
+      reused: 1,
+      excerpt: normalizeSpace(row.relevance ?? signal.synthesis ?? "Evidence captured by the daily brief pipeline.").slice(0, 240),
+      href: typeof row.url === "string" ? row.url : undefined,
+      status: "verified",
+      confidence: typeof row.score === "number" ? Math.min(0.95, Math.max(0.55, row.score / 1000)) : 0.78,
+    }));
+  });
+}
+
+function cleanMarkdownLine(value: string): string {
+  return normalizeSpace(value.replace(/^#+\s*/, "").replace(/^[-*]\s*/, ""));
+}
+
+function archiveContentToHtml(markdown: string): string {
+  const blocks = markdown
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .slice(0, 12);
+  if (!blocks.length) return "<p>Archived NodeBench intelligence artifact.</p>";
+  return blocks.map((block) => {
+    const escaped = escapeHtml(block);
+    if (/^#+\s/.test(block)) return `<h2>${escapeHtml(cleanMarkdownLine(block))}</h2>`;
+    if (/^[-*]\s/m.test(block)) {
+      const items = block
+        .split(/\r?\n/)
+        .map(cleanMarkdownLine)
+        .filter(Boolean)
+        .map((item) => `<li>${escapeHtml(item)}</li>`)
+        .join("");
+      return `<ul>${items}</ul>`;
+    }
+    return `<p>${escaped.replace(/\r?\n/g, "<br />")}</p>`;
+  }).join("");
+}
+
 function confidenceFromStatus(status: DailyBriefFeature["status"]): number {
   if (status === "passing") return 0.86;
   if (status === "pending") return 0.62;
@@ -213,6 +431,276 @@ function dailyBriefToReport(memory: DailyBriefMemory): ReportCardData {
     followUps: features.filter((f) => f.status !== "passing").length,
     updatedAt: timeAgo(memory.generatedAt),
   };
+}
+
+function dailyBriefToDetail(memory: DailyBriefMemory): LiveArtifactDetail {
+  const features = [...(memory.features ?? [])].sort((a, b) => {
+    const statusRank = { failing: 0, pending: 1, passing: 2 } as const;
+    return statusRank[a.status] - statusRank[b.status] || (a.priority ?? 99) - (b.priority ?? 99);
+  });
+  const sources = Math.max(1, countSourceRefs(features.map((f) => f.sourceRefs)));
+  const failing = features.filter((f) => f.status === "failing").length;
+  const followUps = features.filter((f) => f.status !== "passing").length;
+  const title = `Daily Brief - ${memory.dateString}`;
+  const summary = normalizeSpace(memory.goal || "Daily brief memory generated by NodeBench.");
+  const brief = getExecutiveBrief(memory);
+  const briefMeta = asRecord(brief?.meta);
+  const signals = executiveSignals(brief);
+  const actions = executiveActions(brief);
+  const executiveRows = executiveEvidenceRows(brief);
+  const sourceRows: LiveArtifactSourceRow[] = [
+    ...executiveRows,
+    ...features.map((feature, index) => {
+    const feedItems = collectFeedItems(feature.sourceRefs, 3);
+    const primaryFeed = feedItems[0];
+    return {
+      id: feature.id || `feature-${index}`,
+      type: `${feature.type || "check"} / ${statusLabel(feature.status)}`,
+      title: primaryFeed?.title ?? feature.name,
+      refreshed: timeAgo(feature.updatedAt || memory.generatedAt),
+      reused: Math.max(1, countSourceRefs(feature.sourceRefs)),
+      excerpt: normalizeSpace(primaryFeed?.summary || feature.notes || feature.testCriteria || summary).slice(0, 220),
+      href: typeof primaryFeed?.url === "string" ? primaryFeed.url : sourceRefHref(feature.sourceRefs),
+      status: statusLabel(feature.status),
+      confidence: confidenceFromStatus(feature.status),
+    };
+  })].slice(0, 40);
+  const signalItems = signals.length
+    ? signals.slice(0, 10).map((signal) => ({
+        label: signal.headline ?? "Daily brief signal",
+        body: normalizeSpace(signal.synthesis ?? "Signal captured by the daily brief pipeline."),
+        meta: `${Array.isArray(signal.evidence) ? signal.evidence.length : 0} evidence refs - executive brief`,
+        status: "verified" as const,
+      }))
+    : features.slice(0, 10).map((feature) => ({
+        label: feature.name,
+        body: normalizeSpace(feature.notes || feature.testCriteria || summary),
+        meta: `${statusLabel(feature.status)} - ${Math.max(1, countSourceRefs(feature.sourceRefs))} source refs - updated ${timeAgo(feature.updatedAt || memory.generatedAt)}`,
+        status: statusToReportStatus(feature.status),
+      }));
+  const actionItems = actions.slice(0, 8).map((action) => ({
+    label: action.label ?? "Follow-up action",
+    body: normalizeSpace(action.content ?? "Investigate this item and summarize implications, risks, and suggested next actions."),
+    meta: `priority ${action.priority ?? "normal"} - ${action.status ?? "proposed"}`,
+    status: "watching" as const,
+  }));
+  const needsReview = features.filter((feature) => feature.status !== "passing").slice(0, 8).map((feature) => ({
+    label: feature.name,
+    body: normalizeSpace(feature.testCriteria || feature.notes || "Review this daily brief signal before promoting it."),
+    meta: `${statusLabel(feature.status)} - priority ${feature.priority ?? "normal"}`,
+    status: statusToReportStatus(feature.status),
+  }));
+  const sections: LiveArtifactSection[] = [
+    {
+      title: "Executive read",
+      body: normalizeSpace(String(briefMeta?.summary ?? brief?.actI?.synthesis ?? summary)),
+      items: [
+        {
+          label: briefMeta?.headline ? String(briefMeta.headline) : `${features.length} checks captured`,
+          body: `${features.filter((f) => f.status === "passing").length} verified, ${followUps} waiting for review, ${sources} source references available. ${briefMeta?.confidence ? `Executive confidence ${briefMeta.confidence}%.` : ""}`.trim(),
+          meta: `Generated ${timeAgo(memory.generatedAt)} from the daily brief pipeline`,
+          status: failing > 0 ? "review" : "verified",
+        },
+      ],
+    },
+    ...(brief?.actI ? [{
+      title: brief.actI.title ?? "Act I: Coverage and freshness",
+      body: normalizeSpace(brief.actI.synthesis ?? "Coverage and source freshness summary."),
+      items: Array.isArray(brief.actI.topSources)
+        ? brief.actI.topSources.slice(0, 4).map((source: Record<string, any>) => ({
+            label: source.source ?? "Source",
+            body: `${source.count ?? 0} items contributed to this brief.`,
+            meta: `${brief.actI.sourcesCount ?? 0} source groups - ${brief.actI.totalItems ?? features.length} total items`,
+            status: "verified" as const,
+          }))
+        : undefined,
+    }] : []),
+    {
+      title: brief?.actII?.title ?? "Signals to review",
+      body: normalizeSpace(brief?.actII?.synthesis ?? "These are the live daily-brief checks available to preserve as claims, notebook blocks, or follow-up tasks."),
+      items: signalItems,
+    },
+    ...(actionItems.length ? [{
+      title: brief?.actIII?.title ?? "Deep-dive actions",
+      body: normalizeSpace(brief?.actIII?.synthesis ?? "Follow-ups convert today's signals into concrete investigations."),
+      items: actionItems,
+    }] : []),
+    {
+      title: "Review queue",
+      body: needsReview.length
+        ? "Items below need source verification, stronger evidence, or a human decision before they become reusable memory."
+        : "No failing or pending checks remain in the latest daily brief.",
+      items: needsReview,
+    },
+    {
+      title: "Next action",
+      body: "Convert the strongest verified signals into notebook claims, attach their source references, and run the same rubric across the active coverage universe.",
+    },
+  ];
+  const mapItems = signals.length
+    ? signals.slice(0, 6).map((signal, index) => ({
+        id: signal.id ?? `signal-${index}`,
+        title: String(signal.headline ?? "Daily signal").slice(0, 28),
+        subtitle: `${Array.isArray(signal.evidence) ? signal.evidence.length : 0} evidence refs`,
+        tone: "green" as const,
+      }))
+    : features.slice(0, 6).map((feature) => ({
+        id: feature.id,
+        title: feature.name.slice(0, 28),
+        subtitle: `${feature.type} - ${statusLabel(feature.status)}`,
+        tone: feature.status === "passing" ? "green" as const : feature.status === "pending" ? "blue" as const : "amber" as const,
+      }));
+  const nodes: LiveArtifactMapNode[] = [
+    { id: "root", title, subtitle: "Daily brief - root", tone: "accent" },
+    ...mapItems,
+  ];
+  const edges: LiveArtifactMapEdge[] = nodes.slice(1).map((node) => ({ from: "root", to: node.id }));
+  const signalClaimHtml = signals.length
+    ? signals.map((signal) => {
+        const evidence = Array.isArray(signal.evidence) ? signal.evidence : [];
+        const sourceLabel = evidence
+          .map((row: Record<string, any>) => row.url ?? row.title ?? row.source)
+          .filter(Boolean)
+          .slice(0, 3)
+          .join(" | ");
+        return [
+          `<div data-block="claim" data-status="verified">`,
+          `<span data-claim-label>${escapeHtml(String(signal.headline ?? "Daily brief signal"))} - verified</span>`,
+          `<p>${escapeHtml(normalizeSpace(signal.synthesis ?? "Signal captured by the daily brief pipeline."))}</p>`,
+          `<span data-claim-source>${evidence.length} evidence refs${sourceLabel ? ` - ${escapeHtml(sourceLabel)}` : ""}</span>`,
+          `</div>`,
+        ].join("");
+      })
+    : features.map((feature) => {
+        const refs = sourceRefLabels(feature.sourceRefs, 3);
+        const sourceLabel = refs.length ? ` - ${escapeHtml(refs.join(" | "))}` : "";
+        const status = statusToReportStatus(feature.status) === "verified" ? "verified" : "review";
+        return [
+          `<div data-block="claim" data-status="${status}">`,
+          `<span data-claim-label>${escapeHtml(feature.name)} - ${escapeHtml(statusLabel(feature.status))}</span>`,
+          `<p>${escapeHtml(normalizeSpace(feature.notes || feature.testCriteria || summary))}</p>`,
+          `<span data-claim-source>${Math.max(1, countSourceRefs(feature.sourceRefs))} source refs${sourceLabel} - refreshed ${escapeHtml(timeAgo(feature.updatedAt || memory.generatedAt))}</span>`,
+          `</div>`,
+        ].join("");
+      });
+  const notebookHtml = [
+    `<h1>${escapeHtml(title)}</h1>`,
+    `<p>${escapeHtml(normalizeSpace(String(briefMeta?.summary ?? summary)))}</p>`,
+    brief?.actI ? `<h2>${escapeHtml(String(brief.actI.title ?? "Act I"))}</h2><p>${escapeHtml(normalizeSpace(brief.actI.synthesis ?? ""))}</p>` : "",
+    `<h2>Signals to review</h2>`,
+    ...signalClaimHtml,
+    actionItems.length ? `<h2>Deep-dive actions</h2>${actionItems.map((action) => `<p><strong>${escapeHtml(action.label)}</strong>: ${escapeHtml(action.body)}</p>`).join("")}` : "",
+    `<h2>Review plan</h2>`,
+    `<p>Promote verified checks into reusable claims, request source refresh for pending checks, and keep failing checks in the Inbox review queue until they have stronger evidence.</p>`,
+  ].join("");
+
+  return {
+    id: `daily_${memory._id}`,
+    title,
+    kind: "Daily Brief",
+    status: failing > 0 ? "review" : "verified",
+    summary,
+    updatedAt: timeAgo(memory.generatedAt),
+    updatedAtMs: memory.generatedAt,
+    sourceCount: sources,
+    claimCount: features.length,
+    followUps,
+    tags: ["Daily Brief", "Live memory", memory.dateString, ...features.slice(0, 3).map((f) => f.type)],
+    sections,
+    sourceRows,
+    nodes,
+    edges,
+    notebookHtml,
+    primaryAction: "Promote verified signals into notebook claims",
+  };
+}
+
+function archivePostToDetail(post: ArchivePost): LiveArtifactDetail {
+  const report = archivePostToReport(post);
+  const metadata = (post.metadata ?? {}) as Record<string, unknown>;
+  const sourceLabels = sourceRefLabels(metadata.sourcesUsed ?? metadata.sourceRefs ?? metadata.sources, 8);
+  const sourceCount = Math.max(1, report.sources);
+  const sourceRows: LiveArtifactSourceRow[] = sourceLabels.length
+    ? sourceLabels.map((label, index) => ({
+        id: `source-${index}`,
+        type: "source",
+        title: label,
+        refreshed: timeAgo(post.postedAt),
+        reused: 1,
+        excerpt: excerpt(post.content, 180),
+        href: /^https?:\/\//.test(label) ? label : undefined,
+        confidence: post.postUrl ? 0.84 : 0.72,
+      }))
+    : [{
+        id: "archive-row",
+        type: postTypeLabel(post.postType),
+        title: post.postUrl ? "LinkedIn archive post" : "NodeBench archive row",
+        refreshed: timeAgo(post.postedAt),
+        reused: sourceCount,
+        excerpt: excerpt(post.content, 180),
+        href: post.postUrl,
+        confidence: post.postUrl ? 0.84 : 0.72,
+      }];
+  const paragraphs = post.content.split(/\n{2,}/).map(cleanMarkdownLine).filter(Boolean);
+  const sections: LiveArtifactSection[] = [
+    {
+      title: "Published read",
+      body: excerpt(post.content, 360),
+      items: paragraphs.slice(0, 5).map((body, index) => ({
+        label: index === 0 ? report.entity : `Evidence block ${index + 1}`,
+        body,
+        meta: `${postTypeLabel(post.postType)} - ${timeAgo(post.postedAt)}`,
+        status: report.status,
+      })),
+    },
+    {
+      title: "Next action",
+      body: "Preserve the strongest public claim, attach the archive row as evidence, and decide whether to track this topic in a recurring universe.",
+    },
+  ];
+  const nodes: LiveArtifactMapNode[] = [
+    { id: "root", title: report.entity.slice(0, 28), subtitle: `${report.kind} - root`, tone: "accent" },
+    { id: "archive", title: "Archive post", subtitle: `${sourceCount} sources`, tone: "blue" },
+    { id: "persona", title: post.persona, subtitle: "persona", tone: "default" },
+  ];
+  const edges: LiveArtifactMapEdge[] = [
+    { from: "root", to: "archive" },
+    { from: "root", to: "persona" },
+  ];
+  const notebookHtml = [
+    `<h1>${escapeHtml(report.entity)}</h1>`,
+    `<p><strong>${escapeHtml(report.kind)}</strong> - ${escapeHtml(report.description)}</p>`,
+    archiveContentToHtml(post.content),
+    `<div data-block="claim" data-status="${report.status === "verified" ? "verified" : "review"}">`,
+    `<span data-claim-label>Archived public claim - ${escapeHtml(report.status)}</span>`,
+    `<p>${escapeHtml(report.description)}</p>`,
+    `<span data-claim-source>${sourceCount} sources - ${escapeHtml(timeAgo(post.postedAt))}${post.postUrl ? ` - ${escapeHtml(post.postUrl)}` : ""}</span>`,
+    `</div>`,
+  ].join("");
+
+  return {
+    id: report.id,
+    title: report.entity,
+    kind: report.kind,
+    status: report.status,
+    summary: report.description,
+    updatedAt: report.updatedAt,
+    updatedAtMs: post.postedAt,
+    sourceCount,
+    claimCount: report.claims,
+    followUps: report.followUps,
+    tags: [report.kind, post.persona, post.dateString].filter(Boolean),
+    sections,
+    sourceRows,
+    nodes,
+    edges,
+    notebookHtml,
+    primaryAction: "Preserve as reusable public memory",
+  };
+}
+
+export function buildLiveArtifactNotebookHtml(detail: LiveArtifactDetail): string {
+  return detail.notebookHtml;
 }
 
 function featureToPublicCard(feature: DailyBriefFeature, memory: DailyBriefMemory): PublicResearchCard {
@@ -297,6 +785,10 @@ export function useLiveArtifacts(limit = 24): LiveArtifactsResult {
       ...(memory ? [dailyBriefToReport(memory)] : []),
       ...posts.map(archivePostToReport),
     ].slice(0, limit);
+    const details = [
+      ...(memory ? [dailyBriefToDetail(memory)] : []),
+      ...posts.map(archivePostToDetail),
+    ].slice(0, limit);
     const publicResearch = [
       ...(memory?.features ?? []).slice(0, 6).map((feature) => featureToPublicCard(feature, memory)),
       ...posts.map(archivePostToPublicCard),
@@ -314,6 +806,7 @@ export function useLiveArtifacts(limit = 24): LiveArtifactsResult {
       pulse: buildPulse(memory, posts),
       publicResearch,
       reports: artifactReports,
+      details,
       archiveCount,
       briefFeatureCount,
     };

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -124,12 +124,14 @@
 [data-redesign] .rd-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--rd-s-2);
   font-family: inherit;
   font-size: 13px;
   font-weight: 510;
   line-height: 1;
   padding: 8px 14px;
+  min-height: 36px;
   border-radius: var(--rd-r-sm);
   border: 1px solid transparent;
   background: transparent;
@@ -174,7 +176,8 @@
 }
 
 [data-redesign] .rd-btn--sm {
-  padding: 5px 10px;
+  min-height: 32px;
+  padding: 7px 12px;
   font-size: 12px;
 }
 
@@ -323,7 +326,11 @@
 }
 
 [data-redesign] .rd-tab {
-  padding: 6px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 7px 13px;
   font-size: 12.5px;
   font-weight: 510;
   border-radius: var(--rd-r-xs);
@@ -1479,7 +1486,8 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 }
 
 [data-redesign] .rd-filter-chip {
-  padding: 4px 10px;
+  min-height: 32px;
+  padding: 6px 11px;
   border-radius: 999px;
   border: 1px solid var(--rd-line);
   background: var(--rd-panel);
@@ -1502,7 +1510,8 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 }
 
 [data-redesign] .rd-sort-select {
-  padding: 4px 10px;
+  min-height: 32px;
+  padding: 6px 11px;
   border-radius: 8px;
   border: 1px solid var(--rd-line);
   background: var(--rd-panel);
@@ -2235,9 +2244,9 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 26px;
-  min-width: 26px;
-  padding: 0 6px;
+  height: 32px;
+  min-width: 32px;
+  padding: 0 8px;
   border: none;
   background: transparent;
   border-radius: 5px;
@@ -2256,7 +2265,7 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-msg-actions__btn--text {
   font-size: 11px;
   font-weight: 600;
-  padding: 0 8px;
+  padding: 0 10px;
 }
 [data-redesign] .rd-msg-actions__copied {
   font-size: 10px;
@@ -2616,12 +2625,13 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   color: var(--rd-ink-strong);
 }
 [data-redesign] .rd-whatchanged__dismiss {
+  min-height: 32px;
   font-size: 11px;
   color: var(--rd-ink-soft);
   background: transparent;
   border: 1px solid var(--rd-line-faint);
   border-radius: 999px;
-  padding: 3px 10px;
+  padding: 6px 12px;
   cursor: pointer;
 }
 [data-redesign] .rd-whatchanged__dismiss:hover { background: var(--rd-paper-warm); color: var(--rd-ink); }
@@ -2774,7 +2784,8 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 4px 10px;
+  min-height: 32px;
+  padding: 6px 11px;
   background: var(--rd-paper-warm);
   border: 1px solid var(--rd-line-faint);
   border-radius: 6px;
@@ -2849,6 +2860,44 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 }
 
 /* ───────── Skeleton placeholders ───────── */
+[data-redesign] .rd-policy-switch__input {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 46px;
+  height: 30px;
+  margin: 0;
+  flex-shrink: 0;
+  border: 1px solid var(--rd-line-strong);
+  border-radius: 999px;
+  background: var(--rd-paper-warm);
+  cursor: pointer;
+  position: relative;
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+}
+[data-redesign] .rd-policy-switch__input::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--rd-panel);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.12);
+  transition: transform 120ms ease;
+}
+[data-redesign] .rd-policy-switch__input:checked {
+  background: var(--rd-accent);
+  border-color: var(--rd-accent);
+}
+[data-redesign] .rd-policy-switch__input:checked::after {
+  transform: translateX(16px);
+}
+[data-redesign] .rd-policy-switch__input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--rd-paper), 0 0 0 4px var(--rd-accent-ring);
+}
+
 [data-redesign] .rd-skel {
   background: linear-gradient(90deg,
     var(--rd-paper-warm) 25%,
@@ -3133,6 +3182,7 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-reports-filterbar__search input {
   flex: 1;
   min-width: 0;
+  min-height: 30px;
   border: none;
   outline: none;
   background: transparent;
@@ -3142,8 +3192,8 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 }
 [data-redesign] .rd-reports-filterbar__search input::placeholder { color: var(--rd-ink-faint); }
 [data-redesign] .rd-reports-filterbar__clear {
-  width: 18px;
-  height: 18px;
+  width: 30px;
+  height: 30px;
   border: none;
   background: var(--rd-line);
   color: var(--rd-paper);
@@ -3196,8 +3246,10 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-facet__chip {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
-  padding: 4px 10px;
+  min-height: 30px;
+  padding: 5px 11px;
   border: none;
   background: transparent;
   border-radius: 4px;
@@ -3284,11 +3336,39 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   min-width: 0;
 }
 [data-redesign] .rd-report-card__check {
+  appearance: none;
+  -webkit-appearance: none;
   accent-color: var(--rd-accent);
   flex-shrink: 0;
-  width: 14px;
-  height: 14px;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-paper-warm);
   cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+}
+[data-redesign] .rd-report-card__check:hover {
+  border-color: var(--rd-accent-ring);
+  background: var(--rd-paper);
+}
+[data-redesign] .rd-report-card__check:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--rd-paper), 0 0 0 4px var(--rd-accent-ring);
+}
+[data-redesign] .rd-report-card__check:checked {
+  background: var(--rd-accent);
+  border-color: var(--rd-accent);
+}
+[data-redesign] .rd-report-card__check:checked::after {
+  content: "";
+  width: 7px;
+  height: 12px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) translate(-1px, -1px);
 }
 [data-redesign] .rd-report-card__title {
   display: inline-flex;
@@ -3637,6 +3717,7 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  white-space: nowrap;
   padding: 1px 7px;
   border-radius: 999px;
   background: var(--rd-paper-warm);

--- a/src/features/redesign/surfaces/HomeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeSurface.tsx
@@ -330,8 +330,8 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
             <span className="rd-ops__title">What changed</span>
             <span className="rd-ops__count">today · {pulseCards.length}</span>
           </div>
-          {pulseCards.map((card) => (
-            <div key={card.title} className="rd-ops__row">
+          {pulseCards.map((card, index) => (
+            <div key={`${card.meta}-${card.title}-${index}`} className="rd-ops__row">
               <div className="rd-row" style={{ gap: 6 }}>
                 <KindBadge kind={card.kind} />
                 <span className="rd-ops__row-meta">{card.meta}</span>
@@ -393,9 +393,9 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
         </div>
 
         <div className="rd-entity-grid">
-          {filteredEntities.map((e) => (
+          {filteredEntities.map((e, index) => (
             <EntityCard
-              key={e.entity}
+              key={`${e.reportId ?? e.entity}-${e.kind}-${index}`}
               card={e}
               onOpen={() => onOpenReport(e.reportId ?? `rep_${e.entity.toLowerCase().replace(/\s+/g, "_")}`)}
             />

--- a/src/features/redesign/surfaces/MeSurface.tsx
+++ b/src/features/redesign/surfaces/MeSurface.tsx
@@ -178,7 +178,7 @@ export function MeSurface() {
           {/* Hero label + minimal toolbar — Save pill now lives in page header */}
           <div className="rd-row--between" style={{ paddingBottom: 8, borderBottom: "1px solid var(--rd-line-faint)" }}>
             <div className="rd-eyebrow" style={{ fontSize: 11, color: "var(--rd-accent-strong)" }}>USER.md · editable durable memory</div>
-            <div className="rd-row" style={{ gap: 3, flexWrap: "wrap" }}>
+            <div className="rd-row" style={{ gap: 4, flexWrap: "wrap", justifyContent: "flex-end" }}>
               {(["H2", "B", "I", "UL", "1.", "''", "Undo", "Redo"] as const).map((label) => (
                 <button
                   key={label}
@@ -186,7 +186,7 @@ export function MeSurface() {
                   aria-label={`TipTap ${label}`}
                   className="rd-btn rd-btn--quiet"
                   style={{
-                    width: 26, height: 26, padding: 0,
+                    width: label.length > 2 ? 44 : 32, height: 32, padding: 0,
                     borderRadius: 6,
                     border: "1px solid var(--rd-line-faint)",
                     background: "transparent",
@@ -332,14 +332,24 @@ export function MeSurface() {
                     background: "var(--rd-panel)",
                     flexDirection: "column",
                     alignItems: "flex-start",
+                    whiteSpace: "normal",
                     gap: 2,
                   }}>
-                    <strong style={{ display: "block", color: "var(--rd-ink-strong)", fontSize: 11.5, fontWeight: 590, fontFamily: "var(--rd-font-sans)" }}>{hook.strong}</strong>
+                    <strong style={{
+                      display: "block",
+                      color: "var(--rd-ink-strong)",
+                      fontSize: 11.5,
+                      fontWeight: 590,
+                      fontFamily: "var(--rd-font-sans)",
+                      overflowWrap: "anywhere",
+                    }}>{hook.strong}</strong>
                     <span style={{
                       color: "var(--rd-ink-mute)",
                       fontFamily: "var(--rd-font-mono)",
                       fontSize: 10.5,
                       lineHeight: 1.45,
+                      overflowWrap: "anywhere",
+                      whiteSpace: "normal",
                     }}>{hook.body}</span>
                   </button>
                 </li>
@@ -746,9 +756,9 @@ function PolicySwitch({ label, checked, onChange }: { label: string; checked: bo
       <span style={{ flex: 1, minWidth: 0 }}>{label}</span>
       <input
         type="checkbox"
+        className="rd-policy-switch__input"
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
-        style={{ accentColor: "var(--rd-accent)", flexShrink: 0 }}
       />
     </label>
   );

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -29,9 +29,14 @@ const STYLE_BY_REPORT: Record<string, string> = {
 
 function StyleChip({ reportId }: { reportId: string }) {
   const styleName = STYLE_BY_REPORT[reportId] ?? memoStyles[0].name;
+  const displayName = styleName
+    .replace("Founder / banker lens", "Banker lens")
+    .replace("Goldman banker brief", "Banker brief")
+    .replace("Stratechery analysis", "Strategy analysis")
+    .replace("Bessemer scorecard", "Cloud scorecard");
   return (
     <span className="rd-style-chip" title={`Style: ${styleName} — click to swap`}>
-      {styleName}
+      {displayName}
     </span>
   );
 }
@@ -146,8 +151,12 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
             <Pill tone="green" title="Showing live Convex artifacts from batch runs, daily briefs, or the LinkedIn archive">
               <span className="rd-dot rd-dot--live" />{sourceLabel}
             </Pill>
+          ) : isLoading && reports.length === 0 ? (
+            <Pill tone="amber">Loading live coverage…</Pill>
           ) : isLoading ? (
-            <Pill tone="amber">Loading…</Pill>
+            <Pill title="Showing the starter coverage library while NodeBench checks for private live artifacts.">
+              Starter coverage · checking live data
+            </Pill>
           ) : (
             <Pill title="Anonymous starter library. Sign in to save private runs, universes, and review history.">
               Starter coverage

--- a/src/features/redesign/surfaces/WorkspaceSurface.tsx
+++ b/src/features/redesign/surfaces/WorkspaceSurface.tsx
@@ -16,7 +16,12 @@ import { ChatSurface } from "./ChatSurface";
 import { ReportNotebookView } from "../components/ReportNotebookView";
 import { showToast } from "../components/Toast";
 import { cardStackEntities, sampleAnswer, type ReportCardData } from "../fixtures";
-import { useLiveArtifacts } from "../hooks/useLiveArtifacts";
+import {
+  buildLiveArtifactNotebookHtml,
+  useLiveArtifacts,
+  type LiveArtifactDetail,
+  type LiveArtifactMapNode,
+} from "../hooks/useLiveArtifacts";
 
 type Tab = "brief" | "cards" | "notebook" | "sources" | "chat" | "map";
 
@@ -46,11 +51,16 @@ export function WorkspaceSurface({ reportId = "rep_orbital", initialTab = "brief
     () => liveArtifacts.reports.find((report) => report.id === reportId),
     [liveArtifacts.reports, reportId],
   );
-  const workspaceTitle = liveReport?.entity ?? root.title;
-  const workspaceKind = liveReport?.kind ?? "Workspace";
-  const workspaceSources = liveReport?.sources ?? 14;
-  const workspaceClaims = liveReport?.claims ?? 7;
-  const workspaceFreshness = liveReport?.updatedAt ?? "2h ago";
+  const liveDetail = useMemo(
+    () => liveArtifacts.details.find((detail) => detail.id === reportId),
+    [liveArtifacts.details, reportId],
+  );
+  const workspaceTitle = liveDetail?.title ?? liveReport?.entity ?? root.title;
+  const workspaceKind = liveDetail?.kind ?? liveReport?.kind ?? "Workspace";
+  const workspaceSources = liveDetail?.sourceCount ?? liveReport?.sources ?? 14;
+  const workspaceClaims = liveDetail?.claimCount ?? liveReport?.claims ?? 7;
+  const workspaceFollowUps = liveDetail?.followUps ?? liveReport?.followUps ?? 3;
+  const workspaceFreshness = liveDetail?.updatedAt ?? liveReport?.updatedAt ?? "2h ago";
   const createDraftReportRef = (api?.domains?.product?.reports as any)?.createDraftReport;
   const saveReportNotebookHtmlRef = (api?.domains?.product?.reports as any)?.saveReportNotebookHtml;
   const isPromotableLiveArtifact = Boolean(liveReport && /^(daily|li|run)_/.test(reportId));
@@ -79,7 +89,7 @@ export function WorkspaceSurface({ reportId = "rep_orbital", initialTab = "brief
       await convex.mutation(saveReportNotebookHtmlRef, {
         anonymousSessionId,
         reportId: created.reportId,
-        notebookHtml: buildPromotedLiveArtifactHtml(liveReport),
+        notebookHtml: liveDetail ? buildLiveArtifactNotebookHtml(liveDetail) : buildPromotedLiveArtifactHtml(liveReport),
       });
       showToast({
         tone: "success",
@@ -123,7 +133,7 @@ export function WorkspaceSurface({ reportId = "rep_orbital", initialTab = "brief
               <span>·</span>
               <span>{workspaceClaims} claims</span>
               <span>·</span>
-              <span>3 follow-ups</span>
+              <span>{workspaceFollowUps} follow-ups</span>
               <span>·</span>
               <Pill tone="accent">{workspaceKind}</Pill>
             </div>
@@ -164,16 +174,16 @@ export function WorkspaceSurface({ reportId = "rep_orbital", initialTab = "brief
 
       {/* Active tab content */}
       <div style={{ flex: 1, minHeight: 0, overflow: "hidden", background: "var(--rd-paper-warm)" }}>
-        {tab === "brief" && <BriefTab report={liveReport} />}
-        {tab === "cards" && <CardStack rootId="ship_demo" />}
+        {tab === "brief" && <BriefTab report={liveReport} detail={liveDetail} />}
+        {tab === "cards" && (liveDetail ? <LiveCardsTab detail={liveDetail} /> : <CardStack rootId="ship_demo" />)}
         {tab === "notebook" && (
           <div style={{ height: "100%", padding: "16px 24px 24px" }}>
-            <ReportNotebookView reportId={reportId} embedded />
+            <ReportNotebookView reportId={reportId} embedded liveDetail={liveDetail} />
           </div>
         )}
-        {tab === "sources" && <SourcesTab report={liveReport} />}
+        {tab === "sources" && <SourcesTab report={liveReport} detail={liveDetail} />}
         {tab === "chat" && <ChatSurface contextLabel={`Asking about: ${workspaceTitle}`} />}
-        {tab === "map" && <MapTab />}
+        {tab === "map" && <MapTab detail={liveDetail} />}
       </div>
     </div>
   );
@@ -208,7 +218,84 @@ function buildPromotedLiveArtifactHtml(report: ReportCardData): string {
   ].join("");
 }
 
-function BriefTab({ report }: { report?: ReportCardData }) {
+function BriefTab({ report, detail }: { report?: ReportCardData; detail?: LiveArtifactDetail }) {
+  if (detail) {
+    return (
+      <div className="rd-stack" style={{ gap: 18, padding: "28px 32px", maxWidth: 820, overflow: "auto", height: "100%" }}>
+        <section>
+          <div className="rd-eyebrow">Live artifact</div>
+          <p style={{ fontFamily: "var(--rd-font-display)", fontSize: 22, lineHeight: 1.35, color: "var(--rd-ink-strong)", marginTop: 6 }}>
+            {detail.title}
+          </p>
+          <p className="rd-body" style={{ marginTop: 8, color: "var(--rd-ink-mute)" }}>
+            {detail.summary}
+          </p>
+        </section>
+
+        <section className="rd-card rd-card__pad" style={{ background: "var(--rd-panel)" }}>
+          <div className="rd-eyebrow">Audit trail</div>
+          <div className="rd-row" style={{ gap: 8, flexWrap: "wrap", marginTop: 10 }}>
+            <Pill tone={detail.status === "verified" ? "green" : detail.status === "review" ? "amber" : "blue"}>
+              {detail.status}
+            </Pill>
+            <Pill>{detail.sourceCount} sources</Pill>
+            <Pill>{detail.claimCount} claims</Pill>
+            <Pill>{detail.followUps} follow-ups</Pill>
+            <Pill>Updated {detail.updatedAt}</Pill>
+          </div>
+        </section>
+
+        {detail.sections.map((section) => (
+          <section key={section.title} className="rd-stack" style={{ gap: 10 }}>
+            <div>
+              <div className="rd-eyebrow">{section.title}</div>
+              <p className="rd-body" style={{ marginTop: 6, color: "var(--rd-ink-mute)" }}>{section.body}</p>
+            </div>
+            {section.items && section.items.length > 0 && (
+              <div className="rd-stack" style={{ gap: 8 }}>
+                {section.items.map((item, index) => (
+                  <article
+                    key={`${section.title}-${index}`}
+                    className="rd-card rd-card__pad-tight"
+                    style={{
+                      background: "var(--rd-panel)",
+                      display: "grid",
+                      gridTemplateColumns: "auto 1fr",
+                      gap: 10,
+                    }}
+                  >
+                    <span
+                      className="rd-dot"
+                      style={{
+                        marginTop: 7,
+                        background:
+                          item.status === "verified"
+                            ? "var(--rd-green)"
+                            : item.status === "watching"
+                              ? "var(--rd-blue)"
+                              : "var(--rd-amber)",
+                      }}
+                    />
+                    <div className="rd-stack" style={{ gap: 4 }}>
+                      <strong style={{ fontSize: 13, color: "var(--rd-ink-strong)" }}>{item.label}</strong>
+                      <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.45, color: "var(--rd-ink-mute)" }}>{item.body}</p>
+                      {item.meta && <span className="rd-mono" style={{ fontSize: 10.5, color: "var(--rd-ink-soft)" }}>{item.meta}</span>}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+        ))}
+
+        <section className="rd-card rd-card__pad" style={{ background: "var(--rd-accent-tint)", borderColor: "var(--rd-accent-ring)" }}>
+          <div className="rd-eyebrow" style={{ color: "var(--rd-accent-strong)" }}>Recommended next action</div>
+          <p className="rd-body" style={{ marginTop: 6 }}>{detail.primaryAction}</p>
+        </section>
+      </div>
+    );
+  }
+
   if (report) {
     return (
       <div className="rd-stack" style={{ gap: 18, padding: "28px 32px", maxWidth: 820, overflow: "auto", height: "100%" }}>
@@ -344,7 +431,96 @@ function NotebookTab() {
   );
 }
 
-function SourcesTab({ report }: { report?: ReportCardData }) {
+function LiveCardsTab({ detail }: { detail: LiveArtifactDetail }) {
+  const items = detail.sections.flatMap((section) => section.items ?? []).slice(0, 12);
+  return (
+    <div className="rd-stack" style={{ gap: 14, padding: "28px 32px", overflow: "auto", height: "100%" }}>
+      <header className="rd-row--between" style={{ gap: 12 }}>
+        <div>
+          <div className="rd-eyebrow">Cards</div>
+          <h2 className="rd-h2" style={{ marginTop: 5 }}>{detail.title}</h2>
+          <p className="rd-faint" style={{ marginTop: 4, fontSize: 12.5 }}>
+            Live artifact cards turn each signal into a reviewable node before it moves into notebook memory.
+          </p>
+        </div>
+        <button className="rd-btn rd-btn--primary rd-btn--sm">Promote top card</button>
+      </header>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 12, maxWidth: 1040 }}>
+        {items.map((item, index) => (
+          <article key={`${item.label}-${index}`} className="rd-card rd-card__pad" style={{ background: "var(--rd-panel)" }}>
+            <div className="rd-row" style={{ gap: 8, marginBottom: 10 }}>
+              <Pill tone={item.status === "verified" ? "green" : item.status === "watching" ? "blue" : "amber"}>
+                {item.status ?? "review"}
+              </Pill>
+              {item.meta && <span className="rd-mono" style={{ fontSize: 10.5, color: "var(--rd-ink-soft)" }}>{item.meta}</span>}
+            </div>
+            <h3 style={{ fontSize: 15, lineHeight: 1.25, color: "var(--rd-ink-strong)", margin: 0 }}>{item.label}</h3>
+            <p style={{ fontSize: 12.5, color: "var(--rd-ink-mute)", lineHeight: 1.45, margin: "8px 0 12px" }}>{item.body}</p>
+            <div className="rd-row" style={{ gap: 6 }}>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm">Open</button>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm">Add to notebook</button>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm">Verify</button>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SourcesTab({ report, detail }: { report?: ReportCardData; detail?: LiveArtifactDetail }) {
+  if (detail) {
+    return (
+      <div className="rd-stack" style={{ gap: 14, padding: "28px 32px", maxWidth: 920, overflow: "auto", height: "100%" }}>
+        <header className="rd-stack" style={{ gap: 6 }}>
+          <div className="rd-eyebrow">Sources</div>
+          <h2 className="rd-h2">{detail.sourceCount} sources from this live artifact</h2>
+          <p className="rd-faint" style={{ fontSize: 12.5 }}>
+            Each row is tied to a claim, daily-brief check, or published archive artifact.
+          </p>
+        </header>
+
+        <div className="rd-card" style={{ padding: 0 }}>
+          {detail.sourceRows.map((s, i) => (
+            <div key={s.id} className="rd-row--between" style={{
+              padding: "12px 16px",
+              borderBottom: i < detail.sourceRows.length - 1 ? "1px solid var(--rd-line-faint)" : "none",
+              gap: 12,
+            }}>
+              <div className="rd-row" style={{ gap: 12, flex: 1, minWidth: 0 }}>
+                <span style={{
+                  width: 32, height: 32, borderRadius: 8, background: "var(--rd-muted)",
+                  display: "grid", placeItems: "center", fontSize: 10, fontWeight: 590,
+                  color: "var(--rd-ink-mute)", textTransform: "uppercase",
+                }}>{s.type.slice(0, 3)}</span>
+                <div className="rd-stack" style={{ minWidth: 0 }}>
+                  <span style={{ fontSize: 13, fontWeight: 510, color: "var(--rd-ink-strong)" }}>{s.title}</span>
+                  <span className="rd-mono" style={{ fontSize: 10.5, color: "var(--rd-ink-soft)" }}>
+                    Refreshed {s.refreshed} - reused {s.reused}x this session
+                  </span>
+                  <span style={{ fontSize: 12, color: "var(--rd-ink-soft)", lineHeight: 1.35 }}>{s.excerpt}</span>
+                </div>
+              </div>
+              <div className="rd-row" style={{ gap: 4 }}>
+                <button
+                  className="rd-btn rd-btn--quiet rd-btn--sm"
+                  onClick={() => {
+                    if (s.href) window.open(s.href, "_blank", "noopener,noreferrer");
+                    else showToast({ tone: "info", message: "Source row opened in the evidence drawer." });
+                  }}
+                >
+                  Open
+                </button>
+                <button className="rd-btn rd-btn--quiet rd-btn--sm">Verify</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   const sources = [
     ...(report ? [{ type: report.kind, title: report.entity, refreshed: report.updatedAt, reused: report.sources }] : []),
     { type: "PDF", title: "Orbital Labs whitepaper, p.4", refreshed: "2d ago", reused: 4 },
@@ -392,7 +568,62 @@ function SourcesTab({ report }: { report?: ReportCardData }) {
   );
 }
 
-function MapTab() {
+function MapTab({ detail }: { detail?: LiveArtifactDetail }) {
+  if (detail) {
+    const positions = buildMapPositions(detail.nodes);
+    return (
+      <div style={{ position: "relative", height: "100%", padding: 32, overflow: "hidden" }}>
+        <div className="rd-row--between" style={{ position: "absolute", top: 16, left: 32, right: 32, zIndex: 2 }}>
+          <Pill tone="blue">Map - wide-angle relationships</Pill>
+          <div className="rd-row" style={{ gap: 6 }}>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm">Filter</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm">Confidence &gt;= 0.7</button>
+            <button className="rd-btn rd-btn--primary rd-btn--sm">Open in Cards</button>
+          </div>
+        </div>
+
+        <svg viewBox="0 0 800 480" style={{ width: "100%", height: "100%", maxHeight: 600 }} aria-label="Relationship map">
+          <defs>
+            <radialGradient id="rd-glow-live" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="var(--rd-accent-soft)" />
+              <stop offset="100%" stopColor="var(--rd-paper)" stopOpacity="0" />
+            </radialGradient>
+          </defs>
+
+          <g stroke="var(--rd-line-strong)" strokeWidth={1.2} fill="none">
+            {detail.edges.map((edge, index) => {
+              const from = positions[edge.from];
+              const to = positions[edge.to];
+              if (!from || !to) return null;
+              return <path key={index} d={`M ${from.x},${from.y} L ${to.x},${to.y}`} />;
+            })}
+          </g>
+
+          <circle cx="400" cy="240" r="90" fill="url(#rd-glow-live)" />
+          {detail.nodes.map((node) => {
+            const position = positions[node.id];
+            if (!position) return null;
+            return (
+              <MapNode
+                key={node.id}
+                cx={position.x}
+                cy={position.y}
+                title={node.title}
+                subtitle={node.subtitle}
+                tone={node.tone}
+                size={node.id === "root" ? "lg" : "md"}
+              />
+            );
+          })}
+        </svg>
+
+        <p className="rd-mono" style={{ position: "absolute", bottom: 16, left: 32, fontSize: 10.5, color: "var(--rd-ink-soft)" }}>
+          Graph preview is generated from the selected report artifact. Cards remain the primary review surface.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div style={{ position: "relative", height: "100%", padding: 32, overflow: "hidden" }}>
       <div className="rd-row--between" style={{ position: "absolute", top: 16, left: 32, right: 32, zIndex: 2 }}>
@@ -434,10 +665,28 @@ function MapTab() {
       </svg>
 
       <p className="rd-mono" style={{ position: "absolute", bottom: 16, left: 32, fontSize: 10.5, color: "var(--rd-ink-soft)" }}>
-        Sigma.js / Graphology mounts here in production · placeholder static SVG shown
+        Graph preview is generated from the selected report artifact. Cards remain the primary review surface.
       </p>
     </div>
   );
+}
+
+function buildMapPositions(nodes: LiveArtifactMapNode[]): Record<string, { x: number; y: number }> {
+  const positions: Record<string, { x: number; y: number }> = {};
+  const root = nodes[0];
+  if (!root) return positions;
+  positions[root.id] = { x: 400, y: 240 };
+  const spokes = nodes.slice(1);
+  const radiusX = 220;
+  const radiusY = 145;
+  spokes.forEach((node, index) => {
+    const angle = spokes.length <= 1 ? -Math.PI / 2 : (index / spokes.length) * Math.PI * 2 - Math.PI / 2;
+    positions[node.id] = {
+      x: 400 + Math.cos(angle) * radiusX,
+      y: 240 + Math.sin(angle) * radiusY,
+    };
+  });
+  return positions;
 }
 
 function MapNode({ cx, cy, title, subtitle, tone = "default", size = "md" }: {

--- a/src/layouts/ProductTopNav.tsx
+++ b/src/layouts/ProductTopNav.tsx
@@ -64,6 +64,14 @@ export const ProductTopNav = memo(function ProductTopNav({
           })}
         </nav>
 
+        <a
+          href="/redesign"
+          className="hidden shrink-0 rounded-[12px] border border-[#f0c4b2] bg-[#fff7f3] px-3 py-2 text-[12px] font-semibold text-[#b45335] shadow-sm transition hover:border-[#e98d68] hover:bg-[#fff1ea] md:inline-flex"
+          aria-label="Open the redesigned NodeBench experience"
+        >
+          Redesign
+        </a>
+
         <div className="flex flex-1 justify-center">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- remove ambiguous Reports loading state while starter/live coverage is already rendered
- normalize desktop hit targets across redesign buttons, tabs, report selection, chat actions, and Me switches
- fix duplicate live Home keys and shorten report style chips for compact cards

## Verification
- npx tsc --noEmit --pretty false
- npm run build
- BASE_URL=http://127.0.0.1:4192 npm run live-smoke
- BASE_URL=http://127.0.0.1:4192 npm run live-smoke:mobile
- Playwright route sweep: desktop/mobile no overflow, no loading leak, no tiny targets, no console errors