### PR TITLE
P0 #2: guest bootstrap content for §1 Pulse - public trending fallback

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -883,6 +883,7 @@ import type * as domains_operations_utilities_seedGoldenDataset from "../domains
 import type * as domains_operations_utilities_snapshotMigrations from "../domains/operations/utilities/snapshotMigrations.js";
 import type * as domains_operations_validationWorkflow from "../domains/operations/validationWorkflow.js";
 import type * as domains_operatorProfile_filesystemSync from "../domains/operatorProfile/filesystemSync.js";
+import type * as domains_operatorProfile_manifest from "../domains/operatorProfile/manifest.js";
 import type * as domains_operatorProfile_mutations from "../domains/operatorProfile/mutations.js";
 import type * as domains_operatorProfile_parser from "../domains/operatorProfile/parser.js";
 import type * as domains_operatorProfile_queries from "../domains/operatorProfile/queries.js";
@@ -2365,6 +2366,7 @@ declare const fullApi: ApiFromModules<{
   "domains/operations/utilities/snapshotMigrations": typeof domains_operations_utilities_snapshotMigrations;
   "domains/operations/validationWorkflow": typeof domains_operations_validationWorkflow;
   "domains/operatorProfile/filesystemSync": typeof domains_operatorProfile_filesystemSync;
+  "domains/operatorProfile/manifest": typeof domains_operatorProfile_manifest;
   "domains/operatorProfile/mutations": typeof domains_operatorProfile_mutations;
   "domains/operatorProfile/parser": typeof domains_operatorProfile_parser;
   "domains/operatorProfile/queries": typeof domains_operatorProfile_queries;

--- a/convex/domains/research/editionQueries.ts
+++ b/convex/domains/research/editionQueries.ts
@@ -23,6 +23,7 @@
 
 import { v } from "convex/values";
 import { query } from "../../_generated/server";
+import type { QueryCtx } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { resolveProductIdentitySafely } from "../product/helpers";
 import {
@@ -71,7 +72,78 @@ function boundLimit(value: number | undefined, def: number, max: number): number
 
 /* ────────────────────────────────────────────────────────────────────
  * §1 — "What moved today" : today's pulses for the current owner.
+ *
+ * P0 #2 (2026-05-09) — bootstrap content for guests + empty users.
+ * When the caller has no pulse for today (anonymous, or signed-in but
+ * inactive), fall back to a "public-trending" feed sourced from
+ * `industryUpdates`.  The fallback is labelled `provenance:
+ * "public-trending"` so the surface can render an explicit affordance
+ * ("You haven't run a pulse today.  Here's what's trending publicly").
+ *
+ * agentic_reliability invariants:
+ *  - BOUND: fallback hard-capped at PULSE_FALLBACK_MAX (5) regardless
+ *    of `args.limit`.
+ *  - HONEST_STATUS: when both pulse AND industryUpdates are empty, we
+ *    return `provenance: "empty"` and `pulses: []` — no fabrication.
+ *  - HONEST_SCORES: change counts are TRUE counts (1) per industry
+ *    update; we do not invent material-change counts.  The
+ *    `summaryMarkdown` field is the actual provider summary.
  * ────────────────────────────────────────────────────────────────── */
+const PULSE_FALLBACK_MAX = 5;
+
+type PulseProjection = {
+  _id: string;
+  entitySlug: string;
+  dateKey: string;
+  status: "generating" | "ready" | "failed";
+  summaryMarkdown: string | null;
+  changeCount: number;
+  materialChangeCount: number;
+  generatedAt: number;
+};
+
+/**
+ * Slugify a provider name into a stable entitySlug-shaped string.
+ * Keeps the rendering path's `entitySlug.replace(/-/g, " ")` cosmetic
+ * happy without inventing a fake entity.
+ */
+function providerNameToSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64) || "trending";
+}
+
+/** Compose a public-trending fallback from industryUpdates. */
+async function loadPublicTrendingFallback(
+  ctx: QueryCtx,
+  dateKey: string,
+): Promise<PulseProjection[]> {
+  // Read at most PULSE_FALLBACK_MAX rows directly from the
+  // most-recent `by_scanned_at` ordering — bounded read.
+  const rows = await ctx.db
+    .query("industryUpdates")
+    .withIndex("by_scanned_at")
+    .order("desc")
+    .take(PULSE_FALLBACK_MAX);
+  return rows.map((u) => ({
+    _id: u._id as string,
+    entitySlug: providerNameToSlug(u.providerName ?? u.provider ?? "trending"),
+    dateKey,
+    status: "ready" as const,
+    summaryMarkdown:
+      typeof u.summary === "string" && u.summary.trim().length > 0
+        ? `**${u.title}**\n\n${u.summary}`
+        : (u.title as string) ?? null,
+    // honest counts: 1 update = 1 change, 0 material claims (we don't
+    // know whether a public update is "material" to any owner).
+    changeCount: 1,
+    materialChangeCount: 0,
+    generatedAt: typeof u.scannedAt === "number" ? u.scannedAt : Date.now(),
+  }));
+}
+
 export const getTodayPulse = query({
   args: {
     anonymousSessionId: v.optional(v.string()),
@@ -79,49 +151,85 @@ export const getTodayPulse = query({
   },
   handler: async (ctx, args) => {
     const limit = boundLimit(args.limit, PULSE_DEFAULT, 50);
+    const dateKey = todayDateKey();
     const identity = await resolveProductIdentitySafely(
       ctx,
       args.anonymousSessionId,
     );
-    if (!identity) {
-      return { pulses: [], dateKey: todayDateKey(), lastDateKey: null as string | null };
-    }
-    const ownerKey = identity.anonymousSessionId ?? (identity.ownerKey as string);
-    const dateKey = todayDateKey();
 
-    // Today's pulses.
-    const today = await ctx.db
-      .query("pulseReports")
-      .withIndex("by_owner_date", (q) =>
-        q.eq("ownerKey", ownerKey).eq("dateKey", dateKey),
-      )
-      .order("desc")
-      .take(limit);
+    // ── Branch A: identifiable user (authed or anonymous-session). ──
+    if (identity) {
+      const ownerKey =
+        identity.anonymousSessionId ?? (identity.ownerKey as string);
+      const today = await ctx.db
+        .query("pulseReports")
+        .withIndex("by_owner_date", (q) =>
+          q.eq("ownerKey", ownerKey).eq("dateKey", dateKey),
+        )
+        .order("desc")
+        .take(limit);
 
-    // If empty, surface the most-recent dateKey so the empty state can be honest.
-    let lastDateKey: string | null = null;
-    if (today.length === 0) {
+      if (today.length > 0) {
+        return {
+          provenance: "user" as const,
+          pulses: today.map<PulseProjection>((p) => ({
+            _id: p._id,
+            entitySlug: p.entitySlug,
+            dateKey: p.dateKey,
+            status: p.status,
+            summaryMarkdown: p.summaryMarkdown ?? null,
+            changeCount: p.changeCount,
+            materialChangeCount: p.materialChangeCount,
+            generatedAt: p.generatedAt,
+          })),
+          dateKey,
+          lastDateKey: null as string | null,
+        };
+      }
+
+      // Empty for today — surface the user's most-recent pulse date so
+      // the affordance line can be honest ("Last pulse: 2026-05-04").
       const last = await ctx.db
         .query("pulseReports")
         .withIndex("by_owner_date", (q) => q.eq("ownerKey", ownerKey))
         .order("desc")
         .first();
-      lastDateKey = last?.dateKey ?? null;
+      const lastDateKey = last?.dateKey ?? null;
+
+      // Fall through to the public-trending fallback when even the
+      // user's history is empty (cold-start).
+      const fallback = await loadPublicTrendingFallback(ctx, dateKey);
+      if (fallback.length === 0) {
+        return {
+          provenance: "empty" as const,
+          pulses: [],
+          dateKey,
+          lastDateKey,
+        };
+      }
+      return {
+        provenance: "public-trending" as const,
+        pulses: fallback,
+        dateKey,
+        lastDateKey,
+      };
     }
 
+    // ── Branch B: anonymous, no resolvable session — guest visitor. ──
+    const fallback = await loadPublicTrendingFallback(ctx, dateKey);
+    if (fallback.length === 0) {
+      return {
+        provenance: "empty" as const,
+        pulses: [],
+        dateKey,
+        lastDateKey: null as string | null,
+      };
+    }
     return {
-      pulses: today.map((p) => ({
-        _id: p._id,
-        entitySlug: p.entitySlug,
-        dateKey: p.dateKey,
-        status: p.status,
-        summaryMarkdown: p.summaryMarkdown ?? null,
-        changeCount: p.changeCount,
-        materialChangeCount: p.materialChangeCount,
-        generatedAt: p.generatedAt,
-      })),
+      provenance: "public-trending" as const,
+      pulses: fallback,
       dateKey,
-      lastDateKey,
+      lastDateKey: null as string | null,
     };
   },
 });

--- a/src/features/redesign/components/edition/EditorialSection.tsx
+++ b/src/features/redesign/components/edition/EditorialSection.tsx
@@ -21,9 +21,19 @@
  * (Scenario D verifies consecutive numbering).
  */
 
-import type { ReactNode } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
 
-interface Props {
+/**
+ * Accept any `data-*` attribute via index signature so callers can
+ * attach extra testids (e.g. `data-provenance` for the §1 trending
+ * fallback added in P0 #2).  We do NOT widen to arbitrary HTML props
+ * — only `data-*` is forwarded.
+ */
+type DataAttributes = {
+  [K in `data-${string}`]?: HTMLAttributes<HTMLElement>[K];
+};
+
+interface Props extends DataAttributes {
   /** The data-section testid; used by Playwright + the live-smoke. */
   id: string;
   /** Plain-language ARIA label for the region. */
@@ -44,6 +54,7 @@ export function EditorialSection({
   kicker,
   heading,
   children,
+  ...dataAttrs
 }: Props) {
   const eyebrow = `${number} · ${kicker}`;
   return (
@@ -55,6 +66,7 @@ export function EditorialSection({
       data-section-number={number}
       data-section-kicker={kicker}
       data-eyebrow={eyebrow}
+      {...dataAttrs}
     >
       <header style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <p className="rd-edition-section__eyebrow">{eyebrow}</p>

--- a/src/features/redesign/hooks/useTodayPulse.ts
+++ b/src/features/redesign/hooks/useTodayPulse.ts
@@ -2,14 +2,21 @@
  * useTodayPulse — wraps the public Convex query
  * `domains.research.editionQueries.getTodayPulse` for §1 of the
  * editorial home.  Returns `undefined` while loading, then
- * `{ pulses, dateKey, lastDateKey }`.
+ * `{ provenance, pulses, dateKey, lastDateKey }`.
  *
  * Identity is the same anonymous-session contract used by Fast Agent.
+ *
+ * P0 #2 (2026-05-09): the query now returns a `provenance` field that
+ * distinguishes between "user" (the caller's own pulse), "public-
+ * trending" (industryUpdates fallback for guests + cold-start users),
+ * and "empty" (HONEST_STATUS — no fallback available).
  */
 
 import { useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { getStoredAnonymousSessionId } from "./editionSession";
+
+export type TodayPulseProvenance = "user" | "public-trending" | "empty";
 
 export interface TodayPulseEntry {
   _id: string;
@@ -23,6 +30,11 @@ export interface TodayPulseEntry {
 }
 
 export interface TodayPulseResult {
+  /**
+   * Where the items came from.  Surfaces use this to label the
+   * section honestly ("Public · trending" vs "Your pulse").
+   */
+  provenance: TodayPulseProvenance;
   pulses: TodayPulseEntry[];
   dateKey: string;
   lastDateKey: string | null;

--- a/src/features/redesign/surfaces/EditorialHomeSurface.tsx
+++ b/src/features/redesign/surfaces/EditorialHomeSurface.tsx
@@ -146,6 +146,10 @@ function WhatMovedSection({
     (n, p) => n + (p.materialChangeCount ?? 0),
     0,
   );
+  // P0 #2: provenance tells us whether this is the user's own pulse or
+  // the public-trending fallback (or honestly empty).
+  const provenance = pulses.provenance;
+  const isTrending = provenance === "public-trending";
 
   return (
     <EditorialSection
@@ -154,8 +158,45 @@ function WhatMovedSection({
       number={number}
       kicker={kicker}
       heading={heading}
+      data-provenance={provenance}
     >
       <FormatStrip dateString={dateString} editionId={editionId} />
+      {isTrending && (
+        <p
+          className="rd-edition-trending-leadin"
+          data-trending-leadin
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "baseline",
+            gap: 8,
+            margin: "0 0 10px",
+            color: "var(--rd-ink-mute)",
+            fontSize: 14,
+          }}
+        >
+          <span
+            data-provenance-badge
+            aria-label="Public trending fallback"
+            style={{
+              fontFamily: "var(--rd-mono, ui-monospace, monospace)",
+              fontSize: 11,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--rd-accent, #d97757)",
+              border: "1px solid var(--rd-accent, #d97757)",
+              padding: "2px 6px",
+              borderRadius: 3,
+            }}
+          >
+            Public · trending
+          </span>
+          <span>
+            You haven&rsquo;t run a pulse today. Here&rsquo;s what&rsquo;s
+            trending publicly.
+          </span>
+        </p>
+      )}
       {pulses.pulses.length === 0 ? (
         <p className="rd-edition-empty">
           No pulse generated yet today.
@@ -163,12 +204,18 @@ function WhatMovedSection({
         </p>
       ) : (
         <>
-          <p className="rd-edition-meta">
-            <span className="rd-edition-delta" aria-label={`${totalMaterial} material changes`}>
-              {totalMaterial} material change{totalMaterial === 1 ? "" : "s"}
-            </span>{" "}
-            across {pulses.pulses.length} entit{pulses.pulses.length === 1 ? "y" : "ies"}
-          </p>
+          {!isTrending && (
+            <p className="rd-edition-meta">
+              <span
+                className="rd-edition-delta"
+                aria-label={`${totalMaterial} material changes`}
+              >
+                {totalMaterial} material change{totalMaterial === 1 ? "" : "s"}
+              </span>{" "}
+              across {pulses.pulses.length} entit
+              {pulses.pulses.length === 1 ? "y" : "ies"}
+            </p>
+          )}
           <div className="rd-edition-prose">
             {pulses.pulses.map((p, i) => (
               <article
@@ -181,10 +228,13 @@ function WhatMovedSection({
                     {p.entitySlug.replace(/-/g, " ")}
                   </strong>{" "}
                   <span className="rd-edition-meta">
-                    · {p.changeCount} change{p.changeCount === 1 ? "" : "s"}
-                    {p.materialChangeCount > 0
-                      ? `, ${p.materialChangeCount} material`
-                      : ""}
+                    {isTrending
+                      ? "· trending"
+                      : `· ${p.changeCount} change${p.changeCount === 1 ? "" : "s"}${
+                          p.materialChangeCount > 0
+                            ? `, ${p.materialChangeCount} material`
+                            : ""
+                        }`}
                   </span>
                   <Footnote
                     id={`pulse-${i + 1}`}

--- a/tests/e2e/edition-home.spec.ts
+++ b/tests/e2e/edition-home.spec.ts
@@ -90,6 +90,32 @@
  *              Strings allowed elsewhere in the document (e.g. SEO
  *              meta) are filtered out by scoping the search to
  *              [data-edition].
+ *
+ * ─── Scenario I — guest sees public-trending fallback or honest empty
+ * User:        Anonymous guest (no auth, no anonymousSession yet)
+ * Goal:        Find something useful in §1 instead of a blank "no
+ *              pulse" message.
+ * Prior state: `pulseReports` for this guest is necessarily empty
+ *              (they have no ownerKey).  `industryUpdates` may or may
+ *              not have rows depending on cron freshness.
+ * Actions:     1) Navigate to /redesign as a guest.
+ *              2) Read [data-section="what-moved"]'s data-provenance.
+ *              3) If "public-trending": assert the
+ *                 [data-provenance-badge] is visible AND the lead-in
+ *                 text matches.
+ *              4) If "empty": assert the genuine empty state copy is
+ *                 visible AND no provenance badge renders.
+ *              5) FAIL if a fixture string from
+ *                 src/features/redesign/fixtures.ts leaks into the
+ *                 §1 prose (HONEST_STATUS).
+ * Scale:       1 user.
+ * Duration:    Single page load.
+ * Expected:    The §1 affordance is honest about where its content
+ *              came from; signal counts are not fabricated (HONEST_
+ *              SCORES — fallback rows always render `· trending`,
+ *              never a fake material-change tally).
+ * Edge cases:  Convex query unavailable → §1 stays in skeleton state
+ *              and the test waits up to 10s; should not falsely pass.
  */
 
 import { test, expect } from "@playwright/test";
@@ -325,13 +351,8 @@ test.describe("Editorial home — Phase 7b + 7c", () => {
     expect(await accordionByText.count()).toBe(0);
 
     // 2. Known fixture strings must not appear inside the editorial DOM.
-    //    These are surface verbatim from src/features/redesign/fixtures.ts.
     const editionRoot = page.locator("[data-edition]");
     const editionText = (await editionRoot.textContent()) ?? "";
-    // Strings copied verbatim from src/features/redesign/fixtures.ts
-    // (pulseCards / continueWorking / watchlist).  If any of these
-    // appears inside [data-edition], the operations accordion
-    // regressed and a fixture is leaking onto the public surface.
     const fixtureSignals = [
       "Orbital Labs answered from event corpus",
       "Ship Demo Day report updated",
@@ -347,9 +368,79 @@ test.describe("Editorial home — Phase 7b + 7c", () => {
       ).toBe(false);
     }
 
-    // 3. Belt-and-suspenders — the data attribute we used to mark the
+    // 3. Belt-and-suspenders — the data attribute used to mark the
     //    legacy-fallback accordion source is gone too.
     const opsSourceMark = page.locator("[data-edition] [data-ops-source]");
     expect(await opsSourceMark.count()).toBe(0);
+  });
+
+  test("Scenario I: guest §1 shows trending fallback OR honest empty (P0 #2)", async ({
+    page,
+    context,
+  }) => {
+    // Clear any anonymous-session state so the visit is a clean guest.
+    await context.clearCookies();
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.clear();
+        window.sessionStorage.clear();
+      } catch {
+        /* ignore — storage may be unavailable in test mode */
+      }
+    });
+
+    await page.goto(`${BASE_URL}/redesign`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+
+    const whatMoved = page.locator('[data-section="what-moved"]');
+    await expect(whatMoved).toBeVisible({ timeout: 10_000 });
+
+    // Wait for the provenance attribute (proves the query resolved).
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('[data-section="what-moved"]');
+        return el?.hasAttribute("data-provenance") ?? false;
+      },
+      { timeout: 10_000 },
+    );
+    const provenance = await whatMoved.getAttribute("data-provenance");
+
+    expect(["user", "public-trending", "empty"]).toContain(provenance ?? "");
+
+    if (provenance === "public-trending") {
+      const badge = whatMoved.locator("[data-provenance-badge]");
+      await expect(badge).toBeVisible({ timeout: 5_000 });
+      await expect(badge).toContainText(/Public/i);
+      await expect(badge).toContainText(/trending/i);
+
+      const leadIn = whatMoved.locator("[data-trending-leadin]");
+      await expect(leadIn).toBeVisible();
+      const leadInText = (await leadIn.textContent()) ?? "";
+      expect(leadInText.toLowerCase()).toContain("trending publicly");
+
+      // BOUND assertion: at most 5 trending rows in §1.
+      const items = whatMoved.locator("[data-pulse-entity]");
+      const count = await items.count();
+      expect(count).toBeGreaterThan(0);
+      expect(count).toBeLessThanOrEqual(5);
+    } else if (provenance === "empty") {
+      await expect(whatMoved).toContainText(/No pulse generated yet today/i);
+      const badge = whatMoved.locator("[data-provenance-badge]");
+      expect(await badge.count()).toBe(0);
+    }
+
+    // HONEST_STATUS regression — no known fixture string in §1.
+    const sectionText = (await whatMoved.textContent()) ?? "";
+    const fixtureSignals = [
+      "Orbital Labs answered from event corpus",
+      "Ship Demo Day report updated",
+      "Voice-agent evaluation",
+    ];
+    for (const signal of fixtureSignals) {
+      expect(
+        sectionText.includes(signal),
+        `§1 must not contain fixture string "${signal}"`,
+      ).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Second of three P0s in the user's editorial-home sprint loop directive
("go with all of them loop again and again until all done").

Today, every guest visiting `/redesign` sees §1 "What moved today" as
literally `"No pulse generated yet today."`. HONEST_STATUS-correct, but
the editorial-as-default landing reads as mostly empty for a fresh
visitor. This PR adds a public-trending fallback sourced from
`industryUpdates` (cron-fed every morning, already public), labelled
explicitly so the affordance is honest about provenance.

## Diagnostic

- **Symptom**: guests see "No pulse generated yet today." with no
  recovery affordance.
- **Why**: `getTodayPulse` returns `[]` for guests by design, then the
  surface's literal empty state kicks in.
- **Why is the substrate not surfaced**: the daily content pipeline
  (`convex/workflows/dailyLinkedInPost.ts`, populating
  `dailyBriefSnapshots` + `industryUpdates`) was the very thing the
  redesign spec §0 called the "ai-2027-shaped substrate." The pulse
  query just wasn't wired to it.

## Fix

| Layer | Change |
|---|---|
| Backend | `getTodayPulse` returns `provenance: "user" \| "public-trending" \| "empty"` and falls back to up to **5** rows from `industryUpdates.by_scanned_at` desc when the user has no pulse. When `industryUpdates` is also empty, returns `provenance: "empty"` honestly. |
| Hook | `useTodayPulse` re-exports the provenance type. |
| Surface | `WhatMovedSection` renders a `Public · trending` terracotta badge + lead-in ("You haven't run a pulse today. Here's what's trending publicly.") when provenance is `public-trending`. Entity-line meta says `· trending` instead of fabricating a change count. |
| Section | `EditorialSection` accepts arbitrary `data-*` attrs so §1 can carry `data-provenance`. |
| Tests | Scenario I (guest §1 shows trending fallback or honest empty). |

The fallback's `summaryMarkdown` is the provider's actual title +
summary verbatim — no fabricated narrative. `changeCount = 1`,
`materialChangeCount = 0` for trending rows because we cannot honestly
claim a public update is "material" to any owner.

## 8-point reliability checklist

| Item | Status |
|---|---|
| BOUND | `PULSE_FALLBACK_MAX = 5` with `.take(5)` |
| HONEST_STATUS | 3-state provenance enum, `empty` literal when both sources empty |
| HONEST_SCORES | counts are real (1 update = 1 change, 0 material), summary comes from provider field |
| TIMEOUT | n/a (Convex-managed) |
| SSRF | n/a (no fetch added) |
| BOUND_READ | n/a (no external HTTP) |
| ERROR_BOUNDARY | preserved (`EditionErrorBoundary` wraps §1) |
| DETERMINISTIC | `by_scanned_at` desc is stable |

## Scenario I anatomy

- **User**: Anonymous guest (cookies + localStorage cleared)
- **Goal**: Find something useful in §1 instead of a blank "no pulse"
- **Prior state**: `pulseReports` empty for this guest; `industryUpdates`
  may or may not have rows depending on cron freshness
- **Actions**: navigate `/redesign` → wait for `data-provenance` to
  appear → branch on its value
- **Scale**: 1 user
- **Duration**: single page load
- **Expected**: §1 affordance honest about provenance; signal counts
  not fabricated
- **Edge cases**: Convex unavailable → §1 stays in skeleton (test
  waits up to 10s, won't falsely pass)

## Verification

- [x] `npx convex codegen` — clean
- [x] `npx tsc --noEmit --pretty false` — 0 errors
- [x] `npx vite build` — clean (built in 9.89s)
- [ ] Live verification on prod after merge (Tier A bundle hash + Tier B Scenario I against prod)

## Test plan
- [x] Local Vitest unaffected
- [x] Scenario I locally (both `public-trending` and `empty` branches covered)
- [ ] After merge: `vercel build --prod && vercel deploy --prebuilt --prod`
- [ ] After merge: `BASE_URL=https://www.nodebenchai.com npx playwright test tests/e2e/edition-home.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)