### PR TITLE
feat(edition): Phase 9a — §5 capability deltas vs 7d

### DIFF
--- a/convex/domains/research/editionQueries.ts
+++ b/convex/domains/research/editionQueries.ts
@@ -514,6 +514,108 @@ export const getLatestDailyBriefSnapshot = query({
   },
 });
 
+/**
+ * Phase 9a §5 — Capability delta vs window.
+ *
+ * Returns today's `techReadiness` plus the same field from
+ * `windowDays` ago, plus per-bucket deltas.  `null` for a bucket
+ * means "no comparison available" (HONEST_STATUS — never invent
+ * a "→" indicator if there's no prior snapshot to compare against).
+ *
+ * Bounds: `windowDays` is clamped to [1, 30].  Reads at most 2 rows
+ * (today's + the closest snapshot ≤ priorKey).
+ */
+export const getCapabilitiesDelta = query({
+  args: { windowDays: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const windowDays = (() => {
+      const n = Math.floor(args.windowDays ?? 1);
+      if (!Number.isFinite(n) || n <= 0) return 1;
+      return Math.min(n, 30);
+    })();
+
+    // 1. Today's snapshot — most recent by generatedAt.
+    const today = await ctx.db
+      .query("dailyBriefSnapshots")
+      .withIndex("by_generated_at")
+      .order("desc")
+      .first();
+    if (!today) {
+      return {
+        windowDays,
+        today: null,
+        prior: null,
+        priorDateString: null,
+        deltas: null,
+      };
+    }
+
+    const todayTr = today.dashboardMetrics?.techReadiness ?? null;
+    const todayDate = today.dateString;
+
+    // 2. Prior snapshot — find the latest with dateString ≤ priorKey.
+    //    We use "by_date_string" filter scan with a take(1) ordered desc.
+    const priorKey = (() => {
+      // Prefer arithmetic from today's dateString (always YYYY-MM-DD).
+      const t = Date.parse(`${todayDate}T00:00:00Z`);
+      if (!Number.isFinite(t)) return null;
+      const prior = new Date(t - windowDays * 86_400_000);
+      return prior.toISOString().slice(0, 10);
+    })();
+
+    let prior: typeof today | null = null;
+    if (priorKey) {
+      // Look for an EXACT match first — scoreboard cron writes one row
+      // per dateString, so this is usually the right hit.
+      const exact = await ctx.db
+        .query("dailyBriefSnapshots")
+        .withIndex("by_date_string", (q) => q.eq("dateString", priorKey))
+        .first();
+      if (exact) {
+        prior = exact;
+      } else {
+        // Fall back: scan all snapshots ordered desc and pick the
+        // first whose dateString is ≤ priorKey.  Bounded scan capped
+        // at 90 rows (~3 months of daily snapshots).
+        const recent = await ctx.db
+          .query("dailyBriefSnapshots")
+          .withIndex("by_generated_at")
+          .order("desc")
+          .take(90);
+        for (const row of recent) {
+          if (row.dateString && row.dateString <= priorKey) {
+            prior = row;
+            break;
+          }
+        }
+      }
+    }
+
+    const priorTr = prior?.dashboardMetrics?.techReadiness ?? null;
+
+    // 3. Compute deltas — null per-bucket if either side is missing.
+    const deltas: {
+      existing: number | null;
+      emerging: number | null;
+      sciFi: number | null;
+    } | null = todayTr && priorTr
+      ? {
+          existing: (todayTr.existing ?? 0) - (priorTr.existing ?? 0),
+          emerging: (todayTr.emerging ?? 0) - (priorTr.emerging ?? 0),
+          sciFi: (todayTr.sciFi ?? 0) - (priorTr.sciFi ?? 0),
+        }
+      : null;
+
+    return {
+      windowDays,
+      today: todayTr,
+      prior: priorTr,
+      priorDateString: prior?.dateString ?? null,
+      deltas,
+    };
+  },
+});
+
 /* ────────────────────────────────────────────────────────────────────
  * §6 — Footnotes : evidenceArtifacts referenced by §1–§3 plus recent
  * industryUpdates capped at MAX.

--- a/src/features/redesign/components/edition/CapabilitiesMap.tsx
+++ b/src/features/redesign/components/edition/CapabilitiesMap.tsx
@@ -4,8 +4,15 @@
  * `dashboardMetrics.capabilities`.  THIS IS THE VISUAL SIGNATURE of
  * the editorial home (matches ai-2027 "Currently Exists / Emerging /
  * Science Fiction" indicator).
+ *
+ * Phase 9a: optional `deltas` prop renders week-over-week (or
+ * day-over-day) movement next to each bucket count.  Honest —
+ * if a delta is null (no prior snapshot to compare), NOTHING is
+ * rendered (NOT "→") so the user isn't misled about whether a
+ * comparison happened.  Per agentic_reliability HONEST_STATUS.
  */
 
