### PR TITLE
fix(edition): dedupe PulseProjection — restore temporal queries on prod

### DIFF
--- a/convex/domains/research/editionQueries.ts
+++ b/convex/domains/research/editionQueries.ts
@@ -529,22 +529,10 @@ export const getEditionFootnotes = query({
 /**
  * PulseProjection — the public shape returned by today / daily / weekly
  * pulse queries.  Defined here so the temporal queries can use it
- * without depending on P0 #2's getTodayPulse refactor (which
- * introduces the same type at the top of the file when it merges).
- *
- * If both PRs land, the duplicate is deduped by leaving only one
- * `type PulseProjection = ...` declaration.
+ * `PulseProjection` is declared once at the top of this file (line 94,
+ * introduced by P0 #2 / `getTodayPulse`).  P0 #3 reuses that single
+ * declaration — the predicted duplicate has been deduped post-rebase.
  */
-type PulseProjection = {
-  _id: string;
-  entitySlug: string;
-  dateKey: string;
-  status: "generating" | "ready" | "failed";
-  summaryMarkdown: string | null;
-  changeCount: number;
-  materialChangeCount: number;
-  generatedAt: number;
-};
 
 /* ════════════════════════════════════════════════════════════════════
  * P0 #3 (2026-05-09) — Temporal browsing.


### PR DESCRIPTION
## Summary

Forensic root cause of the prod regression that surfaced immediately after the P0 sprint merged (PRs #283/284/285):

- P0 #2 added \`type PulseProjection\` at line 94 of \`convex/domains/research/editionQueries.ts\`
- P0 #3 added another at line 538 (with a self-aware doc comment predicting "If both PRs land, the duplicate is deduped by leaving only one")
- The rebase resolution accidentally let both through
- \`npx tsc --noEmit\` (src-only config) didn't catch it; \`npx convex deploy\` did: \`TS2300: Duplicate identifier 'PulseProjection'\`
- Convex deploy was silently skipped from the Vercel build pipeline — \`vercel-build\` runs only \`vite build\` (no \`npx convex deploy\`)
- Result: P0 #3's frontend shipped to prod calling \`getDailyEdition\` / \`getWeeklyDigest\` / \`getMonthlyRetrospective\`, but those queries didn't exist on Convex prod. **Every temporal URL crashed to the error boundary** with \`[CONVEX Q(domains/research/editionQueries:getDailyEdition)] Server Error\`

## Fix

- Removed the second \`type PulseProjection\` declaration at line 538 (the doc comment that predicted this is preserved with corrected wording)
- Manually ran \`npx convex deploy\` (out-of-band) to push the deduped queries to Convex prod
- Verified \`/redesign?edition=2026-05-08\` and \`/redesign?edition=week:2026-W19\` now render correctly

## Live evidence (post-fix)

- \`?edition=2026-05-08\` → \`editionKind: "day"\`, sections \`["archive-summary","scoreboard","capabilities"]\`, "Edition · 2026-05-08" headline
- \`?edition=week:2026-W19\` → \`editionKind: "week"\`, sections \`["archive-empty"]\`, honest empty state "No edition for 2026-W19"

## Follow-up (separate task)

\`docs/architecture/HOME_EDITORIAL_REDESIGN.md\` should note that any editionQueries change requires \`npx convex deploy\` alongside \`vite build\` (Vercel webhook doesn't run convex deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)