### PR TITLE
Phase 7a: editorial home (Variant C) behind ?edition=1

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -883,7 +883,6 @@ import type * as domains_operations_utilities_seedGoldenDataset from "../domains
 import type * as domains_operations_utilities_snapshotMigrations from "../domains/operations/utilities/snapshotMigrations.js";
 import type * as domains_operations_validationWorkflow from "../domains/operations/validationWorkflow.js";
 import type * as domains_operatorProfile_filesystemSync from "../domains/operatorProfile/filesystemSync.js";
-import type * as domains_operatorProfile_manifest from "../domains/operatorProfile/manifest.js";
 import type * as domains_operatorProfile_mutations from "../domains/operatorProfile/mutations.js";
 import type * as domains_operatorProfile_parser from "../domains/operatorProfile/parser.js";
 import type * as domains_operatorProfile_queries from "../domains/operatorProfile/queries.js";
@@ -1016,6 +1015,7 @@ import type * as domains_research_dashboardQueries from "../domains/research/das
 import type * as domains_research_dealFlow from "../domains/research/dealFlow.js";
 import type * as domains_research_dealFlowQueries from "../domains/research/dealFlowQueries.js";
 import type * as domains_research_documentDiscovery from "../domains/research/documentDiscovery.js";
+import type * as domains_research_editionQueries from "../domains/research/editionQueries.js";
 import type * as domains_research_entities_decayManager from "../domains/research/entities/decayManager.js";
 import type * as domains_research_entities_entityLifecycle from "../domains/research/entities/entityLifecycle.js";
 import type * as domains_research_entities_index from "../domains/research/entities/index.js";
@@ -2365,7 +2365,6 @@ declare const fullApi: ApiFromModules<{
   "domains/operations/utilities/snapshotMigrations": typeof domains_operations_utilities_snapshotMigrations;
   "domains/operations/validationWorkflow": typeof domains_operations_validationWorkflow;
   "domains/operatorProfile/filesystemSync": typeof domains_operatorProfile_filesystemSync;
-  "domains/operatorProfile/manifest": typeof domains_operatorProfile_manifest;
   "domains/operatorProfile/mutations": typeof domains_operatorProfile_mutations;
   "domains/operatorProfile/parser": typeof domains_operatorProfile_parser;
   "domains/operatorProfile/queries": typeof domains_operatorProfile_queries;
@@ -2498,6 +2497,7 @@ declare const fullApi: ApiFromModules<{
   "domains/research/dealFlow": typeof domains_research_dealFlow;
   "domains/research/dealFlowQueries": typeof domains_research_dealFlowQueries;
   "domains/research/documentDiscovery": typeof domains_research_documentDiscovery;
+  "domains/research/editionQueries": typeof domains_research_editionQueries;
   "domains/research/entities/decayManager": typeof domains_research_entities_decayManager;
   "domains/research/entities/entityLifecycle": typeof domains_research_entities_entityLifecycle;
   "domains/research/entities/index": typeof domains_research_entities_index;

--- a/convex/domains/research/editionQueries.ts
+++ b/convex/domains/research/editionQueries.ts
@@ -1,0 +1,419 @@
+/**
+ * Editorial Home — public queries (Phase 7a).
+ *
+ * Source of truth: docs/architecture/HOME_EDITORIAL_REDESIGN.md §5.
+ * Each query is bounded, fails honestly, and never fakes data. Per
+ * .claude/rules/agentic_reliability.md (BOUND, HONEST_STATUS,
+ * HONEST_SCORES) and .claude/rules/scratchpad_first.md (the persisted
+ * fields are the source of truth — derive, don't fabricate).
+ *
+ * Public queries here are scoped to the redesign editorial home and
+ * intentionally do NOT require an authenticated user. They read
+ * already-publishable substrates:
+ *   - dailyBriefSnapshots (curated daily metrics)
+ *   - narrativeHypotheses on public threads
+ *   - forecasts (active set used by the LinkedIn pipeline)
+ *   - evidenceArtifacts referenced by the above
+ *   - industryUpdates (already publicly browsable)
+ *
+ * The pulse query *does* require an owner identity because pulses are
+ * per-user. It uses resolveProductIdentitySafely so guests get []
+ * rather than a thrown error.
+ */
+
+import { v } from "convex/values";
+import { query } from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { resolveProductIdentitySafely } from "../product/helpers";
+import {
+  type EvidenceChecklist,
+  countPassingChecks,
+  deriveEvidenceLevel,
+} from "./narrative/validators";
+
+/* ────────────────────────────────────────────────────────────────────
+ * BOUNDS — every list query caps results.  agentic_reliability::BOUND.
+ * ────────────────────────────────────────────────────────────────── */
+const HARD_CAP = 200;
+const PULSE_DEFAULT = 12;
+const HYPOTHESIS_DEFAULT = 8;
+const HYPOTHESIS_MAX = 20;
+const FORECAST_DEFAULT = 5;
+const FORECAST_MAX = 12;
+const FOOTNOTE_ARTIFACT_DEFAULT = 24;
+const FOOTNOTE_ARTIFACT_MAX = 60;
+const FOOTNOTE_INDUSTRY_DEFAULT = 8;
+const FOOTNOTE_INDUSTRY_MAX = 24;
+
+const ACTIVE_STATUSES = new Set<Doc<"narrativeHypotheses">["status"]>([
+  "active",
+  "supported",
+  "weakened",
+]);
+
+const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** Date-key used by pulseReports — UTC YYYY-MM-DD. */
+function todayDateKey(now = Date.now()): string {
+  const d = new Date(now);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Bound a user-supplied limit to [1, max]. */
+function boundLimit(value: number | undefined, def: number, max: number): number {
+  const n = Math.floor(value ?? def);
+  if (!Number.isFinite(n) || n <= 0) return def;
+  return Math.min(n, max, HARD_CAP);
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * §1 — "What moved today" : today's pulses for the current owner.
+ * ────────────────────────────────────────────────────────────────── */
+export const getTodayPulse = query({
+  args: {
+    anonymousSessionId: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = boundLimit(args.limit, PULSE_DEFAULT, 50);
+    const identity = await resolveProductIdentitySafely(
+      ctx,
+      args.anonymousSessionId,
+    );
+    if (!identity) {
+      return { pulses: [], dateKey: todayDateKey(), lastDateKey: null as string | null };
+    }
+    const ownerKey = identity.anonymousSessionId ?? (identity.ownerKey as string);
+    const dateKey = todayDateKey();
+
+    // Today's pulses.
+    const today = await ctx.db
+      .query("pulseReports")
+      .withIndex("by_owner_date", (q) =>
+        q.eq("ownerKey", ownerKey).eq("dateKey", dateKey),
+      )
+      .order("desc")
+      .take(limit);
+
+    // If empty, surface the most-recent dateKey so the empty state can be honest.
+    let lastDateKey: string | null = null;
+    if (today.length === 0) {
+      const last = await ctx.db
+        .query("pulseReports")
+        .withIndex("by_owner_date", (q) => q.eq("ownerKey", ownerKey))
+        .order("desc")
+        .first();
+      lastDateKey = last?.dateKey ?? null;
+    }
+
+    return {
+      pulses: today.map((p) => ({
+        _id: p._id,
+        entitySlug: p.entitySlug,
+        dateKey: p.dateKey,
+        status: p.status,
+        summaryMarkdown: p.summaryMarkdown ?? null,
+        changeCount: p.changeCount,
+        materialChangeCount: p.materialChangeCount,
+        generatedAt: p.generatedAt,
+      })),
+      dateKey,
+      lastDateKey,
+    };
+  },
+});
+
+/* ────────────────────────────────────────────────────────────────────
+ * §2 — "The competing explanations" : active hypotheses on public
+ * threads, recent.  We deterministically derive a 6-bool checklist
+ * from persisted hypothesis fields (HONEST_SCORES — no fakes).
+ * ────────────────────────────────────────────────────────────────── */
+function deriveHypothesisChecklist(
+  hyp: Doc<"narrativeHypotheses">,
+): EvidenceChecklist {
+  // Each boolean has a deterministic, observable trigger.  These
+  // mirror the spirit of evidenceChecklistValidator without inventing
+  // new state.  When the persisted record adds a real checklist field
+  // later, replace this derivation with the stored value.
+  const supporting = hyp.supportingEvidenceCount ?? 0;
+  const contradicting = hyp.contradictingEvidenceCount ?? 0;
+  const totalEvidence = supporting + contradicting;
+  return {
+    hasPrimarySource: supporting > 0,                        // at least one supporting artifact
+    hasCorroboration: supporting >= 2,                       // 2+ supporting artifacts
+    hasFalsifiableClaim: !!hyp.falsificationCriteria,        // explicit falsification text
+    hasQuantitativeData: hyp.measurementApproach.length > 0  // measurement plan recorded
+      && /\d/.test(hyp.measurementApproach),                 //   …with at least one number
+    hasNamedAttribution: !!hyp.reviewedBy && hyp.reviewedBy.length > 0,
+    isReproducible: totalEvidence >= 2 && hyp.confidence >= 0.5,
+  };
+}
+
+export const getActiveHypotheses = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = boundLimit(args.limit, HYPOTHESIS_DEFAULT, HYPOTHESIS_MAX);
+    const cutoff = Date.now() - RECENT_WINDOW_MS;
+
+    // Fetch each status separately via the by_status index, then merge.
+    const statusBatches = await Promise.all(
+      Array.from(ACTIVE_STATUSES).map((status) =>
+        ctx.db
+          .query("narrativeHypotheses")
+          .withIndex("by_status", (q) => q.eq("status", status))
+          .order("desc")
+          .take(limit * 3),
+      ),
+    );
+
+    const merged: Doc<"narrativeHypotheses">[] = [];
+    const seen = new Set<string>();
+    for (const batch of statusBatches) {
+      for (const h of batch) {
+        if (seen.has(h._id)) continue;
+        if (h.updatedAt < cutoff) continue;
+        seen.add(h._id);
+        merged.push(h);
+      }
+    }
+    merged.sort((a, b) => b.updatedAt - a.updatedAt);
+    const recent = merged.slice(0, limit);
+
+    // Resolve thread for visibility — only return hypotheses on
+    // threads marked public.  Authenticated callers can use the
+    // existing per-thread query for private threads.
+    type EditionHypothesis = {
+      _id: Id<"narrativeHypotheses">;
+      hypothesisId: string;
+      threadId: Id<"narrativeThreads">;
+      threadName: string;
+      label: string;
+      title: string;
+      claimForm: string;
+      measurementApproach: string;
+      falsificationCriteria: string | null;
+      status: Doc<"narrativeHypotheses">["status"];
+      confidence: number;
+      speculativeRisk: Doc<"narrativeHypotheses">["speculativeRisk"];
+      supportingEvidenceCount: number;
+      contradictingEvidenceCount: number;
+      evidenceArtifactIds: string[];
+      competingHypothesisIds: string[];
+      updatedAt: number;
+      evidenceChecklist: EvidenceChecklist;
+      evidenceChecksPassing: number;
+      evidenceChecksTotal: number;
+      evidenceLevel: ReturnType<typeof deriveEvidenceLevel>;
+    };
+    const result: EditionHypothesis[] = [];
+    for (const h of recent) {
+      const thread = await ctx.db.get(h.threadId);
+      if (!thread || !thread.isPublic) continue;
+      const checklist = deriveHypothesisChecklist(h);
+      const passing = countPassingChecks(checklist);
+      const evidenceLevel = deriveEvidenceLevel(checklist);
+      result.push({
+        _id: h._id,
+        hypothesisId: h.hypothesisId,
+        threadId: h.threadId,
+        threadName: thread.name,
+        label: h.label,
+        title: h.title,
+        claimForm: h.claimForm,
+        measurementApproach: h.measurementApproach,
+        falsificationCriteria: h.falsificationCriteria ?? null,
+        status: h.status,
+        confidence: h.confidence,
+        speculativeRisk: h.speculativeRisk,
+        supportingEvidenceCount: h.supportingEvidenceCount,
+        contradictingEvidenceCount: h.contradictingEvidenceCount,
+        evidenceArtifactIds: h.evidenceArtifactIds,
+        competingHypothesisIds: h.competingHypothesisIds ?? [],
+        updatedAt: h.updatedAt,
+        evidenceChecklist: checklist,
+        evidenceChecksPassing: passing,
+        evidenceChecksTotal: 6,
+        evidenceLevel,
+      });
+    }
+    return result;
+  },
+});
+
+/* ────────────────────────────────────────────────────────────────────
+ * §3 — "What to look at this week" : top forecasts (public wrapper
+ * over the existing internal getTopForecastsForLinkedIn shape).
+ * ────────────────────────────────────────────────────────────────── */
+export const getTopForecasts = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = boundLimit(args.limit, FORECAST_DEFAULT, FORECAST_MAX);
+
+    const all = await ctx.db
+      .query("forecasts")
+      .withIndex("by_status", (q) => q.eq("status", "active"))
+      .take(limit * 6);
+
+    const updated = all.filter(
+      (f) => f.updateCount > 0 && f.probability != null,
+    );
+    updated.sort((a, b) => {
+      const aFresh = a.lastRefreshedAt ?? a.createdAt;
+      const bFresh = b.lastRefreshedAt ?? b.createdAt;
+      const freshDiff = bFresh - aFresh;
+      if (Math.abs(freshDiff) > 86_400_000) return freshDiff;
+      const aDate = new Date(a.resolutionDate).getTime();
+      const bDate = new Date(b.resolutionDate).getTime();
+      return aDate - bDate;
+    });
+
+    const top = updated.slice(0, limit);
+    type EditionForecast = {
+      _id: Id<"forecasts">;
+      question: string;
+      forecastType: Doc<"forecasts">["forecastType"];
+      probability: number | null;
+      previousProbability: number | null;
+      confidenceInterval: Doc<"forecasts">["confidenceInterval"] | null;
+      resolutionDate: string;
+      resolutionCriteria: string;
+      topDrivers: string[];
+      topCounterarguments: string[];
+      updateCount: number;
+      lastRefreshedAt: number;
+      status: Doc<"forecasts">["status"];
+    };
+    const enriched: EditionForecast[] = [];
+    for (const f of top) {
+      const lastUpdate = await ctx.db
+        .query("forecastUpdateHistory")
+        .withIndex("by_forecast_date", (q) => q.eq("forecastId", f._id))
+        .order("desc")
+        .first();
+      enriched.push({
+        _id: f._id,
+        question: f.question,
+        forecastType: f.forecastType,
+        probability: f.probability ?? null,
+        previousProbability: lastUpdate?.previousProbability ?? null,
+        confidenceInterval: f.confidenceInterval ?? null,
+        resolutionDate: f.resolutionDate,
+        resolutionCriteria: f.resolutionCriteria,
+        topDrivers: f.topDrivers ?? [],
+        topCounterarguments: f.topCounterarguments ?? [],
+        updateCount: f.updateCount,
+        lastRefreshedAt: f.lastRefreshedAt ?? f.createdAt,
+        status: f.status,
+      });
+    }
+    return enriched;
+  },
+});
+
+/* ────────────────────────────────────────────────────────────────────
+ * §4 — Latest dailyBriefSnapshot : already-public, used as-is.
+ * Re-exported here so the editorial home has a single import surface
+ * and so the BOUND contract stays in this file.
+ * ────────────────────────────────────────────────────────────────── */
+export const getLatestDailyBriefSnapshot = query({
+  args: {},
+  handler: async (ctx) => {
+    const snapshot = await ctx.db
+      .query("dailyBriefSnapshots")
+      .withIndex("by_generated_at")
+      .order("desc")
+      .first();
+    if (!snapshot) return null;
+    return {
+      _id: snapshot._id,
+      dateString: snapshot.dateString,
+      generatedAt: snapshot.generatedAt,
+      version: snapshot.version,
+      dashboardMetrics: snapshot.dashboardMetrics,
+      sourceSummary: snapshot.sourceSummary,
+    };
+  },
+});
+
+/* ────────────────────────────────────────────────────────────────────
+ * §6 — Footnotes : evidenceArtifacts referenced by §1–§3 plus recent
+ * industryUpdates capped at MAX.
+ * ────────────────────────────────────────────────────────────────── */
+export const getEditionFootnotes = query({
+  args: {
+    artifactIds: v.optional(v.array(v.string())),
+    industryLimit: v.optional(v.number()),
+    artifactLimit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const industryLimit = boundLimit(
+      args.industryLimit,
+      FOOTNOTE_INDUSTRY_DEFAULT,
+      FOOTNOTE_INDUSTRY_MAX,
+    );
+    const artifactLimit = boundLimit(
+      args.artifactLimit,
+      FOOTNOTE_ARTIFACT_DEFAULT,
+      FOOTNOTE_ARTIFACT_MAX,
+    );
+
+    // 1. Evidence artifacts by (string) artifactId.
+    const requestedIds = (args.artifactIds ?? []).slice(0, artifactLimit);
+    const artifacts: Array<{
+      _id: Id<"evidenceArtifacts">;
+      artifactId: string;
+      url: string;
+      canonicalUrl: string;
+      publisher: string;
+      publishedAt: number | null;
+      credibilityTier: string;
+      firstQuote: string | null;
+    }> = [];
+    const seen = new Set<string>();
+    for (const id of requestedIds) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const row = await ctx.db
+        .query("evidenceArtifacts")
+        .withIndex("by_artifact_id", (q) => q.eq("artifactId", id))
+        .first();
+      if (!row) continue;
+      artifacts.push({
+        _id: row._id,
+        artifactId: row.artifactId,
+        url: row.url,
+        canonicalUrl: row.canonicalUrl,
+        publisher: row.publisher,
+        publishedAt: row.publishedAt ?? null,
+        credibilityTier: row.credibilityTier,
+        firstQuote: row.extractedQuotes[0]?.text ?? null,
+      });
+    }
+
+    // 2. Industry updates — most recent first.
+    const industryRows = await ctx.db
+      .query("industryUpdates")
+      .withIndex("by_scanned_at")
+      .order("desc")
+      .take(industryLimit);
+    const industry = industryRows.map((u) => ({
+      _id: u._id,
+      provider: u.provider,
+      providerName: u.providerName,
+      url: u.url,
+      title: u.title,
+      summary: u.summary,
+      relevance: u.relevance,
+      scannedAt: u.scannedAt,
+    }));
+
+    return { artifacts, industry };
+  },
+});

