### PR TITLE
Phase 7b + 7c: editorial home — scroll-spy + footnotes + share + visibility affordance

### DIFF
--- a/docs/architecture/HOME_EDITORIAL_REDESIGN.md
+++ b/docs/architecture/HOME_EDITORIAL_REDESIGN.md
@@ -232,3 +232,151 @@ User directive: *"do no need new route, build revamp ontop of existing redeisgn"
 ---
 
 **Next action**: open PR #279 implementing Phase 7a — editorial render of `HomeSurface.tsx` behind `?edition=1` flag, binding §1-§5 to the existing Convex queries per §5.
+
+---
+
+## 9. Phase 7a — shipped
+
+- **Status**: ✅ shipped 2026-05-08 in PR #280, commit `8cb0c19a` on `main`.
+- **Live**: https://www.nodebenchai.com/redesign?edition=1
+- **Outcome**: All §5 sections render against live Convex queries. The
+  legacy home is preserved when the flag is absent. Single-column,
+  720px max, mobile-parity-by-construction (Variant C).
+
+### Phase 7a follow-ups (Bug 0a + Bug 0b — fixed 2026-05-08)
+
+The first live render exposed two editorial-rhythm bugs that weren't
+caught by the structural smoke. Both fixed in this rev:
+
+**Bug 0a — non-consecutive section numbers.** Sections were labeled
+statically `01..06`. When `competing-explanations` honestly hid (no
+active hypotheses), the visible sequence read `01, 03, 04, 05, 06` —
+the eye stuttered on the gap. Root cause: section numbers should be
+DYNAMIC, derived from each section's index in the visible list.
+
+Fix: `EditorialHomeSurface.tsx` now builds a `visibleSections`
+array, computes `numberForId` once per render, and passes the
+zero-padded number to `<EditorialSection number=... kicker=... />`.
+The numbers always read 01 → 02 → 03 → ... regardless of which
+conditional sections are present. Verified by E2E **Scenario D**.
+
+**Bug 0b — kicker drift between sessions.** Some sections rendered
+the eyebrow as `01 · {dateString}` (e.g. `01 · 2026-05-08`) instead
+of a labeled subtitle like `01 · TODAY'S EDITION`. Root cause:
+date strings are session-coupled and break the editorial voice.
+
+Fix: `EditorialSection` now takes `number` and `kicker` as separate
+props. The kicker is a STABLE label (`Today's edition`, `Hypotheses
+under test`, etc.); the date appears once in the FormatStrip
+(`Today's edition · {dateString}`) where it belongs. The eyebrow
+rendering is `{number} · {kicker}` for every section. Each section
+also exposes `data-section-number` and `data-section-kicker` so e2e
+can verify the contract.
+
+---
+
+## 10. Phase 7b — implementation notes
+
+Shipped together with Phase 7c in PR #281 (this rev).
+
+### Footnote anchors
+
+Each `<sup data-footnote>` superscript renders an `<a href="#fn-N">`
+that targets a `<li id="fn-N" tabindex="-1">` in §6 Footnotes. The
+`tabindex="-1"` lets screen readers focus the footnote target on
+anchor click without making it a tab-order interruption.
+
+Footnote IDs are computed contiguously across the artifact list and
+the industry-update fallback list, so the user sees `fn-1, fn-2, ...`
+even when the data sources mix.
+
+### Scroll-spy + table of contents
+
+- **Hook**: `src/features/redesign/hooks/useScrollSpy.ts`. Watches
+  `[data-section]` elements, picks the one with the highest
+  intersection ratio (NOT the first to cross threshold — that
+  thrashes mid-scroll). `rootMargin: "-20% 0px -55% 0px"` biases
+  toward the upper-third of the viewport, mirroring ai-2027.com.
+- **Component**: `src/features/redesign/components/edition/EditionTOC.tsx`.
+  Position is `fixed` at the right edge so the rail never displaces
+  the 720px center column. Rendered only when
+  `(min-width: 1024px)` matches; mobile is intentionally
+  single-column with no rail.
+- **Source list**: derived from the same `visibleSections` array the
+  surface uses — no hard-coded duplication.
+- **Reduced motion**: smooth-scroll → instant snap when
+  `(prefers-reduced-motion: reduce)`.
+
+Verified by E2E **Scenario F** (desktop has TOC, mobile doesn't).
+
+---
+
+## 11. Phase 7c — implementation notes
+
+### Format strip
+
+`src/features/redesign/components/edition/FormatStrip.tsx` renders
+beneath the §1 header (not the global page header) reading:
+
+```
+Today's edition · {dateString} · PDF · Copy share-link
+```
+
+- **PDF**: opens `/redesign/edition/print?id={editionId}` in a new
+  tab. The print page is a stripped-down render of the editorial
+  layout backed by the same Convex queries; on data-load it
+  auto-triggers `window.print()` so the user lands directly in the
+  print dialog. Approach chosen per spec §7c "do NOT introduce new
+  heavy dependencies" — no puppeteer, no server-side renderer, no
+  PDFKit. The browser's print engine produces the artifact.
+- **Copy share-link**: writes
+  `https://www.nodebenchai.com/redesign?edition=1&share={editionId}`
+  via `navigator.clipboard.writeText`. On success → `Copied!`
+  toast; on failure → warning toast surfacing the URL so the user
+  can copy manually (HONEST_STATUS — never claim success when the
+  clipboard API is unavailable).
+- **Listen + watch**: deferred to Phase 8 per spec §6 — no stubs
+  rendered, per `agentic_reliability.md` "don't render disabled
+  placeholders that imply functionality which doesn't exist".
+
+`editionId` resolves to the daily-brief snapshot `_id` when
+present, falling back to `dateKey` so the URL is always stable.
+Verified by E2E **Scenario G**.
+
+### Discoverability affordance
+
+Phase 7d will promote `?edition=1` to default at `/redesign` after
+dogfood. Until then, both directions are one click:
+
+- **Legacy → editorial**: `<a data-edition-discover href="?edition=1">`
+  in `LegacyHomeSurface`'s pulse-hero header. Quiet anchor with
+  terracotta accent, no banner.
+- **Editorial → legacy**: `<button data-edition-switch>` in the
+  editorial header. Removes `edition` from the URLSearchParams and
+  navigates with `replace: true` so the back button doesn't
+  re-enter the loop.
+
+Both have `aria-label`, focus rings via the existing
+`a:focus-visible` rule, and respect `prefers-reduced-motion`.
+Verified by E2E **Scenario C**.
+
+### Print page route
+
+`src/features/redesign/pages/EditionPrintPage.tsx` is wired in
+`src/App.tsx` BEFORE the general `/redesign/*` match so it renders
+without the surrounding shell chrome (no rail, no toast viewport,
+no body-overflow lock). The print stylesheet
+`edition-print.css` strips interactive chrome and adds
+`page-break-inside: avoid` to each section.
+
+---
+
+## 12. Verification evidence (Phase 7b + 7c)
+
+- `npx convex codegen` — clean
+- `npx tsc --noEmit --pretty false` — 0 errors
+- `npx vite build` — clean
+- `BASE_URL=http://127.0.0.1:4173 npx playwright test tests/e2e/edition-home.spec.ts` —
+  **7/7 passing** (Scenarios A, B, C, D, E, F, G)
+- `BASE_URL=http://127.0.0.1:4173 npx playwright test tests/e2e/live-smoke.spec.ts` —
+  **9/9 passing** (no regression on Tier B)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,11 @@ import { WorkspaceModeToggle } from "@/features/financialOperator/components/Wor
 import { WorkspaceModePane } from "@/features/financialOperator/components/WorkspaceModePane";
 
 const RedesignShell = lazy(() => import("@/features/redesign/RedesignShell"));
+const EditionPrintPage = lazy(() =>
+  import("@/features/redesign/pages/EditionPrintPage").then((m) => ({
+    default: m.EditionPrintPage,
+  })),
+);
 const ShareableMemoView = lazy(() => import("@/features/founder/views/ShareableMemoView"));
 const PublicEntityShareView = lazy(() => import("@/features/share/views/PublicEntityShareView"));
 const PublicCompanyProfileView = lazy(() => import("@/features/founder/views/PublicCompanyProfileView"));
@@ -193,6 +198,25 @@ function App() {
     rootParams.delete("surface");
     const nextSearch = rootParams.toString();
     return <Navigate to={`/redesign${nextSearch ? `?${nextSearch}` : ""}`} replace />;
+  }
+
+  // Phase 7c — print-friendly edition route at /redesign/edition/print.
+  // MUST be checked before the general /redesign/* match below so the
+  // page renders without the surrounding shell chrome (no rail, no
+  // toast viewport, no body-overflow lock).
+  const isEditionPrintRoute = location.pathname === "/redesign/edition/print";
+  if (isEditionPrintRoute) {
+    return (
+      <ThemeProvider>
+        <ErrorBoundary title="Something went wrong">
+          <Suspense fallback={<ViewSkeleton />}>
+            <div key="edition-print" className="route-fade-in">
+              <EditionPrintPage />
+            </div>
+          </Suspense>
+        </ErrorBoundary>
+      </ThemeProvider>
+    );
   }
 
   // Standalone route: /redesign* showcases the parity-studio + open-design redesign.

--- a/src/features/redesign/components/edition/EditionTOC.tsx
+++ b/src/features/redesign/components/edition/EditionTOC.tsx
@@ -1,0 +1,125 @@
+/**
+ * EditionTOC — desktop-only sticky table-of-contents rail for the
+ * editorial home (Phase 7b).  Shown to the right of the 720px center
+ * column on viewports >= 1024px; hidden entirely on mobile so the
+ * single-column reading flow is preserved.
+ *
+ * Behavior:
+ *   - Lists every visible section in document order.
+ *   - The currently-in-view section gets `aria-current="true"` and
+ *     the terracotta active style (per `.claude/rules/reexamine_a11y.md`).
+ *   - Click → smooth-scroll to the target section.  Honors
+ *     `prefers-reduced-motion` (instant snap when reduce is set).
+ *   - Position is `fixed` at the right edge of the viewport so it
+ *     never displaces the center column.
+ *
+ * Source spec: docs/architecture/HOME_EDITORIAL_REDESIGN.md Phase 7b
+ * Rules: reexamine_a11y, reexamine_keyboard (Tab/Enter activation),
+ *        agentic_reliability (BOUND — sections list is bounded).
+ */
+
+import { useEffect, useState } from "react";
+import { useScrollSpy } from "../../hooks/useScrollSpy";
+
+export interface EditionTOCEntry {
+  id: string;
+  /** Two-digit number ("01"). */
+  number: string;
+  /** Short label for the rail (e.g. "Pulse", "Forecasts"). */
+  label: string;
+}
+
+interface Props {
+  entries: ReadonlyArray<EditionTOCEntry>;
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+}
+
+export function EditionTOC({ entries }: Props) {
+  // Watch viewport — only render at >= 1024px.  We mount the
+  // observer hook unconditionally so React's hook order stays
+  // stable; the rail JSX itself is gated on the `isDesktop` flag.
+  const ids = entries.map((e) => e.id);
+  const active = useScrollSpy(ids);
+
+  const [isDesktop, setIsDesktop] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.matchMedia("(min-width: 1024px)").matches;
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const onChange = () => setIsDesktop(mq.matches);
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, []);
+
+  if (!isDesktop || entries.length === 0) return null;
+
+  return (
+    <nav
+      className="rd-edition-toc"
+      aria-label="Edition contents"
+      role="navigation"
+      data-edition-toc
+    >
+      <p className="rd-edition-toc__eyebrow" aria-hidden="true">
+        Contents
+      </p>
+      <ol className="rd-edition-toc__list">
+        {entries.map((e) => {
+          const isActive = active === e.id;
+          return (
+            <li key={e.id} className="rd-edition-toc__item">
+              <a
+                href={`#section-${e.id}`}
+                className={
+                  isActive
+                    ? "rd-edition-toc__link rd-edition-toc__link--active"
+                    : "rd-edition-toc__link"
+                }
+                aria-current={isActive ? "true" : undefined}
+                aria-label={`Jump to section ${e.number}: ${e.label}`}
+                data-toc-id={e.id}
+                onClick={(ev) => {
+                  ev.preventDefault();
+                  const target = document.querySelector<HTMLElement>(
+                    `[data-section="${CSS.escape(e.id)}"]`,
+                  );
+                  if (!target) return;
+                  const reduce = prefersReducedMotion();
+                  target.scrollIntoView({
+                    behavior: reduce ? "auto" : "smooth",
+                    block: "start",
+                  });
+                  // Move focus to the section header for screen
+                  // readers; section element gets a tabindex when
+                  // focused programmatically.
+                  target.setAttribute("tabindex", "-1");
+                  target.focus({ preventScroll: true });
+                }}
+              >
+                <span className="rd-edition-toc__num" aria-hidden="true">
+                  {e.number}
+                </span>
+                <span className="rd-edition-toc__label">{e.label}</span>
+              </a>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/features/redesign/components/edition/EditorialSection.tsx
+++ b/src/features/redesign/components/edition/EditorialSection.tsx
@@ -2,6 +2,23 @@
  * EditorialSection — wraps a chapter with a `data-section` testid,
  * an eyebrow + H2, and a hairline rule.  Each section is a landmark
  * region for screen readers (per `.claude/rules/reexamine_a11y.md`).
+ *
+ * The section number (01, 02, ...) is DYNAMIC — passed in by the
+ * parent surface based on which sections are visible in the current
+ * render.  This ensures readers see consecutive 01 → 02 → 03 even
+ * when conditional sections (e.g. competing-explanations) hide.
+ *
+ * The kicker is split into:
+ *   - `number`  — formatted "01" / "02" (computed by parent)
+ *   - `kicker`  — STABLE labeled subtitle ("Today's edition" /
+ *                 "Hypotheses under test").  Never use a raw date
+ *                 here — date strings drift between sessions and
+ *                 break the editorial rhythm.
+ *
+ * Both are rendered as `{number} · {kicker}` so existing eyebrow
+ * styles still apply.  The full eyebrow text is also persisted as a
+ * `data-eyebrow` attribute on the section root for e2e assertions
+ * (Scenario D verifies consecutive numbering).
  */
 
 import type { ReactNode } from "react";
@@ -11,8 +28,10 @@ interface Props {
   id: string;
   /** Plain-language ARIA label for the region. */
   ariaLabel: string;
-  /** Small uppercase eyebrow above the H2 ("01 · today" etc). */
-  eyebrow: string;
+  /** Two-digit zero-padded section number ("01", "02", ...). */
+  number: string;
+  /** Stable labeled subtitle — NEVER a raw date string. */
+  kicker: string;
   /** Section heading. */
   heading: string;
   children: ReactNode;
@@ -21,16 +40,21 @@ interface Props {
 export function EditorialSection({
   id,
   ariaLabel,
-  eyebrow,
+  number,
+  kicker,
   heading,
   children,
 }: Props) {
+  const eyebrow = `${number} · ${kicker}`;
   return (
     <section
       role="region"
       aria-label={ariaLabel}
       className="rd-edition-section"
       data-section={id}
+      data-section-number={number}
+      data-section-kicker={kicker}
+      data-eyebrow={eyebrow}
     >
       <header style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <p className="rd-edition-section__eyebrow">{eyebrow}</p>

--- a/src/features/redesign/components/edition/FormatStrip.tsx
+++ b/src/features/redesign/components/edition/FormatStrip.tsx
@@ -1,0 +1,127 @@
+/**
+ * FormatStrip — Phase 7c.  Renders a compact strip beneath the §1
+ * header reading:
+ *
+ *   Today's edition · {dateString} · PDF · Copy share-link
+ *
+ * Buttons are quiet anchors with monospace caption styling, focus
+ * rings, and aria-labels — never icon-only.  The PDF action navigates
+ * to a print-friendly route at `/redesign/edition/print?id=...` so
+ * the user's browser print dialog renders the PDF (no heavy server
+ * dependency per spec §7c "do NOT introduce new heavy dependencies").
+ *
+ * The "Copy share-link" action writes
+ * `https://www.nodebenchai.com/redesign?edition=1&share={editionId}`
+ * to the system clipboard via `navigator.clipboard.writeText` and
+ * shows a transient `Copied!` toast (per `Toast.tsx`'s contract).
+ *
+ * "Listen" + "watch" are deferred to Phase 8 per spec §6 — no
+ * stubs (per `agentic_reliability.md` HONEST_STATUS: don't render
+ * disabled placeholders that imply functionality which doesn't exist).
+ *
+ * Source spec: docs/architecture/HOME_EDITORIAL_REDESIGN.md Phase 7c
+ * Rules: reexamine_a11y, agentic_reliability.
+ */
+
+import { showToast } from "../Toast";
+
+interface Props {
+  /** ISO-ish date string for the current edition (YYYY-MM-DD). */
+  dateString: string;
+  /** Stable identifier the share URL embeds. */
+  editionId: string;
+}
+
+const SHARE_BASE_URL = "https://www.nodebenchai.com/redesign";
+
+function buildShareUrl(editionId: string): string {
+  return `${SHARE_BASE_URL}?edition=1&share=${encodeURIComponent(editionId)}`;
+}
+
+function buildPrintUrl(editionId: string): string {
+  // Same-origin print route — keeps the user's auth state for any
+  // gated content and avoids opening a new tab to a public URL.
+  return `/redesign/edition/print?id=${encodeURIComponent(editionId)}`;
+}
+
+export function FormatStrip({ dateString, editionId }: Props) {
+  const onCopyShare = async () => {
+    const url = buildShareUrl(editionId);
+    let copied = false;
+    try {
+      if (
+        typeof navigator !== "undefined" &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === "function"
+      ) {
+        await navigator.clipboard.writeText(url);
+        copied = true;
+      }
+    } catch {
+      copied = false;
+    }
+    if (copied) {
+      showToast({
+        tone: "success",
+        message: "Copied! Share link in clipboard.",
+        durationMs: 2500,
+      });
+    } else {
+      // HONEST_STATUS — don't claim success when the clipboard API
+      // failed.  Surface the URL so the user can copy manually.
+      showToast({
+        tone: "warning",
+        message: `Clipboard unavailable. Link: ${url}`,
+        durationMs: 6000,
+      });
+    }
+  };
+
+  const onPrintPdf = () => {
+    if (typeof window === "undefined") return;
+    // Open in a new tab so the print prompt doesn't disrupt the
+    // user's reading position; the print route is a same-origin
+    // route so cookies travel.
+    window.open(buildPrintUrl(editionId), "_blank", "noopener");
+  };
+
+  return (
+    <div
+      className="rd-edition-format-strip"
+      data-format-strip
+      role="group"
+      aria-label="Edition format options"
+    >
+      <span
+        className="rd-edition-format-strip__caption"
+        data-format-strip-caption
+      >
+        Today's edition · {dateString}
+      </span>
+      <span aria-hidden="true" className="rd-edition-format-strip__sep">
+        ·
+      </span>
+      <button
+        type="button"
+        className="rd-edition-format-strip__btn"
+        aria-label="Open print-friendly edition (PDF)"
+        data-format-pdf
+        onClick={onPrintPdf}
+      >
+        PDF
+      </button>
+      <span aria-hidden="true" className="rd-edition-format-strip__sep">
+        ·
+      </span>
+      <button
+        type="button"
+        className="rd-edition-format-strip__btn"
+        aria-label="Copy share link to clipboard"
+        data-format-share
+        onClick={onCopyShare}
+      >
+        Copy share-link
+      </button>
+    </div>
+  );
+}

--- a/src/features/redesign/components/edition/edition-print.css
+++ b/src/features/redesign/components/edition/edition-print.css
@@ -1,0 +1,63 @@
+/**
+ * Edition print stylesheet — Phase 7c.
+ *
+ * Used by `EditionPrintPage` (route: /redesign/edition/print) to
+ * generate a clean PDF via the browser's print dialog.  No new
+ * dependencies — just media-print rules that strip chrome and let
+ * the same editorial markup render as a long-form document.
+ */
+
+[data-redesign][data-edition-print] {
+  background: #ffffff;
+  color: #15140f;
+}
+
+[data-redesign][data-edition-print] .rd-edition-root--print {
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 32px 32px 64px;
+  background: #ffffff;
+}
+
+[data-redesign][data-edition-print] .rd-edition-print-header {
+  margin-bottom: 28px;
+  border-bottom: 1px solid rgba(21, 20, 15, 0.18);
+  padding-bottom: 16px;
+}
+
+[data-redesign][data-edition-print] .rd-edition-print-title {
+  font-size: 30px;
+  font-weight: 700;
+  color: #15140f;
+  margin: 6px 0 0 0;
+  letter-spacing: -0.5px;
+}
+
+@media print {
+  [data-redesign][data-edition-print] {
+    background: white !important;
+    color: black !important;
+  }
+  [data-redesign][data-edition-print] .rd-edition-root--print {
+    padding: 0 !important;
+    max-width: 100% !important;
+  }
+  [data-redesign][data-edition-print] .rd-edition-section {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  [data-redesign][data-edition-print] .rd-edition-skeleton {
+    display: none !important;
+  }
+  /* Skip the auto-print toolbar and any links — make every link a
+     plain underline so the printed page reads as prose. */
+  [data-redesign][data-edition-print] a {
+    color: black !important;
+    text-decoration: underline !important;
+  }
+  /* Drop the dotted underlines on footnotes for cleaner print. */
+  [data-redesign][data-edition-print] .rd-edition-footnotes a {
+    border-bottom: none !important;
+  }
+}

--- a/src/features/redesign/components/edition/edition.css
+++ b/src/features/redesign/components/edition/edition.css
@@ -479,3 +479,152 @@
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+/* ─── Phase 7b: Edition TOC (right-rail scroll-spy) ─────────────── */
+/* Hidden on mobile (single column rules); shown on >=1024px as a
+   fixed rail that doesn't displace the 720px center column.        */
+[data-redesign] [data-edition] .rd-edition-toc {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  [data-redesign] [data-edition] .rd-edition-toc {
+    display: block;
+    position: fixed;
+    top: 96px;
+    right: 24px;
+    width: 180px;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+    border-left: 1px solid var(--rd-edition-rule);
+    padding: 8px 0 8px 16px;
+    z-index: 5;
+    /* The center column is centered by `margin: 0 auto` on .rd-edition-root
+       so this fixed rail sits independently. */
+  }
+}
+
+@media (min-width: 1280px) {
+  [data-redesign] [data-edition] .rd-edition-toc {
+    /* On wide viewports, push the rail farther from the column. */
+    right: max(24px, calc((100vw - 720px) / 2 - 240px));
+  }
+}
+
+[data-redesign] [data-edition] .rd-edition-toc__eyebrow {
+  font-size: 10px;
+  font-family: ui-monospace, "JetBrains Mono", "Roboto Mono", monospace;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--rd-ink-soft);
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+
+[data-redesign] [data-edition] .rd-edition-toc__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+[data-redesign] [data-edition] .rd-edition-toc__item {
+  margin: 0;
+  padding: 0;
+}
+
+[data-redesign] [data-edition] .rd-edition-toc__link {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  text-decoration: none;
+  padding: 4px 0;
+  font-family: ui-monospace, "JetBrains Mono", "Roboto Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--rd-ink-soft);
+  border-radius: 3px;
+  transition: color 120ms ease;
+}
+
+[data-redesign] [data-edition] .rd-edition-toc__link:hover {
+  color: var(--rd-ink-strong);
+}
+
+[data-redesign] [data-edition] .rd-edition-toc__link--active {
+  color: var(--rd-accent-strong, #d97757);
+  font-weight: 700;
+}
+
+[data-redesign] [data-edition] .rd-edition-toc__num {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: inherit;
+  min-width: 22px;
+  display: inline-block;
+}
+
+[data-redesign] [data-edition] .rd-edition-toc__label {
+  text-transform: uppercase;
+  font-size: 10.5px;
+  letter-spacing: 0.10em;
+  font-weight: 600;
+}
+
+/* ─── Phase 7c: Format strip ───────────────────────────────────── */
+[data-redesign] [data-edition] .rd-edition-format-strip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 8px 0 12px;
+  border-bottom: 1px solid var(--rd-edition-rule);
+  margin-bottom: 4px;
+  font-family: ui-monospace, "JetBrains Mono", "Roboto Mono", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+}
+
+[data-redesign] [data-edition] .rd-edition-format-strip__caption {
+  color: var(--rd-ink-soft);
+  font-weight: 500;
+}
+
+[data-redesign] [data-edition] .rd-edition-format-strip__sep {
+  color: var(--rd-ink-soft);
+  opacity: 0.6;
+}
+
+[data-redesign] [data-edition] .rd-edition-format-strip__btn {
+  background: transparent;
+  border: none;
+  color: var(--rd-accent-strong, #d97757);
+  font-family: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 3px;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+[data-redesign] [data-edition] .rd-edition-format-strip__btn:hover {
+  color: var(--rd-accent-strong, #d97757);
+  text-decoration-thickness: 2px;
+}
+
+/* ─── Phase 7c: Switch to classic link in editorial header ─────── */
+[data-redesign] [data-edition] .rd-edition-switch:hover {
+  color: var(--rd-ink-strong);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-redesign] [data-edition] .rd-edition-toc__link {
+    transition: none;
+  }
+}

--- a/src/features/redesign/hooks/useScrollSpy.ts
+++ b/src/features/redesign/hooks/useScrollSpy.ts
@@ -1,0 +1,94 @@
+/**
+ * useScrollSpy — observes a list of section IDs (matched against
+ * `[data-section="..."]` in the DOM) and returns the id that is
+ * currently most-visible in the viewport.  Used by `EditionTOC` to
+ * highlight the active chapter as the user scrolls.
+ *
+ * Implementation notes:
+ *   - Uses IntersectionObserver with a `rootMargin` that biases the
+ *     active section to the one whose top is near the upper third of
+ *     the viewport — same pattern as ai-2027.com's scroll-spy.
+ *   - Re-binds when `ids` changes (sections can mount/unmount based
+ *     on data presence, so the watch list isn't static).
+ *   - SSR safe — returns the first id immediately when window is
+ *     undefined.  Hydration replaces with the live observer state.
+ *   - Honors `prefers-reduced-motion`: the observer still runs, but
+ *     callers should snap-scroll instead of smooth-scrolling.
+ *
+ * Source spec: docs/architecture/HOME_EDITORIAL_REDESIGN.md Phase 7b
+ * Rules: .claude/rules/reexamine_a11y.md (reduced motion),
+ *        .claude/rules/agentic_reliability.md (BOUND — observer
+ *        targets are bounded by `ids.length`).
+ */
+
+import { useEffect, useState } from "react";
+
+export function useScrollSpy(ids: ReadonlyArray<string>): string | null {
+  const [active, setActive] = useState<string | null>(
+    ids.length > 0 ? ids[0] : null,
+  );
+
+  useEffect(() => {
+    if (ids.length === 0) {
+      setActive(null);
+      return;
+    }
+    if (typeof window === "undefined" || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    // Track every observed section's intersection ratio so we can
+    // pick the most-visible one (instead of "first to cross
+    // threshold" which thrashes mid-scroll).
+    const ratios = new Map<string, number>();
+    for (const id of ids) ratios.set(id, 0);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = (entry.target as HTMLElement).dataset.section;
+          if (!id) continue;
+          ratios.set(id, entry.isIntersecting ? entry.intersectionRatio : 0);
+        }
+        // Pick the highest-ratio id; tie-broken by document order
+        // (which `ids` already preserves).
+        let bestId: string | null = null;
+        let bestRatio = -1;
+        for (const id of ids) {
+          const r = ratios.get(id) ?? 0;
+          if (r > bestRatio) {
+            bestRatio = r;
+            bestId = id;
+          }
+        }
+        // Only update when we actually have a section in view; if
+        // the user scrolls above the first section, keep the
+        // previous active id.
+        if (bestRatio > 0 && bestId) {
+          setActive(bestId);
+        }
+      },
+      {
+        // Bias toward the upper-third of the viewport — mirrors
+        // ai-2027's scroll-spy where the rail highlights the
+        // section the eye is reading, not the one bottom-flushed.
+        rootMargin: "-20% 0px -55% 0px",
+        threshold: [0, 0.25, 0.5, 0.75, 1],
+      },
+    );
+
+    const targets: HTMLElement[] = [];
+    for (const id of ids) {
+      const el = document.querySelector<HTMLElement>(
+        `[data-section="${CSS.escape(id)}"]`,
+      );
+      if (el) {
+        observer.observe(el);
+        targets.push(el);
+      }
+    }
+    return () => observer.disconnect();
+  }, [ids]);
+
+  return active;
+}

--- a/src/features/redesign/pages/EditionPrintPage.tsx
+++ b/src/features/redesign/pages/EditionPrintPage.tsx
@@ -1,0 +1,331 @@
+/**
+ * EditionPrintPage — Phase 7c print-friendly route at
+ * `/redesign/edition/print?id=<editionId>`.
+ *
+ * Per the design doc Phase 7c "do NOT introduce new heavy
+ * dependencies" — this is a stripped-down render of the same
+ * editorial sections as the live home, but in a layout optimized for
+ * `window.print()`.  The user clicks "PDF" in the FormatStrip, the
+ * route opens in a new tab, the print dialog renders the edition.
+ *
+ * What's stripped:
+ *   - The interactive composer + scroll-spy TOC
+ *   - The "Switch to classic" link
+ *   - All hover/focus chrome
+ *   - Skeletons (we wait for data; if empty, render the empty state
+ *     plainly)
+ *
+ * What's kept:
+ *   - Section numbering (consecutive 01-N)
+ *   - Footnote anchors (sup superscripts → fn-N targets)
+ *   - The format strip caption (date + edition id) at the top so the
+ *     PDF reader knows when it was generated
+ *
+ * Source spec: docs/architecture/HOME_EDITORIAL_REDESIGN.md Phase 7c
+ * Rules: agentic_reliability (HONEST_STATUS — empty state is honest),
+ *        reexamine_a11y (semantic landmarks preserved).
+ */
+
+import { useEffect, useMemo } from "react";
+import { useLocation } from "react-router-dom";
+import { EditionErrorBoundary } from "../components/edition/EditionErrorBoundary";
+import { Footnote } from "../components/edition/Footnote";
+import { Scoreboard } from "../components/edition/Scoreboard";
+import { CapabilitiesMap } from "../components/edition/CapabilitiesMap";
+import { EvidenceChecklistStrip } from "../components/edition/EvidenceChecklistStrip";
+import { useTodayPulse } from "../hooks/useTodayPulse";
+import { useActiveHypotheses } from "../hooks/useActiveHypotheses";
+import { useTopForecasts } from "../hooks/useTopForecasts";
+import { useLatestDailyBriefSnapshot } from "../hooks/useLatestDailyBriefSnapshot";
+import { useEditionFootnotes } from "../hooks/useEditionFootnotes";
+import "../components/edition/edition.css";
+import "../components/edition/edition-print.css";
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+function formatProbability(p: number | null): string {
+  if (p === null || p === undefined || !Number.isFinite(p)) return "—";
+  return `${Math.round(p * 100)}%`;
+}
+
+export function EditionPrintPage() {
+  const location = useLocation();
+  const editionId = useMemo(() => {
+    return new URLSearchParams(location.search).get("id") ?? "current";
+  }, [location.search]);
+
+  const todayPulse = useTodayPulse(12);
+  const hypotheses = useActiveHypotheses(5);
+  const forecasts = useTopForecasts(5);
+  const snapshot = useLatestDailyBriefSnapshot();
+
+  const artifactIds = useMemo(() => {
+    const ids: string[] = [];
+    if (Array.isArray(hypotheses)) {
+      for (const h of hypotheses) {
+        for (const id of h.evidenceArtifactIds ?? []) ids.push(id);
+      }
+    }
+    return ids;
+  }, [hypotheses]);
+
+  const footnoteData = useEditionFootnotes(artifactIds, 8, 24);
+
+  // Once all data has loaded, automatically trigger the print dialog
+  // so the PDF tab "just works" without an extra click — but only on
+  // first mount, not on every state update.
+  const allLoaded =
+    todayPulse !== undefined &&
+    hypotheses !== undefined &&
+    forecasts !== undefined &&
+    snapshot !== undefined &&
+    footnoteData !== undefined;
+
+  useEffect(() => {
+    if (!allLoaded) return;
+    if (typeof window === "undefined") return;
+    // Tiny delay so the browser paints first.
+    const t = window.setTimeout(() => {
+      try {
+        window.print();
+      } catch {
+        // ignore — user can still trigger via menu
+      }
+    }, 600);
+    return () => window.clearTimeout(t);
+  }, [allLoaded]);
+
+  // Build the visible section list (mirror the surface logic).
+  const visibleSections: Array<{ id: string; kicker: string; heading: string }> = [];
+  visibleSections.push({
+    id: "what-moved",
+    kicker: "Today's edition",
+    heading: "What moved today",
+  });
+  if (Array.isArray(hypotheses) && hypotheses.length > 0) {
+    visibleSections.push({
+      id: "competing-explanations",
+      kicker: "Hypotheses under test",
+      heading: "The competing explanations",
+    });
+  }
+  visibleSections.push({
+    id: "what-to-look-at",
+    kicker: "Forecasts in motion",
+    heading: "What to look at this week",
+  });
+  visibleSections.push({
+    id: "scoreboard",
+    kicker: "Scoreboard",
+    heading: "Today's scoreboard",
+  });
+  visibleSections.push({
+    id: "capabilities",
+    kicker: "The capability landscape",
+    heading: "Capabilities map",
+  });
+  visibleSections.push({
+    id: "footnotes",
+    kicker: "Sources",
+    heading: "Footnotes",
+  });
+
+  const dateString =
+    snapshot?.dateString ??
+    (todayPulse ? todayPulse.dateKey : new Date().toISOString().slice(0, 10));
+
+  const numberFor = (idx: number) => pad2(idx + 1);
+
+  return (
+    <div data-redesign data-edition data-edition-print>
+      <div className="rd-edition-root rd-edition-root--print">
+        <header className="rd-edition-print-header">
+          <p className="rd-edition-meta" aria-label="Edition metadata">
+            Today's edition · {dateString} · id:{editionId}
+          </p>
+          <h1 className="rd-edition-print-title">Today's intelligence brief</h1>
+        </header>
+
+        <EditionErrorBoundary label="print-what-moved">
+          <section
+            role="region"
+            aria-label="What moved today"
+            className="rd-edition-section"
+            data-section="what-moved"
+            data-section-number={numberFor(visibleSections.findIndex((s) => s.id === "what-moved"))}
+            data-section-kicker="Today's edition"
+          >
+            <header>
+              <p className="rd-edition-section__eyebrow">
+                {numberFor(visibleSections.findIndex((s) => s.id === "what-moved"))} · Today's edition
+              </p>
+              <h2 className="rd-edition-section__h2">What moved today</h2>
+            </header>
+            {todayPulse?.pulses.length === 0 ? (
+              <p className="rd-edition-empty">No pulse generated yet today.</p>
+            ) : (
+              <div className="rd-edition-prose">
+                {(todayPulse?.pulses ?? []).map((p, i) => (
+                  <article key={p._id} style={{ marginBottom: 12 }}>
+                    <p>
+                      <strong style={{ textTransform: "capitalize" }}>
+                        {p.entitySlug.replace(/-/g, " ")}
+                      </strong>{" "}
+                      <span className="rd-edition-meta">
+                        · {p.changeCount} change{p.changeCount === 1 ? "" : "s"}
+                      </span>
+                      <Footnote id={`pulse-${i + 1}`} index={i + 1} />
+                    </p>
+                    {p.summaryMarkdown && (
+                      <p>{p.summaryMarkdown.split("\n\n")[0]?.replace(/^#+\s*/, "")}</p>
+                    )}
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+        </EditionErrorBoundary>
+
+        {Array.isArray(hypotheses) && hypotheses.length > 0 && (
+          <EditionErrorBoundary label="print-hypotheses">
+            <section
+              role="region"
+              aria-label="The competing explanations"
+              className="rd-edition-section"
+              data-section="competing-explanations"
+              data-section-number={numberFor(visibleSections.findIndex((s) => s.id === "competing-explanations"))}
+              data-section-kicker="Hypotheses under test"
+            >
+              <header>
+                <p className="rd-edition-section__eyebrow">
+                  {numberFor(visibleSections.findIndex((s) => s.id === "competing-explanations"))} · Hypotheses under test
+                </p>
+                <h2 className="rd-edition-section__h2">The competing explanations</h2>
+              </header>
+              {hypotheses.map((h) => (
+                <article key={h._id} className="rd-edition-hypothesis">
+                  <div className="rd-edition-hypothesis__head">
+                    <span className="rd-edition-hypothesis__label">{h.label}</span>
+                    <h3 className="rd-edition-hypothesis__title">{h.title}</h3>
+                  </div>
+                  <p className="rd-edition-hypothesis__claim">{h.claimForm}</p>
+                  <EvidenceChecklistStrip
+                    checklist={h.evidenceChecklist}
+                    passing={h.evidenceChecksPassing}
+                    total={h.evidenceChecksTotal}
+                    level={h.evidenceLevel}
+                  />
+                </article>
+              ))}
+            </section>
+          </EditionErrorBoundary>
+        )}
+
+        <EditionErrorBoundary label="print-forecasts">
+          <section
+            role="region"
+            aria-label="What to look at this week"
+            className="rd-edition-section"
+            data-section="what-to-look-at"
+            data-section-number={numberFor(visibleSections.findIndex((s) => s.id === "what-to-look-at"))}
+            data-section-kicker="Forecasts in motion"
+          >
+            <header>
+              <p className="rd-edition-section__eyebrow">
+                {numberFor(visibleSections.findIndex((s) => s.id === "what-to-look-at"))} · Forecasts in motion
+              </p>
+              <h2 className="rd-edition-section__h2">What to look at this week</h2>
+            </header>
+            {(forecasts ?? []).length === 0 ? (
+              <p className="rd-edition-empty">No active forecasts.</p>
+            ) : (
+              (forecasts ?? []).slice(0, 5).map((f) => (
+                <article key={f._id} className="rd-edition-forecast">
+                  <p className="rd-edition-forecast__claim">{f.question}</p>
+                  <span className="rd-edition-forecast__prob">
+                    {formatProbability(f.probability)}
+                  </span>
+                </article>
+              ))
+            )}
+          </section>
+        </EditionErrorBoundary>
+
+        <EditionErrorBoundary label="print-scoreboard">
+          <section
+            role="region"
+            aria-label="Today's scoreboard"
+            className="rd-edition-section"
+            data-section="scoreboard"
+            data-section-number={numberFor(visibleSections.findIndex((s) => s.id === "scoreboard"))}
+            data-section-kicker="Scoreboard"
+          >
+            <header>
+              <p className="rd-edition-section__eyebrow">
+                {numberFor(visibleSections.findIndex((s) => s.id === "scoreboard"))} · Scoreboard
+              </p>
+              <h2 className="rd-edition-section__h2">Today's scoreboard</h2>
+            </header>
+            <Scoreboard stats={snapshot?.dashboardMetrics?.keyStats ?? []} />
+          </section>
+        </EditionErrorBoundary>
+
+        <EditionErrorBoundary label="print-capabilities">
+          <section
+            role="region"
+            aria-label="Capabilities map"
+            className="rd-edition-section"
+            data-section="capabilities"
+            data-section-number={numberFor(visibleSections.findIndex((s) => s.id === "capabilities"))}
+            data-section-kicker="The capability landscape"
+          >
+            <header>
+              <p className="rd-edition-section__eyebrow">
+                {numberFor(visibleSections.findIndex((s) => s.id === "capabilities"))} · The capability landscape
+              </p>
+              <h2 className="rd-edition-section__h2">Capabilities map</h2>
+            </header>
+            <CapabilitiesMap
+              techReadiness={snapshot?.dashboardMetrics?.techReadiness ?? null}
+              capabilities={snapshot?.dashboardMetrics?.capabilities ?? null}
+            />
+          </section>
+        </EditionErrorBoundary>
+
+        {footnoteData && (footnoteData.artifacts.length > 0 || footnoteData.industry.length > 0) && (
+          <EditionErrorBoundary label="print-footnotes">
+            <section
+              role="region"
+              aria-label="Footnotes and sources"
+              className="rd-edition-section"
+              data-section="footnotes"
+              data-section-number={numberFor(visibleSections.findIndex((s) => s.id === "footnotes"))}
+              data-section-kicker="Sources"
+            >
+              <header>
+                <p className="rd-edition-section__eyebrow">
+                  {numberFor(visibleSections.findIndex((s) => s.id === "footnotes"))} · Sources
+                </p>
+                <h2 className="rd-edition-section__h2">Footnotes</h2>
+              </header>
+              <div className="rd-edition-footnotes">
+                <ol>
+                  {footnoteData.artifacts.map((a, i) => (
+                    <li key={a._id} id={`fn-${i + 1}`}>
+                      <span>
+                        {a.publisher || (() => { try { return new URL(a.url).hostname; } catch { return a.url; } })()}
+                        {a.firstQuote ? ` — "${a.firstQuote}"` : ""}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </section>
+          </EditionErrorBoundary>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/redesign/surfaces/EditorialHomeSurface.tsx
+++ b/src/features/redesign/surfaces/EditorialHomeSurface.tsx
@@ -10,13 +10,39 @@
  * Layout: ONE column, max 720px, no card chrome, hairline rules
  * between sections.  Mobile and desktop are identical (per Variant C
  * — "mobile parity by construction").
+ *
+ * ─── Phase 7a follow-ups (2026-05-08) ───────────────────────────
+ * Bug 0a — section numbers must be DYNAMIC.  Static "01..06" labels
+ * break consecutive reading when conditional sections (hypotheses)
+ * hide.  Fix: build a `visibleSections` array at the top, derive each
+ * section's number from its index in that list, pass it to
+ * `<EditorialSection number kicker ...>`.
+ *
+ * Bug 0b — kicker must be a STABLE labeled subtitle, never a raw
+ * date.  The date appears once in the FormatStrip (`Today's edition ·
+ * {dateString}`) and inline within sections that need it; the
+ * eyebrow is always `{N} · {label}`.
+ *
+ * ─── Phase 7b additions ─────────────────────────────────────────
+ * - Footnote `<sup>` anchors target `id="fn-{N}"` in §6, with
+ *   `tabindex="-1"` on each `<li>` so screen readers focus the
+ *   target.
+ * - Right-rail `<EditionTOC>` (desktop only, ≥1024px) with scroll-spy
+ *   active state.
+ *
+ * ─── Phase 7c additions ─────────────────────────────────────────
+ * - `<FormatStrip>` beneath §1 header — PDF + Copy share-link.
+ * - "Switch to classic" link in the header (reciprocal of the
+ *   discoverability link added to LegacyHomeSurface).
  */
 
 import { useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { UniversalComposer } from "../components/UniversalComposer";
 import { EditorialSection } from "../components/edition/EditorialSection";
 import { EditionErrorBoundary } from "../components/edition/EditionErrorBoundary";
+import { EditionTOC, type EditionTOCEntry } from "../components/edition/EditionTOC";
+import { FormatStrip } from "../components/edition/FormatStrip";
 import { Footnote } from "../components/edition/Footnote";
 import { Scoreboard } from "../components/edition/Scoreboard";
 import { CapabilitiesMap } from "../components/edition/CapabilitiesMap";
@@ -38,7 +64,11 @@ interface Props {
 
 const ABSENT = Symbol("absent");
 
-/* ─── helpers ───────────────────────────────────────────────────── */
+/* ─── Helpers ───────────────────────────────────────────────────── */
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
 
 function formatProbability(p: number | null): string {
   if (p === null || p === undefined || !Number.isFinite(p)) return "—";
@@ -61,38 +91,60 @@ function formatProbabilityDelta(
   };
 }
 
-/** Render markdown summary as serif paragraphs.  Phase 7a uses a
- * minimal renderer — strip headings, render leading bullet points
- * inline, preserve paragraph breaks.  Anything fancier waits for 7b. */
 function renderPulseMarkdown(md: string): string[] {
   return md
     .split(/\r?\n\r?\n/)
     .map((p) => p.trim())
     .filter(Boolean)
-    // Keep up to 4 paragraphs to stay editorial.
     .slice(0, 4);
+}
+
+/* ─── Section descriptors ──────────────────────────────────────── */
+
+interface SectionDescriptor {
+  id: string;
+  /** Stable label used in eyebrow + TOC.  NEVER a date. */
+  kicker: string;
+  /** Short TOC label (the rail uses this). */
+  tocLabel: string;
+  /** Section heading. */
+  heading: string;
 }
 
 /* ─── §1 — What moved today ─────────────────────────────────────── */
 
-function WhatMovedSection() {
-  const data = useTodayPulse(12);
-  if (data === undefined) {
+function WhatMovedSection({
+  number,
+  kicker,
+  heading,
+  dateString,
+  editionId,
+  pulses,
+}: {
+  number: string;
+  kicker: string;
+  heading: string;
+  dateString: string;
+  editionId: string;
+  pulses: ReturnType<typeof useTodayPulse>;
+}) {
+  if (pulses === undefined) {
     return (
       <EditorialSection
         id="what-moved"
         ariaLabel="What moved today"
-        eyebrow="01 · Today's edition"
-        heading="What moved today"
+        number={number}
+        kicker={kicker}
+        heading={heading}
       >
+        <FormatStrip dateString={dateString} editionId={editionId} />
         <div className="rd-edition-skeleton" style={{ width: "92%" }} />
         <div className="rd-edition-skeleton" style={{ width: "78%" }} />
         <div className="rd-edition-skeleton" style={{ width: "84%" }} />
       </EditorialSection>
     );
   }
-  const { pulses, dateKey, lastDateKey } = data;
-  const totalMaterial = pulses.reduce(
+  const totalMaterial = pulses.pulses.reduce(
     (n, p) => n + (p.materialChangeCount ?? 0),
     0,
   );
@@ -101,13 +153,15 @@ function WhatMovedSection() {
     <EditorialSection
       id="what-moved"
       ariaLabel="What moved today"
-      eyebrow={`01 · ${dateKey}`}
-      heading="What moved today"
+      number={number}
+      kicker={kicker}
+      heading={heading}
     >
-      {pulses.length === 0 ? (
+      <FormatStrip dateString={dateString} editionId={editionId} />
+      {pulses.pulses.length === 0 ? (
         <p className="rd-edition-empty">
           No pulse generated yet today.
-          {lastDateKey ? ` Last pulse: ${lastDateKey}.` : ""}
+          {pulses.lastDateKey ? ` Last pulse: ${pulses.lastDateKey}.` : ""}
         </p>
       ) : (
         <>
@@ -115,10 +169,10 @@ function WhatMovedSection() {
             <span className="rd-edition-delta" aria-label={`${totalMaterial} material changes`}>
               {totalMaterial} material change{totalMaterial === 1 ? "" : "s"}
             </span>{" "}
-            across {pulses.length} entit{pulses.length === 1 ? "y" : "ies"}
+            across {pulses.pulses.length} entit{pulses.pulses.length === 1 ? "y" : "ies"}
           </p>
           <div className="rd-edition-prose">
-            {pulses.map((p, i) => (
+            {pulses.pulses.map((p, i) => (
               <article
                 key={p._id}
                 data-pulse-entity={p.entitySlug}
@@ -134,7 +188,11 @@ function WhatMovedSection() {
                       ? `, ${p.materialChangeCount} material`
                       : ""}
                   </span>
-                  <Footnote id={`pulse-${i + 1}`} index={i + 1} label={`Pulse for ${p.entitySlug}`} />
+                  <Footnote
+                    id={`pulse-${i + 1}`}
+                    index={i + 1}
+                    label={`Pulse for ${p.entitySlug}`}
+                  />
                 </p>
                 {p.summaryMarkdown
                   ? renderPulseMarkdown(p.summaryMarkdown).map((para, j) => (
@@ -157,39 +215,26 @@ function WhatMovedSection() {
 /* ─── §2 — Competing explanations ───────────────────────────────── */
 
 function CompetingExplanationsSection({
+  number,
+  kicker,
+  heading,
   hypotheses,
 }: {
-  hypotheses: EditionHypothesis[] | undefined;
+  number: string;
+  kicker: string;
+  heading: string;
+  hypotheses: EditionHypothesis[];
 }) {
-  if (hypotheses === undefined) {
-    return (
-      <EditorialSection
-        id="competing-explanations"
-        ariaLabel="The competing explanations"
-        eyebrow="02 · Hypotheses under test"
-        heading="The competing explanations"
-      >
-        <div className="rd-edition-skeleton" style={{ width: "70%" }} />
-        <div className="rd-edition-skeleton" style={{ width: "92%" }} />
-        <div className="rd-edition-skeleton" style={{ width: "60%" }} />
-      </EditorialSection>
-    );
-  }
-
-  if (hypotheses.length === 0) {
-    // Spec §5: "Empty state: hide section. Don't fake hypotheses."
-    return null;
-  }
-
   return (
     <EditorialSection
       id="competing-explanations"
       ariaLabel="The competing explanations"
-      eyebrow="02 · Hypotheses under test"
-      heading="The competing explanations"
+      number={number}
+      kicker={kicker}
+      heading={heading}
     >
       <div>
-        {hypotheses.map((h) => (
+        {hypotheses.map((h, i) => (
           <article
             key={h._id}
             className="rd-edition-hypothesis"
@@ -198,7 +243,14 @@ function CompetingExplanationsSection({
           >
             <div className="rd-edition-hypothesis__head">
               <span className="rd-edition-hypothesis__label">{h.label}</span>
-              <h3 className="rd-edition-hypothesis__title">{h.title}</h3>
+              <h3 className="rd-edition-hypothesis__title">
+                {h.title}
+                <Footnote
+                  id={`hyp-${i + 1}`}
+                  index={i + 1}
+                  label={`Source for ${h.title}`}
+                />
+              </h3>
             </div>
             <p className="rd-edition-hypothesis__claim">{h.claimForm}</p>
             <EvidenceChecklistStrip
@@ -225,8 +277,14 @@ function CompetingExplanationsSection({
 /* ─── §3 — What to look at this week ────────────────────────────── */
 
 function WhatToLookAtSection({
+  number,
+  kicker,
+  heading,
   forecasts,
 }: {
+  number: string;
+  kicker: string;
+  heading: string;
   forecasts: EditionForecast[] | undefined;
 }) {
   const navigate = useNavigate();
@@ -235,8 +293,9 @@ function WhatToLookAtSection({
       <EditorialSection
         id="what-to-look-at"
         ariaLabel="What to look at this week"
-        eyebrow="03 · Forecasts in motion"
-        heading="What to look at this week"
+        number={number}
+        kicker={kicker}
+        heading={heading}
       >
         <div className="rd-edition-skeleton" style={{ width: "85%" }} />
         <div className="rd-edition-skeleton" style={{ width: "60%" }} />
@@ -249,8 +308,9 @@ function WhatToLookAtSection({
     <EditorialSection
       id="what-to-look-at"
       ariaLabel="What to look at this week"
-      eyebrow="03 · Forecasts in motion"
-      heading="What to look at this week"
+      number={number}
+      kicker={kicker}
+      heading={heading}
     >
       {forecasts.length === 0 ? (
         <p className="rd-edition-empty">
@@ -303,8 +363,17 @@ function WhatToLookAtSection({
 
 /* ─── §4 — Scoreboard + Operations accordion ────────────────────── */
 
-function ScoreboardSection() {
-  const snapshot = useLatestDailyBriefSnapshot();
+function ScoreboardSection({
+  number,
+  kicker,
+  heading,
+  snapshot,
+}: {
+  number: string;
+  kicker: string;
+  heading: string;
+  snapshot: ReturnType<typeof useLatestDailyBriefSnapshot>;
+}) {
   const { pulse: livePulseCards } = useHomePulseLive();
   const opsCards = livePulseCards.length > 0 ? livePulseCards : fixturePulseCards;
 
@@ -313,8 +382,9 @@ function ScoreboardSection() {
       <EditorialSection
         id="scoreboard"
         ariaLabel="Today's scoreboard"
-        eyebrow="04 · Scoreboard"
-        heading="Today's scoreboard"
+        number={number}
+        kicker={kicker}
+        heading={heading}
       >
         <div className="rd-edition-skeleton" style={{ width: "100%", height: 28 }} />
         <div className="rd-edition-skeleton" style={{ width: "92%", height: 28 }} />
@@ -329,8 +399,9 @@ function ScoreboardSection() {
     <EditorialSection
       id="scoreboard"
       ariaLabel="Today's scoreboard"
-      eyebrow={`04 · ${snapshot?.dateString ?? "Scoreboard"}`}
-      heading="Today's scoreboard"
+      number={number}
+      kicker={kicker}
+      heading={heading}
     >
       <Scoreboard stats={stats} />
 
@@ -381,16 +452,25 @@ function ScoreboardSection() {
 
 /* ─── §5 — Capabilities map ─────────────────────────────────────── */
 
-function CapabilitiesSection() {
-  const snapshot = useLatestDailyBriefSnapshot();
-
+function CapabilitiesSection({
+  number,
+  kicker,
+  heading,
+  snapshot,
+}: {
+  number: string;
+  kicker: string;
+  heading: string;
+  snapshot: ReturnType<typeof useLatestDailyBriefSnapshot>;
+}) {
   if (snapshot === undefined) {
     return (
       <EditorialSection
         id="capabilities"
         ariaLabel="Capabilities map"
-        eyebrow="05 · The capability landscape"
-        heading="Capabilities map"
+        number={number}
+        kicker={kicker}
+        heading={heading}
       >
         <div className="rd-edition-skeleton" style={{ width: "70%", height: 18 }} />
         <div className="rd-edition-skeleton" style={{ width: "70%", height: 18 }} />
@@ -406,19 +486,26 @@ function CapabilitiesSection() {
     <EditorialSection
       id="capabilities"
       ariaLabel="Capabilities map"
-      eyebrow="05 · The capability landscape"
-      heading="Capabilities map"
+      number={number}
+      kicker={kicker}
+      heading={heading}
     >
       <CapabilitiesMap techReadiness={tr} capabilities={caps} />
     </EditorialSection>
   );
 }
 
-/* ─── Footnotes ─────────────────────────────────────────────────── */
+/* ─── §6 — Footnotes ──────────────────────────────────────────── */
 
 function FootnotesSection({
+  number,
+  kicker,
+  heading,
   artifactIds,
 }: {
+  number: string;
+  kicker: string;
+  heading: string;
   artifactIds: string[];
 }) {
   const data = useEditionFootnotes(artifactIds, 8, 24);
@@ -427,8 +514,9 @@ function FootnotesSection({
       <EditorialSection
         id="footnotes"
         ariaLabel="Footnotes and sources"
-        eyebrow="06 · Sources"
-        heading="Footnotes"
+        number={number}
+        kicker={kicker}
+        heading={heading}
       >
         <div className="rd-edition-skeleton" style={{ width: "60%" }} />
         <div className="rd-edition-skeleton" style={{ width: "85%" }} />
@@ -442,19 +530,25 @@ function FootnotesSection({
     <EditorialSection
       id="footnotes"
       ariaLabel="Footnotes and sources"
-      eyebrow="06 · Sources"
-      heading="Footnotes"
+      number={number}
+      kicker={kicker}
+      heading={heading}
     >
       {totalCount === 0 ? (
-        <p className="rd-edition-empty">No source artifacts referenced in today's edition.</p>
+        <p className="rd-edition-empty">
+          No source artifacts referenced in today's edition.
+        </p>
       ) : (
         <div className="rd-edition-footnotes">
           <ol>
             {data.artifacts.map((a, i) => (
-              <li key={a._id} id={`fn-art-${i + 1}`}>
+              <li key={a._id} id={`fn-${i + 1}`} tabIndex={-1}>
                 <span>
                   <a href={a.url} target="_blank" rel="noopener noreferrer">
-                    {a.publisher || new URL(a.url).hostname}
+                    {a.publisher || (() => {
+                      try { return new URL(a.url).hostname; }
+                      catch { return a.url; }
+                    })()}
                   </a>
                   {a.firstQuote ? <> — &ldquo;{a.firstQuote}&rdquo;</> : null}
                   {a.publishedAt ? (
@@ -466,7 +560,11 @@ function FootnotesSection({
               </li>
             ))}
             {data.industry.map((u, i) => (
-              <li key={u._id} id={`fn-ind-${i + 1}`}>
+              <li
+                key={u._id}
+                id={`fn-${data.artifacts.length + i + 1}`}
+                tabIndex={-1}
+              >
                 <span>
                   <a href={u.url} target="_blank" rel="noopener noreferrer">
                     {u.providerName} — {u.title}
@@ -487,9 +585,12 @@ function FootnotesSection({
 /* ─── EditorialHomeSurface root ─────────────────────────────────── */
 
 export function EditorialHomeSurface({ onAsk }: Props) {
+  const navigate = useNavigate();
+  const location = useLocation();
   const hypotheses = useActiveHypotheses(5);
   const forecasts = useTopForecasts(5);
   const todayPulse = useTodayPulse(12);
+  const snapshot = useLatestDailyBriefSnapshot();
 
   // Collect artifactIds from §2's hypotheses for footnotes (§6).
   const artifactIds = useMemo(() => {
@@ -499,15 +600,116 @@ export function EditorialHomeSurface({ onAsk }: Props) {
         for (const id of h.evidenceArtifactIds ?? []) ids.push(id);
       }
     }
-    void todayPulse; // pulses don't carry artifactIds in v1 schema
+    void todayPulse;
     void ABSENT;
     return ids;
   }, [hypotheses, todayPulse]);
 
+  // ── Build the visible-section list ─────────────────────────────
+  // Bug 0a fix — section numbers are derived from the index in this
+  // array, not hardcoded.  When `competing-explanations` hides
+  // (no active hypotheses), every later section's number shifts down
+  // by one so the eye reads consecutive 01 → 02 → 03 → 04 → 05.
+  const visibleSections: SectionDescriptor[] = useMemo(() => {
+    const sections: SectionDescriptor[] = [];
+    sections.push({
+      id: "what-moved",
+      kicker: "Today's edition",
+      tocLabel: "Pulse",
+      heading: "What moved today",
+    });
+    if (Array.isArray(hypotheses) && hypotheses.length > 0) {
+      sections.push({
+        id: "competing-explanations",
+        kicker: "Hypotheses under test",
+        tocLabel: "Hypotheses",
+        heading: "The competing explanations",
+      });
+    }
+    sections.push({
+      id: "what-to-look-at",
+      kicker: "Forecasts in motion",
+      tocLabel: "Forecasts",
+      heading: "What to look at this week",
+    });
+    sections.push({
+      id: "scoreboard",
+      kicker: "Scoreboard",
+      tocLabel: "Scoreboard",
+      heading: "Today's scoreboard",
+    });
+    sections.push({
+      id: "capabilities",
+      kicker: "The capability landscape",
+      tocLabel: "Capabilities",
+      heading: "Capabilities map",
+    });
+    sections.push({
+      id: "footnotes",
+      kicker: "Sources",
+      tocLabel: "Sources",
+      heading: "Footnotes",
+    });
+    return sections;
+  }, [hypotheses]);
+
+  // Map section id → its computed number for use in render.
+  const numberForId = useMemo(() => {
+    const map = new Map<string, string>();
+    visibleSections.forEach((s, i) => map.set(s.id, pad2(i + 1)));
+    return map;
+  }, [visibleSections]);
+
+  const tocEntries: EditionTOCEntry[] = useMemo(
+    () =>
+      visibleSections.map((s) => ({
+        id: s.id,
+        number: numberForId.get(s.id) ?? "",
+        label: s.tocLabel,
+      })),
+    [visibleSections, numberForId],
+  );
+
+  // Derive a stable date string + edition id for the format strip.
+  // The date prefers the daily-brief snapshot, falls back to today's
+  // pulse `dateKey`, then a current-day ISO slice as a last resort.
+  const dateString =
+    snapshot?.dateString ??
+    (todayPulse ? todayPulse.dateKey : new Date().toISOString().slice(0, 10));
+  // Use the daily-brief snapshot id when present so the share URL
+  // points to a stable artifact; fall back to the date key.
+  const editionId =
+    snapshot?._id ?? (todayPulse?.dateKey ?? "current");
+
+  // Reciprocal of the LegacyHomeSurface "Try the daily edition →"
+  // discoverability link — return to the legacy home with the flag
+  // cleared.  Uses navigate() so React-Router state stays in sync.
+  const onSwitchToClassic = () => {
+    const params = new URLSearchParams(location.search);
+    params.delete("edition");
+    const search = params.toString();
+    navigate(search ? `${location.pathname}?${search}` : location.pathname, {
+      replace: true,
+    });
+  };
+
+  // Helper to look up a section's data and bail out cleanly when it's
+  // not in the visible list.
+  const find = (id: string) =>
+    visibleSections.find((s) => s.id === id);
+  const wm = find("what-moved")!;
+  const ce = find("competing-explanations");
+  const wl = find("what-to-look-at")!;
+  const sb = find("scoreboard")!;
+  const cap = find("capabilities")!;
+  const fn = find("footnotes")!;
+
   return (
     <div data-edition>
+      <EditionTOC entries={tocEntries} />
       <div className="rd-edition-root">
         <header
+          className="rd-edition-header"
           style={{
             display: "flex",
             flexDirection: "column",
@@ -516,11 +718,41 @@ export function EditorialHomeSurface({ onAsk }: Props) {
             borderBottom: "1px solid var(--rd-edition-rule-strong)",
           }}
         >
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
             <Pill tone="accent">Daily edition</Pill>
             <span className="rd-edition-meta">
               Single-document brief · max 720px · keyboard-first
             </span>
+            <button
+              type="button"
+              onClick={onSwitchToClassic}
+              className="rd-edition-switch"
+              aria-label="Switch to classic home"
+              data-edition-switch
+              style={{
+                marginLeft: "auto",
+                background: "transparent",
+                border: "none",
+                color: "var(--rd-ink-mute)",
+                fontSize: 12,
+                fontWeight: 500,
+                letterSpacing: "0.04em",
+                cursor: "pointer",
+                padding: "4px 8px",
+                borderRadius: 4,
+                textDecoration: "underline",
+                textUnderlineOffset: 3,
+              }}
+            >
+              ← Switch to classic home
+            </button>
           </div>
           <h1
             style={{
@@ -554,27 +786,61 @@ export function EditorialHomeSurface({ onAsk }: Props) {
         />
 
         <EditionErrorBoundary label="what-moved">
-          <WhatMovedSection />
+          <WhatMovedSection
+            number={numberForId.get(wm.id) ?? "01"}
+            kicker={wm.kicker}
+            heading={wm.heading}
+            dateString={dateString}
+            editionId={editionId}
+            pulses={todayPulse}
+          />
         </EditionErrorBoundary>
 
-        <EditionErrorBoundary label="competing-explanations">
-          <CompetingExplanationsSection hypotheses={hypotheses} />
-        </EditionErrorBoundary>
+        {ce && Array.isArray(hypotheses) && hypotheses.length > 0 && (
+          <EditionErrorBoundary label="competing-explanations">
+            <CompetingExplanationsSection
+              number={numberForId.get(ce.id) ?? "02"}
+              kicker={ce.kicker}
+              heading={ce.heading}
+              hypotheses={hypotheses}
+            />
+          </EditionErrorBoundary>
+        )}
 
         <EditionErrorBoundary label="what-to-look-at">
-          <WhatToLookAtSection forecasts={forecasts} />
+          <WhatToLookAtSection
+            number={numberForId.get(wl.id) ?? "03"}
+            kicker={wl.kicker}
+            heading={wl.heading}
+            forecasts={forecasts}
+          />
         </EditionErrorBoundary>
 
         <EditionErrorBoundary label="scoreboard">
-          <ScoreboardSection />
+          <ScoreboardSection
+            number={numberForId.get(sb.id) ?? "04"}
+            kicker={sb.kicker}
+            heading={sb.heading}
+            snapshot={snapshot}
+          />
         </EditionErrorBoundary>
 
         <EditionErrorBoundary label="capabilities">
-          <CapabilitiesSection />
+          <CapabilitiesSection
+            number={numberForId.get(cap.id) ?? "05"}
+            kicker={cap.kicker}
+            heading={cap.heading}
+            snapshot={snapshot}
+          />
         </EditionErrorBoundary>
 
         <EditionErrorBoundary label="footnotes">
-          <FootnotesSection artifactIds={artifactIds} />
+          <FootnotesSection
+            number={numberForId.get(fn.id) ?? "06"}
+            kicker={fn.kicker}
+            heading={fn.heading}
+            artifactIds={artifactIds}
+          />
         </EditionErrorBoundary>
       </div>
     </div>

--- a/src/features/redesign/surfaces/HomeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeSurface.tsx
@@ -197,6 +197,32 @@ function LegacyHomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
           <span className="rd-mono rd-faint" style={{ fontSize: 10.5 }}>
             {liveArtifacts.isLive ? `${effectiveContinueWorking.length} active reports · ${effectiveWatchlist.length} watched entities` : "starter pulse — sign in for live signals"}
           </span>
+          {/* Phase 7c — discoverability affordance for the editorial
+              home.  Quiet anchor, not a banner — the user decides
+              when to opt in.  Reciprocal "Switch to classic" lives
+              in EditorialHomeSurface.tsx so the round-trip is one
+              click in either direction. */}
+          <a
+            href="?edition=1"
+            className="rd-edition-discover-link"
+            data-edition-discover
+            aria-label="Try the daily edition (single-document brief)"
+            style={{
+              marginLeft: "auto",
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              color: "var(--rd-accent-strong, #d97757)",
+              textDecoration: "none",
+              padding: "4px 10px",
+              borderRadius: 999,
+              border: "1px solid var(--rd-accent-soft, rgba(217,119,87,0.32))",
+              background: "var(--rd-accent-tint, rgba(217,119,87,0.08))",
+              whiteSpace: "nowrap",
+            }}
+          >
+            Try the daily edition →
+          </a>
           <button
             type="button"
             aria-label={pulseVoice.isListening ? "Stop voice input" : "Voice input using browser mode"}
@@ -204,7 +230,6 @@ function LegacyHomeSurface({ onAsk, onOpenReport }: HomeSurfaceProps) {
             onClick={pulseVoice.toggle}
             data-state={pulseVoice.isListening ? "active" : "idle"}
             style={{
-              marginLeft: "auto",
               width: 44,
               height: 44,
               borderRadius: 999,

--- a/tests/e2e/edition-home.spec.ts
+++ b/tests/e2e/edition-home.spec.ts
@@ -1,5 +1,5 @@
 /**
- * E2E — Editorial home (Phase 7a, gated by `?edition=1`).
+ * E2E — Editorial home (Phase 7a + 7b + 7c).
  *
  * Source spec: docs/architecture/HOME_EDITORIAL_REDESIGN.md
  * Rules cited: .claude/rules/scenario_testing.md (anatomy below),
@@ -25,6 +25,43 @@
  * Actions:     Navigate to /redesign (no flag)
  * Expected:    Operations dashboard region renders (legacy marker).
  *              No `[data-edition]` root in the document.
+ *
+ * ─── Scenario C — discoverability round-trip (Phase 7c) ──────────
+ * User:        Returning visitor on the legacy home, never opted in
+ * Goal:        Discover the editorial edition + return to classic
+ * Actions:     /redesign → click "Try the daily edition" → verify
+ *              the editorial layout mounts → click "Switch to classic"
+ *              → verify legacy operations dashboard returns.
+ * Expected:    Round-trip is one click in either direction; URL
+ *              reflects the current view (`?edition=1` ↔ no flag).
+ *
+ * ─── Scenario D — section numbers are consecutive (Bug 0a) ───────
+ * User:        Any visitor on the editorial home
+ * Goal:        Read 01 → 02 → ... → N with no gaps even when a
+ *              conditional section (hypotheses) is hidden.
+ * Actions:     Navigate to /redesign?edition=1, query
+ *              `[data-section-number]` attributes in document order.
+ * Expected:    Numbers are consecutive starting at "01".
+ *
+ * ─── Scenario E — footnote sup anchors point to real targets ─────
+ * User:        Reader hopping between body text and Sources
+ * Goal:        Every superscript citation jumps to a real footnote.
+ * Actions:     Find every `[data-footnote]` sup with an href
+ *              `#fn-N`; assert each `id="fn-N"` exists in §6 OR the
+ *              page has zero footnote refs (honest empty state).
+ *
+ * ─── Scenario F — TOC scroll-spy is desktop only (Phase 7b) ──────
+ * User:        Desktop reader vs mobile reader
+ * Goal:        Desktop sees rail; mobile does not.
+ * Actions:     1440px → assert `[data-edition-toc]` is in DOM.
+ *              375px  → assert it is hidden or absent.
+ *
+ * ─── Scenario G — Copy share-link writes to clipboard (7c) ───────
+ * User:        Reader who wants to share the edition
+ * Goal:        One-click copy of a shareable URL.
+ * Actions:     Stub `navigator.clipboard.writeText`, click
+ *              `[data-format-share]`, assert the stub was called
+ *              with a URL containing `?edition=1&share=`.
  */
 
 import { test, expect } from "@playwright/test";
@@ -50,30 +87,19 @@ test.describe("Editorial home — Phase 7a", () => {
     await page.goto(`${BASE_URL}/redesign?edition=1`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle");
 
-    // Edition root mounts (proves the flag took effect).
     const editionRoot = page.locator("[data-edition]");
     await expect(editionRoot).toBeVisible({ timeout: 10_000 });
 
-    // Each guaranteed section should render (the only conditional one
-    // is `competing-explanations`, which is allowed to be absent per
-    // spec §5 when no public hypotheses are active).
     for (const id of EDITION_SECTIONS) {
       const section = page.locator(`[data-section="${id}"]`);
       await expect(section).toBeVisible({ timeout: 5_000 });
     }
 
-    // Hypotheses section: present OR honestly absent (no fake data).
     const hypotheses = page.locator('[data-section="competing-explanations"]');
     const hypCount = await hypotheses.count();
     expect(hypCount === 0 || hypCount === 1).toBeTruthy();
 
-    // No horizontal overflow at mobile width (375px) — Phase 7a's
-    // edition flag bypasses MobileShell at the home surface so the
-    // single-column editorial layout stays responsive (spec §3
-    // Variant C: "mobile and desktop are identical").
     await page.setViewportSize({ width: 375, height: 720 });
-    // Allow re-render + the editorial mount to settle (the shell
-    // checks isMobile via a media-query listener).
     await page.waitForSelector("[data-edition]", { timeout: 5_000 });
     await page.waitForTimeout(300);
     const horizontalOverflow = await page.evaluate(() => {
@@ -84,11 +110,9 @@ test.describe("Editorial home — Phase 7a", () => {
     expect(horizontalOverflow).not.toBeNull();
     expect(horizontalOverflow ?? 999).toBeLessThanOrEqual(2);
 
-    // Legacy operations dashboard MUST NOT render in editorial mode.
     const legacyOps = page.locator('section[aria-label="Operations dashboard"]');
     expect(await legacyOps.count()).toBe(0);
 
-    // No console / page errors.
     expect(errors, `Errors:\n${errors.join("\n")}`).toEqual([]);
   });
 
@@ -96,12 +120,149 @@ test.describe("Editorial home — Phase 7a", () => {
     await page.goto(`${BASE_URL}/redesign`, { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("networkidle");
 
-    // Editorial root MUST NOT render.
     const editionRoot = page.locator("[data-edition]");
     expect(await editionRoot.count()).toBe(0);
 
-    // Legacy "Operations dashboard" landmark must still render.
     const legacyOps = page.locator('section[aria-label="Operations dashboard"]');
     await expect(legacyOps).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+test.describe("Editorial home — Phase 7b + 7c", () => {
+  test("Scenario C: discoverability round-trip via legacy → editorial → classic", async ({ page }) => {
+    await page.goto(`${BASE_URL}/redesign`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    // Discoverability link is present on the legacy home.
+    const tryEdition = page.locator("[data-edition-discover]").first();
+    await expect(tryEdition).toBeVisible({ timeout: 10_000 });
+
+    // Click it — URL should now include ?edition=1, editorial mounts.
+    await tryEdition.click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\?edition=1$/);
+    await expect(page.locator("[data-edition]")).toBeVisible({ timeout: 10_000 });
+
+    // Reciprocal "Switch to classic" returns the user.
+    const switchToClassic = page.locator("[data-edition-switch]").first();
+    await expect(switchToClassic).toBeVisible({ timeout: 5_000 });
+    await switchToClassic.click();
+    await page.waitForLoadState("networkidle");
+
+    // URL no longer carries the flag, legacy ops dashboard is back.
+    await expect(page).not.toHaveURL(/edition=1/);
+    const legacyOps = page.locator('section[aria-label="Operations dashboard"]');
+    await expect(legacyOps).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("Scenario D: section numbers render consecutively (Bug 0a)", async ({ page }) => {
+    await page.goto(`${BASE_URL}/redesign?edition=1`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    await page.waitForSelector("[data-edition]", { timeout: 10_000 });
+
+    const numbers = await page.$$eval(
+      "[data-edition] [data-section-number]",
+      (nodes) => nodes.map((n) => (n as HTMLElement).dataset.sectionNumber ?? ""),
+    );
+
+    expect(numbers.length).toBeGreaterThan(0);
+    // Each number must be the zero-padded 1-based index.
+    numbers.forEach((n, i) => {
+      const expected = (i + 1).toString().padStart(2, "0");
+      expect(n).toBe(expected);
+    });
+  });
+
+  test("Scenario E: footnote sup anchors point to real targets", async ({ page }) => {
+    await page.goto(`${BASE_URL}/redesign?edition=1`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    await page.waitForSelector("[data-edition]", { timeout: 10_000 });
+
+    const supRefs = await page.$$eval(
+      '[data-edition] sup[data-footnote] a[href^="#fn-"]',
+      (nodes) =>
+        nodes.map((n) => {
+          const href = (n as HTMLAnchorElement).getAttribute("href") ?? "";
+          return href.replace(/^#/, "");
+        }),
+    );
+
+    if (supRefs.length === 0) {
+      // Honest empty state — no footnotes referenced today.  Test
+      // passes trivially with a clear message.
+      // eslint-disable-next-line no-console
+      console.log("Scenario E: no footnote sup refs in today's edition (honest empty state).");
+      return;
+    }
+
+    for (const id of supRefs) {
+      const target = page.locator(`#${CSS.escape(id)}`);
+      const count = await target.count();
+      expect(count, `Footnote target ${id} should exist`).toBe(1);
+    }
+  });
+
+  test("Scenario F: TOC scroll-spy is desktop only", async ({ page }) => {
+    // Desktop viewport — TOC must be present.
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(`${BASE_URL}/redesign?edition=1`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+    await page.waitForSelector("[data-edition]", { timeout: 10_000 });
+
+    const tocDesktop = page.locator("[data-edition-toc]");
+    await expect(tocDesktop).toBeVisible({ timeout: 5_000 });
+
+    // Mobile viewport — TOC hidden via media query.
+    await page.setViewportSize({ width: 375, height: 720 });
+    // Wait for re-render of media-query-driven mount state.
+    await page.waitForTimeout(400);
+    const tocMobileVisible = await page.evaluate(() => {
+      const el = document.querySelector("[data-edition-toc]");
+      if (!el) return false;
+      const styles = window.getComputedStyle(el);
+      return styles.display !== "none" && styles.visibility !== "hidden";
+    });
+    expect(tocMobileVisible).toBe(false);
+  });
+
+  test("Scenario G: Copy share-link writes to clipboard", async ({ page }) => {
+    // Stub navigator.clipboard.writeText BEFORE the page loads so the
+    // FormatStrip onClick uses our stub.
+    await page.addInitScript(() => {
+      (window as unknown as { __copiedUrls: string[] }).__copiedUrls = [];
+      const stub = (text: string) => {
+        (window as unknown as { __copiedUrls: string[] }).__copiedUrls.push(text);
+        return Promise.resolve();
+      };
+      try {
+        Object.defineProperty(navigator, "clipboard", {
+          value: { writeText: stub, readText: () => Promise.resolve("") },
+          configurable: true,
+        });
+      } catch {
+        // Fallback: define on existing clipboard.
+        (navigator as unknown as { clipboard: { writeText: (t: string) => Promise<void> } }).clipboard.writeText = stub;
+      }
+    });
+
+    await page.goto(`${BASE_URL}/redesign?edition=1`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+    await page.waitForSelector("[data-edition]", { timeout: 10_000 });
+
+    const shareBtn = page.locator("[data-format-share]").first();
+    await expect(shareBtn).toBeVisible({ timeout: 5_000 });
+    await shareBtn.click();
+
+    // Allow click handler + promise to flush.
+    await page.waitForTimeout(200);
+
+    const copied = await page.evaluate(
+      () => (window as unknown as { __copiedUrls: string[] }).__copiedUrls,
+    );
+    expect(copied.length).toBeGreaterThanOrEqual(1);
+    expect(copied[0]).toMatch(/[?&]edition=1(?:&|$)/);
+    expect(copied[0]).toMatch(/[?&]share=/);
   });
 });


### PR DESCRIPTION
## Summary

Closes the discoverability gap and lands Phases 7b + 7c per [`docs/architecture/HOME_EDITORIAL_REDESIGN.md`](docs/architecture/HOME_EDITORIAL_REDESIGN.md). Predecessor: PR #280 (Phase 7a, commit `8cb0c19a`).

**User cite**: *"i dont see changes, but keep going in sequence"* — the legacy `/redesign` home now surfaces a quiet "Try the daily edition →" link, and the editorial home has a reciprocal "← Switch to classic home". One-click round-trip in either direction. (No auto-promotion of `?edition=1` to default — Phase 7d will do that after dogfood.)

### Phase 7a follow-up bugs (both fixed)

- **Bug 0a — non-consecutive section numbers.** Static `01..06` labels broke consecutive reading when `competing-explanations` hid (no active hypotheses). Section numbers are now DYNAMIC — derived from `visibleSections.indexOf(...)`. The eye reads `01 → 02 → 03 → ...` regardless of which conditional sections render. Verified by **Scenario D**.
- **Bug 0b — kicker inconsistency.** Some sections rendered `01 · 2026-05-08` (date string) instead of `01 · TODAY'S EDITION` (labeled subtitle). `EditorialSection` now takes `number` and `kicker` as separate props; the date appears only in the FormatStrip caption.

### Phase 7b — scroll-spy + footnote anchors

- New `useScrollSpy` hook (IntersectionObserver, biased toward viewport upper-third).
- New `EditionTOC` component — fixed right-rail at `≥1024px`, hidden on mobile, terracotta active state, smooth-scroll honoring `prefers-reduced-motion`.
- Footnote `<sup>` superscripts → `id="fn-N"` targets in §6 (each `<li tabindex="-1">` so screen readers focus on click).

### Phase 7c — format strip + share artifact

- `FormatStrip` beneath §1 header: `Today's edition · {date} · PDF · Copy share-link`.
- **PDF**: opens `/redesign/edition/print?id=...` (new same-origin route via `EditionPrintPage`) which auto-triggers `window.print()`. No new heavy dependencies (puppeteer/PDFKit avoided per spec §7c).
- **Copy share-link**: `navigator.clipboard.writeText` with HONEST_STATUS — surfaces the URL via warning toast when the clipboard API is unavailable instead of claiming success.
- **Listen + watch**: deferred to Phase 8 — no stubs (per `agentic_reliability.md`).

### Files added/modified

```
A  src/features/redesign/components/edition/EditionTOC.tsx
A  src/features/redesign/components/edition/FormatStrip.tsx
A  src/features/redesign/components/edition/edition-print.css
A  src/features/redesign/hooks/useScrollSpy.ts
A  src/features/redesign/pages/EditionPrintPage.tsx
M  src/App.tsx                                                    (route wiring)
M  src/features/redesign/components/edition/EditorialSection.tsx  (number/kicker props)
M  src/features/redesign/components/edition/edition.css           (TOC + format strip)
M  src/features/redesign/surfaces/EditorialHomeSurface.tsx        (visibleSections + bug fixes)
M  src/features/redesign/surfaces/HomeSurface.tsx                 (discoverability link)
M  tests/e2e/edition-home.spec.ts                                 (Scenarios C–G)
M  docs/architecture/HOME_EDITORIAL_REDESIGN.md                   (§9-12 added)
```

## Test plan

- [x] `npx tsc --noEmit --pretty false` — 0 errors
- [x] `npx convex codegen` — clean
- [x] `npx vite build` — clean
- [x] `BASE_URL=http://127.0.0.1:4173 npx playwright test tests/e2e/edition-home.spec.ts` — **7/7 pass**
  - Scenario A: `?edition=1` renders editorial layout
  - Scenario B: legacy home preserved without flag
  - Scenario C: discoverability round-trip (legacy → editorial → classic)
  - Scenario D: section numbers consecutive (Bug 0a)
  - Scenario E: footnote sup anchors target real `id="fn-N"`
  - Scenario F: TOC desktop-only (1440px present, 375px hidden)
  - Scenario G: Copy share-link writes URL to clipboard
- [x] `BASE_URL=http://127.0.0.1:4173 npx playwright test tests/e2e/live-smoke.spec.ts` — **9/9 pass** (no regression on Tier B)
- [ ] Tier A: `npx tsx scripts/verify-live.ts` against prod after merge
- [ ] Tier B: e2e suite against prod after merge (`BASE_URL=https://www.nodebenchai.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)