### PR TITLE
feat(redesign-chat): inline correction + source freshness + open-questions tray (Sprint 3)

### DIFF
--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -2255,10 +2255,307 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   color: var(--rd-ink-soft);
   letter-spacing: 0.02em;
 }
+/* Sprint 3 P2.9 — source freshness pill inside popover */
+[data-redesign] .rd-cite-popover__freshness {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 2px 6px;
+  font-family: var(--rd-font-mono);
+  font-size: 9.5px;
+  color: var(--rd-ink-mute);
+  background: var(--rd-line-faint);
+  border-radius: 4px;
+  letter-spacing: 0.04em;
+}
 @media (prefers-reduced-motion: reduce) {
   [data-redesign] .rd-cite-wrap .rd-cite-popover {
     transition: none;
   }
+}
+
+/* ───────── Sprint 3 P2.11 — Open-questions tray ───────── */
+[data-redesign] .rd-open-q {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  background: var(--rd-paper);
+  border: 1px solid var(--rd-line-strong);
+  border-radius: var(--rd-r-sm);
+  position: sticky;
+  top: 8px;
+  z-index: 5;
+}
+[data-redesign] .rd-open-q__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+[data-redesign] .rd-open-q__toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: var(--rd-ink);
+  cursor: pointer;
+  font-family: inherit;
+}
+[data-redesign] .rd-open-q__toggle:focus-visible {
+  outline: 2px solid var(--rd-accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+[data-redesign] .rd-open-q__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 5px;
+  font-family: var(--rd-font-mono);
+  font-size: 10px;
+  font-weight: 590;
+  color: var(--rd-accent-strong);
+  background: var(--rd-accent-tint);
+  border: 1px solid var(--rd-accent-ring);
+  border-radius: 8px;
+}
+[data-redesign] .rd-open-q__hint {
+  margin-left: auto;
+  font-family: var(--rd-font-mono);
+  font-size: 10.5px;
+  color: var(--rd-ink-soft);
+}
+[data-redesign] .rd-open-q__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+[data-redesign] .rd-open-q__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+[data-redesign] .rd-open-q__item:last-child {
+  border-bottom: 0;
+}
+[data-redesign] .rd-open-q__pill {
+  font-size: 14px;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  background: var(--rd-line-faint);
+}
+[data-redesign] .rd-open-q__pill[data-flag="user"] {
+  background: rgba(212, 145, 60, 0.15);
+}
+[data-redesign] .rd-open-q__label {
+  display: block;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--rd-ink);
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-redesign] .rd-open-q__label:hover,
+[data-redesign] .rd-open-q__label:focus-visible {
+  color: var(--rd-accent-strong);
+  outline: none;
+  text-decoration: underline;
+  text-decoration-color: var(--rd-accent-ring);
+  text-underline-offset: 3px;
+}
+[data-redesign] .rd-open-q__when {
+  font-family: var(--rd-font-mono);
+  font-size: 10.5px;
+  color: var(--rd-ink-soft);
+  white-space: nowrap;
+}
+[data-redesign] .rd-open-q__clear {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--rd-line-strong);
+  border-radius: 5px;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+[data-redesign] .rd-open-q__clear:hover,
+[data-redesign] .rd-open-q__clear:focus-visible {
+  background: var(--rd-accent-tint);
+  border-color: var(--rd-accent-ring);
+  color: var(--rd-accent-strong);
+  outline: none;
+}
+
+/* Flash highlight when jumping to a turn from open-questions */
+[data-redesign] .rd-flash-attention {
+  animation: rd-flash-attn 1.6s ease-out;
+}
+@keyframes rd-flash-attn {
+  0%   { box-shadow: 0 0 0 0 var(--rd-accent); background: var(--rd-accent-tint); }
+  40%  { box-shadow: 0 0 0 4px var(--rd-accent-soft); background: var(--rd-accent-tint); }
+  100% { box-shadow: 0 0 0 0 transparent; background: transparent; }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-redesign] .rd-flash-attention {
+    animation: none;
+    outline: 2px solid var(--rd-accent);
+    outline-offset: 2px;
+  }
+}
+
+/* ───────── Sprint 3 P1.4 — inline correction ───────── */
+
+/* Floating "Correct this" bubble shown above text selection */
+[data-redesign] .rd-correct-bubble {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--rd-paper);
+  color: var(--rd-ink);
+  border: 1px solid var(--rd-line-strong);
+  border-radius: 999px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.20);
+  font-family: var(--rd-font-display);
+  font-size: 12.5px;
+  font-weight: 590;
+  cursor: pointer;
+  z-index: 95;
+  white-space: nowrap;
+  animation: rd-correct-bubble-in 120ms ease-out;
+}
+@keyframes rd-correct-bubble-in {
+  from { opacity: 0; transform: translate(-50%, calc(-100% + 4px)); }
+  to   { opacity: 1; transform: translate(-50%, -100%); }
+}
+[data-redesign] .rd-correct-bubble:hover,
+[data-redesign] .rd-correct-bubble:focus-visible {
+  background: var(--rd-accent);
+  color: #fff;
+  border-color: var(--rd-accent);
+  outline: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-redesign] .rd-correct-bubble {
+    animation: none;
+  }
+}
+
+/* Modal overlay + dialog for the correction editor */
+[data-redesign] .rd-correct-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.42);
+  display: grid;
+  place-items: center;
+  z-index: 110;
+  animation: rd-correct-fade-in 140ms ease-out;
+}
+@keyframes rd-correct-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+[data-redesign] .rd-correct-dialog {
+  background: var(--rd-paper);
+  border: 1px solid var(--rd-line-strong);
+  border-radius: var(--rd-r-sm);
+  width: min(560px, calc(100vw - 32px));
+  padding: 18px 18px 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.40);
+}
+[data-redesign] .rd-correct-dialog__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+[data-redesign] .rd-correct-dialog__close {
+  margin-left: auto;
+  width: 26px;
+  height: 26px;
+  background: transparent;
+  border: 0;
+  color: var(--rd-ink-mute);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+[data-redesign] .rd-correct-dialog__close:hover {
+  background: var(--rd-line-faint);
+  color: var(--rd-ink);
+}
+[data-redesign] .rd-correct-dialog__label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 10px;
+  color: var(--rd-ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+[data-redesign] .rd-correct-dialog__original {
+  padding: 10px 12px;
+  background: var(--rd-line-faint);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--rd-ink);
+  line-height: 1.5;
+}
+[data-redesign] .rd-correct-dialog__original p {
+  margin: 0;
+}
+[data-redesign] .rd-correct-dialog__edit {
+  display: flex;
+  flex-direction: column;
+}
+[data-redesign] .rd-correct-dialog__textarea {
+  background: var(--rd-paper);
+  border: 1px solid var(--rd-line-strong);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: var(--rd-font-display);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--rd-ink);
+  resize: vertical;
+}
+[data-redesign] .rd-correct-dialog__textarea:focus-visible {
+  outline: 2px solid var(--rd-accent);
+  outline-offset: 1px;
+  border-color: var(--rd-accent);
+}
+[data-redesign] .rd-correct-dialog__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 /* ───────── Sprint 2 P0.3 — counterfactual probe ───────── */

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -21,6 +21,37 @@ import { ChatEmptyState } from "../components/ChatEmptyState";
 import { showToast } from "../components/Toast";
 
 /**
+ * Sprint 3 P2.11 — fixture for the open-questions tray (claims flagged
+ * uncertain by the agent or 👎'd by the user). Once chat is live-wired,
+ * this becomes a `useAgentRunFeedback({ filter: "thumbs_down" })` query.
+ */
+const OPEN_QUESTIONS: Array<{
+  id: string;
+  label: string;
+  turnId: string;
+  flagged: "agent" | "user";
+  when: string;
+}> = [
+  { id: "oq1", label: "Procurement timing for Orbital Labs pilots", turnId: "a1", flagged: "agent", when: "2h ago" },
+  { id: "oq2", label: "Hippocratic AI traction vs Abridge",         turnId: "a2", flagged: "user",  when: "12m ago" },
+  { id: "oq3", label: "Voice-agent eval competitors within 6 months", turnId: "a1", flagged: "agent", when: "5h ago" },
+];
+
+/**
+ * Sprint 3 P2.9 — deterministic fixture for source freshness so each citation
+ * popover can show "refreshed Xh ago". Replace with `sourceRefs.lastFetchedAt`
+ * once chat is live-wired.
+ */
+function sourceFreshness(source: string): string {
+  let h = 0;
+  for (let i = 0; i < source.length; i++) h = (h * 31 + source.charCodeAt(i)) >>> 0;
+  const hours = h % 72;
+  if (hours < 1) return "just refreshed";
+  if (hours < 24) return `refreshed ${hours}h ago`;
+  return `refreshed ${Math.floor(hours / 24)}d ago`;
+}
+
+/**
  * Sprint 2 P0.2 — Streaming scratchpad fixture.
  *
  * Showcase content reflecting the same pipeline shape as the backend
@@ -368,6 +399,9 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
           </div>
         </header>
 
+        {/* Sprint 3 P2.11 — open-questions tray */}
+        <OpenQuestionsTray />
+
         {turns.length === 0 ? (
           <ChatEmptyState
             starters={liveStarters}
@@ -379,31 +413,33 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
           />
         ) : (
           turns.map((t) => {
-            if (t.role === "user") return <UserBubble key={t.id} text={t.text!} createdAt={t.createdAt} />;
-            if (t.thinking) return <ChatThinking key={t.id} />;
-            if (t.markdown) return (
-              <StreamingAnswer
-                key={t.id}
-                text={t.markdown}
-                streaming={t.streaming}
-                tier={t.tier ?? "auto"}
-                createdAt={t.createdAt}
-                onRegenerate={(tierOverride) => regenerate(t.id, tierOverride)}
-                onBranch={() => branchFromTurn(t.id)}
-              />
-            );
-            return (
-              <AnswerPacket
-                key={t.id}
-                packet={t.packet!}
-                tier={t.tier ?? "auto"}
-                toolCalls={t.toolCalls}
-                reportTitle={liveDetail?.title}
-                createdAt={t.createdAt}
-                onRegenerate={(tierOverride) => regenerate(t.id, tierOverride)}
-                onBranch={() => branchFromTurn(t.id)}
-              />
-            );
+            // Sprint 3 P2.11 — wrap with data-turn-id so OpenQuestionsTray jump can target it
+            const inner = (() => {
+              if (t.role === "user") return <UserBubble text={t.text!} createdAt={t.createdAt} />;
+              if (t.thinking) return <ChatThinking />;
+              if (t.markdown) return (
+                <StreamingAnswer
+                  text={t.markdown}
+                  streaming={t.streaming}
+                  tier={t.tier ?? "auto"}
+                  createdAt={t.createdAt}
+                  onRegenerate={(tierOverride) => regenerate(t.id, tierOverride)}
+                  onBranch={() => branchFromTurn(t.id)}
+                />
+              );
+              return (
+                <AnswerPacket
+                  packet={t.packet!}
+                  tier={t.tier ?? "auto"}
+                  toolCalls={t.toolCalls}
+                  reportTitle={liveDetail?.title}
+                  createdAt={t.createdAt}
+                  onRegenerate={(tierOverride) => regenerate(t.id, tierOverride)}
+                  onBranch={() => branchFromTurn(t.id)}
+                />
+              );
+            })();
+            return <div key={t.id} data-turn-id={t.id}>{inner}</div>;
           })
         )}
       </div>