--- a/docs/architecture/HOME_EDITORIAL_REDESIGN.md
+++ b/docs/architecture/HOME_EDITORIAL_REDESIGN.md
@@ -1,0 +1,234 @@
+# Home — Editorial Redesign Proposal
+
+**Status**: design audit + phased implementation plan. Pre-implementation.
+**Trigger**: user feedback 2026-05-08 — *"feel like if we draw professional references, there are much better ways to design this home page, for example, check out https://ai-2027.com/"* + *"we do have daily content pipeline with linkedin daily brief, we can sync them all up and expand"*.
+**Related**: PR #276 (home reduction), `usability_scorecard.md`, `reexamine_design_reduction.md`, `self_judge_loop.md`, `forecasting_os.md`.
+
+---
+
+## 0. Headline finding
+
+**The data substrate is already ai-2027-shaped.** `dailyBriefSnapshots.dashboardMetrics` (convex/schema.ts:7123) contains:
+
+| Schema field | What ai-2027 renders as |
+|---|---|
+| `meta.timelineProgress` | Left-rail chronological scroll-spy |
+| `charts.trendLine` | Right-rail "Unreliable Agent" line chart |
+| `charts.marketShare` | Right-rail compute/share donut |
+| `techReadiness: { existing, emerging, sciFi }` | **Three-bucket "Currently Exists / Emerging Tech / Science Fiction" dot grids** |
+| `keyStats: KeyStat[]` | Right-rail scoreboard rows (Approval, Revenue, Valuation, ...) |
+| `capabilities: CapabilityEntry[]` | AI Capabilities icon grid (Hacking, Coding, Politics, ...) |
+| `entityGraph: { nodes, edges }` | Inline compute-scaling diagram |
+| `annotations` | Footnote-style citations |
+
+This is not coincidence — the schema is a port. The LinkedIn pipeline (`convex/workflows/dailyLinkedInPost.ts`) writes here daily.
+
+**`narrativeHypotheses`** (schema.ts:13982) is the competing-explanations substrate:
+- `claimForm` + `measurementApproach` + `falsificationCriteria` + `confidence` + `speculativeRisk`
+- `supportingEvidenceCount` / `contradictingEvidenceCount` → evidence breakdown
+- `competingHypothesisIds` → hypothesis link graph
+- Paired with `evidenceChecklistValidator` (6 booleans → grounded/mixed/speculative via `deriveEvidenceLevel`)
+
+**`pulseReports`** (schema.ts:15308) is per-entity daily pulse:
+- `summaryMarkdown` (already markdown narrative)
+- `changeCount` / `materialChangeCount` for delta badges
+
+**Conclusion**: the home doesn't need new infra. It needs an editorial render pass over data that's already produced and queryable. This collapses Variant C (single-document daily edition) from "ambitious bet" to "render what exists."
+
+---
+
+## 1. What ai-2027.com actually does (observed 2026-05-08)
+
+Captured 4 progressive scroll screenshots. Structural choices:
+
+1. **Three-column scroll-spine.** Left = chronological scroll-spy. Center = serif narrative. Right = sticky "live dashboard" that swaps panels with scroll position.
+2. **Single narrative thread.** No card grid. H2 chapter headers ARE the scroll anchors.
+3. **Co-temporal right rail.** Right-rail panels are the state of the world at the chapter you're reading.
+4. **Calibrated dot-grids.** "Currently Exists / Emerging Tech / Science Fiction" rendered as three 6-dot strips per claim.
+5. **Inline `<details>`** for tangents (PR #276 already uses this).
+6. **Editorial typography.** Serif body, generous line-height, no card chrome, footnote superscripts.
+7. **Format strip**: "Daniel Kokotajlo, Scott Alexander... | Published April 3rd 2025 | PDF | listen | watch".
+
+---
+
+## 2. Why this matters for NodeBench
+
+Three rules already point this direction; ai-2027 is the worked example:
+
+- `usability_scorecard.md`: "**The output is the distribution. Every result is shareable.**"
+- `reexamine_design_reduction.md`: "**Earned complexity.** Every section must justify its existence."
+- `scratchpad_first.md`: agents write *markdown narrative* before structured output. The home should mirror what the agent produces — not hide it behind tiles.
+
+Current home (post-PR #276) is structurally correct (5 sections, 2 collapsed) but editorially flat: it reads as a tool dashboard, not a daily edition of operating intelligence.
+
+---
+
+## 3. Three competing variants
+
+Per `self_judge_loop.md`: never produce one version. Each variant has a clear sweet spot.
+
+### Variant A — "Editorial long-read" (full ai-2027 transplant)
+
+**Shape**:
+- Left rail (220px sticky): scroll-spy `Today · This week · 30d · Quarter · Year`. Replaces redesign tab nav at home only.
+- Center column (max 720px): serif narrative — *Pulse → What moved → What it means → What to look at*. WhatChangedStrip dissolves into prose with footnote-cited claims.
+- Right rail (320px sticky): co-temporal widgets driven by `dashboardMetrics`.
+- Format strip on every Decision Memo: `PDF · listen · watch · share-link`.
+
+**Tradeoffs**:
+- ✅ Strongest editorial identity. Hard to copy.
+- ✅ Right-rail context-swap is the "wow" moment.
+- ❌ Scroll-spy + IntersectionObserver + per-section right-rail payloads is real engineering.
+- ❌ Mobile collapse story is hard.
+- ❌ Serif body conflicts with existing Manrope.
+
+**Effort**: ~5 days. **Risk**: high (mobile + font).
+
+---
+
+### Variant B — "Magazine cover + reduced home below" (low-risk delta)
+
+**Shape**:
+- Above fold: full-width "Today's edition" cover (one headline + one chart + one citation).
+- Below fold: keep PR #276 structure unchanged.
+- Adopt only footnote-style citations + format strip globally.
+
+**Tradeoffs**:
+- ✅ Smallest delta (~1-2 days).
+- ✅ Cover hero is screenshot-worthy.
+- ❌ Only the cover is editorial; rest is still cards.
+- ❌ Doesn't capture the right-rail co-temporal innovation.
+
+**Effort**: ~1-2 days. **Risk**: low.
+
+---
+
+### Variant C — "Single-document daily edition" — **RECOMMENDED**
+
+**Shape**:
+- One column, max 720px. No rails desktop OR mobile.
+- Numbered editorial structure:
+  - `1. What moved today` ← `pulseReports.summaryMarkdown` + `changeCount`
+  - `2. The competing explanations` ← `narrativeHypotheses` rendered with 6-dot strips
+  - `3. What to look at this week` ← `forecasts` with Δ badges (per `forecasting_os.md`)
+  - `4. Today's scoreboard` ← `dailyBriefSnapshots.dashboardMetrics.keyStats` rendered inline
+  - `5. Capabilities map` ← `dashboardMetrics.capabilities` + `techReadiness` dot grid
+  - `Footnotes` ← `evidenceArtifacts` + `industryUpdates`
+- Inline charts/citations like ai-2027 (compute-scaling diagram from `entityGraph`).
+- Operations dashboard becomes a rendered table inside section 4.
+- Mobile and desktop are identical.
+
+**Tradeoffs**:
+- ✅ Strongest editorial identity, closest to ai-2027 in spirit.
+- ✅ Mobile parity by construction.
+- ✅ Maximally screenshot-worthy.
+- ✅ **Daily content pipeline already exists** — the LinkedIn workflow writes the substrate every morning.
+- ❌ Eliminates the 3-col Operations grid from home (moves to `/?surface=memo` or a dedicated route).
+- ❌ Loses "operational tool" feel. Risk of being read as a blog rather than software.
+- ❌ Bet on positioning shift: "operating intelligence" → "daily intelligence brief".
+
+**Effort**: ~3-4 days for layout (content pipeline ready). **Risk**: medium (positioning).
+
+---
+
+## 4. Recommendation (revised)
+
+**Variant C as Phase 7.** The content pipeline that previously gated this is confirmed to exist. The schema is already ai-2027 shape. Variant B's "cover hero only" leaves the right-rail co-temporal innovation on the table, and the user explicitly named ai-2027 as the reference — meaning the long-read shape, not just the cover.
+
+Phasing:
+
+- **Phase 7a — Editorial render (2 days)**. Build the single-column daily-edition shell. Bind each section to its existing query. Deploy behind `/?edition=1` flag. Keep current home reachable at `/`.
+- **Phase 7b — Scroll-spy + footnote citations (1 day)**. Add chapter anchors driven by `dashboardMetrics.meta.timelineProgress`. Render `evidenceArtifacts` as inline footnote superscripts.
+- **Phase 7c — Format strip + share artifact (1 day)**. PDF render via existing `publicShares` table. `share-link` opens a public route. (Listen/watch deferred — TTS/video infra is separate.)
+- **Phase 7d — Promote (decision gate)**. After 7a-c live behind flag, run `dogfood:full:local` + `gemini-qa-loop` for 3 cycles. If editorial scorecard ≥ 75/100 (per `usability_scorecard.md`), promote `?edition=1` to default at `/`. Otherwise iterate.
+
+Variants A and B remain on the shelf. A's three-column scroll-spine can be added as Phase 8 if the editorial column proves out and the right-rail co-temporal panels are wanted as a desktop enhancement. B is now strictly dominated by C since the content cost objection is gone.
+
+---
+
+## 5. Concrete data binding (Phase 7a)
+
+Each section names the table, query, and editorial render rule.
+
+### §1 — "What moved today"
+
+- **Source**: `pulseReports` (15308) where `dateKey === today` AND `ownerKey === currentUser`.
+- **Render**: render `summaryMarkdown` as serif paragraph. Inline a Δ badge: `[N material changes]`. Link entity slug → `/redesign/entity/{slug}`.
+- **Empty state**: "No pulse generated yet today. Last pulse: {dateKey}."
+
+### §2 — "The competing explanations"
+
+- **Source**: `narrativeHypotheses` (13982) where `status IN (active, supported, weakened)` AND `updatedAt >= today - 24h`. Group by `threadId`.
+- **Render**: each hypothesis = one paragraph block:
+  - H1 label + title (serif heading)
+  - `claimForm` (body)
+  - **6-dot strip** rendering `evidenceChecklist` booleans (per `validators.ts`). Filled = pass. `deriveEvidenceLevel` → text annotation `[grounded]` / `[mixed]` / `[speculative]`.
+  - `falsificationCriteria` rendered as small italic line: *"Would change my mind: ..."*
+  - Tally line: `{supportingEvidenceCount} supporting · {contradictingEvidenceCount} contradicting`.
+- **Compete-link**: when two hypotheses share `competingHypothesisIds`, render a connector line between blocks.
+- **Empty state**: hide section. Don't fake hypotheses.
+
+### §3 — "What to look at this week"
+
+- **Source**: `getTopForecastsForLinkedIn` (forecastManager.ts:311) — already exists, already enriched with `previousProbability`.
+- **Render**: per forecast — claim line, current probability bold, Δ badge `[was 62%, +6pp today]` (existing `formatDeltaBadge` from `forecasting_os.md`), Brier note if resolved.
+- **Cap**: 5 forecasts. "View all forecasts →" link to `/forecasts`.
+
+### §4 — "Today's scoreboard"
+
+- **Source**: `dailyBriefSnapshots` (7123), latest by `dateString DESC`. `dashboardMetrics.keyStats`.
+- **Render**: inline two-column table — label + value + small delta arrow. Mirror ai-2027's right-rail scoreboard format.
+- **No card chrome** — flush table, hairline rule above and below.
+
+### §5 — "Capabilities map" (the dot grids)
+
+- **Source**: `dashboardMetrics.techReadiness: { existing, emerging, sciFi }` + `dashboardMetrics.capabilities`.
+- **Render**: three rows, each labeled (`Currently Exists`, `Emerging`, `Science Fiction`), with a 6-dot strip showing the count out of total. Below: capability icon grid (Hacking, Coding, Politics, Bioweapons, Robotics, Forecasting from `capabilities`).
+- **This is the visual signature** — the section that makes the home feel like ai-2027.
+
+### Footnotes
+
+- **Source**: `evidenceArtifacts` (13631) referenced by §1-§3 via `evidenceArtifactIds`. Plus `industryUpdates` (13221) capped at 8 most-recent.
+- **Render**: numbered list, monospace caption, link → `evidenceArtifact.url` or `industryUpdates.sourceUrl`. Footnote superscripts inline in body sections link here via anchor.
+
+---
+
+## 6. What this proposal does NOT do
+
+- Does **not** propose touching the redesign tab nav (Home / Reports / Chat / Inbox / Me) — canonical per `CLAUDE.md`.
+- Does **not** propose changing Decision Workbench, Postmortem, or Telemetry surfaces. Editorial pattern is home-only until proven.
+- Does **not** propose introducing a new font for Phase 7. Manrope at editorial scale (1.7 line-height, 17px body) before considering a serif.
+- Does **not** propose removing the operations dashboard from the product — only moving it off home into `?surface=memo` in §3 of the new home or a dedicated `/operations` route.
+- Does **not** propose new tables. The substrate is complete.
+
+---
+
+## 7. Verification plan
+
+Per `live_dom_verification.md` and `pre_release_review.md` Layer 8:
+
+1. `npm run live-smoke` extended with editorial-home assertions:
+   - `[data-section="what-moved"]` rendered and has body text
+   - `[data-section="competing-explanations"]` either rendered or absent (no fake state)
+   - `[data-dot-grid]` count matches `techReadiness` totals
+   - `[data-footnote]` superscripts link to anchors that exist
+2. `scripts/verify-live.ts` extended with editorial signals.
+3. Mobile viewport (375px) — single column should match desktop. No horizontal overflow.
+4. Reduced-motion: scroll-spy active class still applies, no scroll-jacking.
+5. `npm run dogfood:full:local` to capture before/after for `/dogfood`.
+6. `gemini-qa-loop` (per `gemini_qa_loop.md`) — Pro+Flash rotation, target editorial scorecard ≥ 75/100 after 3 cycles before flipping `?edition=1` to default.
+7. Per `agentic_reliability.md`: every query in §5 has BOUND (caps), HONEST_STATUS (no fake 200 on missing data), HONEST_SCORES (`evidenceChecklist` is already deterministic-boolean — keep it).
+
+---
+
+## 8. Decisions (locked 2026-05-08)
+
+User directive: *"do no need new route, build revamp ontop of existing redeisgn"*.
+
+1. **No new route.** Phase 7a lands inside `src/features/redesign/surfaces/HomeSurface.tsx` directly. The 3-col operations grid collapses into a `<details>` accordion inside §4 of the new editorial home, NOT a separate `/operations` route.
+2. **Format strip in 7c = PDF + share-link only.** `publicShares` table already exists. Listen (TTS) + watch (video) deferred to Phase 8 — separate infra.
+3. **Promotion gate = manual call.** After Phase 7a-c land behind `?edition=1` and `npm run dogfood:full:local` produces clean evidence, ship a manual promotion. `gemini-qa-loop` informs the call but doesn't auto-promote.
+
+---
+
+**Next action**: open PR #279 implementing Phase 7a — editorial render of `HomeSurface.tsx` behind `?edition=1` flag, binding §1-§5 to the existing Convex queries per §5.

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -109,9 +109,35 @@ export default function RedesignShell() {
     };
   }, []);
 
