### PR TITLE
fix(qa-rescore): /mcp/ledger crash + agent UI lint HIGH

### DIFF
--- a/src/features/mcp/components/SharedContextProtocolPanel.tsx
+++ b/src/features/mcp/components/SharedContextProtocolPanel.tsx
@@ -400,12 +400,16 @@ export function SharedContextProtocolPanel() {
         </div>
       </div>
 
+      {/* QA fix (2026-05-08): chain optional through `counts` too — anonymous
+          users hit this panel with snapshot defined but counts undefined,
+          which threw "Cannot read properties of undefined (reading
+          'activePeers')" and triggered the ErrorBoundary on /mcp/ledger. */}
       <div className="mt-4 grid gap-3 md:grid-cols-5">
-        <Stat icon={<Users className="h-3.5 w-3.5" />} label="Active peers" value={snapshot?.counts.activePeers ?? 0} />
-        <Stat icon={<Boxes className="h-3.5 w-3.5" />} label="Active packets" value={snapshot?.counts.activePackets ?? 0} />
-        <Stat icon={<Link2 className="h-3.5 w-3.5" />} label="Invalidated" value={snapshot?.counts.invalidatedPackets ?? 0} />
-        <Stat icon={<RefreshCw className="h-3.5 w-3.5" />} label="Open tasks" value={snapshot?.counts.openTasks ?? 0} />
-        <Stat icon={<Mail className="h-3.5 w-3.5" />} label="Unread" value={snapshot?.counts.unreadMessages ?? 0} />
+        <Stat icon={<Users className="h-3.5 w-3.5" />} label="Active peers" value={snapshot?.counts?.activePeers ?? 0} />
+        <Stat icon={<Boxes className="h-3.5 w-3.5" />} label="Active packets" value={snapshot?.counts?.activePackets ?? 0} />
+        <Stat icon={<Link2 className="h-3.5 w-3.5" />} label="Invalidated" value={snapshot?.counts?.invalidatedPackets ?? 0} />
+        <Stat icon={<RefreshCw className="h-3.5 w-3.5" />} label="Open tasks" value={snapshot?.counts?.openTasks ?? 0} />
+        <Stat icon={<Mail className="h-3.5 w-3.5" />} label="Unread" value={snapshot?.counts?.unreadMessages ?? 0} />
       </div>
 
       {loading && <div className="mt-4 text-sm text-content-secondary">Loading shared context snapshot...</div>}

--- a/src/features/mcp/components/SyncBridgeAccountPanel.tsx
+++ b/src/features/mcp/components/SyncBridgeAccountPanel.tsx
@@ -266,7 +266,7 @@ export function SyncBridgeAccountPanel() {
         />
         <StatCard
           label="Shared ops"
-          value={snapshot?.recentOperations.length ?? 0}
+          value={snapshot?.recentOperations?.length ?? 0}
         />
       </div>
 

--- a/src/layouts/CommandBar.tsx
+++ b/src/layouts/CommandBar.tsx
@@ -208,6 +208,7 @@ export const CommandBar = memo(function CommandBar({
           aria-label="Open command palette"
           data-agent-id="cockpit:action:palette"
           data-agent-action="search"
+          data-agent-label="Open command palette"
         >
           <kbd className="rounded border border-white/[0.06] bg-white/[0.02] px-1.5 py-0.5">{isMac ? "⌘K" : "Ctrl+K"}</kbd>
         </button>


### PR DESCRIPTION
Rescore audit caught a P0 regression and a HIGH lint violation:

**P0 regression** — /mcp/ledger threw 'Cannot read properties of undefined (reading activePeers)' inside ErrorBoundary because PR #261 routed it to McpLedgerPage but SharedContextProtocolPanel chained optional only on snapshot, not on counts. Fixed all 5 stat reads + SyncBridgeAccountPanel.recentOperations.

**HIGH lint** — CommandBar palette button missing data-agent-label (agentNativeUiLinter). Added.

Visual sweep confirmed all 3 P1 surfaces (Daily Pulse, LiveResearchChecklist, ProofDrawer) render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)