### PR TITLE
P0 #3: temporal browsing - Today | 7d | 30d | Archive

### DIFF
--- a/convex/domains/research/editionQueries.ts
+++ b/convex/domains/research/editionQueries.ts
@@ -525,3 +525,537 @@ export const getEditionFootnotes = query({
     return { artifacts, industry };
   },
 });
+
+/**
+ * PulseProjection — the public shape returned by today / daily / weekly
+ * pulse queries.  Defined here so the temporal queries can use it
+ * without depending on P0 #2's getTodayPulse refactor (which
+ * introduces the same type at the top of the file when it merges).
+ *
+ * If both PRs land, the duplicate is deduped by leaving only one
+ * `type PulseProjection = ...` declaration.
+ */
+type PulseProjection = {
+  _id: string;
+  entitySlug: string;
+  dateKey: string;
+  status: "generating" | "ready" | "failed";
+  summaryMarkdown: string | null;
+  changeCount: number;
+  materialChangeCount: number;
+  generatedAt: number;
+};
+
+/* ════════════════════════════════════════════════════════════════════
+ * P0 #3 (2026-05-09) — Temporal browsing.
+ *
+ * The editorial home has only ever shown "today."  This block adds
+ * three sibling queries that let the surface render an arbitrary day,
+ * a 7-day digest, or a 4-5-week monthly retrospective — all bounded,
+ * all honest about empty windows, and all returning shapes that are
+ * compatible with the existing today-render path so WhatMovedSection,
+ * ScoreboardSection, and friends don't need to branch on edition kind.
+ *
+ * URL contract (read by EditorialHomeSurface):
+ *   /redesign?edition=YYYY-MM-DD       → getDailyEdition
+ *   /redesign?edition=week:YYYY-Www    → getWeeklyDigest
+ *   /redesign?edition=month:YYYY-MM    → getMonthlyRetrospective
+ *   /redesign or ?edition=1            → today (existing queries)
+ *
+ * 8-point checklist:
+ *   - BOUND          per-section caps reuse the existing constants
+ *   - HONEST_STATUS  empty arrays + `available: false` flag, no fakes
+ *   - HONEST_SCORES  brier counts come from forecastResolutions, not
+ *                    invented; "top edition per week" picks the row
+ *                    with the highest dashboardMetrics.keyStats count
+ *   - TIMEOUT        n/a (Convex)
+ *   - SSRF           n/a
+ *   - BOUND_READ     n/a
+ *   - ERROR_BOUNDARY malformed args fail-fast via boundLimit; route
+ *                    layer falls back to today on a parse error
+ *   - DETERMINISTIC  no JSON.stringify on dynamic-key objects.
+ * ──────────────────────────────────────────────────────────────── */
+
+/** ISO YYYY-MM-DD pattern. */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+/** ISO YYYY-Www pattern (week 01-53). */
+const ISO_WEEK_RE = /^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])$/;
+/** ISO YYYY-MM pattern (month 01-12). */
+const ISO_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+function isValidDateKey(s: string): boolean {
+  if (!ISO_DATE_RE.test(s)) return false;
+  const t = Date.parse(`${s}T00:00:00Z`);
+  if (!Number.isFinite(t)) return false;
+  // Round-trip — guards against e.g. 2026-02-30 being parsed forgivingly.
+  const back = new Date(t).toISOString().slice(0, 10);
+  return back === s;
+}
+
+function dateKeyFromMs(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** Compute ISO-week boundaries (Mon..Sun UTC) from a YYYY-Www key. */
+function isoWeekRange(weekKey: string): { startMs: number; endMs: number } | null {
+  const m = weekKey.match(/^(\d{4})-W(\d{2})$/);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const week = Number(m[2]);
+  // ISO week 1 contains Jan 4. Find Monday on/before Jan 4.
+  const jan4 = Date.UTC(year, 0, 4);
+  const jan4Day = new Date(jan4).getUTCDay() || 7; // 1..7 (Mon..Sun)
+  const week1Mon = jan4 - (jan4Day - 1) * 86_400_000;
+  const startMs = week1Mon + (week - 1) * 7 * 86_400_000;
+  const endMs = startMs + 7 * 86_400_000 - 1;
+  return { startMs, endMs };
+}
+
+/** Compute month boundaries from a YYYY-MM key. */
+function monthRange(monthKey: string): { startMs: number; endMs: number } | null {
+  const m = monthKey.match(/^(\d{4})-(\d{2})$/);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const startMs = Date.UTC(year, month - 1, 1);
+  const endMs = Date.UTC(year, month, 1) - 1;
+  return { startMs, endMs };
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Daily edition — a specific past (or today) date.  Uses the same
+ * shape as the today-queries combined: { pulses, hypotheses, forecasts,
+ * snapshot, footnotes }.  The surface threads each piece through to
+ * the existing section components.
+ * ────────────────────────────────────────────────────────────────── */
+export const getDailyEdition = query({
+  args: {
+    dateKey: v.string(),
+    anonymousSessionId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    if (!isValidDateKey(args.dateKey)) {
+      // HONEST_STATUS: malformed input → available: false, no body.
+      return {
+        available: false as const,
+        reason: "invalid_date" as const,
+        dateKey: args.dateKey,
+        earliestDateKey: null as string | null,
+      };
+    }
+    const dateKey = args.dateKey;
+    const dayStartMs = Date.parse(`${dateKey}T00:00:00Z`);
+    const dayEndMs = dayStartMs + 86_400_000 - 1;
+
+    // 1. Snapshot for that day (dailyBriefSnapshots is keyed by
+    //    dateString === dateKey).
+    const snapshot = await ctx.db
+      .query("dailyBriefSnapshots")
+      .withIndex("by_date_string", (q) => q.eq("dateString", dateKey))
+      .first();
+
+    // Earliest snapshot date — used as the "no edition for this date"
+    // fallback link target.
+    let earliestDateKey: string | null = null;
+    if (!snapshot) {
+      const earliest = await ctx.db
+        .query("dailyBriefSnapshots")
+        .withIndex("by_date_string")
+        .order("asc")
+        .first();
+      earliestDateKey = earliest?.dateString ?? null;
+    }
+
+    // 2. Pulses for that owner+day (auth-aware).
+    const identity = await resolveProductIdentitySafely(
+      ctx,
+      args.anonymousSessionId,
+    );
+    let pulses: PulseProjection[] = [];
+    if (identity) {
+      const ownerKey =
+        identity.anonymousSessionId ?? (identity.ownerKey as string);
+      const rows = await ctx.db
+        .query("pulseReports")
+        .withIndex("by_owner_date", (q) =>
+          q.eq("ownerKey", ownerKey).eq("dateKey", dateKey),
+        )
+        .order("desc")
+        .take(PULSE_DEFAULT);
+      pulses = rows.map<PulseProjection>((p) => ({
+        _id: p._id,
+        entitySlug: p.entitySlug,
+        dateKey: p.dateKey,
+        status: p.status,
+        summaryMarkdown: p.summaryMarkdown ?? null,
+        changeCount: p.changeCount,
+        materialChangeCount: p.materialChangeCount,
+        generatedAt: p.generatedAt,
+      }));
+    }
+
+    // 3. Hypotheses updated within the requested day (UTC bounds).
+    const hypothesesAll = await Promise.all(
+      Array.from(ACTIVE_STATUSES).map((status) =>
+        ctx.db
+          .query("narrativeHypotheses")
+          .withIndex("by_status", (q) => q.eq("status", status))
+          .order("desc")
+          .take(HYPOTHESIS_MAX * 3),
+      ),
+    );
+    const hypMerged: Doc<"narrativeHypotheses">[] = [];
+    const hypSeen = new Set<string>();
+    for (const batch of hypothesesAll) {
+      for (const h of batch) {
+        if (hypSeen.has(h._id)) continue;
+        if (h.updatedAt < dayStartMs || h.updatedAt > dayEndMs) continue;
+        hypSeen.add(h._id);
+        hypMerged.push(h);
+      }
+    }
+    hypMerged.sort((a, b) => b.updatedAt - a.updatedAt);
+
+    // 4. Forecasts active that day, with last-update history.
+    const forecastRows = await ctx.db
+      .query("forecasts")
+      .withIndex("by_status", (q) => q.eq("status", "active"))
+      .take(FORECAST_MAX * 4);
+    const forecasts = forecastRows
+      .filter((f) => f.updateCount > 0 && f.probability != null)
+      .filter((f) => (f.lastRefreshedAt ?? f.createdAt) <= dayEndMs)
+      .slice(0, FORECAST_MAX);
+
+    if (!snapshot && pulses.length === 0 && hypMerged.length === 0 && forecasts.length === 0) {
+      return {
+        available: false as const,
+        reason: "no_edition" as const,
+        dateKey,
+        earliestDateKey,
+      };
+    }
+
+    return {
+      available: true as const,
+      dateKey,
+      earliestDateKey,
+      snapshot: snapshot
+        ? {
+            _id: snapshot._id,
+            dateString: snapshot.dateString,
+            generatedAt: snapshot.generatedAt,
+            version: snapshot.version,
+            dashboardMetrics: snapshot.dashboardMetrics,
+            sourceSummary: snapshot.sourceSummary,
+          }
+        : null,
+      pulses,
+      hypothesisCount: hypMerged.length,
+      forecastCount: forecasts.length,
+    };
+  },
+});
+
+/* ────────────────────────────────────────────────────────────────────
+ * Weekly digest — 7-day window, aggregated.
+ * Returns: total material-changes, top forecasts by abs Δ, hypothesis
+ * count, and a span-summary (start/end dateKey).
+ * ────────────────────────────────────────────────────────────────── */
+export const getWeeklyDigest = query({
+  args: {
+    weekKey: v.string(),
+    anonymousSessionId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const range = isoWeekRange(args.weekKey);
+    if (!range) {
+      return {
+        available: false as const,
+        reason: "invalid_week" as const,
+        weekKey: args.weekKey,
+        startDateKey: null as string | null,
+        endDateKey: null as string | null,
+      };
+    }
+    const { startMs, endMs } = range;
+    const startDateKey = dateKeyFromMs(startMs);
+    const endDateKey = dateKeyFromMs(endMs);
+
+    // 1. Pulses across the window.
+    const identity = await resolveProductIdentitySafely(
+      ctx,
+      args.anonymousSessionId,
+    );
+    let totalMaterial = 0;
+    let totalChanges = 0;
+    let pulseCount = 0;
+    let topPulses: PulseProjection[] = [];
+    if (identity) {
+      const ownerKey =
+        identity.anonymousSessionId ?? (identity.ownerKey as string);
+      // Iterate per-day; pulseReports.by_owner_date supports
+      // (ownerKey, dateKey) point queries.  We take 7 day-keys.
+      const dayKeys: string[] = [];
+      for (let d = startMs; d <= endMs; d += 86_400_000) {
+        dayKeys.push(dateKeyFromMs(d));
+      }
+      const dayRows = await Promise.all(
+        dayKeys.map((dk) =>
+          ctx.db
+            .query("pulseReports")
+            .withIndex("by_owner_date", (q) =>
+              q.eq("ownerKey", ownerKey).eq("dateKey", dk),
+            )
+            .order("desc")
+            .take(PULSE_DEFAULT),
+        ),
+      );
+      const all = dayRows.flat();
+      totalMaterial = all.reduce(
+        (n, p) => n + (p.materialChangeCount ?? 0),
+        0,
+      );
+      totalChanges = all.reduce((n, p) => n + (p.changeCount ?? 0), 0);
+      pulseCount = all.length;
+      // Top by material change, then change count.
+      topPulses = all
+        .slice()
+        .sort(
+          (a, b) =>
+            (b.materialChangeCount ?? 0) - (a.materialChangeCount ?? 0) ||
+            (b.changeCount ?? 0) - (a.changeCount ?? 0),
+        )
+        .slice(0, 5)
+        .map<PulseProjection>((p) => ({
+          _id: p._id,
+          entitySlug: p.entitySlug,
+          dateKey: p.dateKey,
+          status: p.status,
+          summaryMarkdown: p.summaryMarkdown ?? null,
+          changeCount: p.changeCount,
+          materialChangeCount: p.materialChangeCount,
+          generatedAt: p.generatedAt,
+        }));
+    }
+
+    // 2. Top forecasts by abs probability movement in the window.
+    const forecastRows = await ctx.db
+      .query("forecasts")
+      .withIndex("by_status", (q) => q.eq("status", "active"))
+      .take(FORECAST_MAX * 6);
+    const movements: Array<{
+      forecast: Doc<"forecasts">;
+      delta: number;
+      previousProbability: number;
+      newProbability: number;
+    }> = [];
+    for (const f of forecastRows) {
+      const updates = await ctx.db
+        .query("forecastUpdateHistory")
+        .withIndex("by_forecast_date", (q) => q.eq("forecastId", f._id))
+        .order("desc")
+        .take(20);
+      const inWindow = updates.filter(
+        (u) => u.updatedAt >= startMs && u.updatedAt <= endMs,
+      );
+      if (inWindow.length === 0) continue;
+      const newest = inWindow[0];
+      const oldest = inWindow[inWindow.length - 1];
+      const delta = newest.newProbability - oldest.previousProbability;
+      movements.push({
+        forecast: f,
+        delta,
+        previousProbability: oldest.previousProbability,
+        newProbability: newest.newProbability,
+      });
+    }
+    movements.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+    const topForecasts = movements.slice(0, 3).map((m) => ({
+      _id: m.forecast._id,
+      question: m.forecast.question,
+      forecastType: m.forecast.forecastType,
+      probability: m.newProbability,
+      previousProbability: m.previousProbability,
+      probabilityDelta: m.delta,
+      resolutionDate: m.forecast.resolutionDate,
+    }));
+
+    // 3. Hypotheses updated in the window.
+    const hypothesesAll = await Promise.all(
+      Array.from(ACTIVE_STATUSES).map((status) =>
+        ctx.db
+          .query("narrativeHypotheses")
+          .withIndex("by_status", (q) => q.eq("status", status))
+          .order("desc")
+          .take(HYPOTHESIS_MAX * 3),
+      ),
+    );
+    const hypMerged: Doc<"narrativeHypotheses">[] = [];
+    const hypSeen = new Set<string>();
+    for (const batch of hypothesesAll) {
+      for (const h of batch) {
+        if (hypSeen.has(h._id)) continue;
+        if (h.updatedAt < startMs || h.updatedAt > endMs) continue;
+        hypSeen.add(h._id);
+        hypMerged.push(h);
+      }
+    }
+    hypMerged.sort((a, b) => b.updatedAt - a.updatedAt);
+    const topHypotheses = hypMerged.slice(0, 5).map((h) => ({
+      _id: h._id,
+      label: h.label,
+      title: h.title,
+      claimForm: h.claimForm,
+      status: h.status,
+      updatedAt: h.updatedAt,
+      supportingEvidenceCount: h.supportingEvidenceCount,
+      contradictingEvidenceCount: h.contradictingEvidenceCount,
+    }));
+
+    if (
+      pulseCount === 0 &&
+      topForecasts.length === 0 &&
+      topHypotheses.length === 0
+    ) {
+      return {
+        available: false as const,
+        reason: "no_edition" as const,
+        weekKey: args.weekKey,
+        startDateKey,
+        endDateKey,
+      };
+    }
+
+    return {
+      available: true as const,
+      weekKey: args.weekKey,
+      startDateKey,
+      endDateKey,
+      totals: {
+        pulseCount,
+        materialChanges: totalMaterial,
+        changes: totalChanges,
+      },
+      topPulses,
+      topForecasts,
+      topHypotheses,
+    };
+  },
+});
+
+/* ────────────────────────────────────────────────────────────────────
+ * Monthly retrospective (P0-minimal): top edition per week + brier-
+ * resolved forecast count.  Per spec, this is intentionally small —
+ * deeper per-month synthesis is deferred to a follow-up.
+ * ────────────────────────────────────────────────────────────────── */
+export const getMonthlyRetrospective = query({
+  args: {
+    monthKey: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const range = monthRange(args.monthKey);
+    if (!range) {
+      return {
+        available: false as const,
+        reason: "invalid_month" as const,
+        monthKey: args.monthKey,
+      };
+    }
+    const { startMs, endMs } = range;
+
+    // 1. All daily-brief snapshots in the month — pick the one with
+    //    the longest keyStats per ISO week (deterministic top pick).
+    const snapshotsAll = await ctx.db
+      .query("dailyBriefSnapshots")
+      .withIndex("by_date_string")
+      .order("desc")
+      .take(60);
+    const inMonth = snapshotsAll.filter((s) => {
+      const t = Date.parse(`${s.dateString}T00:00:00Z`);
+      return t >= startMs && t <= endMs;
+    });
+    // Bucket by ISO-week.
+    const weekBuckets = new Map<string, Doc<"dailyBriefSnapshots">[]>();
+    for (const s of inMonth) {
+      const t = Date.parse(`${s.dateString}T00:00:00Z`);
+      const isoWeek = isoWeekKeyFromMs(t);
+      const list = weekBuckets.get(isoWeek) ?? [];
+      list.push(s);
+      weekBuckets.set(isoWeek, list);
+    }
+    const topPerWeek: Array<{
+      weekKey: string;
+      dateString: string;
+      keyStatCount: number;
+    }> = [];
+    for (const [weekKey, snaps] of weekBuckets.entries()) {
+      const top = snaps
+        .slice()
+        .sort(
+          (a, b) =>
+            (b.dashboardMetrics?.keyStats?.length ?? 0) -
+            (a.dashboardMetrics?.keyStats?.length ?? 0),
+        )[0];
+      if (!top) continue;
+      topPerWeek.push({
+        weekKey,
+        dateString: top.dateString,
+        keyStatCount: top.dashboardMetrics?.keyStats?.length ?? 0,
+      });
+    }
+    topPerWeek.sort((a, b) => a.dateString.localeCompare(b.dateString));
+
+    // 2. Brier-resolved forecasts whose resolvedAt fell in the month.
+    const resolutions = await ctx.db
+      .query("forecastResolutions")
+      .order("desc")
+      .take(200);
+    const inMonthRes = resolutions.filter(
+      (r) => r.resolvedAt >= startMs && r.resolvedAt <= endMs,
+    );
+    const brierScores = inMonthRes
+      .map((r) => r.brierScore)
+      .filter((b): b is number => typeof b === "number" && Number.isFinite(b));
+    const meanBrier =
+      brierScores.length > 0
+        ? brierScores.reduce((s, n) => s + n, 0) / brierScores.length
+        : null;
+
+    if (topPerWeek.length === 0 && inMonthRes.length === 0) {
+      return {
+        available: false as const,
+        reason: "no_edition" as const,
+        monthKey: args.monthKey,
+      };
+    }
+
+    return {
+      available: true as const,
+      monthKey: args.monthKey,
+      topPerWeek,
+      resolvedForecastCount: inMonthRes.length,
+      meanBrier,
+    };
+  },
+});
+
+/** Compute YYYY-Www key from a UTC ms timestamp. */
+function isoWeekKeyFromMs(ms: number): string {
+  const d = new Date(ms);
+  const year = d.getUTCFullYear();
+  const jan4 = Date.UTC(year, 0, 4);
+  const jan4Day = new Date(jan4).getUTCDay() || 7;
+  const week1Mon = jan4 - (jan4Day - 1) * 86_400_000;
+  const week = Math.floor((ms - week1Mon) / (7 * 86_400_000)) + 1;
+  // Edge case: year boundary — if the value falls in week 1 of next
+  // year, recurse on next year.
+  if (week > 52) {
+    const nextJan4 = Date.UTC(year + 1, 0, 4);
+    const nextJan4Day = new Date(nextJan4).getUTCDay() || 7;
+    const nextWeek1Mon = nextJan4 - (nextJan4Day - 1) * 86_400_000;
+    if (ms >= nextWeek1Mon) {
+      return `${year + 1}-W${"01".padStart(2, "0")}`;
+    }
+  }
+  return `${year}-W${String(week).padStart(2, "0")}`;
+}

--- a/src/features/redesign/components/edition/EditionSelector.tsx
+++ b/src/features/redesign/components/edition/EditionSelector.tsx
@@ -1,0 +1,261 @@
+/**
+ * EditionSelector — temporal chip group above the §1 header.
+ *
+ * Renders five affordances:
+ *   Today | Yesterday | This week | This month | Archive (date picker)
+ *
+ * Mobile (< 480px) collapses to: Today | 7d | 30d | →
+ *
+ * Selection writes the URL via useNavigate({replace:true}) so the
+ * back button does not stack the user's clicks within a single
+ * editorial session.
+ *
+ * URL contract (see HOME_EDITORIAL_REDESIGN.md P0 #3):
+ *   no flag                  → today (default)
+ *   ?edition=1               → today (back-compat)
+ *   ?edition=2026-05-08      → daily edition for that date
+ *   ?edition=week:2026-W19   → weekly digest
+ *   ?edition=month:2026-05   → monthly retrospective
+ *
+ * The component is purely cosmetic — it does NOT fetch.  The surface
+ * does the fetch based on the parsed URL param.
+ *
+ * a11y: chips are <button> elements with aria-pressed reflecting the
+ * active selection.  Date input is a native <input type="date"> with
+ * a label for screen-reader association.
+ */
+
+import { useId, useState, useCallback } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+export type EditionSelection =
+  | { kind: "today" }
+  | { kind: "day"; dateKey: string }
+  | { kind: "week"; weekKey: string }
+  | { kind: "month"; monthKey: string };
+
+interface Props {
+  /** The currently-active selection, parsed by the surface. */
+  selection: EditionSelection;
+  /**
+   * The earliest dateString known to the system (from
+   * dailyBriefSnapshots).  Used as the min= constraint on the
+   * archive date picker so users can't tab into the void.
+   */
+  earliestDateKey?: string | null;
+}
+
+/* ─── Date helpers (local UTC, matches the queries) ──────────────── */
+
+function todayUtc(): Date {
+  return new Date(new Date().toISOString().slice(0, 10) + "T00:00:00Z");
+}
+
+function dateKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function yesterdayKey(): string {
+  const t = todayUtc().getTime() - 86_400_000;
+  return new Date(t).toISOString().slice(0, 10);
+}
+
+/** Compute the ISO-week containing `now` as YYYY-Www. */
+function currentWeekKey(): string {
+  const now = todayUtc();
+  const year = now.getUTCFullYear();
+  const jan4 = Date.UTC(year, 0, 4);
+  const jan4Day = new Date(jan4).getUTCDay() || 7;
+  const week1Mon = jan4 - (jan4Day - 1) * 86_400_000;
+  const week = Math.floor((now.getTime() - week1Mon) / (7 * 86_400_000)) + 1;
+  return `${year}-W${String(week).padStart(2, "0")}`;
+}
+
+function currentMonthKey(): string {
+  const now = todayUtc();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+/* ─── Chip styles ────────────────────────────────────────────────── */
+
+const baseChipStyle: React.CSSProperties = {
+  font: "inherit",
+  fontSize: 12,
+  lineHeight: "20px",
+  padding: "2px 10px",
+  borderRadius: 999,
+  border: "1px solid var(--rd-edition-rule, rgba(255,255,255,0.08))",
+  background: "transparent",
+  color: "var(--rd-ink-mute)",
+  cursor: "pointer",
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+  fontWeight: 500,
+};
+
+const activeChipStyle: React.CSSProperties = {
+  ...baseChipStyle,
+  borderColor: "var(--rd-accent, #d97757)",
+  color: "var(--rd-accent, #d97757)",
+  fontWeight: 600,
+};
+
+/* ─── Component ──────────────────────────────────────────────────── */
+
+export function EditionSelector({ selection, earliestDateKey }: Props) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const datePickerId = useId();
+
+  const setEdition = useCallback(
+    (paramValue: string | null) => {
+      const params = new URLSearchParams(location.search);
+      if (paramValue === null) {
+        params.delete("edition");
+      } else {
+        params.set("edition", paramValue);
+      }
+      const qs = params.toString();
+      navigate(qs ? `${location.pathname}?${qs}` : location.pathname, {
+        replace: true,
+      });
+    },
+    [navigate, location.pathname, location.search],
+  );
+
+  const isToday = selection.kind === "today";
+  const isDay = selection.kind === "day";
+  const isWeek = selection.kind === "week";
+  const isMonth = selection.kind === "month";
+  const yKey = yesterdayKey();
+  const isYesterday = isDay && selection.dateKey === yKey;
+  const isThisWeek = isWeek && selection.weekKey === currentWeekKey();
+  const isThisMonth = isMonth && selection.monthKey === currentMonthKey();
+
+  const onPickDate = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const v = e.target.value;
+      if (!v || !/^\d{4}-\d{2}-\d{2}$/.test(v)) return;
+      // If the user picks today, write the canonical no-flag form.
+      if (v === dateKey(todayUtc())) {
+        setEdition(null);
+      } else {
+        setEdition(v);
+      }
+      setPickerOpen(false);
+    },
+    [setEdition],
+  );
+
+  return (
+    <div
+      data-edition-selector
+      role="group"
+      aria-label="Edition timeframe selector"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 8,
+        margin: "0 0 12px",
+        alignItems: "center",
+      }}
+    >
+      <button
+        type="button"
+        data-edition-chip="today"
+        aria-pressed={isToday}
+        style={isToday ? activeChipStyle : baseChipStyle}
+        onClick={() => setEdition(null)}
+      >
+        Today
+      </button>
+      <button
+        type="button"
+        data-edition-chip="yesterday"
+        aria-pressed={isYesterday}
+        style={isYesterday ? activeChipStyle : baseChipStyle}
+        onClick={() => setEdition(yKey)}
+      >
+        <span className="rd-edition-chip__full">Yesterday</span>
+        <span className="rd-edition-chip__short">1d</span>
+      </button>
+      <button
+        type="button"
+        data-edition-chip="week"
+        aria-pressed={isThisWeek}
+        style={isThisWeek ? activeChipStyle : baseChipStyle}
+        onClick={() => setEdition(`week:${currentWeekKey()}`)}
+      >
+        <span className="rd-edition-chip__full">This week</span>
+        <span className="rd-edition-chip__short">7d</span>
+      </button>
+      <button
+        type="button"
+        data-edition-chip="month"
+        aria-pressed={isThisMonth}
+        style={isThisMonth ? activeChipStyle : baseChipStyle}
+        onClick={() => setEdition(`month:${currentMonthKey()}`)}
+      >
+        <span className="rd-edition-chip__full">This month</span>
+        <span className="rd-edition-chip__short">30d</span>
+      </button>
+      <button
+        type="button"
+        data-edition-chip="archive"
+        aria-pressed={
+          (isDay && !isYesterday) ||
+          (isMonth && !isThisMonth) ||
+          (isWeek && !isThisWeek)
+        }
+        aria-expanded={pickerOpen}
+        style={baseChipStyle}
+        onClick={() => setPickerOpen((v) => !v)}
+        title="Pick an archive date"
+      >
+        Archive →
+      </button>
+      {pickerOpen && (
+        <span
+          data-edition-archive-picker
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            marginLeft: 4,
+          }}
+        >
+          <label
+            htmlFor={datePickerId}
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "var(--rd-ink-mute)",
+            }}
+          >
+            Pick a day
+          </label>
+          <input
+            id={datePickerId}
+            type="date"
+            data-edition-archive-input
+            min={earliestDateKey ?? undefined}
+            max={dateKey(todayUtc())}
+            defaultValue={isDay ? selection.dateKey : ""}
+            onChange={onPickDate}
+            style={{
+              font: "inherit",
+              fontSize: 12,
+              padding: "2px 6px",
+              border: "1px solid var(--rd-edition-rule, rgba(255,255,255,0.08))",
+              borderRadius: 4,
+              background: "transparent",
+              color: "var(--rd-ink-strong)",
+            }}
+          />
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/features/redesign/components/edition/edition.css
+++ b/src/features/redesign/components/edition/edition.css
@@ -628,3 +628,16 @@
     transition: none;
   }
 }
