### PR TITLE
fix(seo): add /redesign routes to sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -51,6 +51,36 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://www.nodebenchai.com/redesign</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.nodebenchai.com/redesign/reports</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://www.nodebenchai.com/redesign/chat</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://www.nodebenchai.com/redesign/inbox</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://www.nodebenchai.com/redesign/me</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://www.nodebenchai.com/redesign/workspace</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://www.nodebenchai.com/founder/export</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>


### PR DESCRIPTION
Adds the 6 /redesign routes shipped via PRs #240, #242, #243, #244 to public/sitemap.xml so search engines and LLM crawlers can discover them.

- /redesign (priority 0.6)
- /redesign/{reports,chat,inbox,me,workspace} (priority 0.5)

Static-asset only. No code paths touched. Will deploy with the next Vercel build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)