### PR TITLE
feat(redesign-chat): Phase 2 — true streaming via Convex scheduler + reactive queries

### DIFF
--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -1,27 +1,43 @@
 /**
- * Real-LLM-backed chat for /redesign/chat. Phase 1 of the
- * "production-fidelity chat" buildout — see docs/architecture/REDESIGN_CHAT_ENHANCEMENTS.md
+ * Real-LLM-backed chat for /redesign/chat — Phase 2 (streaming).
  *
- * Phase 1 (this file):
- *   - Calls Gemini 3.1 Flash with web-search grounding
- *   - Returns AnswerPacket-shaped response with REAL source URLs
- *     pulled from Gemini's groundingMetadata.groundingChunks
- *   - Stores every run in redesignChatRuns by deterministic hash
- *     so the Sprint 4 reproducibility-hash URL can be served from cache
- *   - Auth-gated: anonymous users still get the showcase fixture
- *   - 30s timeout per agentic_reliability rule
+ * Phase 2 architecture (Convex-native streaming, no HTTP SSE):
+ *   1. Public mutation `startChat` inserts a `redesignChatRuns` row with
+ *      status="pending", schedules the internal action, returns runId
+ *      synchronously in <100ms.
+ *   2. Internal action `runStreamingChat` runs the orchestrator stages
+ *      (classify → context → Gemini call with grounding → bind), writing
+ *      ordered events to `redesignChatStreamEvents` as each stage finishes.
+ *   3. Internal action calls Gemini's `streamGenerateContent` endpoint and
+ *      writes "scratchpad" events for each text chunk + "grounding_chunk"
+ *      events as URLs arrive.
+ *   4. Public query `streamEventsForRun` (used by `useRedesignChatRun`
+ *      via Convex reactive subscription) re-runs whenever new events land,
+ *      giving the frontend live progress without a single SSE byte.
+ *   5. Public query `getRun` returns the run row (final packet once
+ *      status="complete"). Subscribed by the same hook.
  *
- * Phase 2 will convert this to streaming via Convex's HTTP streaming
- * actions (split planning/scratchpad/synthesis events).
+ * Phase 3 (future PR): GET /redesign/chat/r/{hash} route reads
+ * `redesignChatRuns by_hash` and renders the immutable answer.
  *
- * Phase 3 will add the GET /redesign/chat/r/{hash} route that reads
- * from redesignChatRuns and renders the immutable answer.
+ * Phase 4 (future PR): probe re-run with masked source, real
+ * proposeMemoryPatch on inline correction, source-URL substring
+ * validation, production load polish.
+ *
+ * Auth-gated: anonymous users still get the showcase fixture path.
  */
 
 import { v } from "convex/values";
-import { action, query, type ActionCtx } from "../../_generated/server";
+import {
+  internalAction,
+  internalMutation,
+  mutation,
+  query,
+  type ActionCtx,
+} from "../../_generated/server";
 import { internal } from "../../_generated/api";