+
+/* ─── P0 #3: EditionSelector responsive chip text ─────────────── */
+[data-redesign] [data-edition] [data-edition-selector] .rd-edition-chip__short {
+  display: none;
+}
+@media (max-width: 480px) {
+  [data-redesign] [data-edition] [data-edition-selector] .rd-edition-chip__full {
+    display: none;
+  }
+  [data-redesign] [data-edition] [data-edition-selector] .rd-edition-chip__short {
+    display: inline;
+  }
+}

--- a/src/features/redesign/hooks/useEditionView.ts
+++ b/src/features/redesign/hooks/useEditionView.ts
@@ -1,0 +1,57 @@
+/**
+ * useEditionView — parse the `?edition=...` URL param into a
+ * temporal selection, with HONEST_STATUS fallback to "today" on any
+ * malformed input.
+ *
+ * Contract (HOME_EDITORIAL_REDESIGN.md P0 #3):
+ *   no flag                  → today
+ *   ?edition=1               → today (back-compat)
+ *   ?edition=YYYY-MM-DD      → day
+ *   ?edition=week:YYYY-Www   → week
+ *   ?edition=month:YYYY-MM   → month
+ *
+ * Anything else (e.g. ?edition=banana) parses to today and is
+ * intentionally not surfaced as an error — the surface still renders.
+ */
+
+import { useMemo } from "react";
+import { useLocation } from "react-router-dom";
+import type { EditionSelection } from "../components/edition/EditionSelector";
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_WEEK_RE = /^week:(\d{4}-W(?:0[1-9]|[1-4]\d|5[0-3]))$/;
+const ISO_MONTH_RE = /^month:(\d{4}-(?:0[1-9]|1[0-2]))$/;
+
+function isValidDateKey(s: string): boolean {
+  if (!ISO_DATE_RE.test(s)) return false;
+  const t = Date.parse(`${s}T00:00:00Z`);
+  if (!Number.isFinite(t)) return false;
+  return new Date(t).toISOString().slice(0, 10) === s;
+}
+
+export function parseEditionParam(value: string | null): EditionSelection {
+  if (value === null || value === "" || value === "1") {
+    return { kind: "today" };
+  }
+  if (isValidDateKey(value)) {
+    return { kind: "day", dateKey: value };
+  }
+  const wMatch = value.match(ISO_WEEK_RE);
+  if (wMatch) {
+    return { kind: "week", weekKey: wMatch[1] };
+  }
+  const mMatch = value.match(ISO_MONTH_RE);
+  if (mMatch) {
+    return { kind: "month", monthKey: mMatch[1] };
+  }
+  // ERROR_BOUNDARY: malformed → fall back to today; never throw.
+  return { kind: "today" };
+}
+
+export function useEditionView(): EditionSelection {
+  const location = useLocation();
+  return useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return parseEditionParam(params.get("edition"));
+  }, [location.search]);
+}

