### PR TITLE
feat(voice): VoiceAuditFeed + VoiceCostBadge components [Phase 5-B]

### DIFF
--- a/src/features/voice/components/VoiceAuditFeed.tsx
+++ b/src/features/voice/components/VoiceAuditFeed.tsx
@@ -1,0 +1,223 @@
+/**
+ * VoiceAuditFeed — list of recent realtime voice gate decisions for a user.
+ *
+ * Pattern: Read-only telemetry surface; subscribes to
+ * `voice/realtimeAudit:listForUser` (landed in PR #274). Renders the gate +
+ * decision + rationale + timestamp for each event so users can see why a
+ * voice capture was redacted, queued for async, or persisted.
+ *
+ * See: docs/architecture/REALTIME_VOICE_INTEGRATION.md §2 (RealtimeAuditEvent)
+ *
+ * Glass card DNA: bg-surface/80 backdrop-blur-md border border-edge/40
+ * Section header: text-[11px] uppercase tracking-[0.12em] text-content-muted
+ * Terracotta accent: #d97757 for active/CTA states (rendered via tailwind tokens)
+ */
+
+import { useQuery } from "convex/react";
+import { useMemo } from "react";
+// The api object has the new realtimeAudit module after PR #274's codegen.
+// Until codegen runs in CI, fall back to a relaxed lookup so tsc passes.
+import { api } from "@/convex/_generated/api";
+
+type AuditGate =
+  | "anonymous_no_persist"
+  | "anonymous_to_linked"
+  | "budget_cap_hit"
+  | "budget_warning_80pct"
+  | "pii_redacted"
+  | "idempotent_replay"
+  | "escalation_to_async"
+  | "approval_required"
+  | "approval_granted"
+  | "approval_rejected"
+  | "model_routing"
+  | "session_terminated_pii"
+  | "session_terminated_cap";
+
+type AuditDecision =
+  | "allowed"
+  | "denied"
+  | "needs_consent"
+  | "needs_approval"
+  | "downgraded";
+
+interface AuditEvent {
+  _id: string;
+  userId?: string;
+  anonId?: string;
+  sessionId?: string;
+  gate: AuditGate;
+  decision: AuditDecision;
+  rationale?: string;
+  metadata?: {
+    modelTier?: string;
+    capUsd?: number;
+    spentUsd?: number;
+    idempotencyKey?: string;
+    redactedSpanCount?: number;
+    temporalJobId?: string;
+  };
+  createdAt: number;
+}
+
+interface VoiceAuditFeedProps {
+  userId: string; // user's Convex id, passed in by parent surface
+  limit?: number; // default 20 — bounded query caps at 200 server-side
+  className?: string;
+}
+
+const GATE_LABELS: Record<AuditGate, string> = {
+  anonymous_no_persist: "Anonymous · no private memory",
+  anonymous_to_linked: "Linked to account",
+  budget_cap_hit: "Daily voice cap hit",
+  budget_warning_80pct: "80% of voice cap",
+  pii_redacted: "PII redacted",
+  idempotent_replay: "Duplicate · returned cached",
+  escalation_to_async: "Queued for deep research",
+  approval_required: "Awaiting approval",
+  approval_granted: "Approved",
+  approval_rejected: "Rejected",
+  model_routing: "Routed to model tier",
+  session_terminated_pii: "Session ended · PII",
+  session_terminated_cap: "Session ended · cap",
+};
+
+const DECISION_TONES: Record<AuditDecision, string> = {
+  allowed: "text-emerald-300/90 border-emerald-300/40 bg-emerald-500/10",
+  denied: "text-rose-300/90 border-rose-300/40 bg-rose-500/10",
+  needs_consent: "text-amber-300/90 border-amber-300/40 bg-amber-500/10",
+  needs_approval: "text-amber-300/90 border-amber-300/40 bg-amber-500/10",
+  downgraded: "text-orange-300/90 border-orange-300/40 bg-orange-500/10",
+};
+
+function formatRelativeTime(ms: number): string {
+  const diff = Date.now() - ms;
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
+}
+
+export function VoiceAuditFeed({ userId, limit = 20, className }: VoiceAuditFeedProps): JSX.Element {
+  // Type-erased lookup — `api.domains.integrations.voice.realtimeAudit.listForUser`
+  // lands when codegen runs against PR #274. Until then, the runtime path is
+  // valid; tsc tolerates the cast.
+  const queryRef = (api as unknown as {
+    domains: { integrations: { voice: { realtimeAudit: { listForUser: unknown } } } };
+  }).domains.integrations.voice.realtimeAudit.listForUser;
+
+  const events = useQuery(
+    queryRef as Parameters<typeof useQuery>[0],
+    { userId, limit } as Parameters<typeof useQuery>[1],
+  ) as AuditEvent[] | undefined;
+
+  const isLoading = events === undefined;
+  const isEmpty = events !== undefined && events.length === 0;
+
+  const sorted = useMemo(() => {
+    if (!events) return [];
+    return [...events].sort((a, b) => b.createdAt - a.createdAt);
+  }, [events]);
+
+  return (
+    <section
+      role="region"
+      aria-label="Voice audit feed"
+      className={[
+        "rounded-2xl border border-edge/40 bg-surface/80 backdrop-blur-md",
+        "p-4 sm:p-5",
+        className ?? "",
+      ].join(" ")}
+    >
+      <header className="flex items-center justify-between gap-3 pb-3">
+        <h3 className="text-[11px] uppercase tracking-[0.12em] text-content-muted">
+          Voice gate decisions
+        </h3>
+        {!isLoading && !isEmpty && (
+          <span className="text-[11px] text-content-muted/80">
+            {sorted.length} event{sorted.length === 1 ? "" : "s"}
+          </span>
+        )}
+      </header>
+
+      {isLoading && (
+        <ul className="space-y-2" aria-busy="true">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <li
+              key={i}
+              className="h-12 rounded-lg border border-edge/20 bg-content/[0.03] animate-pulse"
+            />
+          ))}
+        </ul>
+      )}
+
+      {isEmpty && (
+        <p className="text-sm text-content-muted">
+          No voice gate decisions yet. Capture a voice note to populate this
+          feed — or check that <code className="px-1 rounded bg-content/[0.05]">CONVEX_URL</code> is configured on the gateway.
+        </p>
+      )}
+
+      {!isLoading && !isEmpty && (
+        <ol className="space-y-2">
+          {sorted.map((evt) => (
+            <li
+              key={evt._id}
+              className="flex flex-col gap-1.5 rounded-lg border border-edge/20 bg-content/[0.02] p-3 sm:flex-row sm:items-start sm:justify-between"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium text-content">
+                    {GATE_LABELS[evt.gate] ?? evt.gate}
+                  </span>
+                  <span
+                    className={[
+                      "inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider",
+                      DECISION_TONES[evt.decision] ?? "text-content border-edge/40 bg-content/[0.05]",
+                    ].join(" ")}
+                  >
+                    {evt.decision.replace(/_/g, " ")}
+                  </span>
+                </div>
+                {evt.rationale && (
+                  <p className="mt-1 line-clamp-2 text-xs text-content-muted">
+                    {evt.rationale}
+                  </p>
+                )}
+                {evt.metadata && (
+                  <dl className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-content-muted/80 font-mono">
+                    {evt.metadata.modelTier && (
+                      <div>
+                        <dt className="inline">tier:</dt>{" "}
+                        <dd className="inline">{evt.metadata.modelTier}</dd>
+                      </div>
+                    )}
+                    {typeof evt.metadata.spentUsd === "number" && (
+                      <div>
+                        <dt className="inline">spent:</dt>{" "}
+                        <dd className="inline">${evt.metadata.spentUsd.toFixed(3)}</dd>
+                      </div>
+                    )}
+                    {typeof evt.metadata.redactedSpanCount === "number" &&
+                      evt.metadata.redactedSpanCount > 0 && (
+                        <div>
+                          <dt className="inline">redactions:</dt>{" "}
+                          <dd className="inline">{evt.metadata.redactedSpanCount}</dd>
+                        </div>
+                      )}
+                  </dl>
+                )}
+              </div>
+              <time
+                dateTime={new Date(evt.createdAt).toISOString()}
+                className="shrink-0 text-[11px] text-content-muted/80 font-mono"
+              >
+                {formatRelativeTime(evt.createdAt)}
+              </time>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/src/features/voice/components/VoiceCostBadge.tsx
+++ b/src/features/voice/components/VoiceCostBadge.tsx
@@ -1,0 +1,171 @@
+/**
+ * VoiceCostBadge — daily voice spend indicator.
+ *
+ * Pattern: Read-only spend summary; subscribes to
+ * `voice/costLedger:checkCap` (landed in PR #274). Shows totalUsd vs capUsd
+ * with a horizontal progress bar + warning state at 80% + capped state at
+ * 100%. HONEST_SCORES — totalUsd is server-computed from sum(byTier).
+ *
+ * See: docs/architecture/REALTIME_VOICE_INTEGRATION.md §2 (voiceCostLedger)
+ *
+ * Visual states:
+ *   - Healthy   (< 80%): muted text + slim accent bar
+ *   - Warning   (>=80%): amber accent + warning copy
+ *   - Cap hit  (>=100%): rose accent + "capture-only mode" copy
+ *
+ * Glass card DNA, terracotta accent for the bar fill.
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+
+interface VoiceCostBadgeProps {
+  userId: string; // user's Convex id
+  className?: string;
+}
+
+interface CapSnapshot {
+  userId: string;
+  dayUtc: string;
+  totalUsd: number;
+  capUsd: number;
+  remaining: number;
+  hit: boolean;
+  warning80pct: boolean;
+}
+
+function fmtUsd(n: number): string {
+  return n < 1 ? `$${n.toFixed(3)}` : `$${n.toFixed(2)}`;
+}
+
+export function VoiceCostBadge({ userId, className }: VoiceCostBadgeProps): JSX.Element {
+  // Type-erased lookup — `api.domains.integrations.voice.costLedger.checkCap`
+  // resolves at runtime once codegen has consumed PR #274's mutation files.
+  const queryRef = (api as unknown as {
+    domains: { integrations: { voice: { costLedger: { checkCap: unknown } } } };
+  }).domains.integrations.voice.costLedger.checkCap;
+
+  const snap = useQuery(
+    queryRef as Parameters<typeof useQuery>[0],
+    { userId } as Parameters<typeof useQuery>[1],
+  ) as CapSnapshot | undefined;
+
+  const isLoading = snap === undefined;
+
+  // Tone selection — matches CLAUDE.md design DNA + accessibility (color paired with text)
+  const tone = !snap
+    ? "muted"
+    : snap.hit
+      ? "rose"
+      : snap.warning80pct
+        ? "amber"
+        : "accent";
+
+  const toneClasses: Record<string, string> = {
+    muted: "border-edge/30 bg-content/[0.02]",
+    accent: "border-edge/30 bg-content/[0.02]",
+    amber: "border-amber-300/40 bg-amber-500/10",
+    rose: "border-rose-300/40 bg-rose-500/10",
+  };
+
+  const fillClasses: Record<string, string> = {
+    muted: "bg-content/20",
+    accent: "bg-[#d97757]",
+    amber: "bg-amber-400",
+    rose: "bg-rose-400",
+  };
+
+  const pct = snap ? Math.min(100, Math.round((snap.totalUsd / Math.max(snap.capUsd, 0.01)) * 100)) : 0;
+
+  return (
+    <section
+      role="region"
+      aria-label="Daily voice spend"
+      className={[
+        "rounded-2xl border bg-surface/80 backdrop-blur-md",
+        "p-4 sm:p-5",
+        toneClasses[tone],
+        className ?? "",
+      ].join(" ")}
+    >
+      <header className="flex items-baseline justify-between gap-3 pb-2">
+        <h3 className="text-[11px] uppercase tracking-[0.12em] text-content-muted">
+          Voice spend today
+        </h3>
+        {!isLoading && (
+          <span className="text-[11px] text-content-muted/80 font-mono">
+            {snap?.dayUtc}
+          </span>
+        )}
+      </header>
+
+      {isLoading ? (
+        <div className="space-y-2" aria-busy="true">
+          <div className="h-6 w-32 rounded bg-content/[0.06] animate-pulse" />
+          <div className="h-1.5 w-full rounded-full bg-content/[0.05] animate-pulse" />
+        </div>
+      ) : snap ? (
+        <>
+          <div className="flex items-baseline justify-between gap-3">
+            <p className="text-2xl font-semibold tabular-nums text-content">
+              {fmtUsd(snap.totalUsd)}
+              <span className="ml-2 text-sm font-normal text-content-muted">
+                / {fmtUsd(snap.capUsd)}
+              </span>
+            </p>
+            <span
+              className={[
+                "text-xs font-medium tabular-nums",
+                tone === "rose"
+                  ? "text-rose-300"
+                  : tone === "amber"
+                    ? "text-amber-300"
+                    : "text-content-muted",
+              ].join(" ")}
+            >
+              {pct}%
+            </span>
+          </div>
+
+          <div
+            className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-content/[0.05]"
+            role="progressbar"
+            aria-valuenow={pct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${pct}% of daily voice cap used`}
+          >
+            <div
+              className={[
+                "h-full rounded-full transition-all duration-300",
+                fillClasses[tone],
+              ].join(" ")}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+
+          {snap.hit && (
+            <p className="mt-2 text-xs text-rose-300">
+              Daily cap reached. Capture-only mode until midnight UTC. Agent + translation tiers blocked.
+            </p>
+          )}
+          {!snap.hit && snap.warning80pct && (
+            <p className="mt-2 text-xs text-amber-300">
+              Approaching daily voice cap. {fmtUsd(snap.remaining)} remaining.
+            </p>
+          )}
+          {!snap.hit && !snap.warning80pct && snap.totalUsd > 0 && (
+            <p className="mt-2 text-xs text-content-muted">
+              {fmtUsd(snap.remaining)} remaining today.
+            </p>
+          )}
+          {snap.totalUsd === 0 && (
+            <p className="mt-2 text-xs text-content-muted">
+              No voice activity today.
+            </p>
+          )}
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/voice/index.ts
+++ b/src/features/voice/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Voice feature surfaces — Phase 5-B reusable components for the Realtime
+ * Adapter telemetry surfaces.
+ *
+ * See: docs/architecture/REALTIME_VOICE_INTEGRATION.md
+ *
+ * Usage (drop into MeSurface, AgentTelemetryDashboard, or Inbox):
+ *   import { VoiceAuditFeed, VoiceCostBadge } from "@/features/voice";
+ *   <VoiceCostBadge userId={user._id} />
+ *   <VoiceAuditFeed userId={user._id} limit={20} />
+ *
+ * Both components are READ-ONLY — they subscribe to the Convex queries
+ * landed in PR #274 (`realtimeAudit:listForUser`, `costLedger:checkCap`)
+ * and gracefully render skeleton + empty states when no data is available.
+ */
+
+export { VoiceAuditFeed } from "./components/VoiceAuditFeed";
+export { VoiceCostBadge } from "./components/VoiceCostBadge";


### PR DESCRIPTION
## Summary
Two read-only components that surface the Convex persistence from #274. Designed as additive imports — drop into MeSurface / AgentTelemetryDashboard / Inbox without modifying existing surfaces.

## Components
### `VoiceAuditFeed`
Lists recent voice gate decisions (`anonymous_no_persist`, `pii_redacted`, `budget_cap_hit`, `escalation_to_async`, `model_routing`, etc). Tone-coded decision chips, rationale + structured metadata (modelTier, spentUsd, redactedSpanCount), skeleton loader, honest empty state.

### `VoiceCostBadge`
Daily spend / cap with progress bar. Three tones: healthy (<80%) / warning (>=80%) / cap-hit (>=100% with "capture-only mode" copy). Tabular-nums for stable digit alignment. Terracotta `#d97757` accent.

## Why standalone, not surface-integrated
Modifying live UI surfaces (Inbox/Me/AgentTelemetry) without local tsc + visual verification is too risky — CI is account-disabled, no safety net. Standalone components are additive (zero existing files modified), preserve CLAUDE.md's "main web app nav" hard rule, and let you pick placement with proper dogfood evidence in a follow-up PR.

## Usage (one-line import)
```tsx
import { VoiceAuditFeed, VoiceCostBadge } from "@/features/voice";

<VoiceCostBadge userId={user._id} />
<VoiceAuditFeed userId={user._id} limit={20} />
```

## Design DNA
- Glass cards: `bg-surface/80 backdrop-blur-md border border-edge/40`
- Section headers: `text-[11px] uppercase tracking-[0.12em] text-content-muted`
- Terracotta `#d97757` accent for healthy progress bar fill
- Tabular-nums for stable digit alignment
- A11y: `role="region"`, `role="progressbar"`, `aria-busy`, ISO `datetime`

## Type-erased api lookups
Both components use `(api as unknown as {...}).domains.integrations.voice.*` to avoid tsc-on-stale-codegen failures. Runtime resolves correctly once codegen consumes PR #274. Same pattern as `server/routes/voiceCapture.ts:fireAudit`.

## Test plan
- [ ] `npx tsc --noEmit` clean (currently disabled CI; trust-but-verify on next codegen)
- [ ] `npm run build` clean — additive components, no existing surface imports
- [ ] Visual smoke in next dogfood pass once a surface imports them

## Related PRs
- #270 — REALTIME_VOICE_INTEGRATION spec + 10-scenario matrix
- #271 — schema (`voiceCostLedger`, `realtimeAuditEvents`)
- #273 — Realtime Adapter contract endpoints + runnable harness
- #274 — Convex persistence (`realtimeAudit:append`, `costLedger:checkCap`) consumed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)