+  // Phase 7a edition flag — when `?edition=1` is present, the editorial
+  // home is the single source of truth for /redesign on both mobile +
+  // desktop (per docs/architecture/HOME_EDITORIAL_REDESIGN.md §3
+  // Variant C: "mobile and desktop are identical").
+  const isEditionFlag =
+    typeof window !== "undefined" &&
+    new URLSearchParams(location.search).get("edition") === "1";
+
   // Mobile path overrides everything except /redesign/workspace (which keeps its own surface).
   if (isMobile && surface !== "workspace") {
     const mobileSurface: SurfaceId = (surface === "workspace" ? "reports" : surface) as SurfaceId;
+    // Edition flag bypasses MobileShell at the home surface so the
+    // single-column editorial layout stays responsive at any width.
+    if (isEditionFlag && mobileSurface === "home") {
+      return (
+        <div data-redesign data-redesign-theme={theme} style={{ minHeight: "100dvh", overflow: "auto" }}>
+          <HomeSurface
+            onAsk={(text) => navigate(`/redesign/chat?q=${encodeURIComponent(text)}`)}
+            onOpenReport={(id) => navigate(`/redesign/reports/${id}`)}
+          />
+          {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
+          {showQaChrome && <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />}
+          <NavBanner pathname={location.pathname} />
+          <CommandPalette open={cmdk.open} onClose={() => cmdk.setOpen(false)} />
+          <ShortcutsOverlay />
+          <ToastViewport />
+        </div>
+      );
+    }
     return (
       <div data-redesign data-redesign-theme={theme} style={{ height: "100dvh", overflow: "hidden" }}>
         <MobileShell active={mobileSurface} onChange={(id) => goSurface(id)} />

--- a/src/features/redesign/components/edition/CapabilitiesMap.tsx
+++ b/src/features/redesign/components/edition/CapabilitiesMap.tsx
@@ -1,0 +1,106 @@
+/**
+ * CapabilitiesMap — three readiness rows + capability icon grid.
+ * Source: `dailyBriefSnapshots.dashboardMetrics.techReadiness` and
+ * `dashboardMetrics.capabilities`.  THIS IS THE VISUAL SIGNATURE of
+ * the editorial home (matches ai-2027 "Currently Exists / Emerging /
+ * Science Fiction" indicator).
+ */
+
+import { DotGrid } from "./DotGrid";
+
+interface TechReadiness {
+  existing: number;
+  emerging: number;
+  sciFi: number;
+}
+
+interface CapabilityEntry {
+  name?: string;
+  label?: string;
+  level?: string; // e.g. "current", "emerging", "future"
+  description?: string;
+}
+
+interface Props {
+  techReadiness: TechReadiness | null;
+  capabilities: CapabilityEntry[] | null;
+}
+
+const READINESS_ROWS: Array<{
+  key: keyof TechReadiness;
+  label: string;
+  total: number;
+}> = [
+  { key: "existing", label: "Currently Exists", total: 6 },
+  { key: "emerging", label: "Emerging Tech", total: 6 },
+  { key: "sciFi", label: "Science Fiction", total: 6 },
+];
+
+export function CapabilitiesMap({ techReadiness, capabilities }: Props) {
+  const hasReadiness =
+    techReadiness &&
+    (techReadiness.existing > 0 ||
+      techReadiness.emerging > 0 ||
+      techReadiness.sciFi > 0);
+  const hasCaps = capabilities && capabilities.length > 0;
+
+  if (!hasReadiness && !hasCaps) {
+    return (
+      <div className="rd-edition-empty">
+        Capabilities map not generated for today's edition.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {hasReadiness && (
+        <div role="list" aria-label="Technology readiness">
+          {READINESS_ROWS.map((row) => {
+            const filled = Math.max(
+              0,
+              Math.min(row.total, techReadiness![row.key] ?? 0),
+            );
+            return (
+              <div
+                key={row.key}
+                className="rd-edition-capability-row"
+                role="listitem"
+              >
+                <span className="rd-edition-capability-row__label">
+                  {row.label}
+                </span>
+                <DotGrid
+                  filled={filled}
+                  total={row.total}
+                  caption={`${filled}/${row.total}`}
+                  ariaLabel={`${row.label}: ${filled} of ${row.total}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {hasCaps && (
+        <div className="rd-edition-capability-grid" role="list" aria-label="AI capabilities">
+          {capabilities!.map((c, i) => {
+            const name = c.name ?? c.label ?? `Capability ${i + 1}`;
+            const level = c.level ?? "tracked";
+            return (
+              <div className="rd-edition-capability-card" role="listitem" key={`${name}-${i}`}>
+                <span className="rd-edition-capability-card__name">{name}</span>
+                <span className="rd-edition-capability-card__level">{level}</span>
+                {c.description && (
+                  <span style={{ fontSize: 12, color: "var(--rd-ink-mute)", lineHeight: 1.45 }}>
+                    {c.description}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/redesign/components/edition/DotGrid.tsx
+++ b/src/features/redesign/components/edition/DotGrid.tsx
@@ -1,0 +1,54 @@
+/**
+ * DotGrid — N-of-total dot strip rendering, the visual signature of
+ * the editorial home (mirrors ai-2027.com's "Currently Exists /
+ * Emerging / Science Fiction" indicator).
+ *
+ * Filled = terracotta `#d97757` (rd-accent). Empty = subtle line.
+ * `aria-label` REQUIRED — screen readers should hear something like
+ * "5 of 6 evidence checks pass" instead of decorative dots.
+ *
+ * Reduced motion: no animation here, so nothing to gate.
+ */
+
+interface DotGridProps {
+  /** Number of dots that should render as "filled". Clamped to [0, total]. */
+  filled: number;
+  /** Total dots to render. Default 6 (matches evidenceChecklist length). */
+  total?: number;
+  /** Optional caption shown after the strip (e.g. "5/6"). */
+  caption?: string;
+  /** Required descriptive label for screen readers. */
+  ariaLabel: string;
+}
+
+export function DotGrid({ filled, total = 6, caption, ariaLabel }: DotGridProps) {
+  const safeTotal = Math.max(1, Math.floor(total));
+  const safeFilled = Math.max(0, Math.min(safeTotal, Math.floor(filled)));
+  const dots = Array.from({ length: safeTotal }, (_, i) => i < safeFilled);
+  return (
+    <span
+      className="rd-dot-grid"
+      role="img"
+      aria-label={ariaLabel}
+      data-dot-grid
+      data-filled={safeFilled}
+      data-total={safeTotal}
+    >
+      <span className="rd-dot-grid__strip" aria-hidden="true">
+        {dots.map((isFilled, i) => (
+          <span
+            key={i}
+            className={
+              "rd-dot-grid__dot" + (isFilled ? " rd-dot-grid__dot--filled" : "")
+            }
+          />
+        ))}
+      </span>
+      {caption && (
+        <span className="rd-dot-grid__caption" aria-hidden="true">
+          {caption}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/features/redesign/components/edition/EditionErrorBoundary.tsx
+++ b/src/features/redesign/components/edition/EditionErrorBoundary.tsx
@@ -1,0 +1,61 @@
+/**
+ * EditionErrorBoundary — catches render-time errors inside the
+ * editorial home so a single broken section doesn't blank the page.
+ *
+ * Per .claude/rules/reexamine_resilience.md: error boundaries must
+ * render an actionable fallback, not a blank screen.
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  /** Optional inline label for the fallback message. */
+  label?: string;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class EditionErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Console-log only — telemetry hookup is out of scope for 7a.
+    // eslint-disable-next-line no-console
+    console.error("[EditorialHome]", this.props.label ?? "section", error, info);
+  }
+
+  handleReset = () => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <div
+          role="alert"
+          className="rd-edition-empty"
+          style={{ borderTop: "1px solid var(--rd-line)", paddingTop: 12 }}
+        >
+          Something went wrong rendering this section.
+          {" "}
+          <button
+            type="button"
+            onClick={this.handleReset}
+            className="rd-btn rd-btn--quiet rd-btn--sm"
+            style={{ marginLeft: 8 }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/features/redesign/components/edition/EditorialSection.tsx
+++ b/src/features/redesign/components/edition/EditorialSection.tsx
@@ -1,0 +1,42 @@
+/**
+ * EditorialSection — wraps a chapter with a `data-section` testid,
+ * an eyebrow + H2, and a hairline rule.  Each section is a landmark
+ * region for screen readers (per `.claude/rules/reexamine_a11y.md`).
+ */
+
+import type { ReactNode } from "react";
+
+interface Props {
+  /** The data-section testid; used by Playwright + the live-smoke. */
+  id: string;
+  /** Plain-language ARIA label for the region. */
+  ariaLabel: string;
+  /** Small uppercase eyebrow above the H2 ("01 · today" etc). */
+  eyebrow: string;
+  /** Section heading. */
+  heading: string;
+  children: ReactNode;
+}
+
+export function EditorialSection({
+  id,
+  ariaLabel,
+  eyebrow,
+  heading,
+  children,
+}: Props) {
+  return (
+    <section
+      role="region"
+      aria-label={ariaLabel}
+      className="rd-edition-section"
+      data-section={id}
+    >
+      <header style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <p className="rd-edition-section__eyebrow">{eyebrow}</p>
+        <h2 className="rd-edition-section__h2">{heading}</h2>
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/src/features/redesign/components/edition/EvidenceChecklistStrip.tsx
+++ b/src/features/redesign/components/edition/EvidenceChecklistStrip.tsx
@@ -1,0 +1,45 @@
+/**
+ * EvidenceChecklistStrip — renders a 6-bool evidenceChecklist as a
+ * DotGrid plus a "[grounded]/[mixed]/[speculative]" caption derived
+ * deterministically via `deriveEvidenceLevel`.
+ *
+ * Per .claude/rules/agentic_reliability.md (HONEST_SCORES) the
+ * checklist passed in is the *real* one — never a fabricated
+ * `passed:true`.  When the upstream substrate has no checklist yet,
+ * the caller should pass null and we render a hyphen.
+ */
+
+import type { EvidenceChecklist } from "../../../../../convex/domains/research/narrative/validators";
+import { DotGrid } from "./DotGrid";
+
+const LEVEL_LABEL: Record<"grounded" | "mixed" | "speculative", string> = {
+  grounded: "[grounded]",
+  mixed: "[mixed]",
+  speculative: "[speculative]",
+};
+
+interface Props {
+  checklist: EvidenceChecklist | null;
+  passing: number;
+  total: number;
+  level: "grounded" | "mixed" | "speculative";
+}
+
+export function EvidenceChecklistStrip({ checklist, passing, total, level }: Props) {
+  const ariaLabel = checklist
+    ? `${passing} of ${total} evidence checks pass — ${level}`
+    : "Evidence checklist not yet computed";
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+      <DotGrid
+        filled={passing}
+        total={total}
+        caption={`${passing}/${total}`}
+        ariaLabel={ariaLabel}
+      />
+      <span className="rd-dot-grid__caption" aria-hidden="true">
+        {LEVEL_LABEL[level]}
+      </span>
+    </span>
+  );
+}

--- a/src/features/redesign/components/edition/Footnote.tsx
+++ b/src/features/redesign/components/edition/Footnote.tsx
@@ -1,0 +1,22 @@
+/**
+ * Footnote — inline `<sup>` superscript that links to a footnote
+ * anchor at the bottom of the editorial home.  IDs follow the
+ * convention `fn-<slug>`; the matching `<li id="fn-<slug>">` lives in
+ * <FootnoteList>.
+ */
+
+interface Props {
+  id: string;
+  index: number;
+  label?: string;
+}
+
+export function Footnote({ id, index, label }: Props) {
+  return (
+    <sup className="rd-edition-footnote-ref" data-footnote={id}>
+      <a href={`#fn-${id}`} aria-label={label ?? `Footnote ${index}`}>
+        {index}
+      </a>
+    </sup>
+  );
+}

--- a/src/features/redesign/components/edition/Scoreboard.tsx
+++ b/src/features/redesign/components/edition/Scoreboard.tsx
@@ -1,0 +1,84 @@
+/**
+ * Scoreboard — flush two-column inline table for
+ * `dailyBriefSnapshots.dashboardMetrics.keyStats`.  Mirrors ai-2027's
+ * right-rail scoreboard format but inline / no card chrome (per
+ * docs/architecture/HOME_EDITORIAL_REDESIGN.md §5).
+ */
+
+interface KeyStat {
+  label?: string;
+  name?: string;
+  value?: string | number;
+  delta?: string | number;
+  trend?: "up" | "down" | "flat";
+}
+
+interface Props {
+  stats: KeyStat[];
+}
+
+function fmtValue(v: KeyStat["value"]): string {
+  if (v === undefined || v === null) return "—";
+  if (typeof v === "number") return v.toLocaleString();
+  return String(v);
+}
+
+function fmtDelta(d: KeyStat["delta"]): { text: string; tone: "up" | "down" | "flat" } | null {
+  if (d === undefined || d === null) return null;
+  const text = typeof d === "number" ? (d > 0 ? `+${d}` : `${d}`) : String(d);
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const numericLead = trimmed.match(/^([+-])/);
+  const tone: "up" | "down" | "flat" =
+    numericLead?.[1] === "+" ? "up" : numericLead?.[1] === "-" ? "down" : "flat";
+  return { text: trimmed, tone };
+}
+
+export function Scoreboard({ stats }: Props) {
+  if (!stats || stats.length === 0) {
+    return (
+      <div className="rd-edition-empty">
+        Scoreboard data not generated for today.
+      </div>
+    );
+  }
+  return (
+    <div className="rd-edition-scoreboard" role="table" aria-label="Today's scoreboard">
+      {stats.map((s, i) => {
+        const label = s.label ?? s.name ?? `Stat ${i + 1}`;
+        const value = fmtValue(s.value);
+        const delta = fmtDelta(s.delta);
+        return (
+          <div className="rd-edition-scoreboard__row" role="row" key={`${label}-${i}`}>
+            <span className="rd-edition-scoreboard__label" role="cell">
+              {label}
+            </span>
+            <span className="rd-edition-scoreboard__value" role="cell">
+              {value}
+            </span>
+            <span
+              className={
+                "rd-edition-scoreboard__delta" +
+                (delta
+                  ? ` rd-edition-scoreboard__delta--${delta.tone}`
+                  : "")
+              }
+              role="cell"
+              aria-label={delta ? `Delta ${delta.text}` : "No change recorded"}
+            >
+              {delta ? (
+                <>
+                  {delta.tone === "up" && "↑ "}
+                  {delta.tone === "down" && "↓ "}
+                  {delta.text}
+                </>
+              ) : (
+                "—"
+              )}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/redesign/components/edition/edition.css
+++ b/src/features/redesign/components/edition/edition.css
@@ -1,0 +1,481 @@
+/**
+ * Editorial home — Phase 7a styles.
+ *
+ * Scoped under [data-redesign] [data-edition] so the legacy home is
+ * untouched. Single column, max 720px, body 17px / line-height 1.65,
+ * Manrope at editorial scale (no new font for Phase 7a per
+ * docs/architecture/HOME_EDITORIAL_REDESIGN.md §6).
+ */
+
+[data-redesign] [data-edition] {
+  --rd-edition-max: 720px;
+  --rd-edition-body-size: 17px;
+  --rd-edition-body-leading: 1.65;
+  --rd-edition-rule: rgba(21, 20, 15, 0.10);
+  --rd-edition-rule-strong: rgba(21, 20, 15, 0.16);
+}
+
+[data-redesign] [data-edition] {
+  width: 100%;
+  overflow-x: hidden;
+}
+
+[data-redesign] [data-edition] .rd-edition-root {
+  max-width: var(--rd-edition-max);
+  width: 100%;
+  margin: 0 auto;
+  padding: 24px 24px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+  font-size: var(--rd-edition-body-size);
+  line-height: var(--rd-edition-body-leading);
+  color: var(--rd-ink);
+  overflow-x: hidden;
+}
+
+/* Embedded composer (UniversalComposer) shouldn't grow past the
+   editorial column on narrow widths.  Phase 7a defensive cap. */
+[data-redesign] [data-edition] .rd-edition-root > * {
+  max-width: 100%;
+  min-width: 0;
+}
+
+@media (max-width: 480px) {
+  [data-redesign] [data-edition] .rd-edition-root {
+    padding: 16px 16px 64px;
+    gap: 28px;
+  }
+}
+
+[data-redesign] [data-edition] .rd-edition-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+[data-redesign] [data-edition] .rd-edition-section + .rd-edition-section {
+  border-top: 1px solid var(--rd-edition-rule);
+  padding-top: 32px;
+}
+
+[data-redesign] [data-edition] .rd-edition-section__eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--rd-ink-soft);
+  margin: 0;
+}
+
+[data-redesign] [data-edition] .rd-edition-section__h2 {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.4px;
+  line-height: 1.22;
+  color: var(--rd-ink-strong);
+  margin: 0;
+}
+
+[data-redesign] [data-edition] .rd-edition-prose {
+  font-size: var(--rd-edition-body-size);
+  line-height: var(--rd-edition-body-leading);
+  color: var(--rd-ink);
+}
+
+[data-redesign] [data-edition] .rd-edition-prose p { margin: 0 0 14px; }
+[data-redesign] [data-edition] .rd-edition-prose p:last-child { margin-bottom: 0; }
+[data-redesign] [data-edition] .rd-edition-prose strong { font-weight: 600; color: var(--rd-ink-strong); }
+[data-redesign] [data-edition] .rd-edition-prose em { font-style: italic; }
+
+[data-redesign] [data-edition] .rd-edition-meta {
+  font-size: 12.5px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] [data-edition] .rd-edition-delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--rd-accent-tint);
+  color: var(--rd-accent-strong);
+  letter-spacing: 0.04em;
+}
+
+/* ─── Dot grid (the visual signature) ───────────────────────────── */
+[data-redesign] [data-edition] .rd-dot-grid {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+[data-redesign] [data-edition] .rd-dot-grid__strip {
+  display: inline-flex;
+  gap: 4px;
+}
+
+[data-redesign] [data-edition] .rd-dot-grid__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--rd-line-strong);
+  display: inline-block;
+  border: 1px solid transparent;
+}
+
+[data-redesign] [data-edition] .rd-dot-grid__dot--filled {
+  background: var(--rd-accent);
+  border-color: var(--rd-accent-strong);
+}
+
+[data-redesign] [data-edition] .rd-dot-grid__caption {
+  font-family: ui-monospace, "JetBrains Mono", "Roboto Mono", monospace;
+  font-size: 11px;
+  color: var(--rd-ink-soft);
+  letter-spacing: 0.02em;
+}
+
+/* ─── Hypothesis block ─────────────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-hypothesis {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--rd-edition-rule);
+}
+
+[data-redesign] [data-edition] .rd-edition-hypothesis:last-child {
+  border-bottom: none;
+}
+
+[data-redesign] [data-edition] .rd-edition-hypothesis__head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+[data-redesign] [data-edition] .rd-edition-hypothesis__label {
+  font-family: ui-monospace, "JetBrains Mono", "Roboto Mono", monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] [data-edition] .rd-edition-hypothesis__title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  color: var(--rd-ink-strong);
+  margin: 0;
+}
+
+[data-redesign] [data-edition] .rd-edition-hypothesis__claim {
+  font-size: 16px;
+  line-height: 1.6;
+  margin: 0;
+  color: var(--rd-ink);
+}
+
+[data-redesign] [data-edition] .rd-edition-hypothesis__falsify {
+  font-size: 13.5px;
+  font-style: italic;
+  color: var(--rd-ink-mute);
+  margin: 0;
+  padding-left: 12px;
+  border-left: 2px solid var(--rd-line);
+}
+
+[data-redesign] [data-edition] .rd-edition-hypothesis__tally {
+  font-family: ui-monospace, "JetBrains Mono", "Roboto Mono", monospace;
+  font-size: 11.5px;
+  color: var(--rd-ink-soft);
+  letter-spacing: 0.02em;
+}
+
+/* ─── Forecast row ─────────────────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-forecast {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--rd-edition-rule);
+}
+
+[data-redesign] [data-edition] .rd-edition-forecast:last-child {
+  border-bottom: none;
+}
+
+[data-redesign] [data-edition] .rd-edition-forecast__claim {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--rd-ink-strong);
+  margin: 0;
+  line-height: 1.45;
+}
+
+[data-redesign] [data-edition] .rd-edition-forecast__row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+[data-redesign] [data-edition] .rd-edition-forecast__prob {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--rd-ink-strong);
+  letter-spacing: -0.4px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Scoreboard table ─────────────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-scoreboard {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+[data-redesign] [data-edition] .rd-edition-scoreboard__row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 14px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--rd-edition-rule);
+}
+
+[data-redesign] [data-edition] .rd-edition-scoreboard__row:first-child {
+  border-top: 1px solid var(--rd-edition-rule-strong);
+}
+
+[data-redesign] [data-edition] .rd-edition-scoreboard__row:last-child {
+  border-bottom: 1px solid var(--rd-edition-rule-strong);
+}
+
+[data-redesign] [data-edition] .rd-edition-scoreboard__label {
+  font-size: 13px;
+  color: var(--rd-ink-mute);
+  font-weight: 500;
+}
+
+[data-redesign] [data-edition] .rd-edition-scoreboard__value {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--rd-ink-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+[data-redesign] [data-edition] .rd-edition-scoreboard__delta {
+  font-family: ui-monospace, "JetBrains Mono", "Roboto Mono", monospace;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+[data-redesign] [data-edition] .rd-edition-scoreboard__delta--up { color: var(--rd-green); }
+[data-redesign] [data-edition] .rd-edition-scoreboard__delta--down { color: var(--rd-red); }
+[data-redesign] [data-edition] .rd-edition-scoreboard__delta--flat { color: var(--rd-ink-soft); }
+
+/* ─── Capabilities map ─────────────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-capability-row {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 16px;
+  align-items: center;
+  padding: 8px 0;
+}
+
+@media (max-width: 480px) {
+  [data-redesign] [data-edition] .rd-edition-capability-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+}
+
+[data-redesign] [data-edition] .rd-edition-capability-row__label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--rd-ink-strong);
+}
+
+[data-redesign] [data-edition] .rd-edition-capability-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+[data-redesign] [data-edition] .rd-edition-capability-card {
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--rd-paper-warm);
+}
+
+[data-redesign] [data-edition] .rd-edition-capability-card__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--rd-ink-strong);
+}
+
+[data-redesign] [data-edition] .rd-edition-capability-card__level {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  color: var(--rd-ink-mute);
+  font-weight: 500;
+}
+
+/* ─── Operations accordion ─────────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-ops-details {
+  margin-top: 8px;
+  border-top: 1px solid var(--rd-edition-rule);
+  padding-top: 16px;
+}
+
+[data-redesign] [data-edition] .rd-edition-ops-details > summary {
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--rd-ink-mute);
+  padding: 6px 0;
+  list-style: none;
+}
+
+[data-redesign] [data-edition] .rd-edition-ops-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+[data-redesign] [data-edition] .rd-edition-ops-details > summary::before {
+  content: "▸ ";
+  display: inline-block;
+  margin-right: 6px;
+  transition: transform 200ms ease;
+}
+
+[data-redesign] [data-edition] .rd-edition-ops-details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+[data-redesign] [data-edition] .rd-edition-ops-details .rd-ops {
+  margin-top: 12px;
+}
+
+/* ─── Footnotes ───────────────────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-footnotes {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] [data-edition] .rd-edition-footnotes ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: footnote;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+[data-redesign] [data-edition] .rd-edition-footnotes li {
+  counter-increment: footnote;
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 8px;
+  padding-left: 0;
+}
+
+[data-redesign] [data-edition] .rd-edition-footnotes li::before {
+  content: counter(footnote) ".";
+  font-family: ui-monospace, "JetBrains Mono", "Roboto Mono", monospace;
+  font-size: 11.5px;
+  color: var(--rd-ink-soft);
+  text-align: right;
+  font-weight: 600;
+}
+
+[data-redesign] [data-edition] .rd-edition-footnotes a {
+  color: var(--rd-accent-strong);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--rd-accent-soft);
+}
+
+[data-redesign] [data-edition] .rd-edition-footnotes a:hover,
+[data-redesign] [data-edition] .rd-edition-footnotes a:focus-visible {
+  border-bottom-style: solid;
+  outline: none;
+}
+
+[data-redesign] [data-edition] sup.rd-edition-footnote-ref {
+  font-size: 0.75em;
+  vertical-align: super;
+  margin-left: 1px;
+}
+
+[data-redesign] [data-edition] sup.rd-edition-footnote-ref a {
+  color: var(--rd-accent-strong);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0 2px;
+}
+
+/* ─── Empty state ─────────────────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-empty {
+  font-size: 14px;
+  color: var(--rd-ink-mute);
+  font-style: italic;
+  padding: 12px 0;
+}
+
+/* ─── Skeleton ────────────────────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-skeleton {
+  height: 18px;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    var(--rd-line) 0%,
+    var(--rd-line-faint) 50%,
+    var(--rd-line) 100%
+  );
+  background-size: 200% 100%;
+  animation: rd-edition-shimmer 1.4s ease-in-out infinite;
+  margin-bottom: 8px;
+}
+
+@keyframes rd-edition-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+/* ─── Reduced motion ───────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  [data-redesign] [data-edition] .rd-edition-skeleton {
+    animation: none;
+    background: var(--rd-line);
+  }
+  [data-redesign] [data-edition] .rd-edition-ops-details > summary::before {
+    transition: none;
+  }
+}
+
+/* ─── Focus visible ────────────────────────────────────────────── */
+[data-redesign] [data-edition] a:focus-visible,
+[data-redesign] [data-edition] summary:focus-visible,
+[data-redesign] [data-edition] button:focus-visible {
+  outline: 2px solid var(--rd-accent-ring);
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/src/features/redesign/hooks/editionSession.ts
+++ b/src/features/redesign/hooks/editionSession.ts
@@ -1,0 +1,18 @@
+/**
+ * Local helper for the editorial home — read the same anonymous
+ * session ID the rest of the app uses so guest pulses route to the
+ * same owner.  Mirrors useAnonymousSession's storage contract; we
+ * intentionally do *not* generate a new ID here (avoid double-create).
+ */
+
+const STORAGE_KEY = "nodebench:anonymous:sessionId";
+
+export function getStoredAnonymousSessionId(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return v ?? undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/features/redesign/hooks/useActiveHypotheses.ts
+++ b/src/features/redesign/hooks/useActiveHypotheses.ts
@@ -1,0 +1,42 @@
+/**
+ * useActiveHypotheses — wraps the public Convex query
+ * `domains.research.editionQueries.getActiveHypotheses` for §2.
+ * Returns `undefined` (loading), `[]` (no hypotheses — section
+ * hides), or the array of hypotheses ready to render.
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import type { EvidenceChecklist } from "../../../../convex/domains/research/narrative/validators";
+
+export interface EditionHypothesis {
+  _id: string;
+  hypothesisId: string;
+  threadId: string;
+  threadName: string;
+  label: string;
+  title: string;
+  claimForm: string;
+  measurementApproach: string;
+  falsificationCriteria: string | null;
+  status: "active" | "supported" | "weakened" | "inconclusive" | "retired";
+  confidence: number;
+  speculativeRisk: "grounded" | "mixed" | "speculative";
+  supportingEvidenceCount: number;
+  contradictingEvidenceCount: number;
+  evidenceArtifactIds: string[];
+  competingHypothesisIds: string[];
+  updatedAt: number;
+  evidenceChecklist: EvidenceChecklist;
+  evidenceChecksPassing: number;
+  evidenceChecksTotal: number;
+  evidenceLevel: "grounded" | "mixed" | "speculative";
+}
+
+export function useActiveHypotheses(limit = 5): EditionHypothesis[] | undefined {
+  const data = useQuery(
+    api.domains.research.editionQueries.getActiveHypotheses,
+    { limit },
+  );
+  return data as EditionHypothesis[] | undefined;
+}

--- a/src/features/redesign/hooks/useEditionFootnotes.ts
+++ b/src/features/redesign/hooks/useEditionFootnotes.ts
@@ -1,0 +1,56 @@
+/**
+ * useEditionFootnotes — fetches `evidenceArtifacts` referenced by
+ * §1–§3 of the editorial home plus recent `industryUpdates`.
+ *
+ * Pass the union of `evidenceArtifactIds` collected from pulse +
+ * hypotheses; the hook bounds the request server-side via the
+ * editionQueries module.
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+
+export interface FootnoteArtifact {
+  _id: string;
+  artifactId: string;
+  url: string;
+  canonicalUrl: string;
+  publisher: string;
+  publishedAt: number | null;
+  credibilityTier: string;
+  firstQuote: string | null;
+}
+
+export interface FootnoteIndustryUpdate {
+  _id: string;
+  provider: string;
+  providerName: string;
+  url: string;
+  title: string;
+  summary: string;
+  relevance: number;
+  scannedAt: number;
+}
+
+export interface EditionFootnotes {
+  artifacts: FootnoteArtifact[];
+  industry: FootnoteIndustryUpdate[];
+}
+
+export function useEditionFootnotes(
+  artifactIds: string[],
+  industryLimit = 8,
+  artifactLimit = 24,
+): EditionFootnotes | undefined {
+  // Stable key set — sorted for cache hit consistency.
+  const sorted = [...new Set(artifactIds)].sort();
+  const data = useQuery(
+    api.domains.research.editionQueries.getEditionFootnotes,
+    {
+      artifactIds: sorted,
+      industryLimit,
+      artifactLimit,
+    },
+  );
+  return data as EditionFootnotes | undefined;
+}

--- a/src/features/redesign/hooks/useLatestDailyBriefSnapshot.ts
+++ b/src/features/redesign/hooks/useLatestDailyBriefSnapshot.ts
@@ -1,0 +1,51 @@
+/**
+ * useLatestDailyBriefSnapshot — wraps
+ * `domains.research.editionQueries.getLatestDailyBriefSnapshot`.
+ * Returns `undefined` while loading and `null` if no snapshot exists.
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+
+export interface KeyStat {
+  label?: string;
+  name?: string;
+  value?: string | number;
+  delta?: string | number;
+  trend?: "up" | "down" | "flat";
+}
+
+export interface CapabilityEntry {
+  name?: string;
+  label?: string;
+  level?: string;
+  description?: string;
+}
+
+export interface DashboardMetrics {
+  meta: { currentDate: string; timelineProgress: number };
+  charts: { trendLine: unknown; marketShare: unknown[] };
+  techReadiness: { existing: number; emerging: number; sciFi: number };
+  keyStats: KeyStat[];
+  capabilities: CapabilityEntry[];
+  annotations?: unknown[];
+  agentCount?: { count: number; label: string; speed: number };
+  entityGraph?: unknown;
+}
+
+export interface LatestSnapshot {
+  _id: string;
+  dateString: string;
+  generatedAt: number;
+  version: number;
+  dashboardMetrics: DashboardMetrics;
+  sourceSummary: { totalItems: number; topTrending: string[] };
+}
+
+export function useLatestDailyBriefSnapshot(): LatestSnapshot | null | undefined {
+  const data = useQuery(
+    api.domains.research.editionQueries.getLatestDailyBriefSnapshot,
+    {},
+  );
+  return data as LatestSnapshot | null | undefined;
+}

--- a/src/features/redesign/hooks/useTodayPulse.ts
+++ b/src/features/redesign/hooks/useTodayPulse.ts
@@ -1,0 +1,38 @@
+/**
+ * useTodayPulse — wraps the public Convex query
+ * `domains.research.editionQueries.getTodayPulse` for §1 of the
+ * editorial home.  Returns `undefined` while loading, then
+ * `{ pulses, dateKey, lastDateKey }`.
+ *
+ * Identity is the same anonymous-session contract used by Fast Agent.
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { getStoredAnonymousSessionId } from "./editionSession";
+
+export interface TodayPulseEntry {
+  _id: string;
+  entitySlug: string;
+  dateKey: string;
+  status: "generating" | "ready" | "failed";
+  summaryMarkdown: string | null;
+  changeCount: number;
+  materialChangeCount: number;
+  generatedAt: number;
+}
+
+export interface TodayPulseResult {
+  pulses: TodayPulseEntry[];
+  dateKey: string;
+  lastDateKey: string | null;
+}
+
+export function useTodayPulse(limit = 12): TodayPulseResult | undefined {
+  const sessionId = getStoredAnonymousSessionId();
+  const data = useQuery(
+    api.domains.research.editionQueries.getTodayPulse,
+    { anonymousSessionId: sessionId, limit },
+  );
+  return data as TodayPulseResult | undefined;
+}

--- a/src/features/redesign/hooks/useTopForecasts.ts
+++ b/src/features/redesign/hooks/useTopForecasts.ts
@@ -1,0 +1,34 @@
+/**
+ * useTopForecasts — wraps the public Convex query
+ * `domains.research.editionQueries.getTopForecasts` for §3.  The
+ * underlying internalQuery `getTopForecastsForLinkedIn` is the
+ * source — we expose a public-friendly variant from the edition
+ * queries module.
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+
+export interface EditionForecast {
+  _id: string;
+  question: string;
+  forecastType: string;
+  probability: number | null;
+  previousProbability: number | null;
+  confidenceInterval: { low: number; high: number } | null;
+  resolutionDate: string;
+  resolutionCriteria: string;
+  topDrivers: string[];
+  topCounterarguments: string[];
+  updateCount: number;
+  lastRefreshedAt: number;
+  status: string;
+}
+
+export function useTopForecasts(limit = 5): EditionForecast[] | undefined {
+  const data = useQuery(
+    api.domains.research.editionQueries.getTopForecasts,
+    { limit },
+  );
+  return data as EditionForecast[] | undefined;
+}

--- a/src/features/redesign/surfaces/EditorialHomeSurface.tsx
+++ b/src/features/redesign/surfaces/EditorialHomeSurface.tsx
@@ -1,0 +1,582 @@
+/**
+ * EditorialHomeSurface — the single-column daily-edition render of
+ * the redesign home (Phase 7a).  Gated behind `?edition=1` from
+ * HomeSurface.tsx; the legacy render path is preserved for users
+ * without the flag.
+ *
+ * Source spec: docs/architecture/HOME_EDITORIAL_REDESIGN.md (esp §3
+ * Variant C, §5 data binding, §8 locked decisions).
+ *
+ * Layout: ONE column, max 720px, no card chrome, hairline rules
+ * between sections.  Mobile and desktop are identical (per Variant C
+ * — "mobile parity by construction").
+ */
+
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { UniversalComposer } from "../components/UniversalComposer";
+import { EditorialSection } from "../components/edition/EditorialSection";
+import { EditionErrorBoundary } from "../components/edition/EditionErrorBoundary";
+import { Footnote } from "../components/edition/Footnote";
+import { Scoreboard } from "../components/edition/Scoreboard";
+import { CapabilitiesMap } from "../components/edition/CapabilitiesMap";
+import { EvidenceChecklistStrip } from "../components/edition/EvidenceChecklistStrip";
+import { useTodayPulse } from "../hooks/useTodayPulse";
+import { useActiveHypotheses, type EditionHypothesis } from "../hooks/useActiveHypotheses";
+import { useTopForecasts, type EditionForecast } from "../hooks/useTopForecasts";
+import { useLatestDailyBriefSnapshot } from "../hooks/useLatestDailyBriefSnapshot";
+import { useEditionFootnotes } from "../hooks/useEditionFootnotes";
+import { useHomePulseLive } from "../hooks/useHomePulseLive";
+import { pulseCards as fixturePulseCards, watchlist, continueWorking } from "../fixtures";
+import { Pill } from "../components/Pill";
+import "../components/edition/edition.css";
+
+interface Props {
+  onAsk: (text: string) => void;
+  onOpenReport: (id: string) => void;
+}
+
+const ABSENT = Symbol("absent");
+
+/* ─── helpers ───────────────────────────────────────────────────── */
+
+function formatProbability(p: number | null): string {
+  if (p === null || p === undefined || !Number.isFinite(p)) return "—";
+  return `${Math.round(p * 100)}%`;
+}
+
+function formatProbabilityDelta(
+  current: number | null,
+  prev: number | null,
+): { text: string; tone: "up" | "down" | "flat" } | null {
+  if (current === null || prev === null) return null;
+  if (!Number.isFinite(current) || !Number.isFinite(prev)) return null;
+  const pp = Math.round((current - prev) * 100);
+  if (pp === 0) {
+    return { text: `was ${Math.round(prev * 100)}%, ±0pp`, tone: "flat" };
+  }
+  return {
+    text: `was ${Math.round(prev * 100)}%, ${pp > 0 ? "+" : ""}${pp}pp`,
+    tone: pp > 0 ? "up" : "down",
+  };
+}
+
+/** Render markdown summary as serif paragraphs.  Phase 7a uses a
+ * minimal renderer — strip headings, render leading bullet points
+ * inline, preserve paragraph breaks.  Anything fancier waits for 7b. */
+function renderPulseMarkdown(md: string): string[] {
+  return md
+    .split(/\r?\n\r?\n/)
+    .map((p) => p.trim())
+    .filter(Boolean)
+    // Keep up to 4 paragraphs to stay editorial.
+    .slice(0, 4);
+}
+
+/* ─── §1 — What moved today ─────────────────────────────────────── */
+
+function WhatMovedSection() {
+  const data = useTodayPulse(12);
+  if (data === undefined) {
+    return (
+      <EditorialSection
+        id="what-moved"
+        ariaLabel="What moved today"
+        eyebrow="01 · Today's edition"
+        heading="What moved today"
+      >
+        <div className="rd-edition-skeleton" style={{ width: "92%" }} />
+        <div className="rd-edition-skeleton" style={{ width: "78%" }} />
+        <div className="rd-edition-skeleton" style={{ width: "84%" }} />
+      </EditorialSection>
+    );
+  }
+  const { pulses, dateKey, lastDateKey } = data;
+  const totalMaterial = pulses.reduce(
+    (n, p) => n + (p.materialChangeCount ?? 0),
+    0,
+  );
+
+  return (
+    <EditorialSection
+      id="what-moved"
+      ariaLabel="What moved today"
+      eyebrow={`01 · ${dateKey}`}
+      heading="What moved today"
+    >
+      {pulses.length === 0 ? (
+        <p className="rd-edition-empty">
+          No pulse generated yet today.
+          {lastDateKey ? ` Last pulse: ${lastDateKey}.` : ""}
+        </p>
+      ) : (
+        <>
+          <p className="rd-edition-meta">
+            <span className="rd-edition-delta" aria-label={`${totalMaterial} material changes`}>
+              {totalMaterial} material change{totalMaterial === 1 ? "" : "s"}
+            </span>{" "}
+            across {pulses.length} entit{pulses.length === 1 ? "y" : "ies"}
+          </p>
+          <div className="rd-edition-prose">
+            {pulses.map((p, i) => (
+              <article
+                key={p._id}
+                data-pulse-entity={p.entitySlug}
+                style={{ marginBottom: 18 }}
+              >
+                <p style={{ margin: "0 0 6px" }}>
+                  <strong style={{ textTransform: "capitalize" }}>
+                    {p.entitySlug.replace(/-/g, " ")}
+                  </strong>{" "}
+                  <span className="rd-edition-meta">
+                    · {p.changeCount} change{p.changeCount === 1 ? "" : "s"}
+                    {p.materialChangeCount > 0
+                      ? `, ${p.materialChangeCount} material`
+                      : ""}
+                  </span>
+                  <Footnote id={`pulse-${i + 1}`} index={i + 1} label={`Pulse for ${p.entitySlug}`} />
+                </p>
+                {p.summaryMarkdown
+                  ? renderPulseMarkdown(p.summaryMarkdown).map((para, j) => (
+                      <p key={j}>{para.replace(/^#+\s*/, "")}</p>
+                    ))
+                  : (
+                    <p className="rd-edition-empty" style={{ padding: 0 }}>
+                      Pulse generated; full summary pending.
+                    </p>
+                  )}
+              </article>
+            ))}
+          </div>
+        </>
+      )}
+    </EditorialSection>
+  );
+}
+
+/* ─── §2 — Competing explanations ───────────────────────────────── */
+
+function CompetingExplanationsSection({
+  hypotheses,
+}: {
+  hypotheses: EditionHypothesis[] | undefined;
+}) {
+  if (hypotheses === undefined) {
+    return (
+      <EditorialSection
+        id="competing-explanations"
+        ariaLabel="The competing explanations"
+        eyebrow="02 · Hypotheses under test"
+        heading="The competing explanations"
+      >
+        <div className="rd-edition-skeleton" style={{ width: "70%" }} />
+        <div className="rd-edition-skeleton" style={{ width: "92%" }} />
+        <div className="rd-edition-skeleton" style={{ width: "60%" }} />
+      </EditorialSection>
+    );
+  }
+
+  if (hypotheses.length === 0) {
+    // Spec §5: "Empty state: hide section. Don't fake hypotheses."
+    return null;
+  }
+
+  return (
+    <EditorialSection
+      id="competing-explanations"
+      ariaLabel="The competing explanations"
+      eyebrow="02 · Hypotheses under test"
+      heading="The competing explanations"
+    >
+      <div>
+        {hypotheses.map((h) => (
+          <article
+            key={h._id}
+            className="rd-edition-hypothesis"
+            data-hypothesis-id={h.hypothesisId}
+            data-evidence-level={h.evidenceLevel}
+          >
+            <div className="rd-edition-hypothesis__head">
+              <span className="rd-edition-hypothesis__label">{h.label}</span>
+              <h3 className="rd-edition-hypothesis__title">{h.title}</h3>
+            </div>
+            <p className="rd-edition-hypothesis__claim">{h.claimForm}</p>
+            <EvidenceChecklistStrip
+              checklist={h.evidenceChecklist}
+              passing={h.evidenceChecksPassing}
+              total={h.evidenceChecksTotal}
+              level={h.evidenceLevel}
+            />
+            {h.falsificationCriteria && (
+              <p className="rd-edition-hypothesis__falsify">
+                Would change my mind: {h.falsificationCriteria}
+              </p>
+            )}
+            <p className="rd-edition-hypothesis__tally">
+              {h.supportingEvidenceCount} supporting · {h.contradictingEvidenceCount} contradicting · {h.threadName}
+            </p>
+          </article>
+        ))}
+      </div>
+    </EditorialSection>
+  );
+}
+
+/* ─── §3 — What to look at this week ────────────────────────────── */
+
+function WhatToLookAtSection({
+  forecasts,
+}: {
+  forecasts: EditionForecast[] | undefined;
+}) {
+  const navigate = useNavigate();
+  if (forecasts === undefined) {
+    return (
+      <EditorialSection
+        id="what-to-look-at"
+        ariaLabel="What to look at this week"
+        eyebrow="03 · Forecasts in motion"
+        heading="What to look at this week"
+      >
+        <div className="rd-edition-skeleton" style={{ width: "85%" }} />
+        <div className="rd-edition-skeleton" style={{ width: "60%" }} />
+        <div className="rd-edition-skeleton" style={{ width: "75%" }} />
+      </EditorialSection>
+    );
+  }
+
+  return (
+    <EditorialSection
+      id="what-to-look-at"
+      ariaLabel="What to look at this week"
+      eyebrow="03 · Forecasts in motion"
+      heading="What to look at this week"
+    >
+      {forecasts.length === 0 ? (
+        <p className="rd-edition-empty">
+          No active forecasts have updates yet. Check back after the next refresh.
+        </p>
+      ) : (
+        <>
+          <div>
+            {forecasts.slice(0, 5).map((f) => {
+              const delta = formatProbabilityDelta(f.probability, f.previousProbability);
+              return (
+                <article key={f._id} className="rd-edition-forecast" data-forecast-id={f._id}>
+                  <p className="rd-edition-forecast__claim">{f.question}</p>
+                  <div className="rd-edition-forecast__row">
+                    <span className="rd-edition-forecast__prob">
+                      {formatProbability(f.probability)}
+                    </span>
+                    {delta && (
+                      <span
+                        className={`rd-edition-scoreboard__delta rd-edition-scoreboard__delta--${delta.tone}`}
+                        aria-label={`Probability ${delta.text}`}
+                      >
+                        {delta.tone === "up" && "↑ "}
+                        {delta.tone === "down" && "↓ "}
+                        [{delta.text}]
+                      </span>
+                    )}
+                    <span className="rd-edition-meta">
+                      Resolves {f.resolutionDate}
+                    </span>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+          <p className="rd-edition-meta" style={{ marginTop: 8 }}>
+            <button
+              type="button"
+              className="rd-btn rd-btn--quiet rd-btn--sm"
+              onClick={() => navigate("/forecasts")}
+            >
+              View all forecasts →
+            </button>
+          </p>
+        </>
+      )}
+    </EditorialSection>
+  );
+}
+
+/* ─── §4 — Scoreboard + Operations accordion ────────────────────── */
+
+function ScoreboardSection() {
+  const snapshot = useLatestDailyBriefSnapshot();
+  const { pulse: livePulseCards } = useHomePulseLive();
+  const opsCards = livePulseCards.length > 0 ? livePulseCards : fixturePulseCards;
+
+  if (snapshot === undefined) {
+    return (
+      <EditorialSection
+        id="scoreboard"
+        ariaLabel="Today's scoreboard"
+        eyebrow="04 · Scoreboard"
+        heading="Today's scoreboard"
+      >
+        <div className="rd-edition-skeleton" style={{ width: "100%", height: 28 }} />
+        <div className="rd-edition-skeleton" style={{ width: "92%", height: 28 }} />
+        <div className="rd-edition-skeleton" style={{ width: "85%", height: 28 }} />
+      </EditorialSection>
+    );
+  }
+
+  const stats = snapshot?.dashboardMetrics?.keyStats ?? [];
+
+  return (
+    <EditorialSection
+      id="scoreboard"
+      ariaLabel="Today's scoreboard"
+      eyebrow={`04 · ${snapshot?.dateString ?? "Scoreboard"}`}
+      heading="Today's scoreboard"
+    >
+      <Scoreboard stats={stats} />
+
+      <details className="rd-edition-ops-details">
+        <summary>Today's operations</summary>
+        <div className="rd-ops" data-ops-source="legacy-fallback">
+          <div className="rd-ops__col">
+            <div className="rd-ops__head">
+              <span className="rd-ops__title">Continue working</span>
+              <span className="rd-ops__count">{continueWorking.length} open</span>
+            </div>
+            {continueWorking.slice(0, 3).map((c) => (
+              <div key={c.id} className="rd-ops__row">
+                <div className="rd-ops__row-title">{c.title}</div>
+                <span className="rd-ops__row-meta">{c.kind} · {c.lastTouched}</span>
+              </div>
+            ))}
+          </div>
+          <div className="rd-ops__col">
+            <div className="rd-ops__head">
+              <span className="rd-ops__title">What changed</span>
+              <span className="rd-ops__count">{opsCards.length}</span>
+            </div>
+            {opsCards.slice(0, 3).map((card) => (
+              <div key={card.title} className="rd-ops__row">
+                <div className="rd-ops__row-title" style={{ fontSize: 13 }}>{card.title}</div>
+                <span style={{ fontSize: 12, color: "var(--rd-ink-mute)" }}>{card.body}</span>
+              </div>
+            ))}
+          </div>
+          <div className="rd-ops__col">
+            <div className="rd-ops__head">
+              <span className="rd-ops__title">Watchlist</span>
+              <span className="rd-ops__count">{watchlist.length}</span>
+            </div>
+            {watchlist.slice(0, 3).map((w) => (
+              <div key={w.id} className="rd-ops__row">
+                <div className="rd-ops__row-title">{w.entity}</div>
+                <span style={{ fontSize: 12, color: "var(--rd-ink-mute)" }}>{w.signal}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </details>
+    </EditorialSection>
+  );
+}
+
+/* ─── §5 — Capabilities map ─────────────────────────────────────── */
+
+function CapabilitiesSection() {
+  const snapshot = useLatestDailyBriefSnapshot();
+
+  if (snapshot === undefined) {
+    return (
+      <EditorialSection
+        id="capabilities"
+        ariaLabel="Capabilities map"
+        eyebrow="05 · The capability landscape"
+        heading="Capabilities map"
+      >
+        <div className="rd-edition-skeleton" style={{ width: "70%", height: 18 }} />
+        <div className="rd-edition-skeleton" style={{ width: "70%", height: 18 }} />
+        <div className="rd-edition-skeleton" style={{ width: "70%", height: 18 }} />
+      </EditorialSection>
+    );
+  }
+
+  const tr = snapshot?.dashboardMetrics?.techReadiness ?? null;
+  const caps = snapshot?.dashboardMetrics?.capabilities ?? null;
+
+  return (
+    <EditorialSection
+      id="capabilities"
+      ariaLabel="Capabilities map"
+      eyebrow="05 · The capability landscape"
+      heading="Capabilities map"
+    >
+      <CapabilitiesMap techReadiness={tr} capabilities={caps} />
+    </EditorialSection>
+  );
+}
+
+/* ─── Footnotes ─────────────────────────────────────────────────── */
+
+function FootnotesSection({
+  artifactIds,
+}: {
+  artifactIds: string[];
+}) {
+  const data = useEditionFootnotes(artifactIds, 8, 24);
+  if (data === undefined) {
+    return (
+      <EditorialSection
+        id="footnotes"
+        ariaLabel="Footnotes and sources"
+        eyebrow="06 · Sources"
+        heading="Footnotes"
+      >
+        <div className="rd-edition-skeleton" style={{ width: "60%" }} />
+        <div className="rd-edition-skeleton" style={{ width: "85%" }} />
+      </EditorialSection>
+    );
+  }
+
+  const totalCount = data.artifacts.length + data.industry.length;
+
+  return (
+    <EditorialSection
+      id="footnotes"
+      ariaLabel="Footnotes and sources"
+      eyebrow="06 · Sources"
+      heading="Footnotes"
+    >
+      {totalCount === 0 ? (
+        <p className="rd-edition-empty">No source artifacts referenced in today's edition.</p>
+      ) : (
+        <div className="rd-edition-footnotes">
+          <ol>
+            {data.artifacts.map((a, i) => (
+              <li key={a._id} id={`fn-art-${i + 1}`}>
+                <span>
+                  <a href={a.url} target="_blank" rel="noopener noreferrer">
+                    {a.publisher || new URL(a.url).hostname}
+                  </a>
+                  {a.firstQuote ? <> — &ldquo;{a.firstQuote}&rdquo;</> : null}
+                  {a.publishedAt ? (
+                    <span className="rd-edition-meta">
+                      {" "}· {new Date(a.publishedAt).toISOString().slice(0, 10)}
+                    </span>
+                  ) : null}
+                </span>
+              </li>
+            ))}
+            {data.industry.map((u, i) => (
+              <li key={u._id} id={`fn-ind-${i + 1}`}>
+                <span>
+                  <a href={u.url} target="_blank" rel="noopener noreferrer">
+                    {u.providerName} — {u.title}
+                  </a>
+                  <span className="rd-edition-meta">
+                    {" "}· {new Date(u.scannedAt).toISOString().slice(0, 10)}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </EditorialSection>
+  );
+}
+
+/* ─── EditorialHomeSurface root ─────────────────────────────────── */
+
+export function EditorialHomeSurface({ onAsk }: Props) {
+  const hypotheses = useActiveHypotheses(5);
+  const forecasts = useTopForecasts(5);
+  const todayPulse = useTodayPulse(12);
+
+  // Collect artifactIds from §2's hypotheses for footnotes (§6).
+  const artifactIds = useMemo(() => {
+    const ids: string[] = [];
+    if (Array.isArray(hypotheses)) {
+      for (const h of hypotheses) {
+        for (const id of h.evidenceArtifactIds ?? []) ids.push(id);
+      }
+    }
+    void todayPulse; // pulses don't carry artifactIds in v1 schema
+    void ABSENT;
+    return ids;
+  }, [hypotheses, todayPulse]);
+
+  return (
+    <div data-edition>
+      <div className="rd-edition-root">
+        <header
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            paddingBottom: 8,
+            borderBottom: "1px solid var(--rd-edition-rule-strong)",
+          }}
+        >
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Pill tone="accent">Daily edition</Pill>
+            <span className="rd-edition-meta">
+              Single-document brief · max 720px · keyboard-first
+            </span>
+          </div>
+          <h1
+            style={{
+              fontSize: 32,
+              fontWeight: 700,
+              letterSpacing: "-0.6px",
+              margin: 0,
+              lineHeight: 1.18,
+              color: "var(--rd-ink-strong)",
+            }}
+          >
+            Today's intelligence brief
+          </h1>
+          <p
+            style={{
+              fontSize: 15.5,
+              lineHeight: 1.55,
+              color: "var(--rd-ink-mute)",
+              margin: 0,
+            }}
+          >
+            Pulled live from your pulse, hypotheses, forecasts, and the latest
+            daily brief. Ask anything below to extend the edition.
+          </p>
+        </header>
+
+        <UniversalComposer
+          onSubmit={(text) => onAsk(text)}
+          onChatNow={(text) => onAsk(text)}
+          placeholder="Ask to extend today's edition…"
+        />
+
+        <EditionErrorBoundary label="what-moved">
+          <WhatMovedSection />
+        </EditionErrorBoundary>
+
+        <EditionErrorBoundary label="competing-explanations">
+          <CompetingExplanationsSection hypotheses={hypotheses} />
+        </EditionErrorBoundary>
+
+        <EditionErrorBoundary label="what-to-look-at">
+          <WhatToLookAtSection forecasts={forecasts} />
+        </EditionErrorBoundary>
+
+        <EditionErrorBoundary label="scoreboard">
+          <ScoreboardSection />
+        </EditionErrorBoundary>
+
+        <EditionErrorBoundary label="capabilities">
+          <CapabilitiesSection />
+        </EditionErrorBoundary>
+
+        <EditionErrorBoundary label="footnotes">
+          <FootnotesSection artifactIds={artifactIds} />
+        </EditionErrorBoundary>
+      </div>
+    </div>
+  );
+}

--- a/src/features/redesign/surfaces/HomeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeSurface.tsx
@@ -27,6 +27,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Mic } from "lucide-react";
+import { EditorialHomeSurface } from "./EditorialHomeSurface";
 import { UniversalComposer } from "../components/UniversalComposer";
 import { Pill } from "../components/Pill";
 import { StyleGalleryCard } from "../components/StyleGalleryCard";
@@ -70,7 +71,32 @@ interface HomeSurfaceProps {
   onOpenReport: (id: string) => void;
 }
 
-export function HomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
+/**
+ * Read the `?edition=1` flag from the current URL.  Phase 7a gate per
+ * docs/architecture/HOME_EDITORIAL_REDESIGN.md §8 — when present, the
+ * editorial daily-edition render replaces the legacy home.  Absent =
+ * existing render path is preserved unchanged.  Computed once per
+ * render (no useEffect) so SSR / first-paint match the URL state.
+ */
+function readEditionFlag(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return new URLSearchParams(window.location.search).get("edition") === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function HomeSurface(props: HomeSurfaceProps) {
+  // Gate the entire surface choice at the top level so each branch
+  // owns its own hook order — avoids the "conditional hooks" lint.
+  if (readEditionFlag()) {
+    return <EditorialHomeSurface onAsk={props.onAsk} onOpenReport={props.onOpenReport} />;
+  }
+  return <LegacyHomeSurface {...props} />;
+}
+
+function LegacyHomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
   const navigate = useNavigate();
   const [contextLabel, setContextLabel] = useState("Auto: current context");
   const [situationWindow, setSituationWindow] = useState<SituationWindow>("today");

--- a/tests/e2e/edition-home.spec.ts
+++ b/tests/e2e/edition-home.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * E2E — Editorial home (Phase 7a, gated by `?edition=1`).
+ *
+ * Source spec: docs/architecture/HOME_EDITORIAL_REDESIGN.md
+ * Rules cited: .claude/rules/scenario_testing.md (anatomy below),
+ *              .claude/rules/agentic_reliability.md (HONEST_STATUS),
+ *              .claude/rules/live_dom_verification.md (Tier B).
+ *
+ * ─── Scenario A — first-time visitor flips ?edition=1 ────────────
+ * User:        New user (anonymous, no localStorage state)
+ * Goal:        See the editorial daily edition without logging in
+ * Prior state: No pulses, hypotheses, or forecasts persisted yet
+ * Actions:     Navigate to /redesign?edition=1 directly
+ * Scale:       1 user
+ * Duration:    Single page load (< 5s)
+ * Expected:    Edition root mounts; sections present (or honestly
+ *              hidden where the spec says hide); no horizontal
+ *              overflow at 375px; legacy markers absent.
+ * Edge cases:  Hypotheses empty → section absent (spec §5).
+ *              Daily brief absent → scoreboard shows empty state.
+ *
+ * ─── Scenario B — same user without the flag ─────────────────────
+ * User:        Same anonymous visitor
+ * Goal:        Verify the legacy home is preserved exactly
+ * Actions:     Navigate to /redesign (no flag)
+ * Expected:    Operations dashboard region renders (legacy marker).
+ *              No `[data-edition]` root in the document.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:5173";
+
+const EDITION_SECTIONS = [
+  "what-moved",
+  "what-to-look-at",
+  "scoreboard",
+  "capabilities",
+  "footnotes",
+] as const;
+
+test.describe("Editorial home — Phase 7a", () => {
+  test("Scenario A: ?edition=1 renders the editorial layout", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto(`${BASE_URL}/redesign?edition=1`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    // Edition root mounts (proves the flag took effect).
+    const editionRoot = page.locator("[data-edition]");
+    await expect(editionRoot).toBeVisible({ timeout: 10_000 });
+
+    // Each guaranteed section should render (the only conditional one
+    // is `competing-explanations`, which is allowed to be absent per
+    // spec §5 when no public hypotheses are active).
+    for (const id of EDITION_SECTIONS) {
+      const section = page.locator(`[data-section="${id}"]`);
+      await expect(section).toBeVisible({ timeout: 5_000 });
+    }
+
+    // Hypotheses section: present OR honestly absent (no fake data).
+    const hypotheses = page.locator('[data-section="competing-explanations"]');
+    const hypCount = await hypotheses.count();
+    expect(hypCount === 0 || hypCount === 1).toBeTruthy();
+
+    // No horizontal overflow at mobile width (375px) — Phase 7a's
+    // edition flag bypasses MobileShell at the home surface so the
+    // single-column editorial layout stays responsive (spec §3
+    // Variant C: "mobile and desktop are identical").
+    await page.setViewportSize({ width: 375, height: 720 });
+    // Allow re-render + the editorial mount to settle (the shell
+    // checks isMobile via a media-query listener).
+    await page.waitForSelector("[data-edition]", { timeout: 5_000 });
+    await page.waitForTimeout(300);
+    const horizontalOverflow = await page.evaluate(() => {
+      const root = document.querySelector("[data-edition]");
+      if (!root) return null;
+      return root.scrollWidth - (root as HTMLElement).clientWidth;
+    });
+    expect(horizontalOverflow).not.toBeNull();
+    expect(horizontalOverflow ?? 999).toBeLessThanOrEqual(2);
+
+    // Legacy operations dashboard MUST NOT render in editorial mode.
+    const legacyOps = page.locator('section[aria-label="Operations dashboard"]');
+    expect(await legacyOps.count()).toBe(0);
+
+    // No console / page errors.
+    expect(errors, `Errors:\n${errors.join("\n")}`).toEqual([]);
+  });
+
+  test("Scenario B: legacy home preserved without the flag", async ({ page }) => {
+    await page.goto(`${BASE_URL}/redesign`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    // Editorial root MUST NOT render.
+    const editionRoot = page.locator("[data-edition]");
+    expect(await editionRoot.count()).toBe(0);
+
+    // Legacy "Operations dashboard" landmark must still render.
+    const legacyOps = page.locator('section[aria-label="Operations dashboard"]');
+    await expect(legacyOps).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the single-column editorial daily-edition render of the redesign home (Variant C from `docs/architecture/HOME_EDITORIAL_REDESIGN.md`), gated behind `?edition=1` so the legacy `/redesign` path is preserved unchanged
- Binds §1–§5 directly to existing pipeline substrates (`pulseReports`, `narrativeHypotheses`, `forecasts`, `dailyBriefSnapshots`, `evidenceArtifacts`, `industryUpdates`) — no new tables, no new fonts
- Mirrors ai-2027.com's "Currently Exists / Emerging Tech / Science Fiction" 6-dot strip as the visual signature in the Capabilities map

## Re your requests

- *"feel like if we draw professional references, there are much better ways to design this home page, for example, check out https://ai-2027.com/"* → 6-dot strips for the capabilities map mirror ai-2027's "Currently Exists / Emerging Tech / Science Fiction" indicator
- *"we do have daily content pipeline with linkedin daily brief, we can sync them all up and expand"* → §1–§5 bind to the LinkedIn pipeline substrates that already write daily
- *"do no need new route, build revamp ontop of existing redeisgn"* → renders inside `HomeSurface.tsx`; redesign tab nav (Home/Reports/Chat/Inbox/Me) untouched

## Files added / modified

**Convex queries** (per `.claude/rules/agentic_reliability.md` — BOUND, HONEST_STATUS, HONEST_SCORES):
- `convex/domains/research/editionQueries.ts` (new)
  - `getTodayPulse` — bounded 50, returns `[]` honestly
  - `getActiveHypotheses` — bounded 20, public threads only
  - `getTopForecasts` — bounded 12, public wrapper around the existing internal query
  - `getLatestDailyBriefSnapshot` — returns `null` when no snapshot exists
  - `getEditionFootnotes` — bounded artifacts 60 / industry 24

**Components** (scoped under `[data-redesign] [data-edition]`):
- `src/features/redesign/components/edition/{DotGrid,EvidenceChecklistStrip,Footnote,EditorialSection,Scoreboard,CapabilitiesMap,EditionErrorBoundary,edition.css}`

**Hooks**:
- `src/features/redesign/hooks/{editionSession,useTodayPulse,useActiveHypotheses,useTopForecasts,useLatestDailyBriefSnapshot,useEditionFootnotes}.ts`

**Surface**:
- `src/features/redesign/surfaces/EditorialHomeSurface.tsx` (new)
- `src/features/redesign/surfaces/HomeSurface.tsx` (gated by `readEditionFlag()` at top of component — branches stay hook-stable)
- `src/features/redesign/RedesignShell.tsx` (mobile branch lets `?edition=1` bypass MobileShell so single-column layout renders at any width — spec §3 Variant C "mobile and desktop are identical")

**Tests** (per `.claude/rules/scenario_testing.md`):
- `tests/e2e/edition-home.spec.ts` — Scenario A (edition=1 renders all data-section testids; mobile width has no horizontal overflow); Scenario B (legacy `/redesign` preserves Operations dashboard landmark)

## Verification

- [x] `npx convex codegen` → OK
- [x] `npx tsc --noEmit --pretty false` → exit 0
- [x] `npx vite build` → clean (~11s, 432 PWA precache entries)
- [x] `npx playwright test tests/e2e/edition-home.spec.ts --project=chromium` → 2/2 pass against deployed Convex prod
- [x] Live screenshot of `/redesign?edition=1` shows §1 What moved, §3 Forecasts, §4 Scoreboard with delta arrows, §5 Capabilities map (6-dot strips for Currently Exists / Emerging / Science Fiction), §6 Footnotes — all rendering with honest empty states where data isn't generated yet

## Test plan

- [ ] Visual: `/redesign?edition=1` desktop — sections 1–6, single-column 720px max, no card chrome on the scoreboard table
- [ ] Visual: `/redesign?edition=1` mobile (375px) — same layout, no horizontal overflow, MobileShell bypassed
- [ ] Visual: `/redesign` (no flag) — legacy home unchanged (Operations dashboard, Style strip, Pitchbook entity feed)
- [ ] Hypotheses appear when at least one public thread has active/supported/weakened hypotheses; otherwise §2 hides entirely (no fake data — `.claude/rules/agentic_reliability.md` HONEST_SCORES)
- [ ] `<details>` "Today's operations" accordion inside §4 expands to show the 3-col legacy ops grid

## Decisions worth review

1. **evidenceChecklist derivation** — `narrativeHypotheses` doesn't persist the 6-bool checklist; `editionQueries.ts::deriveHypothesisChecklist` derives it deterministically from `supportingEvidenceCount`, `contradictingEvidenceCount`, `falsificationCriteria`, `measurementApproach`, `reviewedBy`, `confidence`. Each boolean has an observable trigger. When the schema adds a real checklist field, swap derivation for the stored value.
2. **Public visibility** — `getActiveHypotheses` filters to threads with `isPublic === true` so the public query never leaks private narrative work. Authenticated callers should keep using the existing per-thread query.
3. **Operations 3-col grid** — kept alive inside a `<details>` accordion in §4 (spec §8 — "operations grid collapses into a `<details>` accordion, NOT a separate `/operations` route"). The 3 columns each truncate to 3 rows in the editorial path; the legacy path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)