--- a/src/features/redesign/hooks/useTemporalEdition.ts
+++ b/src/features/redesign/hooks/useTemporalEdition.ts
@@ -1,0 +1,140 @@
+/**
+ * useTemporalEdition — wrappers around the three temporal queries
+ * added in P0 #3.  Each hook returns `undefined` while loading and
+ * a discriminated-union shape when resolved.
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { getStoredAnonymousSessionId } from "./editionSession";
+
+/* ─── Daily edition (specific past day) ──────────────────────────── */
+
+export type DailyEditionResult =
+  | {
+      available: true;
+      dateKey: string;
+      earliestDateKey: string | null;
+      snapshot: {
+        _id: string;
+        dateString: string;
+        generatedAt: number;
+        version: number;
+        dashboardMetrics: any;
+        sourceSummary: any;
+      } | null;
+      pulses: Array<{
+        _id: string;
+        entitySlug: string;
+        dateKey: string;
+        status: "generating" | "ready" | "failed";
+        summaryMarkdown: string | null;
+        changeCount: number;
+        materialChangeCount: number;
+        generatedAt: number;
+      }>;
+      hypothesisCount: number;
+      forecastCount: number;
+    }
+  | {
+      available: false;
+      reason: "invalid_date" | "no_edition";
+      dateKey: string;
+      earliestDateKey: string | null;
+    };
+
+export function useDailyEdition(
+  dateKey: string | null,
+): DailyEditionResult | undefined {
+  const sessionId = getStoredAnonymousSessionId();
+  const data = useQuery(
+    api.domains.research.editionQueries.getDailyEdition,
+    dateKey ? { dateKey, anonymousSessionId: sessionId } : "skip",
+  );
+  return data as DailyEditionResult | undefined;
+}
+
+/* ─── Weekly digest ──────────────────────────────────────────────── */
+
+export type WeeklyDigestResult =
+  | {
+      available: true;
+      weekKey: string;
+      startDateKey: string;
+      endDateKey: string;
+      totals: { pulseCount: number; materialChanges: number; changes: number };
+      topPulses: Array<{
+        _id: string;
+        entitySlug: string;
+        dateKey: string;
+        summaryMarkdown: string | null;
+        changeCount: number;
+        materialChangeCount: number;
+      }>;
+      topForecasts: Array<{
+        _id: string;
+        question: string;
+        probability: number;
+        previousProbability: number;
+        probabilityDelta: number;
+        resolutionDate: string;
+      }>;
+      topHypotheses: Array<{
+        _id: string;
+        label: string;
+        title: string;
+        claimForm: string;
+        status: string;
+        updatedAt: number;
+        supportingEvidenceCount: number;
+        contradictingEvidenceCount: number;
+      }>;
+    }
+  | {
+      available: false;
+      reason: "invalid_week" | "no_edition";
+      weekKey: string;
+      startDateKey: string | null;
+      endDateKey: string | null;
+    };
+
+export function useWeeklyDigest(
+  weekKey: string | null,
+): WeeklyDigestResult | undefined {
+  const sessionId = getStoredAnonymousSessionId();
+  const data = useQuery(
+    api.domains.research.editionQueries.getWeeklyDigest,
+    weekKey ? { weekKey, anonymousSessionId: sessionId } : "skip",
+  );
+  return data as WeeklyDigestResult | undefined;
+}
+
+/* ─── Monthly retrospective ──────────────────────────────────────── */
+
+export type MonthlyRetrospectiveResult =
+  | {
+      available: true;
+      monthKey: string;
+      topPerWeek: Array<{
+        weekKey: string;
+        dateString: string;
+        keyStatCount: number;
+      }>;
+      resolvedForecastCount: number;
+      meanBrier: number | null;
+    }
+  | {
+      available: false;
+      reason: "invalid_month" | "no_edition";
+      monthKey: string;
+    };
+
+export function useMonthlyRetrospective(
+  monthKey: string | null,
+): MonthlyRetrospectiveResult | undefined {
+  const data = useQuery(
+    api.domains.research.editionQueries.getMonthlyRetrospective,
+    monthKey ? { monthKey } : "skip",
+  );
+  return data as MonthlyRetrospectiveResult | undefined;
+}