+import type { CSSProperties } from "react";
 import { DotGrid } from "./DotGrid";
 
 interface TechReadiness {
@@ -21,9 +28,21 @@ interface CapabilityEntry {
   description?: string;
 }
 
+export interface CapabilityDeltas {
+  existing: number | null;
+  emerging: number | null;
+  sciFi: number | null;
+}
+
 interface Props {
   techReadiness: TechReadiness | null;
   capabilities: CapabilityEntry[] | null;
+  /** Optional deltas vs prior snapshot (Phase 9a). */
+  deltas?: CapabilityDeltas | null;
+  /** When provided, the badge tooltip references the comparison window. */
+  windowDays?: number;
+  /** Date string of the prior snapshot for hover context. */
+  priorDateString?: string | null;
 }
 
 const READINESS_ROWS: Array<{
@@ -36,7 +55,51 @@ const READINESS_ROWS: Array<{
   { key: "sciFi", label: "Science Fiction", total: 6 },
 ];
 
-export function CapabilitiesMap({ techReadiness, capabilities }: Props) {
+/**
+ * Format a delta number for the visible badge.  Returns null when
+ * the delta itself is null (no comparison data) — caller renders
+ * nothing in that case.  `0` renders as "→" (no change), positive as
+ * `+N`, negative as `-N`.
+ */
+function formatDeltaBadge(
+  delta: number | null,
+): { text: string; tone: "up" | "down" | "flat" } | null {
+  if (delta === null) return null;
+  if (!Number.isFinite(delta)) return null;
+  if (delta === 0) return { text: "→", tone: "flat" };
+  return {
+    text: delta > 0 ? `+${delta}` : `${delta}`,
+    tone: delta > 0 ? "up" : "down",
+  };
+}
+
+function deltaBadgeStyle(tone: "up" | "down" | "flat"): CSSProperties {
+  const base: CSSProperties = {
+    marginLeft: 8,
+    fontFamily: "var(--rd-mono, monospace)",
+    fontSize: 11,
+    letterSpacing: "0.04em",
+    padding: "1px 6px",
+    borderRadius: 4,
+    border: "1px solid currentColor",
+    opacity: 0.85,
+  };
+  if (tone === "up") {
+    return { ...base, color: "var(--rd-accent, #d97757)" };
+  }
+  if (tone === "down") {
+    return { ...base, color: "rgb(120, 160, 220)" };
+  }
+  return { ...base, color: "var(--rd-ink-mute, #888)" };
+}
+
+export function CapabilitiesMap({
+  techReadiness,
+  capabilities,
+  deltas,
+  windowDays,
+  priorDateString,
+}: Props) {
   const hasReadiness =
     techReadiness &&
     (techReadiness.existing > 0 ||
@@ -52,6 +115,13 @@ export function CapabilitiesMap({ techReadiness, capabilities }: Props) {
     );
   }
 
+  const windowLabel =
+    windowDays === 7
+      ? "vs 7 days ago"
+      : windowDays && windowDays > 1
+        ? `vs ${windowDays} days ago`
+        : "vs yesterday";
+
   return (
     <div>
       {hasReadiness && (
@@ -61,11 +131,18 @@ export function CapabilitiesMap({ techReadiness, capabilities }: Props) {
               0,
               Math.min(row.total, techReadiness![row.key] ?? 0),
             );
+            const delta = deltas ? formatDeltaBadge(deltas[row.key]) : null;
+            const tooltipText = delta
+              ? priorDateString
+                ? `${windowLabel} (${priorDateString}): ${delta.text}`
+                : `${windowLabel}: ${delta.text}`
+              : undefined;
             return (
               <div
                 key={row.key}
                 className="rd-edition-capability-row"
                 role="listitem"
+                data-capability-row={row.key}
               >
                 <span className="rd-edition-capability-row__label">
                   {row.label}
@@ -76,6 +153,21 @@ export function CapabilitiesMap({ techReadiness, capabilities }: Props) {
                   caption={`${filled}/${row.total}`}
                   ariaLabel={`${row.label}: ${filled} of ${row.total}`}
                 />
+                {delta && (
+                  <span
+                    style={deltaBadgeStyle(delta.tone)}
+                    title={tooltipText}
+                    aria-label={
+                      delta.tone === "flat"
+                        ? `No change ${windowLabel}`
+                        : `Change ${delta.text} ${windowLabel}`
+                    }
+                    data-capability-delta={row.key}
+                    data-delta-tone={delta.tone}
+                  >
+                    {delta.text}
+                  </span>
+                )}
               </div>
             );
           })}

--- a/src/features/redesign/hooks/useCapabilitiesDelta.ts
+++ b/src/features/redesign/hooks/useCapabilitiesDelta.ts
@@ -1,0 +1,34 @@
+/**
+ * useCapabilitiesDelta — Phase 9a §5.
+ *
+ * Wraps `domains.research.editionQueries.getCapabilitiesDelta` so the
+ * §5 Capabilities map can render `+1`, `-2`, `→` indicators next to
+ * each readiness bucket count.  Honest: returns `null` per-bucket if
+ * there is no prior snapshot to compare against; component must
+ * render NOTHING (not "→") when delta is null.
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+
+export interface CapabilitiesDelta {
+  windowDays: number;
+  today: { existing: number; emerging: number; sciFi: number } | null;
+  prior: { existing: number; emerging: number; sciFi: number } | null;
+  priorDateString: string | null;
+  deltas: {
+    existing: number | null;
+    emerging: number | null;
+    sciFi: number | null;
+  } | null;
+}
+
+export function useCapabilitiesDelta(
+  windowDays: number = 1,
+): CapabilitiesDelta | undefined {
+  const data = useQuery(
+    api.domains.research.editionQueries.getCapabilitiesDelta,
+    { windowDays },
+  );
+  return data as CapabilitiesDelta | undefined;
+}

--- a/src/features/redesign/surfaces/EditorialHomeSurface.tsx
+++ b/src/features/redesign/surfaces/EditorialHomeSurface.tsx
@@ -51,6 +51,7 @@ import { useTodayPulse } from "../hooks/useTodayPulse";
 import { useActiveHypotheses, type EditionHypothesis } from "../hooks/useActiveHypotheses";
 import { useTopForecasts, type EditionForecast } from "../hooks/useTopForecasts";
 import { useLatestDailyBriefSnapshot } from "../hooks/useLatestDailyBriefSnapshot";
+import { useCapabilitiesDelta } from "../hooks/useCapabilitiesDelta";
 import { useEditionFootnotes } from "../hooks/useEditionFootnotes";
 // P0 #3 — temporal browsing imports.  Note: useHomePulseLive +
 // fixturePulseCards / watchlist / continueWorking from #285's branch
@@ -513,6 +514,11 @@ function CapabilitiesSection({
   const tr = snapshot?.dashboardMetrics?.techReadiness ?? null;
   const caps = snapshot?.dashboardMetrics?.capabilities ?? null;
 
+  // Phase 9a §5: optional 7-day delta badges next to each readiness
+  // bucket.  `null` while loading or if no prior snapshot to compare
+  // — CapabilitiesMap renders nothing in that case (HONEST_STATUS).
+  const delta = useCapabilitiesDelta(7);
+
   return (
     <EditorialSection
       id="capabilities"
@@ -521,7 +527,13 @@ function CapabilitiesSection({
       kicker={kicker}
       heading={heading}
     >
-      <CapabilitiesMap techReadiness={tr} capabilities={caps} />
+      <CapabilitiesMap
+        techReadiness={tr}
+        capabilities={caps}
+        deltas={delta?.deltas ?? null}
+        windowDays={delta?.windowDays}
+        priorDateString={delta?.priorDateString ?? null}
+      />
     </EditorialSection>
   );
 }


### PR DESCRIPTION
## Summary

Resolves Phase 9 deferred item #18 from `docs/architecture/EDITION_INGESTION_FLYWHEEL.md`.

Adds week-over-week movement indicators next to each readiness bucket (existing / emerging / sciFi) on the §5 Capabilities map.

## Changes

| Layer | What |
|---|---|
| `convex/domains/research/editionQueries.ts` | New query `getCapabilitiesDelta(windowDays)`. Reads today's `techReadiness` + the closest snapshot ≤ today - windowDays. Bounded scan capped at 90 rows. |
| `src/features/redesign/hooks/useCapabilitiesDelta.ts` | Thin hook wrapping the query (mirrors `useLatestDailyBriefSnapshot`). |
| `src/features/redesign/components/edition/CapabilitiesMap.tsx` | Accepts new `deltas` + `windowDays` + `priorDateString` props. Renders `+N`, `-N`, or `→` badge next to each bucket count. Tooltip references the window. |
| `src/features/redesign/surfaces/EditorialHomeSurface.tsx` | Wires `useCapabilitiesDelta(7)` into the `<CapabilitiesSection>` render. |

## Honest by design

Per-bucket delta is **null** when no prior snapshot exists for the window — component renders **NOTHING** in that case (NOT "→") so the user is never misled into thinking a comparison happened. `→` is reserved for the explicit "no change" case where both today + prior exist and are equal. Per `agentic_reliability.md` HONEST_STATUS.

## Test plan

- [x] `npx convex codegen` clean
- [x] `npx tsc --noEmit --pretty false` clean
- [x] `npx vite build` clean
- [ ] After merge + deploy: §5 dot grids render delta badges (+1, →, etc.) next to the existing/emerging/sciFi count
- [ ] First-day prod deploy may show no badges (no prior snapshot in the 7d window) — that is the intended honest behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)