### PR TITLE
feat(voice): VoiceCostBadge surfaces actualTierUsed fallback transparency

### DIFF
--- a/convex/domains/integrations/voice/realtimeGateway.ts
+++ b/convex/domains/integrations/voice/realtimeGateway.ts
@@ -129,6 +129,37 @@ export const recordVoiceRoutingDecision = mutation({
   },
 });
 
+/**
+ * Returns the most recent routing decision for a user. The UI subscribes to
+ * this so the VoiceCostBadge can surface tier-fallback transparency
+ * (HONEST_STATUS — when actualTierUsed differs from tier, the user sees a
+ * fallback chip instead of silent degradation).
+ *
+ * BOUND — single-row read by indexed (userKey, createdAt) descending.
+ * HONEST_STATUS — returns null when there is no decision yet, never a
+ *   fabricated "all good" state.
+ */
+export const getLatestVoiceRoutingDecision = query({
+  args: {
+    userKey: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const db = ctx.db as any;
+    const row = await db
+      .query("voiceRoutingDecisions")
+      .withIndex("by_user_created", (q: any) => q.eq("userKey", args.userKey))
+      .order("desc")
+      .first();
+    if (!row) return null;
+    return {
+      createdAt: row.createdAt as number,
+      surface: row.surface as string | undefined,
+      requestedTier: row.requestedTier as string | undefined,
+      decision: row.decision as Record<string, unknown>,
+    };
+  },
+});
+
 export const linkAnonymousVoiceCaptures = mutation({
   args: {
     anonymousSessionId: v.string(),

--- a/src/features/voice/components/VoiceCostBadge.tsx
+++ b/src/features/voice/components/VoiceCostBadge.tsx
@@ -1,21 +1,41 @@
 /**
- * VoiceCostBadge — daily voice spend indicator.
+ * VoiceCostBadge — daily voice spend indicator + tier-fallback transparency.
  *
  * Pattern: Read-only spend summary; subscribes to
  * `voice/costLedger:checkCap` (landed in PR #274). Shows totalUsd vs capUsd
  * with a horizontal progress bar + warning state at 80% + capped state at
  * 100%. HONEST_SCORES — totalUsd is server-computed from sum(byTier).
  *
- * See: docs/architecture/REALTIME_VOICE_INTEGRATION.md §2 (voiceCostLedger)
+ * Tier-fallback transparency (PR #311 — May 10, 2026):
+ *   When the latest routing decision shows actualTierUsed !== tier (i.e. the
+ *   request was downgraded from gpt-realtime-2 to gpt-4o-realtime-preview, or
+ *   from openai-* to gemini-flash-live), the badge renders a "Fallback active"
+ *   chip with the reason text. HONEST_STATUS — never silently pretend the
+ *   premium tier served when a degraded model actually responded.
  *
- * Visual states:
+ * See: docs/architecture/REALTIME_VOICE_INTEGRATION.md §2 (voiceCostLedger),
+ *      server/agents/realtimeVoicePolicy.ts (VoiceRoutingDecision shape).
+ *
+ * Visual states (cost):
  *   - Healthy   (< 80%): muted text + slim accent bar
  *   - Warning   (>=80%): amber accent + warning copy
  *   - Cap hit  (>=100%): rose accent + "capture-only mode" copy
  *
+ * Visual states (fallback):
+ *   - None: no chip (request served the requested tier)
+ *   - Active: amber chip with reason; click toggles full reason text
+ *
+ * Reliability invariants (.claude/rules/agentic_reliability.md):
+ *   HONEST_STATUS — fallback chip MUST appear whenever degraded; no silent UI.
+ *
+ * A11y (.claude/rules/reexamine_a11y.md):
+ *   role="status", aria-live="polite" on the chip; aria-expanded on toggle;
+ *   focus-visible ring; no pulse animation (prefers-reduced-motion safe).
+ *
  * Glass card DNA, terracotta accent for the bar fill.
  */
 
+import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 
@@ -34,23 +54,93 @@ interface CapSnapshot {
   warning80pct: boolean;
 }
 
+interface RoutingDecisionRow {
+  createdAt: number;
+  surface?: string;
+  requestedTier?: string;
+  decision: {
+    tier?: string;
+    actualTierUsed?: string;
+    fallbackReason?: string;
+    fallbackChain?: string[];
+    model?: string;
+    [key: string]: unknown;
+  };
+}
+
 function fmtUsd(n: number): string {
   return n < 1 ? `$${n.toFixed(3)}` : `$${n.toFixed(2)}`;
 }
 
+const FALLBACK_REASON_COPY: Record<string, string> = {
+  openai_key_missing: "OpenAI key not configured — using Gemini Live instead",
+  openai_realtime_unavailable:
+    "Account not yet upgraded to gpt-realtime-2 — using legacy realtime preview",
+  openai_legacy_realtime_unavailable:
+    "Both gpt-realtime-2 and legacy preview unavailable — using Gemini Live instead",
+  rate_limited: "OpenAI rate-limited — using Gemini Live instead",
+  session_create_failed:
+    "OpenAI session creation failed — using Gemini Live instead",
+};
+
+function fallbackCopy(reason: string | undefined): string {
+  if (!reason) return "Fallback active";
+  return FALLBACK_REASON_COPY[reason] ?? `Fallback active (${reason})`;
+}
+
 export function VoiceCostBadge({ userId, className }: VoiceCostBadgeProps): JSX.Element {
+  const [showFallbackDetail, setShowFallbackDetail] = useState(false);
+
   // Type-erased lookup — `api.domains.integrations.voice.costLedger.checkCap`
   // resolves at runtime once codegen has consumed PR #274's mutation files.
-  const queryRef = (api as unknown as {
+  const checkCapRef = (api as unknown as {
     domains: { integrations: { voice: { costLedger: { checkCap: unknown } } } };
   }).domains.integrations.voice.costLedger.checkCap;
 
   const snap = useQuery(
-    queryRef as Parameters<typeof useQuery>[0],
+    checkCapRef as Parameters<typeof useQuery>[0],
     { userId } as Parameters<typeof useQuery>[1],
   ) as CapSnapshot | undefined;
 
+  // Subscribe to the latest routing decision so we can surface fallback
+  // transparency. Same type-erasure pattern — codegen resolves at runtime.
+  const routingRef = (api as unknown as {
+    domains: {
+      integrations: {
+        voice: { realtimeGateway: { getLatestVoiceRoutingDecision: unknown } };
+      };
+    };
+  }).domains.integrations.voice.realtimeGateway.getLatestVoiceRoutingDecision;
+
+  const latestRouting = useQuery(
+    routingRef as Parameters<typeof useQuery>[0],
+    { userKey: userId } as Parameters<typeof useQuery>[1],
+  ) as RoutingDecisionRow | null | undefined;
+
   const isLoading = snap === undefined;
+
+  // HONEST_STATUS — fallback active when actualTierUsed differs from tier
+  // OR when fallbackReason is explicitly set. Never assume "no fallback"
+  // from absence of routing data — that just means no decision yet.
+  const fallbackActive = Boolean(
+    latestRouting &&
+      latestRouting.decision &&
+      ((latestRouting.decision.fallbackReason &&
+        latestRouting.decision.fallbackReason.length > 0) ||
+        (latestRouting.decision.actualTierUsed &&
+          latestRouting.decision.tier &&
+          latestRouting.decision.actualTierUsed !==
+            latestRouting.decision.tier)),
+  );
+
+  const fallbackReason = latestRouting?.decision?.fallbackReason as
+    | string
+    | undefined;
+  const requestedTier = latestRouting?.decision?.tier as string | undefined;
+  const servedTier = latestRouting?.decision?.actualTierUsed as
+    | string
+    | undefined;
+  const servedModel = latestRouting?.decision?.model as string | undefined;
 
   // Tone selection — matches CLAUDE.md design DNA + accessibility (color paired with text)
   const tone = !snap
@@ -163,6 +253,77 @@ export function VoiceCostBadge({ userId, className }: VoiceCostBadgeProps): JSX.
             <p className="mt-2 text-xs text-content-muted">
               No voice activity today.
             </p>
+          )}
+
+          {/* HONEST_STATUS fallback transparency — surface when the served
+              tier differs from what was requested. role="status" +
+              aria-live="polite" so screen readers announce the
+              degradation without grabbing focus. */}
+          {fallbackActive && (
+            <div
+              role="status"
+              aria-live="polite"
+              data-testid="voice-fallback-chip"
+              className="mt-3 rounded-xl border border-amber-300/40 bg-amber-500/10 p-3"
+            >
+              <div className="flex items-start gap-2">
+                <span aria-hidden="true" className="mt-0.5 text-amber-300">
+                  &#9888;
+                </span>
+                <div className="flex-1 min-w-0">
+                  <button
+                    type="button"
+                    onClick={() => setShowFallbackDetail((v) => !v)}
+                    aria-expanded={showFallbackDetail}
+                    aria-controls="voice-fallback-detail"
+                    aria-label={`Voice tier fallback active: ${fallbackCopy(fallbackReason)}. Toggle details.`}
+                    className="text-left text-xs text-amber-200 hover:text-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/60 focus-visible:ring-offset-0 rounded"
+                  >
+                    <span className="font-medium">Fallback active.</span>{" "}
+                    <span>{fallbackCopy(fallbackReason)}</span>
+                  </button>
+                  {showFallbackDetail && (
+                    <dl
+                      id="voice-fallback-detail"
+                      className="mt-2 grid grid-cols-[auto,1fr] gap-x-2 gap-y-0.5 text-[11px] text-content-muted"
+                    >
+                      {requestedTier && (
+                        <>
+                          <dt className="font-medium text-content-muted/80">
+                            Requested
+                          </dt>
+                          <dd className="font-mono">{requestedTier}</dd>
+                        </>
+                      )}
+                      {servedTier && servedTier !== requestedTier && (
+                        <>
+                          <dt className="font-medium text-content-muted/80">
+                            Served
+                          </dt>
+                          <dd className="font-mono">{servedTier}</dd>
+                        </>
+                      )}
+                      {servedModel && (
+                        <>
+                          <dt className="font-medium text-content-muted/80">
+                            Model
+                          </dt>
+                          <dd className="font-mono">{servedModel}</dd>
+                        </>
+                      )}
+                      {fallbackReason && (
+                        <>
+                          <dt className="font-medium text-content-muted/80">
+                            Reason
+                          </dt>
+                          <dd className="font-mono">{fallbackReason}</dd>
+                        </>
+                      )}
+                    </dl>
+                  )}
+                </div>
+              </div>
+            </div>
           )}
         </>
       ) : null}


### PR DESCRIPTION
## Summary

- Backend: new `getLatestVoiceRoutingDecision` query returns the latest row from `voiceRoutingDecisions` per user (null when none — HONEST_STATUS, no fake "all good" state)
- Frontend: `VoiceCostBadge` subscribes alongside `checkCap` and renders a "Fallback active" chip when the served tier differs from the requested tier OR `fallbackReason` is set
- Chip copy maps fallback codes (`openai_key_missing`, `openai_realtime_unavailable`, `session_create_failed`, etc.) to plain language; click expands a `<dl>` with requested/served tier, model, raw reason

## Why

PR #307 wired `actualTierUsed` + `fallbackReason` + `fallbackChain` on the voice routing decision so operators could see what was requested vs what served. Backend was honest, UI was not — the badge always rendered cost only. When OpenAI realtime fell back to legacy preview or Gemini Live, users had no way to know.

This PR closes the UI half. Per `agentic_reliability.md` HONEST_STATUS, the badge MUST visibly indicate degradation when the served model is not what was requested.

## A11y

- `role="status"` + `aria-live="polite"` so screen readers announce the degradation without grabbing focus
- `aria-expanded` + `aria-controls` on the disclosure toggle
- `aria-label` on the chip describes both state and toggle action
- `focus-visible:ring-2` on the toggle
- No pulse animation — `prefers-reduced-motion` safe by default

## Verification

- `npx convex codegen` clean
- `npx tsc --noEmit --pretty false` clean
- `npx vite build` clean (sw.js + workbox regenerated)
- `data-testid="voice-fallback-chip"` for Tier B Playwright assertions

## Test plan

- [ ] After deploy, force a routing decision with `fallbackReason: openai_key_missing` (no OPENAI_API_KEY) and confirm the chip renders for that user
- [ ] Confirm raw HTML shipped on `https://www.nodebenchai.com/assets/index-<hash>.js` contains `voice-fallback-chip` testid
- [ ] Confirm SR announces "Fallback active. ..." when chip first appears
- [ ] Confirm Tab focuses the chip toggle, Enter expands the `<dl>`

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)