### PR TITLE
infra: vercel-build runs convex deploy + PWA NetworkFirst nav

### DIFF
--- a/convex/domains/research/editionQueries.ts
+++ b/convex/domains/research/editionQueries.ts
@@ -529,22 +529,10 @@ export const getEditionFootnotes = query({
 /**
  * PulseProjection — the public shape returned by today / daily / weekly
  * pulse queries.  Defined here so the temporal queries can use it
- * without depending on P0 #2's getTodayPulse refactor (which
- * introduces the same type at the top of the file when it merges).
- *
- * If both PRs land, the duplicate is deduped by leaving only one
- * `type PulseProjection = ...` declaration.
+ * `PulseProjection` is declared once at the top of this file (line 94,
+ * introduced by P0 #2 / `getTodayPulse`).  P0 #3 reuses that single
+ * declaration — the predicted duplicate has been deduped post-rebase.
  */
-type PulseProjection = {
-  _id: string;
-  entitySlug: string;
-  dateKey: string;
-  status: "generating" | "ready" | "failed";
-  summaryMarkdown: string | null;
-  changeCount: number;
-  materialChangeCount: number;
-  generatedAt: number;
-};
 
 /* ════════════════════════════════════════════════════════════════════
  * P0 #3 (2026-05-09) — Temporal browsing.

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -8,27 +8,67 @@
 #   any build steps).  Extracting to a script keeps `vercel.json` short
 #   and makes the build logic editable + reviewable.
 #
-# Behavior (DECOUPLED — Convex deploy is now a separate GHA workflow):
-#   Both production and preview run plain `npm run build` here. The
-#   Convex backend is deployed by `.github/workflows/convex-deploy.yml`
-#   on push to main, in parallel with Vercel's frontend deploy.
+# Behavior (RECOUPLED — Convex deploy now runs HERE, before vite build):
+#   Forensic root cause (2026-05-09): the previous DECOUPLED design
+#   relied on .github/workflows/convex-deploy.yml firing on push to
+#   main with paths "convex/**". From 2026-05-04 onwards GitHub
+#   Actions stopped firing entirely on this repo (account-blocked
+#   for billing). PRs #283-#286 (P0 sprint touching convex/domains/
+#   research/editionQueries.ts) merged to main but the convex deploy
+#   workflow never ran — so getDailyEdition / getWeeklyDigest /
+#   getMonthlyRetrospective shipped to the frontend bundle but were
+#   missing from convex prod. Every temporal URL crashed to the
+#   error boundary with "[CONVEX Q(...)] Server Error" until a manual
+#   `npx convex deploy` was run.
 #
-#   Why decoupled:
-#     The old `npx convex deploy --cmd "npm run build"` failure mode
-#     fed Convex push failures (uuid missing dep, @openai/agents-core
-#     zod regression) into the frontend's build pipeline — meaning a
-#     bug in a single Convex tool blocked the entire frontend deploy.
-#     Now those failure surfaces are independent: Convex can be broken
-#     without keeping new frontend code from shipping, and vice versa.
+#   The lesson: Vercel's webhook is more reliable than GHA workflows.
+#   We MUST run convex deploy in the Vercel build pipeline so that
+#   backend + frontend ship atomically, regardless of GHA state.
 #
-#   Ordering note:
-#     Convex push (~30-60s) typically finishes before Vercel build
-#     (~3-4min), so new APIs are usually live before the frontend
-#     that calls them. Race window is small and acceptable.
+#   Why convex deploy MUST run BEFORE vite build:
+#     Frontend code calls Convex queries by name. If the frontend
+#     ships first and the queries don't exist yet on the backend,
+#     users see Server Error. By running convex deploy first:
+#       1. New queries are live on Convex prod.
+#       2. THEN the frontend bundle that calls them ships.
+#       3. Atomic enough — Vercel CDN serves the new bundle within
+#          seconds of build completion, by which time Convex has
+#          had its full deploy duration.
+#
+#   Convex deploy failure mode:
+#     If `npx convex deploy` fails (missing dep, schema validation,
+#     etc.), the script EXITS NON-ZERO. Vercel deploy aborts. No
+#     stale frontend ships. This is correct — we'd rather block the
+#     deploy than ship a broken frontend. The previous "fail open"
+#     design (let Convex errors silently skip the deploy) was the
+#     ROOT CAUSE of the temporal-URL outage.
+#
+#   The .github/workflows/convex-deploy.yml is kept as a secondary
+#   belt-and-suspenders safety net: if Vercel-side deploy somehow
+#   misses a path (e.g. preview deploy doesn't deploy convex), the
+#   GHA still runs convex deploy on push-to-main when Actions is
+#   functioning. Convex deploy is idempotent so running both is safe.
 
 set -euo pipefail
 
 if [ -z "${VITE_CONVEX_URL:-}" ]; then
   echo "::warning::VITE_CONVEX_URL not set — frontend will use baked-in default."
 fi
+
+# Step 1: deploy Convex backend so new queries/mutations are live BEFORE the
+# frontend that calls them ships. Only on production deploys; previews skip.
+# Vercel sets VERCEL_ENV=production for prod, =preview for preview branches.
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+  if [ -z "${CONVEX_DEPLOY_KEY:-}" ]; then
+    echo "::error::CONVEX_DEPLOY_KEY not set on Vercel env. Add it in Vercel project settings -> Environment Variables. Without this, frontend bundles ship before backend queries exist on Convex prod, causing Server Error on every page load."
+    exit 1
+  fi
+  echo "Convex deploy (production) starting..."
+  npx convex deploy --yes --typecheck=enable
+  echo "Convex deploy complete."
+else
+  echo "Skipping convex deploy on preview env (VERCEL_ENV=${VERCEL_ENV:-unknown})"
+fi
+
+# Step 2: build the frontend bundle now that backend is live.
 exec npm run build

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -212,9 +212,39 @@ export default defineConfig(({ mode }) => {
       workbox: {
         skipWaiting: true,
         clientsClaim: true,
+        // CRITICAL: navigateFallbackDenylist with NetworkFirst on navigation
+        // requests means HTML responses are NEVER cache-served. This is the
+        // single biggest cause of "users see stale bundle after deploy".
+        // With NetworkFirst, every navigation goes to the network first,
+        // and only falls back to cache when offline. New deploys reach
+        // users on the next page load, not after manual cache clear.
+        //
+        // The hashed JS/CSS chunks below stay on StaleWhileRevalidate —
+        // they're content-addressed (index-COn3r21_.js) so cache is safe.
+        // It's the entry HTML that points to those chunks that must NOT
+        // be cached, otherwise users get the OLD HTML pointing at OLD chunks.
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
-        // Cache Google Fonts
+        navigateFallback: '/index.html',
+        navigateFallbackDenylist: [/^\/api\//, /^\/voice\//, /^\/install\.sh/],
         runtimeCaching: [
+          // Navigation requests — NetworkFirst with short timeout.
+          // Users see new deploys on the next page load, not after cache clear.
+          {
+            urlPattern: ({ request }) => request.mode === 'navigate',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'navigation-cache',
+              networkTimeoutSeconds: 3,
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24, // 1 day max for HTML
+              },
+              cacheableResponse: {
+                statuses: [200],
+              },
+            },
+          },
+          // Cache Google Fonts
           {
             urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
             handler: 'CacheFirst',


### PR DESCRIPTION
## Summary

Two-part infra fix to prevent recurrence of the 2026-05-09 temporal-URL outage where backend queries shipped to the frontend bundle but never deployed to Convex prod.

**Track A1 - vercel-build runs convex deploy**: scripts/vercel-build.sh now runs `npx convex deploy --yes --typecheck=enable` BEFORE `vite build` on production deploys. Forensic root cause: the previous decoupled design relied on `.github/workflows/convex-deploy.yml` firing on push to main, but GitHub Actions stopped firing on 2026-05-04 (account-blocked). PRs #283-#286 merged but the convex deploy workflow never ran. The fix is to recouple in the Vercel pipeline since Vercel's webhook is more reliable than GHA. If `CONVEX_DEPLOY_KEY` is missing, deploy is aborted (fail closed - we'd rather block than ship broken).

**Track A2 - PWA NetworkFirst for navigation**: vite.config.ts workbox config adds `NetworkFirst` with a 3-second network timeout for navigation requests (request.mode === 'navigate'). The hashed JS/CSS chunks remain StaleWhileRevalidate. New deploys reach users on next page load instead of needing manual cache clear. `registerType: 'autoUpdate'` + `skipWaiting: true` + `clientsClaim: true` + `controllerchange` handler in main.tsx (already in place) work together.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vite build` clean (436 PWA precache entries, dist/sw.js regenerated)
- [x] grep dist/sw.js confirms NetworkFirst + navigation-cache + networkTimeoutSeconds:3
- [ ] Post-merge: visit www.nodebenchai.com/redesign in clean incognito, confirm new bundle loads without manual cache clear
- [ ] Post-merge: confirm Vercel build log shows "Convex deploy (production) starting..." then "Convex deploy complete." then vite build

## Risks
- If CONVEX_DEPLOY_KEY env var is not set on Vercel prod, the next deploy will abort with a clear error. User should verify `vercel env ls | grep CONVEX_DEPLOY_KEY` before merge.
- NetworkFirst with 3s timeout: on a slow network the user waits up to 3s before falling back to cache. Trade-off is correct - "fresh content matters more than 3s offline tolerance" for a daily-edition app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)