### PR TITLE
feat(redesign-chat): Phase 5 — close remaining real-wiring (👍/👎, real probe, real pin)

### DIFF
--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -142,6 +142,18 @@ export const startChat = mutation({
     prompt: v.string(),
     tier: v.union(v.literal("free"), v.literal("fast"), v.literal("auto"), v.literal("deep")),
     contextRef: v.optional(v.string()),
+    /** Phase 5 — pinned claims from prior turns to carry forward as hard
+     *  context. Each item: short text + optional source URL. Server prepends
+     *  these to the system prompt so the next answer respects them. */
+    pinnedClaims: v.optional(v.array(v.object({
+      text: v.string(),
+      source: v.optional(v.string()),
+    }))),
+    /** Phase 5 — counterfactual probe. When set, the run is a probe
+     *  re-evaluation of an earlier run with the cited source masked. */
+    probeOriginRunId: v.optional(v.string()),
+    probeMaskedSourceUrl: v.optional(v.string()),
+    probeMaskedSourceIdx: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<string> => {
     const prompt = args.prompt.slice(0, MAX_PROMPT_CHARS);
@@ -156,7 +168,6 @@ export const startChat = mutation({
     try {
       const identity = await ctx.auth.getUserIdentity();
       if (identity?.subject) {
-        // Best-effort lookup; not strictly required for the run to succeed.
         const found = await ctx.db
           .query("users")
           .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
@@ -180,6 +191,77 @@ export const startChat = mutation({
       tier: args.tier,
       contextRef: args.contextRef,
       model,
+      pinnedClaims: args.pinnedClaims,
+      probeOriginRunId: args.probeOriginRunId,
+      probeMaskedSourceUrl: args.probeMaskedSourceUrl,
+      probeMaskedSourceIdx: args.probeMaskedSourceIdx,
+    });
+    return runId;
+  },
+});
+
+/**
+ * Phase 5 — counterfactual probe. Re-runs a prior chat with one source
+ * marked unreliable in the system prompt. Looks up the original run by
+ * runId, reads the prompt + masked source URL, calls startChat with
+ * probeOriginRunId set so the new run carries the masking instruction.
+ *
+ * Returns the new probedRunId; frontend subscribes via the same
+ * streamEventsForRun pattern. The Sprint 4 P0.3 ProbeBanner can show
+ * "Probed without [N]: <new shortAnswer>" when complete.
+ */
+export const probeRun = mutation({
+  args: {
+    originalRunId: v.string(),
+    maskedSourceIdx: v.number(),
+  },
+  handler: async (ctx, args): Promise<string> => {
+    const orig = await ctx.db
+      .query("redesignChatRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", args.originalRunId))
+      .first();
+    if (!orig) throw new Error("Original run not found");
+    if (!orig.packet || orig.status !== "complete") {
+      throw new Error("Original run not complete — cannot probe yet");
+    }
+    const evidence = (orig.packet.evidence ?? []) as Array<{ idx: number; source: string; quote?: string }>;
+    const masked = evidence.find((e) => e.idx === args.maskedSourceIdx);
+    if (!masked) throw new Error(`No source [${args.maskedSourceIdx}] in original run`);
+    // Reuse startChat semantics for auth, scheduling, etc.
+    const model = orig.tier === "deep" ? "gemini-3.1-pro-preview"
+      : orig.tier === "free" ? "gemini-3.1-flash-lite-preview"
+      : "gemini-3-flash-preview";
+    const runId = generateRunId();
+    let userId: any = undefined;
+    try {
+      const identity = await ctx.auth.getUserIdentity();
+      if (identity?.subject) {
+        const found = await ctx.db
+          .query("users")
+          .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+          .first()
+          .catch(() => null);
+        userId = found?._id;
+      }
+    } catch { /* anonymous OK */ }
+    await ctx.db.insert("redesignChatRuns", {
+      runId,
+      userId,
+      prompt: orig.prompt,
+      tier: orig.tier,
+      model,
+      status: "pending",
+      createdAt: Date.now(),
+    });
+    await ctx.scheduler.runAfter(0, internal.domains.redesign.chatRuns.runStreamingChat, {
+      runId,
+      prompt: orig.prompt,
+      tier: orig.tier as any,
+      contextRef: undefined,
+      model,
+      probeOriginRunId: args.originalRunId,
+      probeMaskedSourceUrl: masked.source,
+      probeMaskedSourceIdx: args.maskedSourceIdx,
     });
     return runId;
   },
@@ -313,6 +395,15 @@ export const runStreamingChat = internalAction({
     tier: v.string(),
     contextRef: v.optional(v.string()),
     model: v.string(),
+    /** Phase 5 — pinned claims to prepend to system prompt */
+    pinnedClaims: v.optional(v.array(v.object({
+      text: v.string(),
+      source: v.optional(v.string()),
+    }))),
+    /** Phase 5 — counterfactual probe origin */
+    probeOriginRunId: v.optional(v.string()),
+    probeMaskedSourceUrl: v.optional(v.string()),
+    probeMaskedSourceIdx: v.optional(v.number()),
   },
   handler: async (ctx: ActionCtx, args) => {
     const t0 = Date.now();
@@ -360,6 +451,14 @@ export const runStreamingChat = internalAction({
 
       // Stage 3 — Gemini streaming with grounding
       const t3 = Date.now();
+      // Phase 5 — pinned claims carry-forward as hard context
+      const pinnedSection = args.pinnedClaims && args.pinnedClaims.length > 0
+        ? `\n\nPinned claims (carry forward as established context — do not contradict without explicit re-grounding):\n${args.pinnedClaims.map((p, i) => `  ${i + 1}. ${p.text}${p.source ? ` (source: ${p.source})` : ""}`).join("\n")}`
+        : "";
+      // Phase 5 — counterfactual probe instruction
+      const probeSection = args.probeMaskedSourceUrl
+        ? `\n\nIMPORTANT — counterfactual probe: The source previously at <${args.probeMaskedSourceUrl}> (originally cited as [${args.probeMaskedSourceIdx ?? "?"}] in run ${args.probeOriginRunId ?? "?"}) is being treated as UNRELIABLE for this answer. DO NOT cite it. DO NOT use it as the basis for any claim. Re-answer the same prompt and explicitly note in "Risks / unknowns" how the conclusion changes (or holds) if that source is excluded. Prefer alternative grounded sources.`
+        : "";
       const systemPrompt = `You are NodeBench's evidence-first analyst. Produce a banker-style memo with:
 1. Short answer (one sentence with citation markers like [1] [2])
 2. Why it matters (one paragraph with citation markers)
@@ -369,7 +468,14 @@ export const runStreamingChat = internalAction({
 
 Use [1], [2], [3] inline cite markers in the prose. Keep claims grounded in the web sources you retrieve. Prefer recency. If you can't find grounded evidence, say so explicitly.
 
-Context: ${JSON.stringify(contextBundle)}`;
+Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
+      // Emit a stage event so the UI can show "Probing without [N]" / "Carrying forward N pins"
+      if (probeSection) {
+        await append("stage", { stage: "probe", maskedUrl: args.probeMaskedSourceUrl, maskedIdx: args.probeMaskedSourceIdx, originRunId: args.probeOriginRunId });
+      }
+      if (pinnedSection) {
+        await append("stage", { stage: "pinned", count: args.pinnedClaims!.length });
+      }
 
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);

--- a/src/features/redesign/hooks/useRedesignChatRun.ts
+++ b/src/features/redesign/hooks/useRedesignChatRun.ts
@@ -138,14 +138,19 @@ export function useRedesignChatRun() {
   }, [projected?.status, projected?.errorMessage]);
 
   const submit = useCallback(
-    async (prompt: string, tier: RouterTier, contextRef?: string): Promise<string | null> => {
+    async (
+      prompt: string,
+      tier: RouterTier,
+      contextRef?: string,
+      pinnedClaims?: Array<{ text: string; source?: string }>,
+    ): Promise<string | null> => {
       if (!isAuthenticated) {
         setError("Sign in to run a real chat with grounded sources.");
         return null;
       }
       setError(null);
       try {
-        const runId = await startChat({ prompt, tier, contextRef });
+        const runId = await startChat({ prompt, tier, contextRef, pinnedClaims });
         setActiveRunId(runId);
         return runId;
       } catch (err: any) {
@@ -160,6 +165,17 @@ export function useRedesignChatRun() {
   const reset = useCallback(() => {
     setActiveRunId(null);
     setError(null);
+  }, []);
+
+  /**
+   * Phase 5 — point the hook at an existing runId (e.g. one returned
+   * by a separate `probeRun` mutation) so its events stream into the
+   * same projected state. Caller is responsible for inserting the
+   * matching turn into the conversation.
+   */
+  const subscribeTo = useCallback((runId: string) => {
+    setError(null);
+    setActiveRunId(runId);
   }, []);
 
   const externalStatus: ChatRunState["status"] =
@@ -178,6 +194,7 @@ export function useRedesignChatRun() {
     } as ChatRunState,
     submit,
     reset,
+    subscribeTo,
     hash: projected?.hash ?? null,
   };
 }

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -301,6 +301,8 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
   const chatRun = useRedesignChatRun();
   // Phase 4 — real reactions for inline correction + 👍/👎 toolbar.
   const recordReaction = useMutation(api.domains.redesign.agentRunFeedback.recordReaction);
+  // Phase 5 — counterfactual probe re-run with masked source.
+  const probeRun = useMutation(api.domains.redesign.chatRuns.probeRun);
   // ?fresh=1 escape hatch: treat as if no live artifact is loaded (uses
   // STARTER_ANSWER with inline [N] cites for the chat-sprints demo recorder).
   const _skipLiveSeed = typeof window !== "undefined"
@@ -356,6 +358,45 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
   };
   const unpinClaim = (id: string) => {
     setPinned((cur) => cur.filter((p) => p.id !== id));
+  };
+
+  // Phase 5 — real counterfactual probe via the probeRun mutation.
+  // Looks up the original run, kicks off a new run with the masked
+  // source flagged unreliable in the system prompt, inserts a new
+  // assistant turn that subscribes to the probed run's stream.
+  const probeWithoutSourceReal = (originalTurnId: string, originalRunId: string, maskedIdx: number) => {
+    const probeId = `a${turns.length + 1}`;
+    setTurns((prev) => [
+      ...prev,
+      {
+        id: probeId,
+        role: "assistant",
+        thinking: true,
+        tier: "auto",
+        createdAt: Date.now(),
+        chatRunId: undefined,
+      },
+    ]);
+    void probeRun({ originalRunId, maskedSourceIdx: maskedIdx })
+      .then((probedRunId) => {
+        setTurns((prev) => prev.map((t) =>
+          t.id === probeId
+            ? { ...t, chatRunId: probedRunId }
+            : t,
+        ));
+        // Point the streaming hook at the probed run so its events
+        // project into projected.run and the effect commits the packet.
+        chatRun.subscribeTo(probedRunId);
+        showToast({
+          tone: "info",
+          message: `Re-running without source [${maskedIdx}] — diff will appear inline.`,
+        });
+      })
+      .catch((err: any) => {
+        const msg = (err?.message || String(err)).slice(0, 200);
+        setTurns((prev) => prev.filter((t) => t.id !== probeId));
+        showToast({ tone: "warning", message: `Probe failed: ${msg}` });
+      });
   };
 
   // Sprint 4 P2.7 — A/B compare modal state.
@@ -445,7 +486,13 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
     // reactively via Convex queries. The effect below watches for
     // status === "complete" to commit the final packet onto this turn.
     if (chatRun.state.available && !_skipLiveSeed) {
-      void chatRun.submit(text, submittedTier, liveDetail?.id).then((runId) => {
+      // Phase 5 — carry pinned claims forward as hard context in the
+      // system prompt. Each pin has a short label (the answer's tier +
+      // shortAnswer) plus the source URL if grounded.
+      const pinnedClaims = pinned.length > 0
+        ? pinned.map((p) => ({ text: p.label || "pinned claim", source: undefined as string | undefined }))
+        : undefined;
+      void chatRun.submit(text, submittedTier, liveDetail?.id, pinnedClaims).then((runId) => {
         if (runId) {
           setTurns((prev) => prev.map((t) =>
             t.id === assistantId
@@ -629,6 +676,19 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
                   onPin={() => pinClaim(t.id, t.packet!, t.tier ?? "auto")}
                   onCompare={() => setCompareTurnId(t.id)}
                   onShare={() => shareAnswer(t.id, t.packet!, t.tier ?? "auto")}
+                  onProbeRunWithoutSource={t.chatRunId ? (idx) => probeWithoutSourceReal(t.id, t.chatRunId!, idx) : undefined}
+                  onReact={t.chatRunId ? (kind) => {
+                    void recordReaction({
+                      runId: t.chatRunId!,
+                      runSource: "redesign-chat",
+                      turnId: t.id,
+                      reaction: kind,
+                    }).then(() => {
+                      showToast({ tone: kind === "up" ? "success" : "info", message: kind === "up" ? "Thanks — recorded as 👍." : "Recorded as 👎. Feeds the eval flywheel." });
+                    }).catch((err: any) => {
+                      showToast({ tone: "warning", message: `Could not save reaction: ${(err?.message || String(err)).slice(0, 100)}` });
+                    });
+                  } : undefined}
                 />
               );
             })();
@@ -1200,6 +1260,8 @@ function AnswerPacket({
   onPin,
   onCompare,
   onShare,
+  onReact,
+  onProbeRunWithoutSource,
 }: {
   packet: ChatAnswer;
   tier: RouterTier;
@@ -1211,6 +1273,12 @@ function AnswerPacket({
   onPin?: () => void;
   onCompare?: () => void;
   onShare?: () => void;
+  /** Phase 5 — when set, the 👍/👎 buttons persist via recordReaction. */
+  onReact?: (kind: "up" | "down") => void;
+  /** Phase 5 — when set, "Probe without [N]" calls a real action that
+   *  re-runs the model with that source masked. The handler returns the
+   *  probedRunId so the AnswerPacket can swap into the probed answer. */
+  onProbeRunWithoutSource?: (maskedSourceIdx: number) => void;
 }) {
   const tierMeta = DEFAULT_TIERS.find((t) => t.id === tier) ?? DEFAULT_TIERS[0];
   const [hoverCite, setHoverCite] = useState<number | null>(null);
@@ -1229,11 +1297,21 @@ function AnswerPacket({
   const probeWithoutSource = (idx: number) => {
     setMaskedIdx(idx);
     setProbeMenu(null);
+    // Phase 5 — if a real probe handler is wired (authenticated user with
+    // an active runId on this turn), call the real action; otherwise fall
+    // back to the showcase toast pair.
+    if (onProbeRunWithoutSource) {
+      showToast({
+        tone: "info",
+        message: `Re-running model without source [${idx}]…`,
+      });
+      onProbeRunWithoutSource(idx);
+      return;
+    }
     showToast({
       tone: "info",
       message: `Probing without source [${idx}]…`,
     });
-    // Simulate model re-eval delay
     window.setTimeout(() => {
       showToast({
         tone: "warning",
@@ -1403,7 +1481,7 @@ function AnswerPacket({
         onPin={onPin}
         onBranch={onBranch}
         onWhy={() => { /* future: opens trace modal */ }}
-        onReact={() => { /* future: agentRunFeedback */ }}
+        onReact={onReact}
         onCompare={onCompare}
         onShare={onShare}
       />


### PR DESCRIPTION
Closes the deferred items from Phase 4: 👍/👎 → recordReaction, counterfactual probe → re-run with masked source instruction, pin/carry-forward → system-prompt prepend.

- New probeRun mutation looks up original run + schedules masked re-run
- runStreamingChat honors pinnedClaims + probe* args in system prompt
- Hook gains subscribeTo(runId) for switching active stream
- Showcase / ?fresh=1 / anonymous path unchanged

Phase 6 next: source-URL substring validation + real A/B Variant B + production load polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)