@@ -446,7 +482,238 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
           />
         </div>
       </div>
+
+      {/* Sprint 3 P1.4 — selection-based inline correction */}
+      <InlineCorrection />
     </div>
+  );
+}
+
+/**
+ * Sprint 3 P2.11 — sticky tray surfacing claims that need verification.
+ * Today: fixture from OPEN_QUESTIONS. Once chat is live-wired, replace
+ * with `useAgentRunFeedback` query filtered to flagged + unresolved items.
+ */
+function OpenQuestionsTray() {
+  const [open, setOpen] = useState(true);
+  const [items, setItems] = useState(OPEN_QUESTIONS);
+  if (items.length === 0) return null;
+  const dismissOne = (id: string) => {
+    setItems((cur) => cur.filter((q) => q.id !== id));
+    showToast({ tone: "success", message: "Question marked verified." });
+  };
+  const jumpTo = (turnId: string) => {
+    const node = document.querySelector(`[data-turn-id="${turnId}"]`);
+    if (node instanceof HTMLElement) {
+      node.scrollIntoView({ block: "start", behavior: "smooth" });
+      node.classList.add("rd-flash-attention");
+      window.setTimeout(() => node.classList.remove("rd-flash-attention"), 1600);
+    }
+  };
+  return (
+    <aside className="rd-open-q" aria-label="Open questions worth verifying">
+      <div className="rd-open-q__head">
+        <button
+          type="button"
+          className="rd-open-q__toggle"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span aria-hidden="true">{open ? "▾" : "▸"}</span>
+          <span className="rd-eyebrow">Open questions</span>
+          <span className="rd-open-q__count">{items.length}</span>
+        </button>
+        <span className="rd-open-q__hint">Claims worth verifying — tap to jump, ✓ to clear</span>
+      </div>
+      {open && (
+        <ul className="rd-open-q__list">
+          {items.map((q) => (
+            <li key={q.id} className="rd-open-q__item">
+              <span
+                className="rd-open-q__pill"
+                data-flag={q.flagged}
+                title={q.flagged === "agent" ? "Flagged by the agent" : "Flagged by you"}
+              >
+                {q.flagged === "agent" ? "🤖" : "👎"}
+              </span>
+              <button
+                type="button"
+                className="rd-open-q__label"
+                onClick={() => jumpTo(q.turnId)}
+              >
+                {q.label}
+              </button>
+              <span className="rd-open-q__when">{q.when}</span>
+              <button
+                type="button"
+                className="rd-open-q__clear"
+                aria-label={`Mark "${q.label}" verified`}
+                title="Mark verified"
+                onClick={() => dismissOne(q.id)}
+              >
+                ✓
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}
+
+/**
+ * Sprint 3 P1.4 — selection-based inline correction.
+ *
+ * Listens for text selections inside `.rd-chat-msg__body` (assistant
+ * messages only). When the user highlights 5–300 chars, a floating
+ * "Correct →" bubble appears at the selection's bounding rect. Clicking
+ * opens an inline edit dialog pre-filled with the selection. Saving
+ * fires a toast and (today) is no-op; once chat is live-wired this calls
+ * `proposeMemoryPatch` from convex/domains/operatorProfile/manifest.ts
+ * (PR #239) so the correction lands in /redesign/me's Memory Update Inbox.
+ */
+function InlineCorrection() {
+  const [bubble, setBubble] = useState<{
+    x: number;
+    y: number;
+    text: string;
+  } | null>(null);
+  const [editing, setEditing] = useState<{ original: string; draft: string } | null>(null);
+
+  useEffect(() => {
+    if (editing) return; // pause selection observer while editing
+    const onSelectionChange = () => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+        setBubble(null);
+        return;
+      }
+      const range = sel.getRangeAt(0);
+      const txt = sel.toString().trim();
+      if (txt.length < 5 || txt.length > 300) {
+        setBubble(null);
+        return;
+      }
+      // Confirm selection is inside an assistant message body
+      const ancestor = range.commonAncestorContainer;
+      const el = ancestor instanceof Element ? ancestor : ancestor.parentElement;
+      if (!el?.closest(".rd-chat-msg--assistant")) {
+        setBubble(null);
+        return;
+      }
+      const rect = range.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) {
+        setBubble(null);
+        return;
+      }
+      setBubble({
+        x: rect.left + rect.width / 2,
+        y: rect.top - 6,
+        text: txt,
+      });
+    };
+    document.addEventListener("selectionchange", onSelectionChange);
+    return () => document.removeEventListener("selectionchange", onSelectionChange);
+  }, [editing]);
+
+  // Esc closes editor
+  useEffect(() => {
+    if (!editing) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setEditing(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [editing]);
+
+  const startCorrection = () => {
+    if (!bubble) return;
+    setEditing({ original: bubble.text, draft: bubble.text });
+    setBubble(null);
+    window.getSelection()?.removeAllRanges();
+  };
+
+  const save = () => {
+    if (!editing) return;
+    if (editing.draft.trim() === editing.original.trim()) {
+      showToast({ tone: "info", message: "No change to save." });
+    } else {
+      showToast({
+        tone: "success",
+        message: "Memory patch queued. Review at /redesign/me.",
+        action: {
+          label: "Open Me",
+          onClick: () => {
+            window.location.href = "/redesign/me";
+          },
+        },
+      });
+    }
+    setEditing(null);
+  };
+
+  return (
+    <>
+      {bubble && !editing && (
+        <button
+          type="button"
+          className="rd-correct-bubble"
+          style={{
+            position: "fixed",
+            top: bubble.y,
+            left: bubble.x,
+            transform: "translate(-50%, -100%)",
+          }}
+          onMouseDown={(e) => e.preventDefault() /* keep selection alive */}
+          onClick={startCorrection}
+        >
+          <span aria-hidden="true">✏️</span>
+          <span>Correct this</span>
+        </button>
+      )}
+      {editing && (
+        <div className="rd-correct-overlay" role="dialog" aria-modal="true" aria-label="Correct claim">
+          <div className="rd-correct-dialog">
+            <div className="rd-correct-dialog__head">
+              <span className="rd-eyebrow">Correct this claim</span>
+              <button
+                type="button"
+                className="rd-correct-dialog__close"
+                aria-label="Cancel correction"
+                onClick={() => setEditing(null)}
+              >
+                ✕
+              </button>
+            </div>
+            <div className="rd-correct-dialog__original">
+              <span className="rd-mono rd-correct-dialog__label">Original</span>
+              <p>{editing.original}</p>
+            </div>
+            <div className="rd-correct-dialog__edit">
+              <label className="rd-mono rd-correct-dialog__label" htmlFor="rd-correct-input">
+                Correction (writes a memory patch — review required)
+              </label>
+              <textarea
+                id="rd-correct-input"
+                className="rd-correct-dialog__textarea"
+                value={editing.draft}
+                onChange={(e) => setEditing({ ...editing, draft: e.target.value })}
+                rows={4}
+                autoFocus
+              />
+            </div>
+            <div className="rd-correct-dialog__actions">
+              <button type="button" className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => setEditing(null)}>
+                Cancel
+              </button>
+              <button type="button" className="rd-btn rd-btn--primary rd-btn--sm" onClick={save}>
+                Queue patch
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -947,6 +1214,8 @@ function renderInlineWithCites(
         >
           <span className="rd-cite-popover__quote">&ldquo;{cite.quote}&rdquo;</span>
           <span className="rd-cite-popover__source">{cite.source}</span>
+          {/* Sprint 3 P2.9 — source freshness */}
+          <span className="rd-cite-popover__freshness">{sourceFreshness(cite.source)}</span>
         </span>
       </span>,
     );


### PR DESCRIPTION
Sprint 3 of [REDESIGN_CHAT_ENHANCEMENTS.md](docs/architecture/REDESIGN_CHAT_ENHANCEMENTS.md).

## P1.4 — Inline correction
Highlight 5-300 chars inside any assistant message → floating 'Correct this' bubble → modal → 'Queue patch' fires success toast with 'Open Me' action that links to /redesign/me. Once live-wired calls proposeMemoryPatch (PR #239).

## P2.9 — Source freshness in citation popover
'refreshed Xh ago' pill below the source name. Deterministic fixture today; swap to sourceRefs.lastFetchedAt later.

## P2.11 — Open-questions tray
Sticky tray with 🤖/👎-flagged claims. Click chip → smooth-scroll to turn with flash-attention pulse. Click ✓ → dismiss + toast.

## Verification
- tsc clean, build clean
- Sprint 1/2 affordances unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)