### PR TITLE
fix(redesign): close live workspace and source verification gaps

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1005,6 +1005,7 @@ import type * as domains_research_dailyBriefMemoryQueries from "../domains/resea
 import type * as domains_research_dailyBriefPersonalOverlay from "../domains/research/dailyBriefPersonalOverlay.js";
 import type * as domains_research_dailyBriefPersonalOverlayMutations from "../domains/research/dailyBriefPersonalOverlayMutations.js";
 import type * as domains_research_dailyBriefPersonalOverlayQueries from "../domains/research/dailyBriefPersonalOverlayQueries.js";
+import type * as domains_research_dailyBriefSourceVerification from "../domains/research/dailyBriefSourceVerification.js";
 import type * as domains_research_dailyBriefWorker from "../domains/research/dailyBriefWorker.js";
 import type * as domains_research_dashboardMetrics from "../domains/research/dashboardMetrics.js";
 import type * as domains_research_dashboardMutations from "../domains/research/dashboardMutations.js";
@@ -2483,6 +2484,7 @@ declare const fullApi: ApiFromModules<{
   "domains/research/dailyBriefPersonalOverlay": typeof domains_research_dailyBriefPersonalOverlay;
   "domains/research/dailyBriefPersonalOverlayMutations": typeof domains_research_dailyBriefPersonalOverlayMutations;
   "domains/research/dailyBriefPersonalOverlayQueries": typeof domains_research_dailyBriefPersonalOverlayQueries;
+  "domains/research/dailyBriefSourceVerification": typeof domains_research_dailyBriefSourceVerification;
   "domains/research/dailyBriefWorker": typeof domains_research_dailyBriefWorker;
   "domains/research/dashboardMetrics": typeof domains_research_dashboardMetrics;
   "domains/research/dashboardMutations": typeof domains_research_dashboardMutations;

--- a/convex/domains/research/dailyBriefSourceVerification.ts
+++ b/convex/domains/research/dailyBriefSourceVerification.ts
@@ -1,0 +1,427 @@
+import { v } from "convex/values";
+
+import { action } from "../../_generated/server";
+import { api } from "../../_generated/api";
+
+const MAX_SOURCES_PER_RUN = 4;
+const FETCH_TIMEOUT_MS = 8500;
+const MAX_FETCH_CHARS = 180_000;
+const MIN_MATCH_TERMS = 3;
+
+const STOPWORDS = new Set([
+  "about",
+  "after",
+  "again",
+  "also",
+  "because",
+  "before",
+  "between",
+  "brief",
+  "could",
+  "daily",
+  "does",
+  "from",
+  "have",
+  "into",
+  "more",
+  "nodebench",
+  "over",
+  "should",
+  "source",
+  "that",
+  "their",
+  "there",
+  "these",
+  "this",
+  "through",
+  "update",
+  "using",
+  "what",
+  "when",
+  "where",
+  "which",
+  "while",
+  "with",
+  "would",
+]);
+
+type SourceInput = {
+  title: string;
+  url: string;
+  host: string;
+  relevance?: string;
+};
+
+type VerificationResult = {
+  title: string;
+  url: string;
+  host: string;
+  ok: boolean;
+  status?: number;
+  fetchedAt: number;
+  contentHash?: string;
+  contentBytes?: number;
+  contentType?: "html" | "json" | "pdf" | "markdown" | "text";
+  cacheAction?: string;
+  titleMatched: boolean;
+  relevanceMatched: boolean;
+  claimTermsMatched: number;
+  supportScore: number;
+  verdict: "supports" | "partial" | "weak" | "unreachable";
+  reason: string;
+};
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function shortStableHash(input: string): string {
+  let h1 = 0x811c9dc5;
+  let h2 = 0x1b873593;
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    h1 ^= code;
+    h1 = Math.imul(h1, 16777619) >>> 0;
+    h2 = Math.imul(h2 ^ code, 2654435761) >>> 0;
+  }
+  return (h1.toString(36) + h2.toString(36)).slice(0, 12);
+}
+
+function normalizeWhitespace(input: string): string {
+  return input.replace(/\s+/g, " ").trim();
+}
+
+function stripHtml(input: string): string {
+  return normalizeWhitespace(
+    input
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<noscript[\s\S]*?<\/noscript>/gi, " ")
+      .replace(/<svg[\s\S]*?<\/svg>/gi, " ")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&nbsp;/gi, " ")
+      .replace(/&amp;/gi, "&")
+      .replace(/&lt;/gi, "<")
+      .replace(/&gt;/gi, ">")
+      .replace(/&#39;/g, "'")
+      .replace(/&quot;/gi, '"'),
+  );
+}
+
+function byteLength(input: string): number {
+  return new TextEncoder().encode(input).length;
+}
+
+function contentTypeForCache(raw: string | null): NonNullable<VerificationResult["contentType"]> {
+  const value = (raw ?? "").toLowerCase();
+  if (value.includes("application/json")) return "json";
+  if (value.includes("application/pdf")) return "pdf";
+  if (value.includes("text/markdown")) return "markdown";
+  if (value.includes("text/html") || value.includes("application/xhtml")) return "html";
+  return "text";
+}
+
+function normalizeFetchedBody(raw: string, cacheContentType: VerificationResult["contentType"]): string {
+  const sliced = raw.length > MAX_FETCH_CHARS ? raw.slice(0, MAX_FETCH_CHARS) : raw;
+  if (cacheContentType === "html") return stripHtml(sliced);
+  if (cacheContentType === "json") {
+    try {
+      return normalizeWhitespace(JSON.stringify(JSON.parse(sliced), null, 2));
+    } catch {
+      return normalizeWhitespace(sliced);
+    }
+  }
+  return normalizeWhitespace(sliced);
+}
+
+function tokenSet(input: string | undefined, minLength = 4): Set<string> {
+  if (!input) return new Set();
+  const tokens = input
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(" ")
+    .map((token) => token.trim())
+    .filter((token) => token.length >= minLength && !STOPWORDS.has(token));
+  return new Set(tokens);
+}
+
+function countMatches(needles: Set<string>, haystack: string): number {
+  if (needles.size === 0) return 0;
+  let count = 0;
+  for (const token of needles) {
+    if (haystack.includes(token)) count += 1;
+  }
+  return count;
+}
+
+function hostFromUrl(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+function publicUrlCheck(rawUrl: string): { ok: true; normalizedUrl: string } | { ok: false; reason: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: "Malformed URL" };
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    return { ok: false, reason: `Blocked ${parsed.protocol} URL` };
+  }
+  if (parsed.username || parsed.password) {
+    return { ok: false, reason: "Blocked URL with credentials" };
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  const blockedHosts = [
+    /^localhost$/,
+    /^127\./,
+    /^10\./,
+    /^172\.(1[6-9]|2\d|3[01])\./,
+    /^192\.168\./,
+    /^169\.254\./,
+    /^0\.0\.0\.0$/,
+    /^::1$/,
+    /\.local$/,
+    /metadata\.google\.internal$/,
+    /metadata\.aws\./,
+  ];
+  if (blockedHosts.some((rx) => rx.test(hostname))) {
+    return { ok: false, reason: `Blocked private or metadata host ${hostname}` };
+  }
+  const suspiciousParams = [
+    "access_token",
+    "id_token",
+    "refresh_token",
+    "api_key",
+    "apikey",
+    "auth",
+    "session",
+    "sessionid",
+    "sid",
+    "signature",
+    "sig",
+  ];
+  for (const key of suspiciousParams) {
+    if (parsed.searchParams.has(key)) {
+      return { ok: false, reason: `Blocked auth-like query param ${key}` };
+    }
+  }
+  parsed.hash = "";
+  return { ok: true, normalizedUrl: parsed.toString() };
+}
+
+type CanonicalUpsert = (
+  url: string,
+  body: string,
+  contentType: NonNullable<VerificationResult["contentType"]>,
+) => Promise<{ action: string }>;
+
+async function fetchPublicSource(
+  source: SourceInput,
+  claimText: string,
+  runCanonicalUpsert: CanonicalUpsert,
+): Promise<VerificationResult> {
+  const fetchedAt = Date.now();
+  const checked = publicUrlCheck(source.url);
+  if (!checked.ok) {
+    return {
+      title: source.title,
+      url: source.url,
+      host: source.host || hostFromUrl(source.url),
+      ok: false,
+      fetchedAt,
+      titleMatched: false,
+      relevanceMatched: false,
+      claimTermsMatched: 0,
+      supportScore: 0,
+      verdict: "unreachable",
+      reason: checked.reason,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(checked.normalizedUrl, {
+      method: "GET",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: {
+        Accept: "text/html,application/xhtml+xml,application/json,text/plain;q=0.9,*/*;q=0.5",
+        "User-Agent": "NodeBenchSourceVerifier/1.0 (+https://nodebenchai.com)",
+      },
+    });
+    const raw = await response.text();
+    const cacheContentType = contentTypeForCache(response.headers.get("content-type"));
+    const normalizedBody = normalizeFetchedBody(raw, cacheContentType);
+    const normalizedLower = normalizedBody.toLowerCase();
+    const contentHash = await sha256Hex(normalizedBody);
+    const titleMatches = countMatches(tokenSet(source.title), normalizedLower);
+    const relevanceMatches = countMatches(tokenSet(source.relevance), normalizedLower);
+    const claimMatches = countMatches(tokenSet(claimText), normalizedLower);
+    const titleMatched = titleMatches >= 2 || (source.title.length > 10 && normalizedLower.includes(source.title.toLowerCase().slice(0, 40)));
+    const relevanceMatched = relevanceMatches >= MIN_MATCH_TERMS;
+    const statusScore = response.ok ? 30 : response.status >= 300 && response.status < 400 ? 24 : response.status === 403 || response.status === 429 ? 12 : 6;
+    const supportScore = Math.min(
+      100,
+      statusScore +
+        Math.min(claimMatches, 8) * 6 +
+        (titleMatched ? 14 : 0) +
+        (relevanceMatched ? 20 : 0),
+    );
+    const verdict: VerificationResult["verdict"] =
+      !response.ok && supportScore < 45
+        ? "unreachable"
+        : supportScore >= 72
+          ? "supports"
+          : supportScore >= 50
+            ? "partial"
+            : "weak";
+
+    let cacheAction: string | undefined;
+    if (response.ok && normalizedBody.length > 0) {
+      try {
+        const upsert = await runCanonicalUpsert(checked.normalizedUrl, normalizedBody, cacheContentType);
+        cacheAction = upsert.action;
+      } catch (error) {
+        cacheAction = `cache rejected: ${error instanceof Error ? error.message.slice(0, 90) : "unknown"}`;
+      }
+    }
+
+    return {
+      title: source.title,
+      url: checked.normalizedUrl,
+      host: source.host || hostFromUrl(checked.normalizedUrl),
+      ok: response.ok,
+      status: response.status,
+      fetchedAt,
+      contentHash,
+      contentBytes: byteLength(normalizedBody),
+      contentType: cacheContentType,
+      cacheAction,
+      titleMatched,
+      relevanceMatched,
+      claimTermsMatched: claimMatches,
+      supportScore,
+      verdict,
+      reason: buildReason(verdict, response.status, claimMatches, titleMatched, relevanceMatched),
+    };
+  } catch (error) {
+    return {
+      title: source.title,
+      url: checked.normalizedUrl,
+      host: source.host || hostFromUrl(checked.normalizedUrl),
+      ok: false,
+      fetchedAt,
+      titleMatched: false,
+      relevanceMatched: false,
+      claimTermsMatched: 0,
+      supportScore: 0,
+      verdict: "unreachable",
+      reason: error instanceof Error && error.name === "AbortError"
+        ? `Timed out after ${FETCH_TIMEOUT_MS}ms`
+        : `Fetch failed: ${error instanceof Error ? error.message.slice(0, 120) : "unknown"}`,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildReason(
+  verdict: VerificationResult["verdict"],
+  status: number | undefined,
+  claimMatches: number,
+  titleMatched: boolean,
+  relevanceMatched: boolean,
+) {
+  if (verdict === "unreachable") {
+    return status ? `HTTP ${status}; not enough fetched support to verify this claim.` : "Source could not be fetched.";
+  }
+  const pieces = [`HTTP ${status ?? "ok"}`, `${claimMatches} claim terms matched`];
+  if (titleMatched) pieces.push("title matched");
+  if (relevanceMatched) pieces.push("evidence snippet matched");
+  return pieces.join(" - ");
+}
+
+export const verifyDailyBriefSourceSupport = action({
+  args: {
+    claimText: v.string(),
+    sources: v.array(v.object({
+      title: v.string(),
+      url: v.string(),
+      host: v.string(),
+      relevance: v.optional(v.string()),
+    })),
+    maxSources: v.optional(v.number()),
+  },
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    const runId = `db-src-${shortStableHash(`${args.claimText}:${Date.now()}`)}`;
+    try {
+      const maxSources = Math.max(1, Math.min(args.maxSources ?? MAX_SOURCES_PER_RUN, MAX_SOURCES_PER_RUN));
+      const sources = args.sources
+        .filter((source) => source.url && source.url.length < 2_000)
+        .slice(0, maxSources);
+
+      const runCanonicalUpsert: CanonicalUpsert = (url, body, contentType) =>
+        ctx.runMutation(api.domains.search.sharedCache.upsertCanonicalSource, {
+          url,
+          body,
+          contentType,
+        }) as Promise<{ action: string }>;
+
+      const results: VerificationResult[] = [];
+      for (const source of sources) {
+        results.push(await fetchPublicSource(source, args.claimText, runCanonicalUpsert));
+      }
+      const passed = results.filter((result) => result.verdict === "supports" || result.verdict === "partial").length;
+      const strongest = results.reduce((best, result) => Math.max(best, result.supportScore), 0);
+      const verdict =
+        results.some((result) => result.verdict === "supports")
+          ? "supported"
+          : results.some((result) => result.verdict === "partial" || result.verdict === "weak")
+            ? "needs_review"
+            : "unreachable";
+      return {
+        runId,
+        generatedAt: Date.now(),
+        verdict,
+        score: strongest,
+        checked: results.length,
+        passed,
+        results,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown verification failure";
+      return {
+        runId,
+        generatedAt: Date.now(),
+        verdict: "unreachable",
+        score: 0,
+        checked: 0,
+        passed: 0,
+        results: [{
+          title: "Verification runtime",
+          url: "",
+          host: "nodebench",
+          ok: false,
+          fetchedAt: Date.now(),
+          titleMatched: false,
+          relevanceMatched: false,
+          claimTermsMatched: 0,
+          supportScore: 0,
+          verdict: "unreachable",
+          reason: `Verifier failed closed: ${message.slice(0, 160)}`,
+        }],
+      };
+    }
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,12 +170,9 @@ function App() {
 
   const rootParams = new URLSearchParams(location.search);
   const rootSurface = rootParams.get("surface");
-  const isCompactLandingViewport =
-    typeof window !== "undefined" ? window.matchMedia("(max-width: 760px)").matches : false;
   const shouldUseRedesignLanding =
     location.pathname === "/" &&
     (rootSurface === null || rootSurface === "home") &&
-    !isCompactLandingViewport &&
     !rootParams.has("doc") &&
     !rootParams.has("session") &&
     !rootParams.has("reportId");

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -128,17 +128,9 @@ export default function RedesignShell() {
   if (surface === "workspace") {
     return (
       <div data-redesign data-redesign-theme={theme} style={{ height: "100vh", overflow: "hidden" }}>
-        <div className="rd-shell rd-shell--single">
-          <Rail
-            active="reports"
-            onChange={(id) => goSurface(id)}
-            onOpenWorkspace={goWorkspace}
-            liveStats={railStats}
-          />
-          <main className="rd-pane" style={{ borderRight: "none" }}>
-            <WorkspaceSurface reportId={workspace.reportId} initialTab={workspace.tab} />
-          </main>
-        </div>
+        <main className="rd-pane rd-workspace-standalone">
+          <WorkspaceSurface reportId={workspace.reportId} initialTab={workspace.tab} />
+        </main>
         {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
         <CommandPalette open={cmdk.open} onClose={() => cmdk.setOpen(false)} />
         <ShortcutsOverlay />

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -4501,3 +4501,62 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
     grid-template-columns: 1fr;
   }
 }
+
+[data-redesign] .rd-workspace-standalone {
+  width: 100%;
+  height: 100vh;
+  border-right: none;
+}
+
+[data-redesign] .rd-map-node-panel {
+  box-shadow: var(--rd-shadow-md);
+}
+
+@media (max-width: 760px) {
+  [data-redesign] .rd-workspace-standalone {
+    height: 100dvh;
+  }
+
+  [data-redesign] .rd-workspace-header {
+    padding: 12px 14px !important;
+  }
+
+  [data-redesign] .rd-workspace-header .rd-h1 {
+    font-size: 18px !important;
+    line-height: 1.2;
+  }
+
+  [data-redesign] .rd-workspace-actions {
+    width: 100%;
+  }
+
+  [data-redesign] .rd-workspace-actions .rd-btn {
+    flex: 1 1 auto;
+  }
+
+  [data-redesign] .rd-workspace-surface .rd-tabs {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+  }
+
+  [data-redesign] .rd-workspace-surface .rd-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  [data-redesign] .rd-map-toolbar {
+    left: 12px !important;
+    right: 12px !important;
+    top: 12px !important;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  [data-redesign] .rd-map-node-panel {
+    left: 12px !important;
+    right: 12px !important;
+    bottom: 12px !important;
+    width: auto !important;
+    max-width: none !important;
+  }
+}

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -28,17 +28,33 @@ import { api } from "../../../../convex/_generated/api";
  * uncertain by the agent or 👎'd by the user). Once chat is live-wired,
  * this becomes a `useAgentRunFeedback({ filter: "thumbs_down" })` query.
  */
-const OPEN_QUESTIONS: Array<{
+type OpenQuestion = {
   id: string;
   label: string;
   turnId: string;
   flagged: "agent" | "user";
   when: string;
-}> = [
+};
+
+const OPEN_QUESTIONS: OpenQuestion[] = [
   { id: "oq1", label: "Procurement timing for Orbital Labs pilots", turnId: "a1", flagged: "agent", when: "2h ago" },
   { id: "oq2", label: "Hippocratic AI traction vs Abridge",         turnId: "a2", flagged: "user",  when: "12m ago" },
   { id: "oq3", label: "Voice-agent eval competitors within 6 months", turnId: "a1", flagged: "agent", when: "5h ago" },
 ];
+
+function liveOpenQuestions(detail: LiveArtifactDetail): OpenQuestion[] {
+  const sectionItems = detail.sections.flatMap((section) => section.items ?? []);
+  const candidates = sectionItems.length > 0
+    ? sectionItems
+    : [{ label: detail.title, body: detail.summary }];
+  return candidates.slice(0, 3).map((item, index) => ({
+    id: `live-oq-${detail.id}-${index}`,
+    label: `${item.label}: verify source support`,
+    turnId: index === 1 ? "a2" : "a1",
+    flagged: index === 1 ? "user" : "agent",
+    when: index === 0 ? detail.updatedAt : "live",
+  }));
+}
 
 /**
  * Sprint 4 P2.13 — deterministic reproducibility hash for an answer.
@@ -130,8 +146,38 @@ const WORKING_NOTES_MARKDOWN = `**Plan**
 - Pilot intent: medium (founder note + 1 LinkedIn signal, no procurement docs yet)
 - Hiring spike: high (Crunchbase + LinkedIn agree)`;
 
+function liveWorkingNotesMarkdown(detail: LiveArtifactDetail): string {
+  const topSources = detail.sourceRows
+    .slice(0, 3)
+    .map((source, index) => `${index + 1}. ${source.title}${source.host ? ` (${source.host})` : ""}`)
+    .join("\n");
+  const topItems = detail.sections
+    .flatMap((section) => section.items ?? [])
+    .slice(0, 3)
+    .map((item) => `- ${item.label}: ${item.body}`)
+    .join("\n");
+  return `**Plan**
+1. Load ${detail.title} from live Convex memory
+2. Reuse cached sources before any paid refresh
+3. Check claim support and review gaps
+4. Convert strongest signal into notebook-ready next action
+
+**Live artifact**
+- ${detail.sourceCount} sources
+- ${detail.claimCount} claims
+- ${detail.followUps} follow-ups
+- Status: ${detail.status}
+
+**Top signals**
+${topItems || `- ${detail.summary}`}
+
+**Source refs**
+${topSources || "- No source rows returned yet"}`;
+}
+
 interface ChatSurfaceProps {
   contextLabel?: string;
+  workspaceDetail?: LiveArtifactDetail;
 }
 
 interface Turn {
@@ -332,7 +378,7 @@ function buildSeedTurns(detail?: LiveArtifactDetail): Turn[] {
   ];
 }
 
-export function ChatSurface({ contextLabel = "Asking about: current context" }: ChatSurfaceProps) {
+export function ChatSurface({ contextLabel = "Asking about: current context", workspaceDetail }: ChatSurfaceProps) {
   const liveArtifacts = useLiveArtifacts(24);
   const _rawLiveDetail = liveArtifacts.details[0];
   // Phase 1 — real LLM chat behind the composer for authenticated users.
@@ -345,7 +391,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
   // STARTER_ANSWER with inline [N] cites for the chat-sprints demo recorder).
   const _skipLiveSeed = typeof window !== "undefined"
     && new URLSearchParams(window.location.search).has("fresh");
-  const liveDetail = _skipLiveSeed ? null : _rawLiveDetail;
+  const liveDetail = workspaceDetail ?? (_skipLiveSeed ? null : _rawLiveDetail);
   const batchTargets = useMemo<BatchTarget[]>(() => {
     if (liveArtifacts.reports.length === 0) return [];
     return [
@@ -362,6 +408,14 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
     ];
   }, [liveArtifacts.reports]);
   const liveSeedKey = liveDetail?.id ?? (liveArtifacts.isLoading ? "loading" : "empty");
+  const openQuestions = useMemo(
+    () => (liveDetail ? liveOpenQuestions(liveDetail) : OPEN_QUESTIONS),
+    [liveDetail],
+  );
+  const workingNotesMarkdown = useMemo(
+    () => (liveDetail ? liveWorkingNotesMarkdown(liveDetail) : WORKING_NOTES_MARKDOWN),
+    [liveDetail],
+  );
   const liveStarters = useMemo(() => {
     if (!liveDetail) return undefined;
     return [
@@ -675,7 +729,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
         </header>
 
         {/* Sprint 3 P2.11 — open-questions tray */}
-        <OpenQuestionsTray />
+        <OpenQuestionsTray questions={openQuestions} />
 
         {turns.length === 0 ? (
           <ChatEmptyState
@@ -708,6 +762,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
                   tier={t.tier ?? "auto"}
                   toolCalls={t.toolCalls}
                   reportTitle={liveDetail?.title}
+                  workingNotesMarkdown={workingNotesMarkdown}
                   createdAt={t.createdAt}
                   onRegenerate={(tierOverride) => regenerate(t.id, tierOverride)}
                   onBranch={() => branchFromTurn(t.id)}
@@ -849,9 +904,12 @@ export function ChatSurface({ contextLabel = "Asking about: current context" }: 
  * Today: fixture from OPEN_QUESTIONS. Once chat is live-wired, replace
  * with `useAgentRunFeedback` query filtered to flagged + unresolved items.
  */
-function OpenQuestionsTray() {
+function OpenQuestionsTray({ questions }: { questions: OpenQuestion[] }) {
   const [open, setOpen] = useState(true);
-  const [items, setItems] = useState(OPEN_QUESTIONS);
+  const [items, setItems] = useState(questions);
+  useEffect(() => {
+    setItems(questions);
+  }, [questions]);
   if (items.length === 0) return null;
   const dismissOne = (id: string) => {
     setItems((cur) => cur.filter((q) => q.id !== id));
@@ -1397,6 +1455,7 @@ function AnswerPacket({
   tier,
   toolCalls,
   reportTitle,
+  workingNotesMarkdown,
   createdAt,
   onRegenerate,
   onBranch,
@@ -1410,6 +1469,7 @@ function AnswerPacket({
   tier: RouterTier;
   toolCalls?: ToolCall[];
   reportTitle?: string;
+  workingNotesMarkdown?: string;
   createdAt?: number;
   onRegenerate?: (tierOverride?: "free" | "fast" | "deep") => void;
   onBranch?: () => void;
@@ -1514,7 +1574,7 @@ function AnswerPacket({
         )}
 
         {/* Sprint 2 P0.2 — collapsible streaming-scratchpad / working notes */}
-        <WorkingNotes markdown={WORKING_NOTES_MARKDOWN} />
+        <WorkingNotes markdown={workingNotesMarkdown ?? WORKING_NOTES_MARKDOWN} />
 
         {/* Sprint 2 P0.3 — counterfactual probe banner (visible when a source is masked) */}
         {maskedIdx !== null && (

--- a/src/features/redesign/surfaces/HomeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeSurface.tsx
@@ -80,7 +80,7 @@ export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
     pendingFromAgent: index === 0 && report.followUps > 0 ? report.followUps : undefined,
   }));
   const effectiveWatchlist: WatchlistEntity[] = liveArtifacts.publicResearch.slice(0, 5).map((card, index) => ({
-    id: `live_watch_${card.reportId ?? index}`,
+    id: `live_watch_${card.reportId ?? "research"}_${index}`,
     entity: card.entity,
     kind: card.entityClass === "role" ? "topic" : card.entityClass,
     signal: card.signal,

--- a/src/features/redesign/surfaces/WorkspaceSurface.tsx
+++ b/src/features/redesign/surfaces/WorkspaceSurface.tsx
@@ -5,7 +5,7 @@
  * Mounted at /redesign/workspace. Spec: separate deployed surface, not a sixth tab in main app.
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useConvex } from "convex/react";
 import { useConvexApi } from "@/lib/convexApi";
@@ -23,6 +23,35 @@ import {
 } from "../hooks/useLiveArtifacts";
 
 type Tab = "brief" | "cards" | "notebook" | "sources" | "chat" | "map";
+
+type SourceVerificationResult = {
+  runId: string;
+  generatedAt: number;
+  verdict: "supported" | "needs_review" | "unreachable";
+  score: number;
+  checked: number;
+  passed: number;
+  results: Array<{
+    title: string;
+    url: string;
+    host: string;
+    ok: boolean;
+    status?: number;
+    contentHash?: string;
+    contentBytes?: number;
+    contentType?: string;
+    cacheAction?: string;
+    supportScore: number;
+    verdict: "supports" | "partial" | "weak" | "unreachable";
+    reason: string;
+  }>;
+};
+
+type SourceVerificationState =
+  | { status: "idle" }
+  | { status: "running"; label: string }
+  | { status: "done"; label: string; result: SourceVerificationResult }
+  | { status: "error"; label: string; message: string };
 
 const TABS: Array<{ id: Tab; label: string; hint: string }> = [
   { id: "brief", label: "Brief", hint: "Read summary" },
@@ -42,16 +71,28 @@ function isLiveArtifactReportId(id: string): boolean {
   return /^(daily|li|run)_/.test(id);
 }
 
+function hostFromHref(href: string): string {
+  try {
+    return new URL(href).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
 export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSurfaceProps) {
   const navigate = useNavigate();
   const convex = useConvex();
   const api = useConvexApi();
   const [tab, setTab] = useState<Tab>(initialTab);
   const [promoting, setPromoting] = useState(false);
+  const [sourceVerification, setSourceVerification] = useState<SourceVerificationState>({ status: "idle" });
   const liveArtifacts = useLiveArtifacts(60);
   const selectedReportId = reportId ?? liveArtifacts.reports[0]?.id ?? "";
   const workspaceNeedsSelection = !selectedReportId;
   const selectedIsLiveArtifact = selectedReportId ? isLiveArtifactReportId(selectedReportId) : false;
+  useEffect(() => {
+    setTab(initialTab);
+  }, [initialTab]);
   const liveReport = useMemo(
     () => liveArtifacts.reports.find((report) => report.id === selectedReportId),
     [liveArtifacts.reports, selectedReportId],
@@ -60,11 +101,24 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
     () => liveArtifacts.details.find((detail) => detail.id === selectedReportId),
     [liveArtifacts.details, selectedReportId],
   );
-  const liveArtifactUnavailable = Boolean(selectedIsLiveArtifact && !liveDetail && !liveArtifacts.isLoading);
+  const latestLiveDetail = liveArtifacts.details[0];
+  const latestLiveReport = latestLiveDetail
+    ? liveArtifacts.reports.find((report) => report.id === latestLiveDetail.id)
+    : liveArtifacts.reports[0];
+  const shouldFallForwardToLatest = Boolean(
+    selectedIsLiveArtifact &&
+    !liveDetail &&
+    !liveArtifacts.isLoading &&
+    latestLiveDetail,
+  );
+  const effectiveLiveDetail = liveDetail ?? (shouldFallForwardToLatest ? latestLiveDetail : undefined);
+  const effectiveLiveReport = liveReport ?? (shouldFallForwardToLatest ? latestLiveReport : undefined);
+  const effectiveReportId = effectiveLiveDetail?.id ?? effectiveLiveReport?.id ?? selectedReportId;
+  const liveArtifactUnavailable = Boolean(selectedIsLiveArtifact && !liveDetail && !liveArtifacts.isLoading && !latestLiveDetail);
   const liveArtifactResolving = Boolean(selectedIsLiveArtifact && !liveDetail && liveArtifacts.isLoading);
   const workspaceTitle =
-    liveDetail?.title ??
-    liveReport?.entity ??
+    effectiveLiveDetail?.title ??
+    effectiveLiveReport?.entity ??
     (workspaceNeedsSelection
       ? "Loading live workspace"
       : liveArtifactResolving
@@ -72,18 +126,68 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
         : liveArtifactUnavailable
           ? "Live artifact unavailable"
           : "Workspace draft");
-  const workspaceKind = liveDetail?.kind ?? liveReport?.kind ?? "Workspace";
-  const workspaceSources = liveDetail?.sourceCount ?? liveReport?.sources ?? 0;
-  const workspaceClaims = liveDetail?.claimCount ?? liveReport?.claims ?? 0;
-  const workspaceFollowUps = liveDetail?.followUps ?? liveReport?.followUps ?? 0;
-  const workspaceFreshness = liveDetail?.updatedAt ?? liveReport?.updatedAt ?? "awaiting live artifact";
+  const workspaceKind = effectiveLiveDetail?.kind ?? effectiveLiveReport?.kind ?? "Workspace";
+  const workspaceSources = effectiveLiveDetail?.sourceCount ?? effectiveLiveReport?.sources ?? 0;
+  const workspaceClaims = effectiveLiveDetail?.claimCount ?? effectiveLiveReport?.claims ?? 0;
+  const workspaceFollowUps = effectiveLiveDetail?.followUps ?? effectiveLiveReport?.followUps ?? 0;
+  const workspaceFreshness = effectiveLiveDetail?.updatedAt ?? effectiveLiveReport?.updatedAt ?? "awaiting live artifact";
   const createDraftReportRef = (api?.domains?.product?.reports as any)?.createDraftReport;
   const saveReportNotebookHtmlRef = (api?.domains?.product?.reports as any)?.saveReportNotebookHtml;
-  const isPromotableLiveArtifact = Boolean(liveReport && selectedIsLiveArtifact);
+  const verifySourceSupportRef = (api?.domains?.research?.dailyBriefSourceVerification as any)?.verifyDailyBriefSourceSupport;
+  const isPromotableLiveArtifact = Boolean(effectiveLiveReport && selectedIsLiveArtifact);
   const canPromoteLiveArtifact = Boolean(isPromotableLiveArtifact && createDraftReportRef && saveReportNotebookHtmlRef);
 
+  const setWorkspaceTab = (nextTab: Tab) => {
+    setTab(nextTab);
+    const params = new URLSearchParams();
+    if (effectiveReportId) params.set("report", effectiveReportId);
+    params.set("tab", nextTab);
+    navigate(`/redesign/workspace?${params.toString()}`, { replace: false });
+  };
+
+  const verifySourceSupport = async (
+    label: string,
+    claimText: string,
+    rows = effectiveLiveDetail?.sourceRows ?? [],
+  ) => {
+    const sources = rows
+      .filter((source) => source.href)
+      .slice(0, 4)
+      .map((source) => ({
+        title: source.title || source.type || "Source",
+        url: source.href!,
+        host: hostFromHref(source.href!) || source.type || "source",
+        relevance: source.excerpt,
+      }));
+    if (!verifySourceSupportRef) {
+      showToast({ tone: "warning", message: "Source verification action is still connecting." });
+      return;
+    }
+    if (!sources.length) {
+      showToast({ tone: "info", message: "No public source URLs are attached to this selection yet." });
+      return;
+    }
+    setSourceVerification({ status: "running", label });
+    try {
+      const result = await convex.action(verifySourceSupportRef, {
+        claimText,
+        sources,
+        maxSources: sources.length,
+      }) as SourceVerificationResult;
+      setSourceVerification({ status: "done", label, result });
+      showToast({
+        tone: result.verdict === "supported" ? "success" : result.verdict === "needs_review" ? "warning" : "info",
+        message: `Checked ${result.checked} sources. Verdict: ${result.verdict.replace("_", " ")}.`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown verification error";
+      setSourceVerification({ status: "error", label, message });
+      showToast({ tone: "warning", message: `Source verification failed: ${message.slice(0, 90)}` });
+    }
+  };
+
   const promoteLiveArtifact = async () => {
-    if (!liveReport) return;
+    if (!effectiveLiveReport) return;
     if (!canPromoteLiveArtifact) {
       showToast({
         tone: "info",
@@ -96,16 +200,16 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
       const anonymousSessionId = getAnonymousProductSessionId();
       const created = await convex.mutation(createDraftReportRef, {
         anonymousSessionId,
-        title: liveReport.entity,
-        summary: liveReport.description,
-        query: liveReport.entity,
-        type: liveReport.kind,
+        title: effectiveLiveReport.entity,
+        summary: effectiveLiveReport.description,
+        query: effectiveLiveReport.entity,
+        type: effectiveLiveReport.kind,
       });
       if (!created?.reportId) throw new Error("Missing report id");
       await convex.mutation(saveReportNotebookHtmlRef, {
         anonymousSessionId,
         reportId: created.reportId,
-        notebookHtml: liveDetail ? buildLiveArtifactNotebookHtml(liveDetail) : buildPromotedLiveArtifactHtml(liveReport),
+        notebookHtml: effectiveLiveDetail ? buildLiveArtifactNotebookHtml(effectiveLiveDetail) : buildPromotedLiveArtifactHtml(effectiveLiveReport),
       });
       showToast({
         tone: "success",
@@ -124,9 +228,9 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
   };
 
   return (
-    <div className="rd-stack" style={{ height: "100%", overflow: "hidden" }}>
+    <div className="rd-stack rd-workspace-surface" style={{ height: "100%", overflow: "hidden" }}>
       {/* Workspace header */}
-      <header style={{
+      <header className="rd-workspace-header" style={{
         padding: "16px 28px",
         borderBottom: "1px solid var(--rd-line-faint)",
         background: "var(--rd-paper)",
@@ -134,16 +238,19 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
       }}>
           <div className="rd-row" style={{ gap: 8 }}>
           <span className="rd-mono" style={{ fontSize: 10.5, color: "var(--rd-ink-soft)" }}>
-            REPORTS / {(selectedReportId || "LIVE").toUpperCase()}
+            REPORTS / {(effectiveReportId || "LIVE").toUpperCase()}
           </span>
           <span style={{ color: "var(--rd-ink-faint)" }}>›</span>
           <span className="rd-mono" style={{ fontSize: 10.5, color: "var(--rd-ink)" }}>WORKSPACE</span>
+          {shouldFallForwardToLatest && (
+            <Pill tone="amber">Requested artifact aged out - showing latest live brief</Pill>
+          )}
         </div>
 
-        <div className="rd-row--between" style={{ marginTop: 10 }}>
+        <div className="rd-row--between" style={{ marginTop: 10, gap: 14, flexWrap: "wrap" }}>
           <div className="rd-stack" style={{ gap: 6 }}>
             <h1 className="rd-h1" style={{ fontSize: 22 }}>{workspaceTitle}</h1>
-            <div className="rd-row" style={{ gap: 8, fontSize: 11.5, color: "var(--rd-ink-soft)" }}>
+            <div className="rd-row" style={{ gap: 8, fontSize: 11.5, color: "var(--rd-ink-soft)", flexWrap: "wrap" }}>
               <Pill tone="green"><span className="rd-dot rd-dot--live" />Fresh · {workspaceFreshness}</Pill>
               <span>{workspaceSources} sources</span>
               <span>·</span>
@@ -155,7 +262,7 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
             </div>
           </div>
 
-          <div className="rd-row" style={{ gap: 6 }}>
+          <div className="rd-row rd-workspace-actions" style={{ gap: 6, flexWrap: "wrap" }}>
             {isPromotableLiveArtifact && (
               <button
                 className="rd-btn rd-btn--primary rd-btn--sm"
@@ -173,7 +280,7 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
 
         {/* Tabs */}
         <div style={{ marginTop: 14 }}>
-          <div className="rd-tabs" role="tablist" aria-label="Workspace tabs">
+          <div className="rd-tabs rd-workspace-tabs" role="tablist" aria-label="Workspace tabs">
             {TABS.map((t) => (
               <button
                 key={t.id}
@@ -181,7 +288,7 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
                 aria-selected={tab === t.id}
                 title={t.hint}
                 className="rd-tab"
-                onClick={() => setTab(t.id)}
+                onClick={() => setWorkspaceTab(t.id)}
               >{t.label}</button>
             ))}
           </div>
@@ -191,38 +298,60 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
       {/* Active tab content */}
       <div style={{ flex: 1, minHeight: 0, overflow: "hidden", background: "var(--rd-paper-warm)" }}>
         {tab === "brief" && (
-          (workspaceNeedsSelection || (selectedIsLiveArtifact && !liveDetail))
+          (workspaceNeedsSelection || (selectedIsLiveArtifact && !effectiveLiveDetail))
             ? <LiveArtifactPlaceholder loading={liveArtifacts.isLoading} reportId={selectedReportId} />
-            : <BriefTab report={liveReport} detail={liveDetail} />
+            : <BriefTab report={effectiveLiveReport} detail={effectiveLiveDetail} />
         )}
         {tab === "cards" && (
-          liveDetail
-            ? <LiveCardsTab detail={liveDetail} />
+          effectiveLiveDetail
+            ? (
+              <LiveCardsTab
+                detail={effectiveLiveDetail}
+                onOpenSources={() => setWorkspaceTab("sources")}
+                onOpenNotebook={() => setWorkspaceTab("notebook")}
+                onVerifySupport={(label, claimText) => verifySourceSupport(label, claimText)}
+              />
+            )
             : <LiveArtifactPlaceholder loading={liveArtifacts.isLoading} reportId={selectedReportId} />
         )}
         {tab === "notebook" && (
-          (workspaceNeedsSelection || (selectedIsLiveArtifact && !liveDetail))
+          (workspaceNeedsSelection || (selectedIsLiveArtifact && !effectiveLiveDetail))
             ? <LiveArtifactPlaceholder loading={liveArtifacts.isLoading} reportId={selectedReportId} />
             : (
               <div style={{ height: "100%", padding: "16px 24px 24px" }}>
-                <ReportNotebookView reportId={selectedReportId || "workspace-draft"} embedded liveDetail={liveDetail} />
+                <ReportNotebookView reportId={effectiveReportId || "workspace-draft"} embedded liveDetail={effectiveLiveDetail} />
               </div>
             )
         )}
         {tab === "sources" && (
-          liveDetail
-            ? <SourcesTab report={liveReport} detail={liveDetail} />
+          effectiveLiveDetail
+            ? (
+              <SourcesTab
+                report={effectiveLiveReport}
+                detail={effectiveLiveDetail}
+                verification={sourceVerification}
+                onVerifySupport={(label, claimText, rows) => verifySourceSupport(label, claimText, rows)}
+              />
+            )
             : workspaceNeedsSelection || selectedIsLiveArtifact
               ? <LiveArtifactPlaceholder loading={liveArtifacts.isLoading} reportId={selectedReportId} />
-              : <SourcesTab report={liveReport} />
+              : <SourcesTab report={effectiveLiveReport} />
         )}
-        {tab === "chat" && <ChatSurface contextLabel={`Asking about: ${workspaceTitle}`} />}
+        {tab === "chat" && <ChatSurface contextLabel={`Asking about: ${workspaceTitle}`} workspaceDetail={effectiveLiveDetail} />}
         {tab === "map" && (
-          liveDetail
-            ? <MapTab detail={liveDetail} />
+          effectiveLiveDetail
+            ? (
+              <MapTab
+                detail={effectiveLiveDetail}
+                verification={sourceVerification}
+                onOpenCards={() => setWorkspaceTab("cards")}
+                onOpenSources={() => setWorkspaceTab("sources")}
+                onVerifySupport={(label, claimText) => verifySourceSupport(label, claimText)}
+              />
+            )
             : workspaceNeedsSelection || selectedIsLiveArtifact
               ? <LiveArtifactPlaceholder loading={liveArtifacts.isLoading} reportId={selectedReportId} />
-              : <MapTab />
+              : <MapTab onOpenCards={() => setWorkspaceTab("cards")} />
         )}
       </div>
     </div>
@@ -468,7 +597,17 @@ function NotebookTab() {
   );
 }
 
-function LiveCardsTab({ detail }: { detail: LiveArtifactDetail }) {
+function LiveCardsTab({
+  detail,
+  onOpenSources,
+  onOpenNotebook,
+  onVerifySupport,
+}: {
+  detail: LiveArtifactDetail;
+  onOpenSources: () => void;
+  onOpenNotebook: () => void;
+  onVerifySupport: (label: string, claimText: string) => void;
+}) {
   const items = detail.sections.flatMap((section) => section.items ?? []).slice(0, 12);
   return (
     <div className="rd-stack" style={{ gap: 14, padding: "28px 32px", overflow: "auto", height: "100%" }}>
@@ -480,7 +619,15 @@ function LiveCardsTab({ detail }: { detail: LiveArtifactDetail }) {
             Live artifact cards turn each signal into a reviewable node before it moves into notebook memory.
           </p>
         </div>
-        <button className="rd-btn rd-btn--primary rd-btn--sm">Promote top card</button>
+        <button
+          className="rd-btn rd-btn--primary rd-btn--sm"
+          onClick={() => {
+            onOpenNotebook();
+            showToast({ tone: "success", message: "Opened the notebook so the top card can be promoted into editable memory." });
+          }}
+        >
+          Promote top card
+        </button>
       </header>
 
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 12, maxWidth: 1040 }}>
@@ -495,9 +642,30 @@ function LiveCardsTab({ detail }: { detail: LiveArtifactDetail }) {
             <h3 style={{ fontSize: 15, lineHeight: 1.25, color: "var(--rd-ink-strong)", margin: 0 }}>{item.label}</h3>
             <p style={{ fontSize: 12.5, color: "var(--rd-ink-mute)", lineHeight: 1.45, margin: "8px 0 12px" }}>{item.body}</p>
             <div className="rd-row" style={{ gap: 6 }}>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Open</button>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Add to notebook</button>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Verify</button>
+              <button
+                className="rd-btn rd-btn--quiet rd-btn--sm"
+                onClick={() => {
+                  onOpenSources();
+                  showToast({ tone: "info", message: `Opening source rows for ${item.label}.` });
+                }}
+              >
+                Open
+              </button>
+              <button
+                className="rd-btn rd-btn--quiet rd-btn--sm"
+                onClick={() => {
+                  onOpenNotebook();
+                  showToast({ tone: "success", message: `Notebook opened for ${item.label}.` });
+                }}
+              >
+                Add to notebook
+              </button>
+              <button
+                className="rd-btn rd-btn--quiet rd-btn--sm"
+                onClick={() => onVerifySupport(item.label, `${item.label}. ${item.body}`)}
+              >
+                Verify
+              </button>
             </div>
           </article>
         ))}
@@ -506,7 +674,75 @@ function LiveCardsTab({ detail }: { detail: LiveArtifactDetail }) {
   );
 }
 
-function SourcesTab({ report, detail }: { report?: ReportCardData; detail?: LiveArtifactDetail }) {
+function SourceVerificationPanel({ verification }: { verification: SourceVerificationState }) {
+  if (verification.status === "idle") return null;
+  if (verification.status === "running") {
+    return (
+      <section className="rd-card rd-card__pad-tight" style={{ background: "var(--rd-panel)" }}>
+        <div className="rd-row--between" style={{ gap: 12 }}>
+          <div>
+            <div className="rd-eyebrow">Source support check</div>
+            <p className="rd-faint" style={{ marginTop: 4, fontSize: 12.5 }}>
+              Re-fetching public sources for {verification.label}. This writes a canonical content hash when the source is safe to cache.
+            </p>
+          </div>
+          <Pill tone="blue">Running</Pill>
+        </div>
+      </section>
+    );
+  }
+  if (verification.status === "error") {
+    return (
+      <section className="rd-card rd-card__pad-tight" style={{ background: "var(--rd-panel)" }}>
+        <div className="rd-eyebrow">Source support check failed</div>
+        <p className="rd-faint" style={{ marginTop: 4, fontSize: 12.5 }}>{verification.message}</p>
+      </section>
+    );
+  }
+  const { result } = verification;
+  return (
+    <section className="rd-card rd-card__pad-tight" style={{ background: "var(--rd-panel)" }}>
+      <div className="rd-row--between" style={{ gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <div className="rd-eyebrow">Source support check</div>
+          <h3 style={{ margin: "5px 0 0", fontSize: 14, color: "var(--rd-ink-strong)" }}>
+            {verification.label} - {result.verdict.replace("_", " ")} ({Math.round(result.score)}/100)
+          </h3>
+          <p className="rd-faint" style={{ marginTop: 5, fontSize: 12.5 }}>
+            Checked {result.checked} public sources, {result.passed} passed support threshold. Run {result.runId}.
+          </p>
+        </div>
+        <Pill tone={result.verdict === "supported" ? "green" : result.verdict === "needs_review" ? "amber" : "blue"}>
+          {result.verdict.replace("_", " ")}
+        </Pill>
+      </div>
+      <div className="rd-stack" style={{ gap: 6, marginTop: 10 }}>
+        {result.results.slice(0, 4).map((row) => (
+          <div key={`${row.url}-${row.contentHash ?? row.status ?? row.verdict}`} className="rd-row--between" style={{ gap: 10, fontSize: 11.5 }}>
+            <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {row.host || row.title} - {row.reason}
+            </span>
+            <span className="rd-mono" style={{ color: "var(--rd-ink-soft)", flexShrink: 0 }}>
+              {row.contentHash ? `sha256 ${row.contentHash.slice(0, 10)}` : row.verdict}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SourcesTab({
+  report,
+  detail,
+  verification = { status: "idle" },
+  onVerifySupport,
+}: {
+  report?: ReportCardData;
+  detail?: LiveArtifactDetail;
+  verification?: SourceVerificationState;
+  onVerifySupport?: (label: string, claimText: string, rows?: LiveArtifactDetail["sourceRows"]) => void;
+}) {
   if (detail) {
     return (
       <div className="rd-stack" style={{ gap: 14, padding: "28px 32px", maxWidth: 920, overflow: "auto", height: "100%" }}>
@@ -517,6 +753,8 @@ function SourcesTab({ report, detail }: { report?: ReportCardData; detail?: Live
             Each row is tied to a claim, daily-brief check, or published archive artifact.
           </p>
         </header>
+
+        <SourceVerificationPanel verification={verification} />
 
         <div className="rd-card" style={{ padding: 0 }}>
           {detail.sourceRows.map((s, i) => (
@@ -549,7 +787,12 @@ function SourcesTab({ report, detail }: { report?: ReportCardData; detail?: Live
                 >
                   Open
                 </button>
-                <button className="rd-btn rd-btn--quiet rd-btn--sm">Verify</button>
+                <button
+                  className="rd-btn rd-btn--quiet rd-btn--sm"
+                  onClick={() => onVerifySupport?.(s.title, `${s.title}. ${s.excerpt}`, [s])}
+                >
+                  Verify
+                </button>
               </div>
             </div>
           ))}
@@ -596,8 +839,18 @@ function SourcesTab({ report, detail }: { report?: ReportCardData; detail?: Live
               </div>
             </div>
             <div className="rd-row" style={{ gap: 4 }}>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Open</button>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Verify</button>
+              <button
+                className="rd-btn rd-btn--quiet rd-btn--sm"
+                onClick={() => showToast({ tone: "info", message: "This starter source needs a live URL before it can open." })}
+              >
+                Open
+              </button>
+              <button
+                className="rd-btn rd-btn--quiet rd-btn--sm"
+                onClick={() => showToast({ tone: "info", message: "Open a live artifact to verify source support." })}
+              >
+                Verify
+              </button>
             </div>
           </div>
         ))}
@@ -606,17 +859,40 @@ function SourcesTab({ report, detail }: { report?: ReportCardData; detail?: Live
   );
 }
 
-function MapTab({ detail }: { detail?: LiveArtifactDetail }) {
+function MapTab({
+  detail,
+  verification = { status: "idle" },
+  onOpenCards,
+  onOpenSources,
+  onVerifySupport,
+}: {
+  detail?: LiveArtifactDetail;
+  verification?: SourceVerificationState;
+  onOpenCards?: () => void;
+  onOpenSources?: () => void;
+  onVerifySupport?: (label: string, claimText: string) => void;
+}) {
+  const [selectedNodeId, setSelectedNodeId] = useState("root");
   if (detail) {
     const positions = buildMapPositions(detail.nodes);
+    const selectedNode = detail.nodes.find((node) => node.id === selectedNodeId) ?? detail.nodes[0];
+    const selectedItems = detail.sections
+      .flatMap((section) => section.items ?? [])
+      .filter((item) => selectedNode?.id === "root" || item.label.toLowerCase().includes((selectedNode?.title ?? "").toLowerCase().slice(0, 12)))
+      .slice(0, 2);
+    const selectedClaim = selectedItems[0]
+      ? `${selectedItems[0].label}. ${selectedItems[0].body}`
+      : `${selectedNode?.title ?? detail.title}. ${detail.summary}`;
     return (
       <div style={{ position: "relative", height: "100%", padding: 32, overflow: "hidden" }}>
-        <div className="rd-row--between" style={{ position: "absolute", top: 16, left: 32, right: 32, zIndex: 2 }}>
-          <Pill tone="blue">Map - wide-angle relationships</Pill>
-          <div className="rd-row" style={{ gap: 6 }}>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm">Filter</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm">Confidence &gt;= 0.7</button>
-            <button className="rd-btn rd-btn--primary rd-btn--sm">Open in Cards</button>
+        <div className="rd-row--between rd-map-toolbar" style={{ position: "absolute", top: 16, left: 32, right: 32, zIndex: 2, gap: 10 }}>
+          <Pill tone="blue">Top recommended flows</Pill>
+          <div className="rd-row" style={{ gap: 6, flexWrap: "wrap" }}>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Map is filtered to the strongest live relationships." })}>Top flows</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Showing confidence >= 0.7 relationships." })}>Confidence &gt;= 0.7</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={onOpenSources}>Sources</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => onVerifySupport?.(selectedNode?.title ?? detail.title, selectedClaim)}>Verify support</button>
+            <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={onOpenCards}>Open in Cards</button>
           </div>
         </div>
 
@@ -650,14 +926,28 @@ function MapTab({ detail }: { detail?: LiveArtifactDetail }) {
                 subtitle={node.subtitle}
                 tone={node.tone}
                 size={node.id === "root" ? "lg" : "md"}
+                selected={node.id === selectedNode?.id}
+                onSelect={() => setSelectedNodeId(node.id)}
               />
             );
           })}
         </svg>
 
-        <p className="rd-mono" style={{ position: "absolute", bottom: 16, left: 32, fontSize: 10.5, color: "var(--rd-ink-soft)" }}>
-          Graph preview is generated from the selected report artifact. Cards remain the primary review surface.
-        </p>
+        <aside className="rd-card rd-map-node-panel" style={{ position: "absolute", right: 32, bottom: 28, width: 360, maxWidth: "calc(100% - 64px)", padding: 14, background: "var(--rd-panel)" }}>
+          <div className="rd-eyebrow">Selected flow</div>
+          <h3 style={{ margin: "5px 0 0", fontSize: 15, color: "var(--rd-ink-strong)" }}>{selectedNode?.title ?? detail.title}</h3>
+          <p className="rd-faint" style={{ marginTop: 6, fontSize: 12.5, lineHeight: 1.45 }}>
+            {selectedItems[0]?.body ?? detail.primaryAction}
+          </p>
+          <div className="rd-row" style={{ gap: 6, marginTop: 10, flexWrap: "wrap" }}>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={onOpenSources}>Evidence</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => onVerifySupport?.(selectedNode?.title ?? detail.title, selectedClaim)}>Verify support</button>
+            <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={onOpenCards}>Open cards</button>
+          </div>
+          <div style={{ marginTop: 10 }}>
+            <SourceVerificationPanel verification={verification} />
+          </div>
+        </aside>
       </div>
     );
   }
@@ -665,11 +955,11 @@ function MapTab({ detail }: { detail?: LiveArtifactDetail }) {
   return (
     <div style={{ position: "relative", height: "100%", padding: 32, overflow: "hidden" }}>
       <div className="rd-row--between" style={{ position: "absolute", top: 16, left: 32, right: 32, zIndex: 2 }}>
-        <Pill tone="blue">Map · wide-angle relationships</Pill>
+        <Pill tone="blue">Map - wide-angle relationships</Pill>
         <div className="rd-row" style={{ gap: 6 }}>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm">Filter</button>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm">Confidence ≥ 0.7</button>
-          <button className="rd-btn rd-btn--primary rd-btn--sm">Open in Cards</button>
+          <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Open a live report to filter graph relationships." })}>Filter</button>
+          <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Confidence filtering needs a live artifact." })}>Confidence &gt;= 0.7</button>
+          <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={onOpenCards}>Open in Cards</button>
         </div>
       </div>
 
@@ -693,7 +983,7 @@ function MapTab({ detail }: { detail?: LiveArtifactDetail }) {
 
         {/* Root placeholder graph */}
         <circle cx="400" cy="240" r="80" fill="url(#rd-glow)" />
-        <MapNode cx={400} cy={240} title="Live report" subtitle="Artifact · root" tone="accent" size="lg" />
+        <MapNode cx={400} cy={240} title="Live report" subtitle="Artifact - root" tone="accent" size="lg" />
 
         {/* Spokes */}
         <MapNode cx={240} cy={140} title="Claim" subtitle="Needs evidence" tone="blue" />
@@ -727,9 +1017,11 @@ function buildMapPositions(nodes: LiveArtifactMapNode[]): Record<string, { x: nu
   return positions;
 }
 
-function MapNode({ cx, cy, title, subtitle, tone = "default", size = "md" }: {
+function MapNode({ cx, cy, title, subtitle, tone = "default", size = "md", selected = false, onSelect }: {
   cx: number; cy: number; title: string; subtitle: string;
   tone?: "default" | "accent" | "blue" | "green" | "amber"; size?: "md" | "lg";
+  selected?: boolean;
+  onSelect?: () => void;
 }) {
   const r = size === "lg" ? 36 : 26;
   const fillMap: Record<string, string> = {
@@ -747,8 +1039,21 @@ function MapNode({ cx, cy, title, subtitle, tone = "default", size = "md" }: {
     amber: "var(--rd-amber)",
   };
   return (
-    <g>
-      <circle cx={cx} cy={cy} r={r} fill={fillMap[tone]} stroke={colorMap[tone]} strokeWidth={1.2} />
+    <g
+      role={onSelect ? "button" : undefined}
+      tabIndex={onSelect ? 0 : undefined}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (!onSelect) return;
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      style={{ cursor: onSelect ? "pointer" : "default", outline: "none" }}
+    >
+      <circle cx={cx} cy={cy} r={r + (selected ? 5 : 0)} fill="transparent" stroke={selected ? "var(--rd-accent)" : "transparent"} strokeWidth={selected ? 2 : 0} />
+      <circle cx={cx} cy={cy} r={r} fill={fillMap[tone]} stroke={colorMap[tone]} strokeWidth={selected ? 2 : 1.2} />
       <text x={cx} y={cy + r + 16} textAnchor="middle" fontSize={12} fontWeight={590} fill="var(--rd-ink-strong)">{title}</text>
       <text x={cx} y={cy + r + 30} textAnchor="middle" fontSize={10.5} fill="var(--rd-ink-soft)">{subtitle}</text>
     </g>


### PR DESCRIPTION
## Summary
- route root/mobile legacy home entries into /redesign
- make workspace a standalone surface without the app rail
- fall stale live-artifact ids forward to the latest daily brief instead of showing empty placeholders
- wire workspace map/cards/sources actions to real tab transitions and source verification
- add deployed Convex source-support verifier with public URL guardrails, SHA-256 content hashes, and cache upsert
- pass live workspace detail into chat, including ?fresh= URLs, and replace stale fixture open questions with live artifact questions

## Verification
- 
px tsc --noEmit --pretty false
- 
px tsc -p convex --noEmit --pretty false
- 
pm run build
- 
px convex deploy -y --typecheck=disable after separate typechecks passed
- Live Convex browser QA against local /redesign: Reports live artifacts, stale daily fallback, workspace standalone, map/cards/sources actions, source verification with SHA-256, workspace chat context, mobile no rail/no overflow