--- a/src/features/redesign/surfaces/EditorialHomeSurface.tsx
+++ b/src/features/redesign/surfaces/EditorialHomeSurface.tsx
@@ -52,6 +52,17 @@ import { useActiveHypotheses, type EditionHypothesis } from "../hooks/useActiveH
 import { useTopForecasts, type EditionForecast } from "../hooks/useTopForecasts";
 import { useLatestDailyBriefSnapshot } from "../hooks/useLatestDailyBriefSnapshot";
 import { useEditionFootnotes } from "../hooks/useEditionFootnotes";
+// P0 #3 — temporal browsing imports.  Note: useHomePulseLive +
+// fixturePulseCards / watchlist / continueWorking from #285's branch
+// were intentionally NOT carried forward here — P0 #1 removed those
+// from the editorial path and they must not return.
+import { useEditionView } from "../hooks/useEditionView";
+import {
+  useDailyEdition,
+  useWeeklyDigest,
+  useMonthlyRetrospective,
+} from "../hooks/useTemporalEdition";
+import { EditionSelector } from "../components/edition/EditionSelector";
 import { Pill } from "../components/Pill";
 import "../components/edition/edition.css";
 
@@ -602,11 +613,580 @@ function FootnotesSection({
   );
 }
 
+/* ─── Archived-day render branch (P0 #3) ────────────────────────── */
+
+function ArchivedDayBranch({
+  dateKey,
+  selection,
+  onSwitchToClassic,
+}: {
+  dateKey: string;
+  selection: { kind: "day"; dateKey: string };
+  onSwitchToClassic: () => void;
+}) {
+  const navigate = useNavigate();
+  const data = useDailyEdition(dateKey);
+  // While loading we keep the chrome so the selector remains responsive.
+  return (
+    <div data-edition data-edition-kind="day">
+      <div className="rd-edition-root">
+        <header
+          className="rd-edition-header"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            paddingBottom: 8,
+            borderBottom: "1px solid var(--rd-edition-rule-strong)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Pill tone="accent">Daily edition</Pill>
+            <span className="rd-edition-meta">
+              Archive view · {dateKey}
+            </span>
+            <button
+              type="button"
+              onClick={onSwitchToClassic}
+              className="rd-edition-switch"
+              aria-label="Switch to classic home"
+              data-edition-switch
+              style={{
+                marginLeft: "auto",
+                background: "transparent",
+                border: "none",
+                color: "var(--rd-ink-mute)",
+                fontSize: 12,
+                fontWeight: 500,
+                letterSpacing: "0.04em",
+                cursor: "pointer",
+                padding: "4px 8px",
+                borderRadius: 4,
+                textDecoration: "underline",
+                textUnderlineOffset: 3,
+              }}
+            >
+              ← Switch to classic home
+            </button>
+          </div>
+          <EditionSelector
+            selection={selection}
+            earliestDateKey={
+              data && !data.available ? data.earliestDateKey : null
+            }
+          />
+          <h1
+            style={{
+              fontSize: 32,
+              fontWeight: 700,
+              letterSpacing: "-0.6px",
+              margin: 0,
+              lineHeight: 1.18,
+              color: "var(--rd-ink-strong)",
+            }}
+          >
+            Edition · {dateKey}
+          </h1>
+        </header>
+
+        {data === undefined && (
+          <section data-section="day-loading" className="rd-edition-section">
+            <div className="rd-edition-skeleton" style={{ width: "85%" }} />
+            <div className="rd-edition-skeleton" style={{ width: "62%" }} />
+          </section>
+        )}
+
+        {data && !data.available && (
+          <section
+            data-section="archive-empty"
+            className="rd-edition-section"
+            role="region"
+            aria-label="No edition for this date"
+          >
+            <p className="rd-edition-empty">
+              No edition for {dateKey}.
+              {data.earliestDateKey ? (
+                <>
+                  {" "}
+                  Earliest available edition:{" "}
+                  <button
+                    type="button"
+                    className="rd-btn rd-btn--quiet rd-btn--sm"
+                    onClick={() => {
+                      const params = new URLSearchParams();
+                      params.set("edition", data.earliestDateKey ?? "");
+                      navigate(`/redesign?${params.toString()}`);
+                    }}
+                  >
+                    {data.earliestDateKey}
+                  </button>
+                  .
+                </>
+              ) : null}
+            </p>
+          </section>
+        )}
+
+        {data && data.available && (
+          <>
+            <section
+              data-section="archive-summary"
+              data-section-number="01"
+              data-section-kicker="Archived edition"
+              className="rd-edition-section"
+              role="region"
+              aria-label={`Archived edition for ${dateKey}`}
+            >
+              <p className="rd-edition-meta">
+                01 · Archived edition · {dateKey}
+              </p>
+              <p>
+                Pulses captured this day: <strong>{data.pulses.length}</strong>.
+                Hypotheses updated: <strong>{data.hypothesisCount}</strong>.
+                Forecasts active: <strong>{data.forecastCount}</strong>.
+              </p>
+              {data.snapshot ? (
+                <p className="rd-edition-meta">
+                  Daily brief snapshot v{data.snapshot.version} captured at{" "}
+                  {new Date(data.snapshot.generatedAt).toISOString().slice(0, 16)}Z.
+                </p>
+              ) : (
+                <p className="rd-edition-empty" style={{ padding: 0 }}>
+                  No daily-brief snapshot was captured this day.
+                </p>
+              )}
+            </section>
+
+            {data.snapshot && (
+              <EditionErrorBoundary label="archive-scoreboard">
+                <ScoreboardSection
+                  number="02"
+                  kicker="Scoreboard"
+                  heading="Day's scoreboard"
+                  snapshot={
+                    data.snapshot as ReturnType<typeof useLatestDailyBriefSnapshot>
+                  }
+                />
+              </EditionErrorBoundary>
+            )}
+
+            {data.snapshot && (
+              <EditionErrorBoundary label="archive-capabilities">
+                <CapabilitiesSection
+                  number={data.snapshot ? "03" : "02"}
+                  kicker="The capability landscape"
+                  heading="Capabilities map"
+                  snapshot={
+                    data.snapshot as ReturnType<typeof useLatestDailyBriefSnapshot>
+                  }
+                />
+              </EditionErrorBoundary>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Weekly-digest render branch (P0 #3) ───────────────────────── */
+
+function WeeklyBranch({
+  weekKey,
+  selection,
+  onSwitchToClassic,
+}: {
+  weekKey: string;
+  selection: { kind: "week"; weekKey: string };
+  onSwitchToClassic: () => void;
+}) {
+  const data = useWeeklyDigest(weekKey);
+  return (
+    <div data-edition data-edition-kind="week">
+      <div className="rd-edition-root">
+        <header
+          className="rd-edition-header"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            paddingBottom: 8,
+            borderBottom: "1px solid var(--rd-edition-rule-strong)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Pill tone="accent">This week</Pill>
+            <span className="rd-edition-meta">
+              {data && data.available
+                ? `${data.startDateKey} → ${data.endDateKey}`
+                : weekKey}
+            </span>
+            <button
+              type="button"
+              onClick={onSwitchToClassic}
+              className="rd-edition-switch"
+              aria-label="Switch to classic home"
+              data-edition-switch
+              style={{
+                marginLeft: "auto",
+                background: "transparent",
+                border: "none",
+                color: "var(--rd-ink-mute)",
+                fontSize: 12,
+                fontWeight: 500,
+                letterSpacing: "0.04em",
+                cursor: "pointer",
+                padding: "4px 8px",
+                borderRadius: 4,
+                textDecoration: "underline",
+                textUnderlineOffset: 3,
+              }}
+            >
+              ← Switch to classic home
+            </button>
+          </div>
+          <EditionSelector selection={selection} />
+          <h1
+            style={{
+              fontSize: 32,
+              fontWeight: 700,
+              letterSpacing: "-0.6px",
+              margin: 0,
+              lineHeight: 1.18,
+              color: "var(--rd-ink-strong)",
+            }}
+          >
+            This week
+          </h1>
+        </header>
+
+        {data === undefined && (
+          <section data-section="week-loading" className="rd-edition-section">
+            <div className="rd-edition-skeleton" style={{ width: "90%" }} />
+            <div className="rd-edition-skeleton" style={{ width: "70%" }} />
+          </section>
+        )}
+
+        {data && !data.available && (
+          <section
+            data-section="archive-empty"
+            className="rd-edition-section"
+            role="region"
+            aria-label="No edition for this week"
+          >
+            <p className="rd-edition-empty">No edition for {weekKey}.</p>
+          </section>
+        )}
+
+        {data && data.available && (
+          <>
+            <section
+              data-section="week-totals"
+              data-section-number="01"
+              data-section-kicker="Week in totals"
+              className="rd-edition-section"
+              role="region"
+              aria-label="This week in totals"
+            >
+              <p className="rd-edition-meta">01 · Week in totals</p>
+              <p>
+                <strong>{data.totals.materialChanges}</strong> material
+                change{data.totals.materialChanges === 1 ? "" : "s"} across{" "}
+                <strong>{data.totals.pulseCount}</strong> pulse
+                {data.totals.pulseCount === 1 ? "" : "s"}.
+              </p>
+            </section>
+
+            {data.topForecasts.length > 0 && (
+              <section
+                data-section="week-forecasts"
+                data-section-number="02"
+                data-section-kicker="Top forecast moves"
+                className="rd-edition-section"
+                role="region"
+                aria-label="Top forecast moves"
+              >
+                <p className="rd-edition-meta">02 · Top forecast moves</p>
+                <ul>
+                  {data.topForecasts.map((f) => {
+                    const pp = Math.round(f.probabilityDelta * 100);
+                    const tone = pp > 0 ? "up" : pp < 0 ? "down" : "flat";
+                    return (
+                      <li key={f._id} style={{ marginBottom: 8 }}>
+                        <strong>{f.question}</strong>{" "}
+                        <span
+                          className={`rd-edition-scoreboard__delta rd-edition-scoreboard__delta--${tone}`}
+                        >
+                          [
+                          {pp > 0 ? "+" : ""}
+                          {pp}pp]
+                        </span>{" "}
+                        <span className="rd-edition-meta">
+                          → {Math.round(f.probability * 100)}% by{" "}
+                          {f.resolutionDate}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            )}
+
+            {data.topHypotheses.length > 0 && (
+              <section
+                data-section="week-hypotheses"
+                data-section-number="03"
+                data-section-kicker="Hypotheses moved"
+                className="rd-edition-section"
+                role="region"
+                aria-label="Hypotheses moved this week"
+              >
+                <p className="rd-edition-meta">03 · Hypotheses moved</p>
+                <ul>
+                  {data.topHypotheses.map((h) => (
+                    <li key={h._id} style={{ marginBottom: 8 }}>
+                      <strong>
+                        {h.label} {h.title}
+                      </strong>
+                      <p className="rd-edition-meta">
+                        {h.supportingEvidenceCount} supporting ·{" "}
+                        {h.contradictingEvidenceCount} contradicting
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Monthly retrospective render branch (P0 #3, minimal) ──────── */
+
+function MonthlyBranch({
+  monthKey,
+  selection,
+  onSwitchToClassic,
+}: {
+  monthKey: string;
+  selection: { kind: "month"; monthKey: string };
+  onSwitchToClassic: () => void;
+}) {
+  const data = useMonthlyRetrospective(monthKey);
+  return (
+    <div data-edition data-edition-kind="month">
+      <div className="rd-edition-root">
+        <header
+          className="rd-edition-header"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            paddingBottom: 8,
+            borderBottom: "1px solid var(--rd-edition-rule-strong)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Pill tone="accent">This month</Pill>
+            <span className="rd-edition-meta">{monthKey}</span>
+            <button
+              type="button"
+              onClick={onSwitchToClassic}
+              className="rd-edition-switch"
+              aria-label="Switch to classic home"
+              data-edition-switch
+              style={{
+                marginLeft: "auto",
+                background: "transparent",
+                border: "none",
+                color: "var(--rd-ink-mute)",
+                fontSize: 12,
+                fontWeight: 500,
+                letterSpacing: "0.04em",
+                cursor: "pointer",
+                padding: "4px 8px",
+                borderRadius: 4,
+                textDecoration: "underline",
+                textUnderlineOffset: 3,
+              }}
+            >
+              ← Switch to classic home
+            </button>
+          </div>
+          <EditionSelector selection={selection} />
+          <h1
+            style={{
+              fontSize: 32,
+              fontWeight: 700,
+              letterSpacing: "-0.6px",
+              margin: 0,
+              lineHeight: 1.18,
+              color: "var(--rd-ink-strong)",
+            }}
+          >
+            This month
+          </h1>
+        </header>
+
+        {data === undefined && (
+          <section data-section="month-loading" className="rd-edition-section">
+            <div className="rd-edition-skeleton" style={{ width: "85%" }} />
+          </section>
+        )}
+
+        {data && !data.available && (
+          <section
+            data-section="archive-empty"
+            className="rd-edition-section"
+            role="region"
+            aria-label="No edition for this month"
+          >
+            <p className="rd-edition-empty">No edition for {monthKey}.</p>
+          </section>
+        )}
+
+        {data && data.available && (
+          <>
+            <section
+              data-section="month-summary"
+              data-section-number="01"
+              data-section-kicker="Top edition per week"
+              className="rd-edition-section"
+              role="region"
+              aria-label="Top edition per week"
+            >
+              <p className="rd-edition-meta">01 · Top edition per week</p>
+              {data.topPerWeek.length === 0 ? (
+                <p className="rd-edition-empty" style={{ padding: 0 }}>
+                  No daily-brief snapshots were captured in {monthKey}.
+                </p>
+              ) : (
+                <ul>
+                  {data.topPerWeek.map((w) => (
+                    <li key={w.weekKey} style={{ marginBottom: 4 }}>
+                      <strong>{w.weekKey}</strong> — top day {w.dateString}{" "}
+                      <span className="rd-edition-meta">
+                        ({w.keyStatCount} key stats)
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <section
+              data-section="month-brier"
+              data-section-number="02"
+              data-section-kicker="Forecast resolution"
+              className="rd-edition-section"
+              role="region"
+              aria-label="Forecast resolution"
+            >
+              <p className="rd-edition-meta">02 · Forecast resolution</p>
+              <p>
+                <strong>{data.resolvedForecastCount}</strong> forecast
+                {data.resolvedForecastCount === 1 ? "" : "s"} resolved this
+                month.
+                {data.meanBrier !== null
+                  ? ` Mean Brier score: ${data.meanBrier.toFixed(3)}.`
+                  : " No Brier scores recorded."}
+              </p>
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
 /* ─── EditorialHomeSurface root ─────────────────────────────────── */
 
 export function EditorialHomeSurface({ onAsk }: Props) {
   const navigate = useNavigate();
   const location = useLocation();
+  const selection = useEditionView();
+  const onSwitchToClassic = () => {
+    const params = new URLSearchParams(location.search);
+    params.delete("edition");
+    params.set("classic", "1");
+    navigate(`${location.pathname}?${params.toString()}`, { replace: true });
+  };
+
+  // P0 #3: temporal branches use their own queries.  The "today"
+  // branch (default + ?edition=1) keeps the existing today-render
+  // path intact.
+  if (selection.kind === "day") {
+    return (
+      <ArchivedDayBranch
+        dateKey={selection.dateKey}
+        selection={selection}
+        onSwitchToClassic={onSwitchToClassic}
+      />
+    );
+  }
+  if (selection.kind === "week") {
+    return (
+      <WeeklyBranch
+        weekKey={selection.weekKey}
+        selection={selection}
+        onSwitchToClassic={onSwitchToClassic}
+      />
+    );
+  }
+  if (selection.kind === "month") {
+    return (
+      <MonthlyBranch
+        monthKey={selection.monthKey}
+        selection={selection}
+        onSwitchToClassic={onSwitchToClassic}
+      />
+    );
+  }
+
+  return (
+    <TodayRender
+      onAsk={onAsk}
+      selection={selection}
+      onSwitchToClassic={onSwitchToClassic}
+    />
+  );
+}
+
+/* ─── Today render (Phase 7a-d body, lifted into a helper) ──────── */
+
+function TodayRender({
+  onAsk,
+  selection,
+  onSwitchToClassic,
+}: {
+  onAsk: Props["onAsk"];
+  selection: { kind: "today" };
+  onSwitchToClassic: () => void;
+}) {
   const hypotheses = useActiveHypotheses(5);
   const forecasts = useTopForecasts(5);
   const todayPulse = useTodayPulse(12);
@@ -701,17 +1281,6 @@ export function EditorialHomeSurface({ onAsk }: Props) {
   const editionId =
     snapshot?._id ?? (todayPulse?.dateKey ?? "current");
 
-  // Phase 7d (2026-05-08): editorial is now the default at /redesign,
-  // so opt-out to the legacy classic home requires explicitly setting
-  // `?classic=1`.  Uses navigate() so React-Router state stays in sync.
-  // Old `?edition` param is cleared on the round-trip so URLs stay clean.
-  const onSwitchToClassic = () => {
-    const params = new URLSearchParams(location.search);
-    params.delete("edition");
-    params.set("classic", "1");
-    navigate(`${location.pathname}?${params.toString()}`, { replace: true });
-  };
-
   // Helper to look up a section's data and bail out cleanly when it's
   // not in the visible list.
   const find = (id: string) =>
@@ -773,6 +1342,7 @@ export function EditorialHomeSurface({ onAsk }: Props) {
               ← Switch to classic home
             </button>
           </div>
+          <EditionSelector selection={selection} />
           <h1
             style={{
               fontSize: 32,

--- a/tests/e2e/edition-home.spec.ts
+++ b/tests/e2e/edition-home.spec.ts
@@ -116,6 +116,42 @@
  *              never a fake material-change tally).
  * Edge cases:  Convex query unavailable → §1 stays in skeleton state
  *              and the test waits up to 10s; should not falsely pass.
+ *
+ * ─── Scenario J — temporal: archived day path (P0 #3 — 2026-05-09)
+ * User:        Reader exploring past editions via URL param.
+ * Goal:        Navigate to /redesign?edition=YYYY-MM-DD and see either
+ *              the archived day's content OR an honest "no edition for
+ *              this date" empty state with the earliest-edition link.
+ * Prior state: dailyBriefSnapshots may or may not have rows for the
+ *              requested date; the test does not pre-seed.
+ * Actions:     1) /redesign?edition=2025-01-01 (way past) → assert
+ *                 [data-section="archive-empty"] OR
+ *                 [data-section="archive-summary"] is visible.  Both
+ *                 are valid renderings depending on data state.
+ *              2) /redesign?edition=banana → asserts that we fall
+ *                 back to today (no error toasts, [data-edition-kind]
+ *                 absent or "today").
+ * Scale:       1 user.
+ * Duration:    Two page loads.
+ * Expected:    No console errors on either path; URL param controls
+ *              the render branch deterministically.
+ *
+ * ─── Scenario K — chip click writes URL (P0 #3) ──────────────────
+ * User:        Reader on the editorial home today.
+ * Goal:        Click "This week" → URL gains ?edition=week:..., header
+ *              switches to the weekly digest layout.
+ * Actions:     /redesign → click [data-edition-chip="week"] → assert
+ *              URL matches /[?&]edition=week:/ AND
+ *              [data-edition-kind="week"] is in the DOM.
+ * Edge cases:  Returning to "Today" via the chip removes the param
+ *              cleanly.
+ *
+ * ─── Scenario L — malformed param falls back honestly (P0 #3) ────
+ * User:        Reader who copy-pastes a corrupted URL.
+ * Goal:        See the editorial home, not a crash.
+ * Actions:     /redesign?edition=banana → assert page renders without
+ *              console errors AND [data-section="what-moved"] is
+ *              visible (today branch).
  */
 
 import { test, expect } from "@playwright/test";
@@ -442,5 +478,82 @@ test.describe("Editorial home — Phase 7b + 7c", () => {
         `§1 must not contain fixture string "${signal}"`,
       ).toBe(false);
     }
+  });
+
+  test("Scenario J: archived-day URL param renders day branch (P0 #3)", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+    });
+
+    // Pick a far-past date most likely to have no archived edition.
+    await page.goto(`${BASE_URL}/redesign?edition=2025-01-01`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForLoadState("networkidle");
+    await page.waitForSelector('[data-edition][data-edition-kind="day"]', {
+      timeout: 10_000,
+    });
+
+    // Either archive-empty OR archive-summary is acceptable.
+    const empty = page.locator('[data-section="archive-empty"]');
+    const summary = page.locator('[data-section="archive-summary"]');
+    const visibleCount = (await empty.count()) + (await summary.count());
+    expect(visibleCount).toBeGreaterThanOrEqual(1);
+
+    expect(errors, `Errors:\n${errors.join("\n")}`).toEqual([]);
+  });
+
+  test("Scenario K: chip click writes URL + renders week branch (P0 #3)", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/redesign`, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+    await page.waitForSelector("[data-edition]", { timeout: 10_000 });
+
+    const weekChip = page.locator('[data-edition-chip="week"]').first();
+    await expect(weekChip).toBeVisible({ timeout: 5_000 });
+    await weekChip.click();
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(/[?&]edition=week:/);
+    await page.waitForSelector('[data-edition][data-edition-kind="week"]', {
+      timeout: 10_000,
+    });
+
+    // Click "Today" chip to clear the param.
+    const todayChip = page.locator('[data-edition-chip="today"]').first();
+    await todayChip.click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).not.toHaveURL(/[?&]edition=week:/);
+    await expect(page.locator("[data-edition]")).toBeVisible();
+  });
+
+  test("Scenario L: malformed ?edition=banana falls back to today (P0 #3)", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto(`${BASE_URL}/redesign?edition=banana`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForLoadState("networkidle");
+    await page.waitForSelector("[data-edition]", { timeout: 10_000 });
+
+    // Today branch carries the §1 "what-moved" section.
+    const whatMoved = page.locator('[data-section="what-moved"]');
+    await expect(whatMoved).toBeVisible({ timeout: 10_000 });
+    // The day branch wrapper marker should NOT be present.
+    const dayBranch = page.locator('[data-edition-kind="day"]');
+    expect(await dayBranch.count()).toBe(0);
+
+    expect(errors, `Errors:\n${errors.join("\n")}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Third of three P0s in the user's editorial-home sprint loop directive
("go with all of them loop again and again until all done"). The
editorial home has only ever shown "today." User explicitly asked for
"past days, weeks, months views." This PR adds:

- **3 new public Convex queries** — `getDailyEdition`,
  `getWeeklyDigest`, `getMonthlyRetrospective`
- **URL-driven navigation** — `?edition=YYYY-MM-DD`,
  `?edition=week:YYYY-Www`, `?edition=month:YYYY-MM`
- **EditionSelector chip group** — Today | Yesterday | This week | This
  month | Archive (native date picker)
- **Three render branches** in `EditorialHomeSurface` — today branch
  unchanged, three new branches for archived day / weekly digest /
  monthly retrospective

## URL contract

| URL | Renders |
|---|---|
| `/redesign` (no flag) | today (existing path) |
| `/redesign?edition=1` | today (back-compat) |
| `/redesign?edition=2026-05-08` | ArchivedDayBranch |
| `/redesign?edition=week:2026-W19` | WeeklyBranch |
| `/redesign?edition=month:2026-05` | MonthlyBranch |
| `/redesign?edition=banana` | today (HONEST_STATUS — no crash) |

## What changed

| File | Change |
|---|---|
| `convex/domains/research/editionQueries.ts` | +3 queries (~360 lines), `PulseProjection` type, fixed `by_date_string` index name |
| `src/features/redesign/components/edition/EditionSelector.tsx` | New chip-group component with native date picker |
| `src/features/redesign/components/edition/edition.css` | Responsive chip text rule (`<480px` shows short forms) |
| `src/features/redesign/hooks/useEditionView.ts` | URL → `EditionSelection` parser with safe fallback to today |
| `src/features/redesign/hooks/useTemporalEdition.ts` | Typed wrappers for all 3 temporal queries |
| `src/features/redesign/surfaces/EditorialHomeSurface.tsx` | Root becomes a dispatcher; today body lifted into `TodayRender` helper; three new branch components |
| `tests/e2e/edition-home.spec.ts` | Scenarios J, K, L |

## Monthly scope discipline

Per the spec: "**KEEP IT MINIMAL for P0** — don't over-engineer. If it
gets complex, ship daily + weekly only and defer monthly to P1."

I shipped a minimal monthly retrospective with two sections (top
edition per ISO week + Brier-resolved forecast count). Per-week
detailed pulse breakdowns and per-day brier histograms are deferred
to a follow-up issue.

## 8-point reliability checklist

| Item | Status |
|---|---|
| BOUND | per-section caps reuse existing constants; snapshots scan capped at 60 |
| HONEST_STATUS | `{available: false, reason}` returned on malformed input or empty windows |
| HONEST_SCORES | weekly forecast deltas computed from real `forecastUpdateHistory` rows; brier counts from real `forecastResolutions.brierScore` |
| TIMEOUT | n/a |
| SSRF | n/a |
| BOUND_READ | n/a |
| ERROR_BOUNDARY | `useEditionView` falls back to today on parse failure (Scenario L); query handlers guard malformed args |
| DETERMINISTIC | no `JSON.stringify` on dynamic-key objects |

## Scenario anatomies

**Scenario J — archived-day URL param renders day branch**
- Pick a far-past date (`2025-01-01`)
- Either `[data-section="archive-empty"]` (no edition) OR
  `[data-section="archive-summary"]` (has edition) is acceptable
- No console errors

**Scenario K — chip click writes URL + renders week branch**
- Click `[data-edition-chip="week"]` → URL gains `?edition=week:`,
  `[data-edition-kind="week"]` mounts
- Click `[data-edition-chip="today"]` → URL strips param

**Scenario L — malformed param falls back to today**
- `?edition=banana` → today branch renders (`[data-section="what-moved"]`
  visible); `[data-edition-kind="day"]` absent

## Verification

- [x] `npx convex codegen` — clean
- [x] `npx tsc --noEmit --pretty false` — 0 errors
- [x] `npx vite build` — clean (built in 13.02s)
- [ ] Live verification on prod after merge

## Test plan
- [x] Scenarios J, K, L locally
- [ ] After merge: `vercel build --prod && vercel deploy --prebuilt --prod`
- [ ] After merge: `BASE_URL=https://www.nodebenchai.com npx playwright test tests/e2e/edition-home.spec.ts`

## Constraints honored
- No new tables
- No new fonts
- No heavy dependencies (date picker is native `<input type="date">`)
- Redesign tab nav untouched
- `viewRegistry.ts` untouched
- `LegacyHomeSurface` rendering untouched
- 3 separate PRs (not bundled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)