### PR TITLE
feat(redesign-chat): hover source preview + cost-per-turn (Sprint 1)

### DIFF
--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -2207,6 +2207,59 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-cite--block {
   vertical-align: 0;
 }
+
+/* ───────── Sprint 1 P0.1 — citation hover popover ───────── */
+[data-redesign] .rd-cite-wrap {
+  position: relative;
+  display: inline;
+}
+[data-redesign] .rd-cite-wrap .rd-cite-popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%) translateY(2px);
+  z-index: 80;
+  width: max-content;
+  max-width: 320px;
+  padding: 10px 12px;
+  background: var(--rd-paper);
+  color: var(--rd-ink);
+  border: 1px solid var(--rd-line-strong);
+  border-radius: var(--rd-r-sm);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.18);
+  font-family: var(--rd-font-display);
+  font-size: 12px;
+  line-height: 1.45;
+  letter-spacing: 0;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease-out, transform 120ms ease-out, visibility 120ms;
+}
+[data-redesign] .rd-cite-wrap .rd-cite:hover + .rd-cite-popover,
+[data-redesign] .rd-cite-wrap .rd-cite:focus-visible + .rd-cite-popover {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+[data-redesign] .rd-cite-popover__quote {
+  display: block;
+  color: var(--rd-ink-strong);
+  font-style: italic;
+  margin-bottom: 6px;
+}
+[data-redesign] .rd-cite-popover__source {
+  display: block;
+  font-family: var(--rd-font-mono);
+  font-size: 10.5px;
+  color: var(--rd-ink-soft);
+  letter-spacing: 0.02em;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-redesign] .rd-cite-wrap .rd-cite-popover {
+    transition: none;
+  }
+}
 [data-redesign] .rd-evidence-row {
   transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
 }

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -580,7 +580,7 @@ function AnswerPacket({
         <header className="rd-chat-msg__header">
           <span className="rd-chat-msg__name">NodeBench</span>
           <span className="rd-chat-msg__sep">·</span>
-          <span className="rd-chat-msg__meta">{tierMeta.label} tier · {packet.sourceCount} sources</span>
+          <span className="rd-chat-msg__meta">{tierMeta.label} tier · {packet.sourceCount} sources · {formatTraceCost(packet)}</span>
           {createdAt && <span className="rd-chat-msg__when"><LiveTime at={createdAt} /></span>}
         </header>
 
@@ -610,7 +610,7 @@ function AnswerPacket({
           letterSpacing: "-0.18px",
           margin: 0,
         }}>
-          {renderInlineWithCites(packet.shortAnswer, packet.evidence.length, handleCiteEnter, handleCiteLeave)}
+          {renderInlineWithCites(packet.shortAnswer, packet.evidence, handleCiteEnter, handleCiteLeave)}
         </p>
       </section>
 
@@ -714,12 +714,27 @@ function AnswerPacket({
 }
 
 /**
+ * Sprint 1 P1.5 — total elapsed + estimated cost from trace durations.
+ * Showcase rate: $0.005/sec (replace with real provider billing once chat is live-wired).
+ */
+function formatTraceCost(packet: typeof sampleAnswer): string {
+  const totalMs = packet.trace.reduce((sum, step) => sum + (step.durationMs ?? 0), 0);
+  const timeStr = totalMs < 1000 ? `${totalMs}ms` : `${(totalMs / 1000).toFixed(1)}s`;
+  const usd = (totalMs / 1000) * 0.005;
+  const costStr = usd >= 0.01 ? `$${usd.toFixed(3)}` : `<$0.01`;
+  return `${timeStr} · ${costStr}`;
+}
+
+/**
  * Render text with [N] citation patterns turned into interactive chips.
- * Hovering a [N] in body fires the linkage handler so the evidence row highlights.
+ *
+ * Sprint 1 P0.1 — hover the chip to see the source quote + provenance in a popover.
+ * The popover is pure-CSS positioned (`.rd-cite-wrap`) so no JS positioning math.
+ * Hovering a [N] also fires the linkage handler so the evidence row highlights.
  */
 function renderInlineWithCites(
   text: string,
-  maxIdx: number,
+  evidence: typeof sampleAnswer.evidence,
   onEnter: (idx: number) => void,
   onLeave: () => void,
 ): ReactNode[] {
@@ -729,22 +744,35 @@ function renderInlineWithCites(
   let m: RegExpExecArray | null;
   while ((m = re.exec(text))) {
     const idx = Number(m[1]);
-    if (idx < 1 || idx > maxIdx) continue;
+    const cite = evidence.find((e) => e.idx === idx);
+    if (!cite) continue;
     if (m.index > last) out.push(<span key={`t${last}`}>{text.slice(last, m.index)}</span>);
     out.push(
-      <a
-        key={`c${m.index}`}
-        href={`#cite-${idx}`}
-        className="rd-cite"
-        data-cite={idx}
-        onMouseEnter={() => onEnter(idx)}
-        onMouseLeave={onLeave}
-        onClick={(e) => {
-          e.preventDefault();
-          const target = document.querySelector(`.rd-evidence-row[data-cite="${idx}"]`);
-          target?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-        }}
-      >{idx}</a>,
+      <span key={`c${m.index}`} className="rd-cite-wrap">
+        <a
+          href={`#cite-${idx}`}
+          className="rd-cite"
+          data-cite={idx}
+          aria-describedby={`rd-cite-pop-${idx}`}
+          onMouseEnter={() => onEnter(idx)}
+          onMouseLeave={onLeave}
+          onFocus={() => onEnter(idx)}
+          onBlur={onLeave}
+          onClick={(e) => {
+            e.preventDefault();
+            const target = document.querySelector(`.rd-evidence-row[data-cite="${idx}"]`);
+            target?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+          }}
+        >{idx}</a>
+        <span
+          id={`rd-cite-pop-${idx}`}
+          className="rd-cite-popover"
+          role="tooltip"
+        >
+          <span className="rd-cite-popover__quote">&ldquo;{cite.quote}&rdquo;</span>
+          <span className="rd-cite-popover__source">{cite.source}</span>
+        </span>
+      </span>,
     );
     last = m.index + m[0].length;
   }


### PR DESCRIPTION
## Summary

Sprint 1 of the chat enhancement roadmap from [docs/architecture/REDESIGN_CHAT_ENHANCEMENTS.md](https://github.com/HomenShum/nodebench-ai/blob/main/docs/architecture/REDESIGN_CHAT_ENHANCEMENTS.md).

### P0.1 — Hover source preview
Hovering a citation chip pops a tooltip with the source quote + provenance label. Adds to the existing scroll-into-view + evidence-row highlight behavior. Pure-CSS positioning, keyboard-accessible, respects prefers-reduced-motion.

### P1.5 — Cost + duration inline per turn
AnswerPacket header meta now reads: \`Auto tier · 4 sources · 2.7s · \$0.013\`. Computed from \`packet.trace.durationMs\` at \$0.005/sec showcase rate. Replace with real provider billing once chat is live-wired.

### Deferred
P0.2 streaming scratchpad — needs ChatThinking component refactor; will land in Sprint 1.5.

## Files
- src/features/redesign/surfaces/ChatSurface.tsx
- src/features/redesign/primitives.css

## Verification
- tsc clean, build clean
- Pure UI on redesign showcase — no Convex changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)