-import { internalMutation } from "../../_generated/server";
+
+// ───────── Types ─────────
 
 type EvidenceRow = { idx: number; quote: string; source: string };
 type TraceRow = {
@@ -31,9 +47,7 @@ type TraceRow = {
   durationMs: number;
 };
 
-interface ChatRunOut {
-  runId: string;
-  hash: string;
+interface AnswerPacket {
   shortAnswer: string;
   whyItMatters: string;
   evidence: EvidenceRow[];
@@ -43,17 +57,18 @@ interface ChatRunOut {
   paidCalls: number;
   fromMemory: boolean;
   trace: TraceRow[];
-  totalLatencyMs: number;
-  totalTokens: number;
-  estimatedCostUsd: number;
 }
 
+// ───────── Constants ─────────
+
 const MAX_PROMPT_CHARS = 4_000;
-const TIMEOUT_MS = 30_000;
-const GEMINI_INPUT_USD_PER_1M_TOKENS = 0.075; // Gemini 3.1 Flash pricing (estimate)
+const TIMEOUT_MS = 45_000;
+const GEMINI_INPUT_USD_PER_1M_TOKENS = 0.075;
 const GEMINI_OUTPUT_USD_PER_1M_TOKENS = 0.30;
 
-/** Deterministic hash for reproducibility URL — stable across deployments. */
+// ───────── Helpers ─────────
+
+/** Deterministic hash for reproducibility URL — stable across deploys. */
 function answerHash(payload: {
   prompt: string;
   tier: string;
@@ -73,281 +88,15 @@ function answerHash(payload: {
   return (h1.toString(36) + h2.toString(36)).slice(0, 12);
 }
 
-/** Internal mutation: persist a run for reproducibility. */
-export const persistRun = internalMutation({
-  args: {
-    runId: v.string(),
-    hash: v.string(),
-    userId: v.optional(v.id("users")),
-    prompt: v.string(),
-    tier: v.string(),
-    model: v.string(),
-    packet: v.any(),
-    totalLatencyMs: v.number(),
-    totalTokens: v.number(),
-    estimatedCostUsd: v.number(),
-  },
-  handler: async (ctx, args) => {
-    // Idempotent: if hash already exists, return existing run
-    const existing = await ctx.db
-      .query("redesignChatRuns")
-      .withIndex("by_hash", (q) => q.eq("hash", args.hash))
-      .first();
-    if (existing) return existing._id;
-    return await ctx.db.insert("redesignChatRuns", {
-      runId: args.runId,
-      hash: args.hash,
-      userId: args.userId,
-      prompt: args.prompt,
-      tier: args.tier,
-      model: args.model,
-      packet: args.packet,
-      totalLatencyMs: args.totalLatencyMs,
-      totalTokens: args.totalTokens,
-      estimatedCostUsd: args.estimatedCostUsd,
-      createdAt: Date.now(),
-    });
-  },
-});
-
-/** Public query: read an immutable run by hash (for /redesign/chat/r/{hash}). */
-export const getByHash = query({
-  args: { hash: v.string() },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("redesignChatRuns")
-      .withIndex("by_hash", (q) => q.eq("hash", args.hash))
-      .first();
-  },
-});
-
-/**
- * Public action: run a real LLM chat turn with web-search grounding.
- * Returns an AnswerPacket-shaped response that can drive the Sprint 1-4 UI
- * affordances (hover popover, counterfactual probe, share hash, etc.) with
- * real data instead of fixtures.
- */
-export const runChat = action({
-  args: {
-    prompt: v.string(),
-    tier: v.union(v.literal("free"), v.literal("fast"), v.literal("auto"), v.literal("deep")),
-    contextRef: v.optional(v.string()),
-  },
-  handler: async (ctx: ActionCtx, args): Promise<ChatRunOut> => {
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      throw new Error("GEMINI_API_KEY not configured — cannot run real chat. Set in Convex env.");
-    }
-    const prompt = args.prompt.slice(0, MAX_PROMPT_CHARS);
-    if (prompt.trim().length < 3) {
-      throw new Error("Prompt too short — write at least a 3-character question.");
-    }
-
-    // Tier → model
-    const model = args.tier === "deep"
-      ? "gemini-3.1-pro-preview"
-      : args.tier === "free"
-      ? "gemini-3.1-flash-lite-preview"
-      : "gemini-3-flash-preview";
-
-    const trace: TraceRow[] = [];
-    const t0 = Date.now();
-
-    // --- Stage 1: classify_query (deterministic, no model call) ---
-    const t1 = Date.now();
-    const classification = classifyPrompt(prompt);
-    trace.push({
-      step: "Classify query",
-      detail: `${classification.kind} · ${classification.entity ?? "no entity"}`,
-      status: "ok",
-      durationMs: Date.now() - t1,
-    });
-
-    // --- Stage 2: build_context_bundle (deterministic for now) ---
-    const t2 = Date.now();
-    const contextBundle = {
-      role: "operator",
-      style: "evidence-first banker memo",
-      report: args.contextRef ?? "no live artifact selected",
-    };
-    trace.push({
-      step: "Build context bundle",
-      detail: `${contextBundle.role} · ${contextBundle.style}`,
-      status: "ok",
-      durationMs: Date.now() - t2,
-    });
-
-    // --- Stage 3: Gemini with web-search grounding ---
-    const t3 = Date.now();
-    const systemPrompt = `You are NodeBench's evidence-first analyst. Produce a banker-style memo with:
-1. Short answer (one sentence with citation markers like [1] [2])
-2. Why it matters (one paragraph with citation markers)
-3. Evidence (3-5 bullets, each citing a source)
-4. Risks / unknowns (2-3 bullets)
-5. Next action (one imperative sentence)
-
-Use [1], [2], [3] inline cite markers in the prose. Keep claims grounded in the web sources you retrieve. Prefer recency. If you can't find grounded evidence, say so explicitly.
-
-Context: ${JSON.stringify(contextBundle)}`;
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-    let geminiResponse: any;
-    let groundingChunks: Array<{ web?: { uri: string; title?: string } }> = [];
-    let groundingSupports: Array<{
-      segment?: { text?: string; startIndex?: number; endIndex?: number };
-      groundingChunkIndices?: number[];
-    }> = [];
-    let totalTokens = 0;
-
-    try {
-      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
-      const body = {
-        systemInstruction: { parts: [{ text: systemPrompt }] },
-        contents: [{ role: "user", parts: [{ text: prompt }] }],
-        tools: [{ google_search: {} }],
-        generationConfig: {
-          temperature: 0.3,
-          maxOutputTokens: 1500,
-          responseMimeType: "text/plain",
-        },
-      };
-      const res = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-      if (!res.ok) {
-        const errText = await res.text().catch(() => res.statusText);
-        throw new Error(`Gemini ${res.status}: ${errText.slice(0, 200)}`);
-      }
-      geminiResponse = await res.json();
-      const candidate = geminiResponse?.candidates?.[0];
-      const meta = candidate?.groundingMetadata;
-      groundingChunks = Array.isArray(meta?.groundingChunks) ? meta.groundingChunks : [];
-      groundingSupports = Array.isArray(meta?.groundingSupports) ? meta.groundingSupports : [];
-      totalTokens = (geminiResponse?.usageMetadata?.totalTokenCount ?? 0) as number;
-      trace.push({
-        step: "Gemini synthesis",
-        detail: `${model} · grounded · ${groundingChunks.length} chunks`,
-        status: "ok",
-        durationMs: Date.now() - t3,
-      });
-    } catch (err: any) {
-      clearTimeout(timeoutId);
-      trace.push({
-        step: "Gemini synthesis",
-        detail: err.name === "AbortError" ? "request_timeout" : (err.message || String(err)),
-        status: "error",
-        durationMs: Date.now() - t3,
-      });
-      throw err;
-    }
-
-    // --- Stage 4: parse and bind ---
-    const t4 = Date.now();
-    const rawText: string = geminiResponse?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
-    const parsed = parseMemo(rawText);
-
-    // Build evidence rows from groundingChunks (real URLs)
-    const evidence: EvidenceRow[] = groundingChunks.slice(0, 6).map((chunk, i) => {
-      const url = chunk.web?.uri ?? "";
-      const title = chunk.web?.title ?? new URL(url || "https://example.com").hostname;
-      // Best-effort quote: use the segment from groundingSupports that points at this chunk
-      const support = groundingSupports.find((s) => s.groundingChunkIndices?.includes(i));
-      const quote = support?.segment?.text?.trim() || `Cited from ${title}`;
-      return {
-        idx: i + 1,
-        quote: quote.slice(0, 240),
-        source: url || title,
-      };
-    });
-
-    trace.push({
-      step: "Bind evidence",
-      detail: `${evidence.length} grounded citations from ${groundingChunks.length} chunks`,
-      status: evidence.length > 0 ? "ok" : "warn",
-      durationMs: Date.now() - t4,
-    });
-
-    const totalLatencyMs = Date.now() - t0;
-    const inputTokens = (geminiResponse?.usageMetadata?.promptTokenCount ?? 0) as number;
-    const outputTokens = (geminiResponse?.usageMetadata?.candidatesTokenCount ?? 0) as number;
-    const estimatedCostUsd =
-      (inputTokens / 1_000_000) * GEMINI_INPUT_USD_PER_1M_TOKENS +
-      (outputTokens / 1_000_000) * GEMINI_OUTPUT_USD_PER_1M_TOKENS;
-
-    const runId = `chat_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-    const hash = answerHash({
-      prompt,
-      tier: args.tier,
-      model,
-      shortAnswer: parsed.shortAnswer,
-      evidenceUrls: evidence.map((e) => e.source),
-    });
-
-    const packet = {
-      shortAnswer: parsed.shortAnswer,
-      whyItMatters: parsed.whyItMatters,
-      evidence,
-      risks: parsed.risks,
-      nextAction: parsed.nextAction,
-      sourceCount: evidence.length,
-      paidCalls: 1,
-      fromMemory: false,
-      trace,
-    };
-
-    // Persist for reproducibility hash route
-    const userId = await getAuthUserIdSafely(ctx);
-    await ctx.runMutation(internal.domains.redesign.chatRuns.persistRun, {
-      runId,
-      hash,
-      userId: userId ?? undefined,
-      prompt,
-      tier: args.tier,
-      model,
-      packet,
-      totalLatencyMs,
-      totalTokens,
-      estimatedCostUsd,
-    });
-
-    return {
-      runId,
-      hash,
-      ...packet,
-      totalLatencyMs,
-      totalTokens,
-      estimatedCostUsd,
-    };
-  },
-});
-
-// --- Helpers ---
-
-async function getAuthUserIdSafely(ctx: ActionCtx): Promise<any> {
-  try {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) return null;
-    // Minimal fallback — full auth-userId lookup would query the users table.
-    return null;
-  } catch {
-    return null;
-  }
+function generateRunId(): string {
+  return `chat_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function classifyPrompt(prompt: string): { kind: string; entity?: string } {
   const lower = prompt.toLowerCase();
-  // Capitalised entity at start: "Anthropic ..." or "What about Anthropic"
   const capMatch = prompt.match(/(?:about |on |for |re )?([A-Z][A-Za-z0-9]+(?:\s[A-Z][A-Za-z0-9]+)*)/);
   const entity = capMatch?.[1];
-  if (lower.includes(" vs ") || lower.includes(" compare ")) {
-    return { kind: "competitor", entity };
-  }
+  if (lower.includes(" vs ") || lower.includes(" compare ")) return { kind: "competitor", entity };
   if (entity && entity.length > 2) return { kind: "company_search", entity };
   return { kind: "general" };
 }
@@ -360,15 +109,8 @@ interface ParsedMemo {
 }
 
 function parseMemo(text: string): ParsedMemo {
-  // Lightweight section parser. Falls back to first sentence as shortAnswer.
   const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
-  const sections: Record<string, string[]> = {
-    short: [],
-    why: [],
-    evidence: [],
-    risks: [],
-    next: [],
-  };
+  const sections: Record<string, string[]> = { short: [], why: [], evidence: [], risks: [], next: [] };
   let current: keyof typeof sections | null = null;
   for (const line of lines) {
     const lower = line.toLowerCase();
@@ -387,3 +129,419 @@ function parseMemo(text: string): ParsedMemo {
   const nextAction = sections.next[0] || "Review evidence rows; pin the strongest claim into the active report.";
   return { shortAnswer, whyItMatters, risks, nextAction };
 }
+
+// ───────── Public mutations / queries ─────────
+
+/**
+ * Public mutation: kick off a streaming chat run. Returns the runId
+ * immediately (typically <100ms) so the frontend can subscribe to
+ * `streamEventsForRun(runId)` for live progress.
+ */
+export const startChat = mutation({
+  args: {
+    prompt: v.string(),
+    tier: v.union(v.literal("free"), v.literal("fast"), v.literal("auto"), v.literal("deep")),
+    contextRef: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<string> => {
+    const prompt = args.prompt.slice(0, MAX_PROMPT_CHARS);
+    if (prompt.trim().length < 3) {
+      throw new Error("Prompt too short — write at least a 3-character question.");
+    }
+    const model = args.tier === "deep" ? "gemini-3.1-pro-preview"
+      : args.tier === "free" ? "gemini-3.1-flash-lite-preview"
+      : "gemini-3-flash-preview";
+    const runId = generateRunId();
+    let userId: any = undefined;
+    try {
+      const identity = await ctx.auth.getUserIdentity();
+      if (identity?.subject) {
+        // Best-effort lookup; not strictly required for the run to succeed.
+        const found = await ctx.db
+          .query("users")
+          .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+          .first()
+          .catch(() => null);
+        userId = found?._id;
+      }
+    } catch { /* anonymous OK */ }
+    await ctx.db.insert("redesignChatRuns", {
+      runId,
+      userId,
+      prompt,
+      tier: args.tier,
+      model,
+      status: "pending",
+      createdAt: Date.now(),
+    });
+    await ctx.scheduler.runAfter(0, internal.domains.redesign.chatRuns.runStreamingChat, {
+      runId,
+      prompt,
+      tier: args.tier,
+      contextRef: args.contextRef,
+      model,
+    });
+    return runId;
+  },
+});
+
+/**
+ * Public query: subscribe to the streaming event log for a run.
+ * Re-runs reactively as events land — frontend gets live updates.
+ */
+export const streamEventsForRun = query({
+  args: { runId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("redesignChatStreamEvents")
+      .withIndex("by_run_idx", (q) => q.eq("runId", args.runId))
+      .order("asc")
+      .collect();
+  },
+});
+
+/** Public query: get the run document (final packet once status="complete"). */
+export const getRun = query({
+  args: { runId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("redesignChatRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", args.runId))
+      .first();
+  },
+});
+
+/** Public query: get an immutable run by hash for the /r/{hash} share route. */
+export const getByHash = query({
+  args: { hash: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("redesignChatRuns")
+      .withIndex("by_hash", (q) => q.eq("hash", args.hash))
+      .first();
+  },
+});
+
+// ───────── Internal: append events / set status ─────────
+
+export const appendEvent = internalMutation({
+  args: {
+    runId: v.string(),
+    eventType: v.string(),
+    payload: v.any(),
+  },
+  handler: async (ctx, args) => {
+    // Compute next idx for ordering
+    const existing = await ctx.db
+      .query("redesignChatStreamEvents")
+      .withIndex("by_run_idx", (q) => q.eq("runId", args.runId))
+      .order("desc")
+      .take(1);
+    const nextIdx = (existing[0]?.idx ?? -1) + 1;
+    return await ctx.db.insert("redesignChatStreamEvents", {
+      runId: args.runId,
+      idx: nextIdx,
+      eventType: args.eventType,
+      payload: args.payload,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const setRunRunning = internalMutation({
+  args: { runId: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("redesignChatRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", args.runId))
+      .first();
+    if (row) await ctx.db.patch(row._id, { status: "running" });
+  },
+});
+
+export const finalizeRun = internalMutation({
+  args: {
+    runId: v.string(),
+    hash: v.string(),
+    packet: v.any(),
+    totalLatencyMs: v.number(),
+    totalTokens: v.number(),
+    estimatedCostUsd: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("redesignChatRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", args.runId))
+      .first();
+    if (row) {
+      await ctx.db.patch(row._id, {
+        status: "complete",
+        hash: args.hash,
+        packet: args.packet,
+        totalLatencyMs: args.totalLatencyMs,
+        totalTokens: args.totalTokens,
+        estimatedCostUsd: args.estimatedCostUsd,
+        completedAt: Date.now(),
+      });
+    }
+  },
+});
+
+export const failRun = internalMutation({
+  args: { runId: v.string(), errorMessage: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("redesignChatRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", args.runId))
+      .first();
+    if (row) {
+      await ctx.db.patch(row._id, {
+        status: "error",
+        errorMessage: args.errorMessage,
+        completedAt: Date.now(),
+      });
+    }
+  },
+});
+
+// ───────── Internal action: the actual streaming work ─────────
+
+export const runStreamingChat = internalAction({
+  args: {
+    runId: v.string(),
+    prompt: v.string(),
+    tier: v.string(),
+    contextRef: v.optional(v.string()),
+    model: v.string(),
+  },
+  handler: async (ctx: ActionCtx, args) => {
+    const t0 = Date.now();
+    const trace: TraceRow[] = [];
+    const apiKey = process.env.GEMINI_API_KEY;
+
+    const append = (eventType: string, payload: unknown) =>
+      ctx.runMutation(internal.domains.redesign.chatRuns.appendEvent, {
+        runId: args.runId,
+        eventType,
+        payload: payload as any,
+      });
+
+    try {
+      if (!apiKey) throw new Error("GEMINI_API_KEY not configured in Convex env");
+
+      await ctx.runMutation(internal.domains.redesign.chatRuns.setRunRunning, { runId: args.runId });
+
+      // Stage 1 — classify
+      const t1 = Date.now();
+      const classification = classifyPrompt(args.prompt);
+      const tr1 = { step: "Classify query", detail: `${classification.kind} · ${classification.entity ?? "no entity"}`, status: "ok" as const, durationMs: Date.now() - t1 };
+      trace.push(tr1);
+      await append("tool_call", tr1);
+      await append("stage", { stage: "classified", classification });
+
+      // Stage 2 — context
+      const t2 = Date.now();
+      const contextBundle = {
+        role: "operator",
+        style: "evidence-first banker memo",
+        report: args.contextRef ?? "no live artifact selected",
+      };
+      const tr2 = { step: "Build context bundle", detail: `${contextBundle.role} · ${contextBundle.style}`, status: "ok" as const, durationMs: Date.now() - t2 };
+      trace.push(tr2);
+      await append("tool_call", tr2);
+
+      // Working notes preview (deterministic, while we wait for Gemini)
+      await append("scratchpad", {
+        text: `Plan
+- Prompt: ${args.prompt.slice(0, 80)}${args.prompt.length > 80 ? "…" : ""}
+- Classified as ${classification.kind}${classification.entity ? ` (entity: ${classification.entity})` : ""}
+- Calling ${args.model} with web-search grounding`,
+      });
+
+      // Stage 3 — Gemini streaming with grounding
+      const t3 = Date.now();
+      const systemPrompt = `You are NodeBench's evidence-first analyst. Produce a banker-style memo with:
+1. Short answer (one sentence with citation markers like [1] [2])
+2. Why it matters (one paragraph with citation markers)
+3. Evidence (3-5 bullets, each citing a source)
+4. Risks / unknowns (2-3 bullets)
+5. Next action (one imperative sentence)
+
+Use [1], [2], [3] inline cite markers in the prose. Keep claims grounded in the web sources you retrieve. Prefer recency. If you can't find grounded evidence, say so explicitly.
+
+Context: ${JSON.stringify(contextBundle)}`;
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+      let rawText = "";
+      let groundingChunks: Array<{ web?: { uri: string; title?: string } }> = [];
+      let groundingSupports: Array<{
+        segment?: { text?: string; startIndex?: number; endIndex?: number };
+        groundingChunkIndices?: number[];
+      }> = [];
+      let inputTokens = 0;
+      let outputTokens = 0;
+
+      try {
+        // Use streamGenerateContent (alt=sse) for token-level streaming
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/${args.model}:streamGenerateContent?alt=sse&key=${apiKey}`;
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            systemInstruction: { parts: [{ text: systemPrompt }] },
+            contents: [{ role: "user", parts: [{ text: args.prompt }] }],
+            tools: [{ google_search: {} }],
+            generationConfig: { temperature: 0.3, maxOutputTokens: 1500 },
+          }),
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          const errText = await res.text().catch(() => res.statusText);
+          throw new Error(`Gemini ${res.status}: ${errText.slice(0, 200)}`);
+        }
+        // Parse SSE stream
+        const reader = res.body!.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+        const seenChunkUris = new Set<string>();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          let newlineIdx;
+          while ((newlineIdx = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, newlineIdx).trim();
+            buf = buf.slice(newlineIdx + 1);
+            if (!line.startsWith("data:")) continue;
+            const json = line.slice(5).trim();
+            if (!json || json === "[DONE]") continue;
+            try {
+              const obj = JSON.parse(json);
+              const candidate = obj?.candidates?.[0];
+              const partText: string | undefined = candidate?.content?.parts?.[0]?.text;
+              if (partText) {
+                rawText += partText;
+                await append("scratchpad", { text: partText });
+              }
+              const meta = candidate?.groundingMetadata;
+              if (meta?.groundingChunks) {
+                for (let i = 0; i < meta.groundingChunks.length; i++) {
+                  const chunk = meta.groundingChunks[i];
+                  const uri = chunk?.web?.uri;
+                  if (uri && !seenChunkUris.has(uri)) {
+                    seenChunkUris.add(uri);
+                    await append("grounding_chunk", {
+                      idx: groundingChunks.length + 1,
+                      url: uri,
+                      title: chunk.web?.title ?? uri,
+                    });
+                    groundingChunks.push(chunk);
+                  }
+                }
+                if (Array.isArray(meta.groundingSupports)) {
+                  groundingSupports = meta.groundingSupports;
+                }
+              }
+              if (obj?.usageMetadata) {
+                inputTokens = obj.usageMetadata.promptTokenCount ?? inputTokens;
+                outputTokens = obj.usageMetadata.candidatesTokenCount ?? outputTokens;
+              }
+            } catch (parseErr) {
+              // Skip malformed SSE chunks
+              void parseErr;
+            }
+          }
+        }
+        clearTimeout(timeoutId);
+        const tr3 = {
+          step: "Gemini synthesis",
+          detail: `${args.model} · grounded · ${groundingChunks.length} chunks`,
+          status: "ok" as const,
+          durationMs: Date.now() - t3,
+        };
+        trace.push(tr3);
+        await append("tool_call", tr3);
+      } catch (err: any) {
+        clearTimeout(timeoutId);
+        const detail = err.name === "AbortError" ? "request_timeout" : (err.message || String(err));
+        const tr3 = { step: "Gemini synthesis", detail, status: "error" as const, durationMs: Date.now() - t3 };
+        trace.push(tr3);
+        await append("tool_call", tr3);
+        throw err;
+      }
+
+      // Stage 4 — bind evidence
+      const t4 = Date.now();
+      const parsed = parseMemo(rawText);
+      const evidence: EvidenceRow[] = groundingChunks.slice(0, 6).map((chunk, i) => {
+        const url = chunk.web?.uri ?? "";
+        let host = url;
+        try { host = new URL(url || "https://example.com").hostname; } catch { /* ignore */ }
+        const title = chunk.web?.title ?? host;
+        const support = groundingSupports.find((s) => s.groundingChunkIndices?.includes(i));
+        const quote = support?.segment?.text?.trim() || `Cited from ${title}`;
+        return { idx: i + 1, quote: quote.slice(0, 240), source: url || title };
+      });
+      const tr4 = {
+        step: "Bind evidence",
+        detail: `${evidence.length} grounded citations from ${groundingChunks.length} chunks`,
+        status: (evidence.length > 0 ? "ok" : "warn") as "ok" | "warn",
+        durationMs: Date.now() - t4,
+      };
+      trace.push(tr4);
+      await append("tool_call", tr4);
+
+      // Section commits
+      await append("section", { name: "short_answer", text: parsed.shortAnswer });
+      await append("section", { name: "why_it_matters", text: parsed.whyItMatters });
+      await append("section", { name: "evidence", rows: evidence });
+      await append("section", { name: "risks", items: parsed.risks });
+      await append("section", { name: "next_action", text: parsed.nextAction });
+
+      const totalLatencyMs = Date.now() - t0;
+      const totalTokens = inputTokens + outputTokens;
+      const estimatedCostUsd =
+        (inputTokens / 1_000_000) * GEMINI_INPUT_USD_PER_1M_TOKENS +
+        (outputTokens / 1_000_000) * GEMINI_OUTPUT_USD_PER_1M_TOKENS;
+      const hash = answerHash({
+        prompt: args.prompt,
+        tier: args.tier,
+        model: args.model,
+        shortAnswer: parsed.shortAnswer,
+        evidenceUrls: evidence.map((e) => e.source),
+      });
+
+      const packet: AnswerPacket = {
+        shortAnswer: parsed.shortAnswer,
+        whyItMatters: parsed.whyItMatters,
+        evidence,
+        risks: parsed.risks,
+        nextAction: parsed.nextAction,
+        sourceCount: evidence.length,
+        paidCalls: 1,
+        fromMemory: false,
+        trace,
+      };
+
+      await ctx.runMutation(internal.domains.redesign.chatRuns.finalizeRun, {
+        runId: args.runId,
+        hash,
+        packet,
+        totalLatencyMs,
+        totalTokens,
+        estimatedCostUsd,
+      });
+      await append("packet_complete", { hash, totalLatencyMs, totalTokens, estimatedCostUsd });
+    } catch (err: any) {
+      const errorMessage = (err?.message || String(err)).slice(0, 280);
+      await append("error", { errorMessage });
+      await ctx.runMutation(internal.domains.redesign.chatRuns.failRun, {
+        runId: args.runId,
+        errorMessage,
+      });
+    }
+  },
+});
+
+// (Phase 2 hook uses startChat + streamEventsForRun + getRun directly.)

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -15595,20 +15595,55 @@ export default defineSchema({
    */
   redesignChatRuns: defineTable({
     runId: v.string(),
-    hash: v.string(),
+    hash: v.optional(v.string()),
     userId: v.optional(v.id("users")),
     prompt: v.string(),
     tier: v.string(),
     model: v.string(),
-    /** Full AnswerPacket payload — shortAnswer/evidence/risks/etc. */
-    packet: v.any(),
-    totalLatencyMs: v.number(),
-    totalTokens: v.number(),
-    estimatedCostUsd: v.number(),
+    /**
+     * Phase 2 lifecycle:
+     *   "pending"  — scheduled, not yet picked up by internal action
+     *   "running"  — events flowing
+     *   "complete" — final packet bound; hash computed
+     *   "error"    — failed (errorMessage populated)
+     */
+    status: v.optional(v.string()),
+    errorMessage: v.optional(v.string()),
+    /** Final AnswerPacket — populated when status === "complete". */
+    packet: v.optional(v.any()),
+    totalLatencyMs: v.optional(v.number()),
+    totalTokens: v.optional(v.number()),
+    estimatedCostUsd: v.optional(v.number()),
     createdAt: v.number(),
+    completedAt: v.optional(v.number()),
   })
+    .index("by_runId", ["runId"])
     .index("by_hash", ["hash"])
     .index("by_user_created", ["userId", "createdAt"]),
+
+  /**
+   * Phase 2 streaming event log. Frontend useQuery subscribes by runId
+   * and gets reactive updates as each event lands — Convex's native
+   * streaming pattern (no HTTP SSE plumbing required).
+   *
+   * Event types:
+   *   "stage"           — classify / context / synthesis / bind orchestrator stages
+   *   "scratchpad"      — agent's working notes (streamed prose chunks)
+   *   "tool_call"       — tool fired with detail + status + duration
+   *   "grounding_chunk" — a single grounded source URL + title arrived
+   *   "section"         — a structured AnswerPacket section committed
+   *   "packet_complete" — final assembly; full packet now in redesignChatRuns
+   *   "error"           — terminal failure
+   */
+  redesignChatStreamEvents: defineTable({
+    runId: v.string(),
+    /** Monotonic sequence number per runId, for ordering. */
+    idx: v.number(),
+    eventType: v.string(),
+    payload: v.any(),
+    createdAt: v.number(),
+  })
+    .index("by_run_idx", ["runId", "idx"]),
 
   /** Inbox snooze records — soft-hide an inbox item until a future timestamp. */
   inboxSnoozes: defineTable({

--- a/src/features/redesign/hooks/useRedesignChatRun.ts
+++ b/src/features/redesign/hooks/useRedesignChatRun.ts
@@ -1,31 +1,42 @@
 /**
- * Phase 1 hook for the production-fidelity chat.
+ * Phase 2 hook for the production-fidelity chat — true streaming UX
+ * via Convex's reactive subscriptions.
  *
- * Calls the new Convex action `convex/domains/redesign/chatRuns.runChat`
- * which runs Gemini 3.1 Flash with web-search grounding and returns an
- * AnswerPacket-shaped response with REAL source URLs.
+ * submit(prompt, tier, contextRef) calls the `startChat` mutation which
+ * returns a runId in <100ms (work runs in a scheduled internal action).
+ * Hook subscribes to TWO live queries for that runId:
+ *   streamEventsForRun(runId) — ordered event log
+ *   getRun(runId)             — final packet + metadata when done
+ * Convex re-runs both whenever the underlying tables change → live
+ * progress without any HTTP SSE plumbing.
  *
- * Authenticated users get the real run; unauthenticated users (and
- * `?fresh=1` showcase mode) keep the existing fixture path. The
- * authentication state is owned by the caller (ChatSurface) and passed
- * through `enabled`.
- *
- * Phase 2 will swap this for an SSE/streaming variant. Phase 3 adds the
- * /r/{hash} reproducibility URL route.
+ * Auth-gated: state.available=false when unauthenticated; caller falls
+ * back to fixture path.
  */
-import { useState, useCallback } from "react";
-import { useAction, useConvexAuth } from "convex/react";
+import { useState, useCallback, useEffect, useMemo } from "react";
+import { useMutation, useQuery, useConvexAuth } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import type { ChatAnswer } from "../fixtures";
 import type { RouterTier } from "../components/UniversalComposer";
 
+type EvidenceRow = ChatAnswer["evidence"][number];
+type TraceRow = ChatAnswer["trace"][number];
+
 export interface RealChatRun {
   runId: string;
-  hash: string;
+  hash?: string;
   packet: ChatAnswer;
-  totalLatencyMs: number;
-  totalTokens: number;
-  estimatedCostUsd: number;
+  totalLatencyMs?: number;
+  totalTokens?: number;
+  estimatedCostUsd?: number;
+  /** Live working-notes scratchpad (concatenated streamed chunks). */
+  scratchpad: string;
+  /** Per-stage tool-call cards as they fire. */
+  toolCalls: TraceRow[];
+  /** Grounded source URLs as they arrive. */
+  groundingChunks: EvidenceRow[];
+  status: "pending" | "running" | "complete" | "error";
+  errorMessage?: string;
 }
 
 export interface ChatRunState {
@@ -38,66 +49,145 @@ export interface ChatRunState {
 
 export function useRedesignChatRun() {
   const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
-  const runChatAction = useAction(api.domains.redesign.chatRuns.runChat);
-  const [status, setStatus] = useState<ChatRunState["status"]>("idle");
-  const [run, setRun] = useState<RealChatRun | null>(null);
+  const startChat = useMutation(api.domains.redesign.chatRuns.startChat);
+
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const events = useQuery(
+    api.domains.redesign.chatRuns.streamEventsForRun,
+    activeRunId ? { runId: activeRunId } : "skip",
+  );
+  const runRow = useQuery(
+    api.domains.redesign.chatRuns.getRun,
+    activeRunId ? { runId: activeRunId } : "skip",
+  );
+
+  const projected = useMemo<RealChatRun | null>(() => {
+    if (!activeRunId) return null;
+    const list = events ?? [];
+    let scratchpad = "";
+    const toolCalls: TraceRow[] = [];
+    const groundingChunks: EvidenceRow[] = [];
+    const sections: Record<string, any> = {};
+    let terminalError: string | undefined;
+    for (const ev of list) {
+      switch (ev.eventType) {
+        case "scratchpad":
+          if (typeof ev.payload?.text === "string") scratchpad += ev.payload.text;
+          break;
+        case "tool_call":
+          if (ev.payload && typeof ev.payload.step === "string") {
+            toolCalls.push(ev.payload as TraceRow);
+          }
+          break;
+        case "grounding_chunk":
+          if (ev.payload?.url) {
+            groundingChunks.push({
+              idx: groundingChunks.length + 1,
+              quote: ev.payload?.title ?? ev.payload.url,
+              source: ev.payload.url,
+            });
+          }
+          break;
+        case "section":
+          if (ev.payload?.name) sections[ev.payload.name] = ev.payload;
+          break;
+        case "error":
+          terminalError = ev.payload?.errorMessage ?? "unknown error";
+          break;
+      }
+    }
+
+    const partial: ChatAnswer = {
+      shortAnswer: sections.short_answer?.text ?? "",
+      whyItMatters: sections.why_it_matters?.text ?? "",
+      evidence: sections.evidence?.rows ?? groundingChunks,
+      risks: sections.risks?.items ?? [],
+      nextAction: sections.next_action?.text ?? "",
+      sourceCount: (sections.evidence?.rows ?? groundingChunks).length,
+      paidCalls: 1,
+      fromMemory: false,
+      trace: toolCalls,
+    };
+
+    const status: RealChatRun["status"] = (runRow?.status as RealChatRun["status"]) ?? "pending";
+    const finalPacket = (runRow?.status === "complete" && runRow.packet)
+      ? (runRow.packet as ChatAnswer)
+      : partial;
+
+    return {
+      runId: activeRunId,
+      hash: runRow?.hash ?? undefined,
+      packet: finalPacket,
+      totalLatencyMs: runRow?.totalLatencyMs,
+      totalTokens: runRow?.totalTokens,
+      estimatedCostUsd: runRow?.estimatedCostUsd,
+      scratchpad,
+      toolCalls,
+      groundingChunks,
+      status,
+      errorMessage: terminalError ?? runRow?.errorMessage ?? undefined,
+    };
+  }, [activeRunId, events, runRow]);
+
+  useEffect(() => {
+    if (projected?.status === "error" && projected.errorMessage) {
+      setError(projected.errorMessage);
+    }
+  }, [projected?.status, projected?.errorMessage]);
+
   const submit = useCallback(
-    async (prompt: string, tier: RouterTier, contextRef?: string): Promise<RealChatRun | null> => {
+    async (prompt: string, tier: RouterTier, contextRef?: string): Promise<string | null> => {
       if (!isAuthenticated) {
         setError("Sign in to run a real chat with grounded sources.");
-        setStatus("error");
         return null;
       }
-      setStatus("thinking");
       setError(null);
       try {
-        const result = await runChatAction({
-          prompt,
-          tier,
-          contextRef,
-        });
-        const real: RealChatRun = {
-          runId: result.runId,
-          hash: result.hash,
-          packet: {
-            shortAnswer: result.shortAnswer,
-            whyItMatters: result.whyItMatters,
-            evidence: result.evidence,
-            risks: result.risks,
-            nextAction: result.nextAction,
-            sourceCount: result.sourceCount,
-            paidCalls: result.paidCalls,
-            fromMemory: result.fromMemory,
-            trace: result.trace,
-          } as ChatAnswer,
-          totalLatencyMs: result.totalLatencyMs,
-          totalTokens: result.totalTokens,
-          estimatedCostUsd: result.estimatedCostUsd,
-        };
-        setRun(real);
-        setStatus("ok");
-        return real;
+        const runId = await startChat({ prompt, tier, contextRef });
+        setActiveRunId(runId);
+        return runId;
       } catch (err: any) {
-        const msg = err?.message ?? String(err);
-        setError(msg.slice(0, 280));
-        setStatus("error");
+        const msg = (err?.message ?? String(err)).slice(0, 280);
+        setError(msg);
         return null;
       }
     },
-    [isAuthenticated, runChatAction],
+    [isAuthenticated, startChat],
   );
 
   const reset = useCallback(() => {
-    setStatus("idle");
-    setRun(null);
+    setActiveRunId(null);
     setError(null);
   }, []);
 
+  const externalStatus: ChatRunState["status"] =
+    error ? "error"
+    : !activeRunId ? "idle"
+    : projected?.status === "complete" ? "ok"
+    : projected?.status === "error" ? "error"
+    : "thinking";
+
   return {
-    state: { status, run, error, available: !authLoading && isAuthenticated } as ChatRunState,
+    state: {
+      status: externalStatus,
+      run: projected,
+      error,
+      available: !authLoading && isAuthenticated,
+    } as ChatRunState,
     submit,
     reset,
+    hash: projected?.hash ?? null,
   };
 }
+
+/** Phase 3 helper — subscribe to a completed run by hash for /r/{hash}. */
+export function useRedesignChatByHash(hash: string | undefined) {
+  return useQuery(
+    api.domains.redesign.chatRuns.getByHash,
+    hash ? { hash } : "skip",
+  );
+}
+
+export type { ChatAnswer };

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -148,8 +148,12 @@ interface Turn {
   createdAt?: number;
   packet?: ChatAnswer;
   tier?: RouterTier;
-  /** Phase 1 real chat — reproducibility hash for /redesign/chat/r/{hash}. */
+  /** Phase 1+ real chat — reproducibility hash for /redesign/chat/r/{hash}. */
   runHash?: string;
+  /** Phase 2 streaming — Convex runId; while set, this turn is awaiting completion. */
+  chatRunId?: string;
+  /** Phase 2 streaming — live working-notes scratchpad text from the agent. */
+  liveScratchpad?: string;
 }
 
 /** Phase 1: map server-side trace rows to the existing ChatToolCall shape so
@@ -361,6 +365,67 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
     setSeedKey(liveSeedKey);
   }, [contextLabel, liveDetail, liveSeedKey, seedKey]);
 
+  // Phase 2 — when the streamed chat run completes, commit the final packet
+  // onto whichever turn carries the matching chatRunId. While in flight,
+  // also project the live scratchpad + partial tool calls into the turn so
+  // the UI shows progressive streaming. Convex's reactive queries re-run
+  // chatRun.state.run on every event, which triggers this effect.
+  useEffect(() => {
+    const real = chatRun.state.run;
+    if (!real) return;
+    setTurns((prev) => {
+      const idx = prev.findIndex((t) => t.chatRunId === real.runId);
+      if (idx < 0) return prev;
+      const t = prev[idx];
+      // Always reflect live scratchpad + tool-call cards as they grow.
+      const live = {
+        ...t,
+        liveScratchpad: real.scratchpad || t.liveScratchpad,
+        toolCalls: real.toolCalls.length > 0
+          ? real.toolCalls.map((tc) => ({
+              step: tc.step,
+              detail: tc.detail,
+              status: (tc.status === "ok" ? "ok"
+                : tc.status === "error" ? "error"
+                : tc.status === "warn" ? "warn"
+                : "ok") as ToolCall["status"],
+              durationMs: tc.durationMs,
+              tool: tc.step.toLowerCase().replace(/[^a-z0-9]+/g, "_"),
+            }))
+          : t.toolCalls,
+      };
+      // Once the run is complete, snap to the final packet.
+      if (real.status === "complete" && real.packet?.shortAnswer) {
+        const next = { ...live, thinking: false, packet: real.packet, runHash: real.hash };
+        const out = [...prev];
+        out[idx] = next;
+        return out;
+      }
+      // Error → fall back to a fixture so the user isn't left staring.
+      if (real.status === "error") {
+        const next = {
+          ...live,
+          thinking: false,
+          packet: liveDetail ? liveAnswer(liveDetail) : STARTER_ANSWER,
+          toolCalls: liveDetail ? liveToolCalls(liveDetail) : SAMPLE_TOOL_CALLS,
+        };
+        const out = [...prev];
+        out[idx] = next;
+        showToast({
+          tone: "warning",
+          message: real.errorMessage
+            ? `Real chat failed: ${real.errorMessage.slice(0, 100)}. Showing showcase fallback.`
+            : "Real chat failed — showing showcase fallback.",
+        });
+        return out;
+      }
+      // Otherwise still in flight — keep thinking, but reflect live progress.
+      const out = [...prev];
+      out[idx] = live;
+      return out;
+    });
+  }, [chatRun.state.run, liveDetail]);
+
   const sendMessage = (text: string, submittedTier: RouterTier) => {
     const now = Date.now();
     const userId = `u${turns.length + 1}`;
@@ -370,20 +435,21 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
       { id: userId, role: "user", text, createdAt: now },
       { id: assistantId, role: "assistant", thinking: true, tier: submittedTier, createdAt: now + 50 },
     ]);
-    // Phase 1: if real chat is available (authenticated user, no ?fresh=1),
-    // run the Convex action that calls Gemini with web-search grounding and
-    // returns a real AnswerPacket with grounded source URLs. Fixture fallback
-    // for unauthenticated visitors / showcase mode keeps demos working offline.
+    // Phase 2: if real chat is available, kick off a streaming run via
+    // Convex scheduler. submit() returns a runId in <100ms; the projected
+    // run state (packet + scratchpad + tool calls + grounding) arrives
+    // reactively via Convex queries. The effect below watches for
+    // status === "complete" to commit the final packet onto this turn.
     if (chatRun.state.available && !_skipLiveSeed) {
-      void chatRun.submit(text, submittedTier, liveDetail?.id).then((real) => {
-        if (real) {
+      void chatRun.submit(text, submittedTier, liveDetail?.id).then((runId) => {
+        if (runId) {
           setTurns((prev) => prev.map((t) =>
             t.id === assistantId
-              ? { ...t, thinking: false, toolCalls: traceToToolCalls(real.packet.trace), packet: real.packet, runHash: real.hash }
+              ? { ...t, chatRunId: runId }
               : t,
           ));
         } else {
-          // Real chat failed — fall back to fixture so the user gets *something*
+          // Submit failed (e.g. auth lost) — fall back to fixture
           setTurns((prev) => prev.map((t) =>
             t.id === assistantId
               ? { ...t, thinking: false, toolCalls: liveDetail ? liveToolCalls(liveDetail) : SAMPLE_TOOL_CALLS, packet: liveDetail ? liveAnswer(liveDetail) : STARTER_ANSWER }


### PR DESCRIPTION
Layer 2 of 4. Replaces synchronous Phase 1 with streaming architecture using Convex's native reactive subscriptions.

- mutation startChat returns runId in <100ms
- internalAction runStreamingChat parses Gemini streamGenerateContent SSE chunks, writes ordered events
- Frontend useQuery subscribes to streamEventsForRun + getRun → live progress
- New event types: scratchpad / tool_call / grounding_chunk / section / packet_complete / error

Phase 3 (next): GET /redesign/chat/r/{hash} share URL route. Phase 4: real probe + correction + validation + load polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)