### PR TITLE
feat(cmdk): federated-search Cmd-K palette consuming PR #310

### DIFF
--- a/src/features/redesign/components/CommandPalette.test.tsx
+++ b/src/features/redesign/components/CommandPalette.test.tsx
@@ -1,0 +1,496 @@
+/**
+ * CommandPalette — scenario tests for the Cmd-K federated-search palette.
+ *
+ * Per .claude/rules/scenario_testing.md, every test models a real user
+ * persona, action sequence, and verifies system behavior under that scenario.
+ *
+ * Scenarios covered:
+ *
+ *   1. Power user — types "Anthropic", sees grouped results, navigates with
+ *      ArrowDown + Enter. Verifies focus, navigation, and recent-search storage.
+ *
+ *   2. First-time visitor (anonymous) — opens palette with empty query, sees
+ *      Commands group + an honest "try searching..." prompt. Types and confirms
+ *      anonymous-scoped collections (entities/reports/blocks/claims) return [].
+ *
+ *   3. Adversarial / degraded — server returns partial=true with one collection
+ *      ok=false. Palette renders successful collections AND surfaces the failure
+ *      inline — never silently hides it (HONEST_STATUS).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { CommandPalette } from "./CommandPalette";
+import type { FederatedSearchResponse } from "../../../layouts/chrome/commandPalette/types";
+import { clearRecentCmdkSearches, getRecentCmdkSearches } from "../../../layouts/chrome/commandPalette/recentSearches";
+
+/* -------------------------------------------------------------------------- */
+/* Mocks                                                                       */
+/* -------------------------------------------------------------------------- */
+
+const federatedSearchMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useAction: () => federatedSearchMock,
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock("@/features/product/lib/productIdentity", () => ({
+  getAnonymousProductSessionId: () => "anon_test_session",
+}));
+
+vi.mock("../../../../convex/_generated/api", () => ({
+  api: {
+    domains: {
+      search: {
+        federatedSearch: {
+          federatedSearch: "domains.search.federatedSearch.federatedSearch",
+        },
+      },
+    },
+  },
+}));
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function authenticatedAnthropicResponse(): FederatedSearchResponse {
+  return {
+    query: "Anthropic",
+    identityScope: "authenticated",
+    total: 4,
+    timedOut: false,
+    partial: false,
+    collections: [
+      {
+        collection: "nb_entities",
+        ok: true,
+        count: 1,
+        results: [
+          {
+            type: "nb_entities",
+            uri: "entity://anthropic",
+            title: "Anthropic",
+            snippet: "AI safety lab building Claude.",
+            score: 1,
+            source: "company",
+            actions: ["open_entity"],
+          },
+        ],
+      },
+      {
+        collection: "nb_reports",
+        ok: true,
+        count: 2,
+        results: [
+          {
+            type: "nb_reports",
+            uri: "report://r1",
+            title: "Anthropic — Q4 2025 diligence",
+            snippet: "Funding round and headcount summary.",
+            score: 1,
+            source: "founder",
+            actions: ["open_report"],
+          },
+          {
+            type: "nb_reports",
+            uri: "report://r2",
+            title: "Anthropic — competitor map",
+            snippet: "OpenAI, DeepMind, Mistral comparison.",
+            score: 1,
+            source: "operator",
+            actions: ["open_report"],
+          },
+        ],
+      },
+      {
+        collection: "nb_notebook_blocks",
+        ok: true,
+        count: 0,
+        results: [],
+      },
+      {
+        collection: "nb_claims",
+        ok: true,
+        count: 0,
+        results: [],
+      },
+      {
+        collection: "nb_sources",
+        ok: true,
+        count: 1,
+        results: [
+          {
+            type: "nb_sources",
+            uri: "https://www.anthropic.com",
+            title: "Anthropic — homepage",
+            snippet: "Official company site.",
+            score: 1,
+            source: "html",
+            actions: ["open_source"],
+          },
+        ],
+      },
+      {
+        collection: "nb_captures",
+        ok: true,
+        count: 0,
+        results: [],
+      },
+      {
+        collection: "nb_threads",
+        ok: true,
+        count: 0,
+        results: [],
+      },
+    ],
+  };
+}
+
+function anonymousMostlyEmpty(): FederatedSearchResponse {
+  // Anon caller: owner-scoped collections come back empty (no ownerKey access);
+  // sources/threads may or may not have content. Honest empty state.
+  return {
+    query: "x",
+    identityScope: "anonymous",
+    total: 0,
+    timedOut: false,
+    partial: false,
+    collections: [
+      { collection: "nb_entities", ok: true, count: 0, results: [] },
+      { collection: "nb_reports", ok: true, count: 0, results: [] },
+      { collection: "nb_notebook_blocks", ok: true, count: 0, results: [] },
+      { collection: "nb_claims", ok: true, count: 0, results: [] },
+      { collection: "nb_sources", ok: true, count: 0, results: [] },
+      { collection: "nb_captures", ok: true, count: 0, results: [] },
+      { collection: "nb_threads", ok: true, count: 0, results: [] },
+    ],
+  };
+}
+
+function partialFailureResponse(): FederatedSearchResponse {
+  return {
+    query: "Anthropic",
+    identityScope: "authenticated",
+    total: 1,
+    timedOut: false,
+    partial: true,
+    collections: [
+      {
+        collection: "nb_entities",
+        ok: false,
+        count: 0,
+        results: [],
+        error: "timeout",
+      },
+      {
+        collection: "nb_reports",
+        ok: true,
+        count: 1,
+        results: [
+          {
+            type: "nb_reports",
+            uri: "report://r99",
+            title: "Anthropic — surviving brief",
+            snippet: "Reports stayed up while entities timed out.",
+            score: 1,
+            source: "founder",
+            actions: ["open_report"],
+          },
+        ],
+      },
+      { collection: "nb_notebook_blocks", ok: true, count: 0, results: [] },
+      { collection: "nb_claims", ok: true, count: 0, results: [] },
+      { collection: "nb_sources", ok: true, count: 0, results: [] },
+      { collection: "nb_captures", ok: true, count: 0, results: [] },
+      { collection: "nb_threads", ok: true, count: 0, results: [] },
+    ],
+  };
+}
+
+function renderPalette() {
+  const onClose = vi.fn();
+  const result = render(
+    <MemoryRouter>
+      <CommandPalette open onClose={onClose} />
+    </MemoryRouter>,
+  );
+  return { onClose, ...result };
+}
+
+beforeEach(() => {
+  federatedSearchMock.mockReset();
+  navigateMock.mockReset();
+  clearRecentCmdkSearches();
+});
+
+afterEach(() => {
+  clearRecentCmdkSearches();
+});
+
+/* -------------------------------------------------------------------------- */
+/* Scenario 1 — Power user, full text query                                    */
+/*                                                                             */
+/* User:      power user (authenticated, founder lens)                         */
+/* Goal:      find the Anthropic diligence report quickly via Cmd-K            */
+/* Actions:   type "Anthropic" -> see grouped results -> ArrowDown -> Enter    */
+/* Scale:     1 user, 1 search                                                 */
+/* Duration:  short-running (< 1s)                                             */
+/* Expected:  - results render grouped by collection                           */
+/*            - status bar shows total + identity scope                        */
+/*            - Enter on a report navigates to its route                       */
+/*            - the query is stored in nb_cmdk_recent_v1                       */
+/* Edge:      result with no snippet still renders (title only)                */
+/* -------------------------------------------------------------------------- */
+
+describe("Scenario 1 — Power user, full text query", () => {
+  it("renders federated results grouped by collection and navigates on Enter", async () => {
+    federatedSearchMock.mockResolvedValue(authenticatedAnthropicResponse());
+
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByLabelText("Search anything") as HTMLInputElement;
+    await user.type(input, "Anthropic");
+
+    // Wait for federated search response to surface.
+    await waitFor(
+      () => expect(screen.getAllByText(/4 results across 7 collections/i).length).toBeGreaterThan(0),
+      { timeout: 3000 },
+    );
+
+    // Groups present (verify by data-cmdk-group attribute).
+    expect(document.querySelector('[data-cmdk-group="nb_entities"]')).toBeTruthy();
+    expect(document.querySelector('[data-cmdk-group="nb_reports"]')).toBeTruthy();
+    expect(document.querySelector('[data-cmdk-group="nb_sources"]')).toBeTruthy();
+
+    // Empty groups should NOT render headers.
+    expect(document.querySelector('[data-cmdk-group="nb_notebook_blocks"]')).toBeNull();
+
+    // Result rows.
+    expect(screen.getByText("Anthropic — Q4 2025 diligence")).toBeInTheDocument();
+    expect(screen.getByText("Anthropic — competitor map")).toBeInTheDocument();
+
+    // Identity scope shown in status bar.
+    expect(screen.getByText(/your account/i)).toBeInTheDocument();
+
+    // ArrowDown twice (entity -> first report) -> Enter -> navigates.
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0][0]).toMatch(/^\/redesign\/reports\//);
+
+    // Recent search persisted.
+    const recents = getRecentCmdkSearches();
+    expect(recents.length).toBe(1);
+    expect(recents[0].query).toBe("Anthropic");
+  });
+
+  it("Cmd+Enter triggers the secondary 'ask about this' action", async () => {
+    federatedSearchMock.mockResolvedValue(authenticatedAnthropicResponse());
+
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByLabelText("Search anything") as HTMLInputElement;
+    await user.type(input, "Anthropic");
+    await waitFor(() =>
+      expect(screen.getAllByText(/4 results across/i).length).toBeGreaterThan(0),
+    );
+
+    // First item is the entity.
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0][0]).toMatch(/^\/redesign\/chat\?q=/);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Scenario 2 — First-time anonymous visitor                                   */
+/*                                                                             */
+/* User:      anonymous (no auth), zero prior recent searches                  */
+/* Goal:      explore the palette with no plan                                 */
+/* Actions:   open with empty query -> see Commands + try-searching prompt    */
+/*            type "x" -> get honest empty state on owner-scoped collections   */
+/* Scale:     1 user, sustained (multiple keystrokes)                          */
+/* Duration:  short-running                                                    */
+/* Expected:  - empty state shows nav Commands + helper copy                   */
+/*            - typed query yields anonymous identity scope in status bar      */
+/*            - "0 results" honest message (not "try a different query")       */
+/* -------------------------------------------------------------------------- */
+
+describe("Scenario 2 — First-time anonymous visitor", () => {
+  it("shows commands + helper copy when query is empty and no recents", () => {
+    federatedSearchMock.mockResolvedValue(anonymousMostlyEmpty());
+    renderPalette();
+
+    // Commands group visible.
+    expect(document.querySelector('[data-cmdk-group="commands"]')).toBeTruthy();
+    expect(screen.getByText("Go to Home")).toBeInTheDocument();
+    expect(screen.getByText("Go to Reports")).toBeInTheDocument();
+
+    // Status bar SHOULD NOT render before any data has come back.
+    expect(document.querySelector("[data-cmdk-status]")).toBeNull();
+  });
+
+  it("renders honest 0-results state for anonymous-scoped collections", async () => {
+    federatedSearchMock.mockResolvedValue(anonymousMostlyEmpty());
+
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByLabelText("Search anything") as HTMLInputElement;
+    // Use a query that won't match any nav-command keyword (so the Commands
+    // bucket is empty and the "0 results for ..." message renders).
+    await user.type(input, "zqxxqz");
+
+    // Wait for the response.
+    await waitFor(
+      () => expect(screen.getAllByText(/0 results across 7 collections/i).length).toBeGreaterThan(0),
+      { timeout: 3000 },
+    );
+
+    expect(screen.getByText(/anonymous/i)).toBeInTheDocument();
+    // No federated result groups render (all anonymous-scoped collections
+    // are empty, so no group headers).
+    expect(document.querySelector('[data-cmdk-group="nb_entities"]')).toBeNull();
+    expect(document.querySelector('[data-cmdk-group="nb_reports"]')).toBeNull();
+    // Honest empty state with the user's literal query.
+    expect(screen.getByText(/0 results for "zqxxqz"/i)).toBeInTheDocument();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Scenario 3 — Adversarial / degraded — partial failure                       */
+/*                                                                             */
+/* User:      power user, slow network, one upstream collection timed out      */
+/* Goal:      still find what they need despite a broken collection            */
+/* Actions:   type "Anthropic" -> server returns partial, nb_entities ok=false */
+/* Scale:     1 user                                                           */
+/* Duration:  short-running                                                    */
+/* Expected:  - reports group renders with the surviving result                */
+/*            - nb_entities group renders an inline "Search failed" message    */
+/*            - status bar shows "partial"                                     */
+/*            - failure is NEVER silently hidden (HONEST_STATUS)               */
+/* -------------------------------------------------------------------------- */
+
+describe("Scenario 3 — Adversarial / degraded", () => {
+  it("renders successful results AND surfaces per-collection failures inline", async () => {
+    federatedSearchMock.mockResolvedValue(partialFailureResponse());
+
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByLabelText("Search anything") as HTMLInputElement;
+    await user.type(input, "Anthropic");
+
+    await waitFor(
+      () => expect(screen.getAllByText(/1 result across 7 collections/i).length).toBeGreaterThan(0),
+      { timeout: 3000 },
+    );
+
+    // Successful group renders the surviving report.
+    expect(screen.getByText("Anthropic — surviving brief")).toBeInTheDocument();
+
+    // Failed group renders the inline failure message.
+    const entityGroup = document.querySelector('[data-cmdk-group="nb_entities"]');
+    expect(entityGroup).toBeTruthy();
+    expect(entityGroup?.textContent ?? "").toMatch(/search failed for entities/i);
+    expect(entityGroup?.textContent ?? "").toMatch(/timeout/i);
+
+    // Status bar must announce partial.
+    expect(screen.getByText(/partial/i)).toBeInTheDocument();
+  });
+
+  it("server returning timedOut surfaces 'timed out' in the status bar", async () => {
+    // Adversarial: server eats the budget, returns timedOut=true with empty
+    // results. Palette must NOT pretend nothing happened — surface it.
+    federatedSearchMock.mockResolvedValue({
+      query: "Anthropic",
+      identityScope: "authenticated",
+      total: 0,
+      timedOut: true,
+      partial: true,
+      collections: [
+        { collection: "nb_entities", ok: false, count: 0, results: [], error: "federated_search_timeout" },
+        { collection: "nb_reports", ok: false, count: 0, results: [], error: "federated_search_timeout" },
+        { collection: "nb_notebook_blocks", ok: false, count: 0, results: [], error: "federated_search_timeout" },
+        { collection: "nb_claims", ok: false, count: 0, results: [], error: "federated_search_timeout" },
+        { collection: "nb_sources", ok: false, count: 0, results: [], error: "federated_search_timeout" },
+        { collection: "nb_captures", ok: false, count: 0, results: [], error: "federated_search_timeout" },
+        { collection: "nb_threads", ok: false, count: 0, results: [], error: "federated_search_timeout" },
+      ],
+    } satisfies FederatedSearchResponse);
+
+    const user = userEvent.setup();
+    renderPalette();
+
+    const input = screen.getByLabelText("Search anything") as HTMLInputElement;
+    await user.type(input, "Anthropic");
+
+    await waitFor(
+      () => expect(screen.getAllByText(/timed out/i).length).toBeGreaterThan(0),
+      { timeout: 3000 },
+    );
+
+    // Per-collection failure messages must be rendered inline — never hidden.
+    const errorGroups = document.querySelectorAll(".rd-cmdk__group-error");
+    expect(errorGroups.length).toBeGreaterThan(0);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* A11y + keyboard sanity                                                      */
+/* -------------------------------------------------------------------------- */
+
+describe("A11y + keyboard", () => {
+  it("dialog has correct ARIA + listbox + option roles", () => {
+    federatedSearchMock.mockResolvedValue(anonymousMostlyEmpty());
+    renderPalette();
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-label", "Command palette");
+
+    const listbox = screen.getByRole("listbox", { name: /search results/i });
+    expect(listbox).toBeInTheDocument();
+
+    // Each command renders as an option with aria-selected.
+    const options = screen.getAllByRole("option");
+    expect(options.length).toBeGreaterThan(0);
+    options.forEach((opt) => {
+      expect(opt).toHaveAttribute("aria-selected");
+    });
+  });
+
+  it("Escape closes the palette and calls onClose", async () => {
+    federatedSearchMock.mockResolvedValue(anonymousMostlyEmpty());
+
+    const { onClose } = renderPalette();
+
+    // Listener is attached to `window` after the open useEffect runs.
+    // Dispatching a real KeyboardEvent on `window` exercises that path
+    // deterministically (userEvent + fake-timers can deadlock here).
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/features/redesign/components/CommandPalette.tsx
+++ b/src/features/redesign/components/CommandPalette.tsx
@@ -1,19 +1,65 @@
 /**
- * CommandPalette — global ⌘K / Ctrl+K spotlight.
+ * CommandPalette — global Cmd-K spotlight backed by Convex federated search.
  *
- * Pattern: Linear / Raycast / Cursor. One keyboard shortcut to navigate, run a command,
- * or jump to an entity. Lives at the redesign layout level so every surface gets it.
+ * Pattern: federated search palette (Linear / Raycast / Cursor shape) that
+ * consumes the `domains/search/federatedSearch:federatedSearch` action
+ * (PR #310). Empty query falls back to the static nav-commands group so
+ * the palette stays useful for navigation alone.
  *
- * V1 commands are static (navigation + common actions). When the inbox aggregator + style
- * profile tables ship, this can read live entities + saved searches via useQuery.
+ * Result groups (collections):
+ *   nb_entities, nb_reports, nb_notebook_blocks, nb_claims, nb_sources,
+ *   nb_captures, nb_threads, plus a synthetic "Commands" group for nav.
+ *
+ * Reliability invariants (.claude/rules/agentic_reliability.md):
+ *   - BOUND        max 5 results per group, 35 total in palette
+ *   - HONEST_STATUS each per-collection failure shows "Search failed for {name}"
+ *                  inline; never silently hidden
+ *   - TIMEOUT      client-side 3.5 s abort (server budget 3 s + 0.5 s buffer)
+ *   - DETERMINISTIC same query + same data → same render order (server-side)
+ *
+ * Accessibility (.claude/rules/reexamine_a11y.md + reexamine_keyboard.md):
+ *   - role="dialog" aria-modal aria-label
+ *   - role="listbox" with role="option" + aria-selected on each result
+ *   - aria-live="polite" announces N results across M collections
+ *   - Focus trap (modal); Escape closes; focus returns to trigger element
+ *   - Tab cycles input <-> result list; Cmd+1..7 jumps groups; Up/Down moves selection
+ *   - Enter opens; Cmd+Enter "ask about this" pre-fills the chat composer
+ *
+ * Design reduction (.claude/rules/reexamine_design_reduction.md):
+ *   - Plain-language group labels: "Reports", "Entities", "Threads"
+ *   - Result count is shown only when >0 (drives scroll vs refine decision)
+ *   - No icons-only labels — every result has a text label
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useFederatedSearch } from "../../../layouts/chrome/commandPalette/useFederatedSearch";
+import {
+  addRecentCmdkSearch,
+  getRecentCmdkSearches,
+  type CmdkRecentSearch,
+} from "../../../layouts/chrome/commandPalette/recentSearches";
+import {
+  resolveResultAction,
+  isExternalPath,
+} from "../../../layouts/chrome/commandPalette/resolveResultAction";
+import {
+  COLLECTION_DISPLAY_ORDER,
+  COLLECTION_LABELS,
+  MAX_RESULTS_PER_GROUP,
+  MAX_RESULTS_TOTAL,
+  type CollectionResult,
+  type FederatedCollection,
+  type FederatedHandle,
+  type FederatedSearchResponse,
+} from "../../../layouts/chrome/commandPalette/types";
+
+/* -------------------------------------------------------------------------- */
+/* Types                                                                       */
+/* -------------------------------------------------------------------------- */
 
 interface PaletteCommand {
   id: string;
-  group: "navigate" | "create" | "action" | "entity";
   label: string;
   hint?: string;
   shortcut?: string;
@@ -24,166 +70,670 @@ interface PaletteCommand {
 interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
-  /** Optional extra commands injected by surface that opened it. */
+  /** Optional extra commands injected by the surface that opened it. */
   extra?: PaletteCommand[];
 }
+
+/**
+ * A flattened, navigable item — either a federated result or a static command.
+ * Selection arithmetic only walks this list (skipping group headers).
+ */
+type FlatItem =
+  | {
+      kind: "result";
+      handle: FederatedHandle;
+      collection: FederatedCollection;
+      flatIndex: number;
+    }
+  | {
+      kind: "command";
+      command: PaletteCommand;
+      flatIndex: number;
+    }
+  | {
+      kind: "recent";
+      query: string;
+      flatIndex: number;
+    };
+
+/* -------------------------------------------------------------------------- */
+/* Component                                                                   */
+/* -------------------------------------------------------------------------- */
 
 export function CommandPalette({ open, onClose, extra = [] }: CommandPaletteProps) {
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const [recents, setRecents] = useState<CmdkRecentSearch[]>([]);
 
-  const baseCommands: PaletteCommand[] = useMemo(() => [
-    { id: "go-home", group: "navigate", label: "Go to Home", shortcut: "G H", run: () => navigate("/redesign"), keywords: "dashboard pulse" },
-    { id: "go-reports", group: "navigate", label: "Go to Reports", shortcut: "G R", run: () => navigate("/redesign/reports"), keywords: "library memory" },
-    { id: "go-chat", group: "navigate", label: "Go to Chat", shortcut: "G C", run: () => navigate("/redesign/chat"), keywords: "ask question converse" },
-    { id: "go-inbox", group: "navigate", label: "Go to Inbox", shortcut: "G I", run: () => navigate("/redesign/inbox"), keywords: "review queue accept" },
-    { id: "go-me", group: "navigate", label: "Go to Me · Personal Context", shortcut: "G M", run: () => navigate("/redesign/me"), keywords: "user.md profile preferences" },
-    { id: "go-workspace", group: "navigate", label: "Open Workspace", run: () => navigate("/redesign/workspace"), keywords: "graph map sources" },
+  const { data, isLoading, error } = useFederatedSearch(query);
 
-    { id: "new-report", group: "create", label: "New report", hint: "Run diligence on a new entity", run: () => navigate("/redesign/chat?intent=new-report"), keywords: "create research" },
-    { id: "new-batch", group: "create", label: "Run on a list", hint: "Spin up a batch across a universe", run: () => navigate("/redesign/chat?intent=batch"), keywords: "universe bulk" },
-    { id: "new-capture", group: "create", label: "Quick capture", hint: "Drop an idea into Inbox · captures", run: () => navigate("/redesign/inbox?lane=captures&intent=new"), keywords: "note paste" },
+  /* -------- static nav commands (preserved as fallback) -------- */
+  const navCommands: PaletteCommand[] = useMemo(
+    () => [
+      {
+        id: "go-home",
+        label: "Go to Home",
+        shortcut: "G H",
+        run: () => navigate("/redesign"),
+        keywords: "dashboard pulse",
+      },
+      {
+        id: "go-reports",
+        label: "Go to Reports",
+        shortcut: "G R",
+        run: () => navigate("/redesign/reports"),
+        keywords: "library memory",
+      },
+      {
+        id: "go-chat",
+        label: "Go to Chat",
+        shortcut: "G C",
+        run: () => navigate("/redesign/chat"),
+        keywords: "ask question",
+      },
+      {
+        id: "go-inbox",
+        label: "Go to Inbox",
+        shortcut: "G I",
+        run: () => navigate("/redesign/inbox"),
+        keywords: "review queue",
+      },
+      {
+        id: "go-me",
+        label: "Go to Me",
+        shortcut: "G M",
+        run: () => navigate("/redesign/me"),
+        keywords: "profile preferences",
+      },
+      {
+        id: "go-workspace",
+        label: "Open Workspace",
+        run: () => navigate("/redesign/workspace"),
+        keywords: "graph map sources",
+      },
+      {
+        id: "act-shortcuts",
+        label: "Show all keyboard shortcuts",
+        shortcut: "?",
+        run: () => {
+          window.dispatchEvent(new CustomEvent("rd:shortcuts:open"));
+        },
+        keywords: "help kbd",
+      },
+      {
+        id: "act-toggle-theme",
+        label: "Toggle dark / light mode",
+        run: () => {
+          document.documentElement.classList.toggle("dark");
+        },
+        keywords: "theme appearance",
+      },
+    ],
+    [navigate],
+  );
 
-    { id: "act-shortcuts", group: "action", label: "Show all keyboard shortcuts", shortcut: "?", run: () => { window.dispatchEvent(new CustomEvent("rd:shortcuts:open")); }, keywords: "help kbd" },
-    { id: "act-toggle-theme", group: "action", label: "Toggle dark / light mode", run: () => { document.documentElement.classList.toggle("dark"); }, keywords: "theme appearance" },
-    { id: "act-focus-mode", group: "action", label: "Toggle writing focus mode", shortcut: "⌘\\", run: () => { document.body.setAttribute("data-redesign-focus-mode", document.body.getAttribute("data-redesign-focus-mode") === "on" ? "off" : "on"); }, keywords: "zen distraction" },
+  const allNavCommands = useMemo(() => [...navCommands, ...extra], [navCommands, extra]);
 
-    { id: "ent-live",      group: "entity", label: "Latest live brief",  hint: "Open first-party Convex artifact",  run: () => navigate("/redesign/workspace") },
-    { id: "ent-sources",   group: "entity", label: "Source review queue", hint: "Inspect claims that need evidence", run: () => navigate("/redesign/inbox") },
-    { id: "ent-library",   group: "entity", label: "Coverage library",   hint: "Browse reusable reports",           run: () => navigate("/redesign/reports") },
-  ], [navigate]);
+  /* -------- filtered nav commands (substring match when query non-empty) -------- */
+  const filteredCommands = useMemo<PaletteCommand[]>(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return allNavCommands;
+    return allNavCommands.filter((c) => {
+      const hay = `${c.label} ${c.hint ?? ""} ${c.keywords ?? ""}`.toLowerCase();
+      return hay.includes(trimmed);
+    });
+  }, [allNavCommands, query]);
 
-  const all = useMemo(() => [...baseCommands, ...extra], [baseCommands, extra]);
-
-  const filtered = useMemo(() => {
-    if (!query.trim()) return all;
-    const q = query.toLowerCase();
-    return all.filter((c) =>
-      c.label.toLowerCase().includes(q) ||
-      (c.hint ?? "").toLowerCase().includes(q) ||
-      (c.keywords ?? "").toLowerCase().includes(q),
-    );
-  }, [all, query]);
-
-  // Reset active index when filter changes
-  useEffect(() => { setActive(0); }, [query]);
-
-  // Focus input on open + reset query
-  useEffect(() => {
-    if (open) {
-      setQuery("");
-      window.setTimeout(() => inputRef.current?.focus(), 30);
+  /* -------- federated result groups (capped) -------- */
+  const collectionResults: CollectionResult[] = useMemo(() => {
+    if (!data) {
+      return COLLECTION_DISPLAY_ORDER.map((c) => ({
+        collection: c,
+        ok: true,
+        results: [],
+        count: 0,
+      }));
     }
+    const byName: Map<FederatedCollection, CollectionResult> = new Map();
+    for (const r of data.collections) byName.set(r.collection, r);
+    return COLLECTION_DISPLAY_ORDER.map(
+      (c): CollectionResult =>
+        byName.get(c) ?? { collection: c, ok: true, results: [], count: 0 },
+    );
+  }, [data]);
+
+  /* -------- flat list of selectable items, in render order -------- */
+  const { flatItems, totalRendered } = useMemo(() => {
+    const items: FlatItem[] = [];
+    let total = 0;
+
+    if (query.trim()) {
+      // Search mode — federated results first, then commands as fallback group.
+      for (const result of collectionResults) {
+        const visible = result.results.slice(0, MAX_RESULTS_PER_GROUP);
+        for (const handle of visible) {
+          if (total >= MAX_RESULTS_TOTAL) break;
+          items.push({
+            kind: "result",
+            handle,
+            collection: result.collection,
+            flatIndex: items.length,
+          });
+          total += 1;
+        }
+        if (total >= MAX_RESULTS_TOTAL) break;
+      }
+      for (const command of filteredCommands) {
+        items.push({ kind: "command", command, flatIndex: items.length });
+      }
+    } else {
+      // Empty mode — recents + commands.
+      for (const r of recents) {
+        items.push({ kind: "recent", query: r.query, flatIndex: items.length });
+      }
+      for (const command of filteredCommands) {
+        items.push({ kind: "command", command, flatIndex: items.length });
+      }
+    }
+
+    return { flatItems: items, totalRendered: total };
+  }, [query, collectionResults, filteredCommands, recents]);
+
+  /* -------- selection arithmetic -------- */
+  useEffect(() => {
+    setActive(0);
+  }, [query]);
+
+  // Clamp selection if items shrink.
+  useEffect(() => {
+    if (active >= flatItems.length) {
+      setActive(Math.max(0, flatItems.length - 1));
+    }
+  }, [active, flatItems.length]);
+
+  /* -------- on-open: focus input, capture trigger element, load recents -------- */
+  useEffect(() => {
+    if (!open) return;
+    triggerRef.current = (document.activeElement as HTMLElement) ?? null;
+    setQuery("");
+    setRecents(getRecentCmdkSearches());
+    const handle = window.setTimeout(() => inputRef.current?.focus(), 30);
+    return () => window.clearTimeout(handle);
   }, [open]);
 
-  // Keyboard: Esc / Up / Down / Enter
+  /* -------- on-close: return focus to trigger -------- */
+  const handleClose = useCallback(() => {
+    onClose();
+    window.setTimeout(() => {
+      if (triggerRef.current && document.contains(triggerRef.current)) {
+        triggerRef.current.focus();
+      }
+    }, 0);
+  }, [onClose]);
+
+  /* -------- execute item — primary or secondary action -------- */
+  const executeItem = useCallback(
+    (item: FlatItem, mode: "primary" | "secondary") => {
+      if (item.kind === "command") {
+        if (query.trim()) addRecentCmdkSearch(query);
+        item.command.run();
+        handleClose();
+        return;
+      }
+      if (item.kind === "recent") {
+        // Re-fire that query — populate input, do NOT close.
+        setQuery(item.query);
+        return;
+      }
+      // result
+      const { primaryPath, secondaryPath } = resolveResultAction(item.handle);
+      const target = mode === "secondary" ? secondaryPath : primaryPath;
+      if (query.trim()) addRecentCmdkSearch(query);
+      if (isExternalPath(target)) {
+        window.open(target, "_blank", "noopener,noreferrer");
+      } else {
+        navigate(target);
+      }
+      handleClose();
+    },
+    [navigate, handleClose, query],
+  );
+
+  /* -------- jump to group via Cmd+1..7 -------- */
+  const jumpToGroup = useCallback(
+    (groupNumber: number) => {
+      // groupNumber is 1-indexed against COLLECTION_DISPLAY_ORDER.
+      if (groupNumber < 1 || groupNumber > COLLECTION_DISPLAY_ORDER.length) return;
+      const targetCollection = COLLECTION_DISPLAY_ORDER[groupNumber - 1];
+      const idx = flatItems.findIndex(
+        (it) => it.kind === "result" && it.collection === targetCollection,
+      );
+      if (idx >= 0) setActive(idx);
+    },
+    [flatItems],
+  );
+
+  /* -------- keyboard handler -------- */
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { e.preventDefault(); onClose(); return; }
-      if (e.key === "ArrowDown") { e.preventDefault(); setActive((a) => Math.min(filtered.length - 1, a + 1)); return; }
-      if (e.key === "ArrowUp")   { e.preventDefault(); setActive((a) => Math.max(0, a - 1)); return; }
+      // Escape — close.
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleClose();
+        return;
+      }
+      // Cmd/Ctrl + 1..7 — jump to group.
+      if ((e.metaKey || e.ctrlKey) && /^[1-9]$/.test(e.key)) {
+        e.preventDefault();
+        jumpToGroup(Number(e.key));
+        return;
+      }
+      // Arrow up/down — move selection.
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActive((a) => Math.min(flatItems.length - 1, a + 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActive((a) => Math.max(0, a - 1));
+        return;
+      }
       if (e.key === "Enter") {
         e.preventDefault();
-        const cmd = filtered[active];
-        if (cmd) { cmd.run(); onClose(); }
+        const item = flatItems[active];
+        if (item) executeItem(item, e.metaKey || e.ctrlKey ? "secondary" : "primary");
+        return;
+      }
+      if (e.key === "?" && !isInTextInput(e.target)) {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("rd:shortcuts:open"));
+        return;
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, filtered, active, onClose]);
+  }, [open, flatItems, active, executeItem, jumpToGroup, handleClose]);
+
+  /* -------- focus trap inside dialog (Tab/Shift+Tab cycles within) -------- */
+  const handleDialogKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Tab") return;
+    const root = dialogRef.current;
+    if (!root) return;
+    const focusable = root.querySelectorAll<HTMLElement>(
+      'input, button, [tabindex]:not([tabindex="-1"])',
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }, []);
+
+  /* -------- scroll active row into view -------- */
+  useEffect(() => {
+    if (!listRef.current || !open) return;
+    const el = listRef.current.querySelector<HTMLElement>(`[data-flat-index="${active}"]`);
+    if (el && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [active, open]);
 
   if (!open) return null;
 
-  // Group filtered commands
-  const groups: Record<string, PaletteCommand[]> = { navigate: [], create: [], action: [], entity: [] };
-  for (const c of filtered) groups[c.group].push(c);
-  const GROUP_LABEL: Record<string, string> = { navigate: "Navigate", create: "Create", action: "Action", entity: "Entity" };
+  /* -------- group + render -------- */
+  const liveRegionMessage = buildLiveRegion({
+    query,
+    isLoading,
+    error,
+    data,
+    totalRendered,
+  });
 
-  let cursor = 0;
+  // Group results for the visible list.
+  const visibleByCollection: Map<FederatedCollection, FlatItem[]> = new Map();
+  const commandsBucket: FlatItem[] = [];
+  const recentsBucket: FlatItem[] = [];
+  for (const it of flatItems) {
+    if (it.kind === "result") {
+      const arr = visibleByCollection.get(it.collection) ?? [];
+      arr.push(it);
+      visibleByCollection.set(it.collection, arr);
+    } else if (it.kind === "command") {
+      commandsBucket.push(it);
+    } else {
+      recentsBucket.push(it);
+    }
+  }
+
+  const showSearchMode = query.trim().length > 0;
+  const totalResults = flatItems.filter((i) => i.kind === "result").length;
+
   return (
-    <div className="rd-cmdk__backdrop" role="dialog" aria-modal="true" aria-label="Command palette" onClick={onClose}>
-      <div className="rd-cmdk" onClick={(e) => e.stopPropagation()}>
+    <div
+      className="rd-cmdk__backdrop"
+      role="presentation"
+      onClick={handleClose}
+      data-cmdk-modal
+    >
+      <div
+        ref={dialogRef}
+        className="rd-cmdk"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleDialogKeyDown}
+      >
         <div className="rd-cmdk__head">
           <SearchIcon />
           <input
             ref={inputRef}
+            data-cmdk-input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search commands, entities, and shortcuts…"
-            aria-label="Command palette search"
+            placeholder="Search anything..."
+            aria-label="Search anything"
+            aria-controls="rd-cmdk-listbox"
+            aria-activedescendant={
+              flatItems[active] ? `rd-cmdk-row-${flatItems[active].flatIndex}` : undefined
+            }
             spellCheck={false}
           />
           <span className="rd-cmdk__esc" aria-label="Close">Esc</span>
         </div>
-        <div className="rd-cmdk__list" role="listbox">
-          {filtered.length === 0 && (
-            <div className="rd-cmdk__empty">No commands match "{query}"</div>
-          )}
-          {(["navigate","create","action","entity"] as const).map((g) => {
-            if (groups[g].length === 0) return null;
-            return (
-              <div key={g} className="rd-cmdk__group">
-                <div className="rd-cmdk__group-label">{GROUP_LABEL[g]}</div>
-                {groups[g].map((c) => {
-                  const idx = cursor++;
-                  const isActive = idx === active;
-                  return (
-                    <button
-                      key={c.id}
-                      type="button"
-                      role="option"
-                      aria-selected={isActive}
-                      data-active={isActive || undefined}
-                      className="rd-cmdk__row"
-                      onMouseEnter={() => setActive(idx)}
-                      onClick={() => { c.run(); onClose(); }}
-                    >
-                      <span className="rd-cmdk__row-label">{c.label}</span>
-                      {c.hint && <span className="rd-cmdk__row-hint">{c.hint}</span>}
-                      {c.shortcut && (
-                        <span className="rd-cmdk__row-kbd">
-                          {c.shortcut.split(" ").map((k, i) => <kbd key={i}>{k}</kbd>)}
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
-            );
-          })}
+
+        {/* Status bar — total + scope + degraded warning */}
+        {(data || isLoading || error) && (
+          <div
+            className="rd-cmdk__status"
+            data-tone={data?.partial || data?.timedOut || error ? "warn" : undefined}
+            data-cmdk-status
+          >
+            <span>
+              {isLoading
+                ? "Searching..."
+                : error
+                  ? "Search request failed - showing the last good result."
+                  : data
+                    ? `${data.total} ${data.total === 1 ? "result" : "results"} across ${data.collections.length} collections`
+                    : ""}
+            </span>
+            {data ? (
+              <span>
+                {data.identityScope === "anonymous" ? "anonymous" : "your account"}
+                {data.partial ? " · partial" : ""}
+                {data.timedOut ? " · timed out" : ""}
+              </span>
+            ) : null}
+          </div>
+        )}
+
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
+          {liveRegionMessage}
+        </span>
+
+        <div
+          ref={listRef}
+          id="rd-cmdk-listbox"
+          className="rd-cmdk__list"
+          role="listbox"
+          aria-label="Search results"
+        >
+          {/* Loading skeleton (only when no prior data is visible) */}
+          {isLoading && !data ? <SkeletonGroups /> : null}
+
+          {/* Empty mode — show recents (if any), then commands */}
+          {!showSearchMode && recentsBucket.length > 0 ? (
+            <div className="rd-cmdk__group" data-cmdk-group="recents">
+              <div className="rd-cmdk__group-label">Recent searches</div>
+              {recentsBucket.map((it) => {
+                if (it.kind !== "recent") return null;
+                const isActive = it.flatIndex === active;
+                return (
+                  <button
+                    key={`recent-${it.query}`}
+                    type="button"
+                    role="option"
+                    id={`rd-cmdk-row-${it.flatIndex}`}
+                    data-flat-index={it.flatIndex}
+                    data-cmdk-result
+                    data-cmdk-active={isActive || undefined}
+                    aria-selected={isActive}
+                    data-active={isActive || undefined}
+                    className="rd-cmdk__row"
+                    onMouseEnter={() => setActive(it.flatIndex)}
+                    onClick={() => executeItem(it, "primary")}
+                  >
+                    <span className="rd-cmdk__row-label">{it.query}</span>
+                    <span className="rd-cmdk__row-hint">Re-run search</span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {/* Search mode — federated result groups */}
+          {showSearchMode
+            ? COLLECTION_DISPLAY_ORDER.map((collection) => {
+                const result = collectionResults.find((r) => r.collection === collection);
+                if (!result) return null;
+                const items = visibleByCollection.get(collection) ?? [];
+                // Render group ONLY when it has results OR an error to surface.
+                if (items.length === 0 && result.ok) return null;
+                return (
+                  <div
+                    key={collection}
+                    className="rd-cmdk__group"
+                    data-cmdk-group={collection}
+                  >
+                    <div className="rd-cmdk__group-label">
+                      {COLLECTION_LABELS[collection]}
+                      {result.count > 0 ? <span> · {result.count}</span> : null}
+                    </div>
+                    {!result.ok ? (
+                      <div className="rd-cmdk__group-error" role="status">
+                        Search failed for {COLLECTION_LABELS[collection].toLowerCase()}
+                        {result.error ? ` - ${result.error}` : ""}
+                      </div>
+                    ) : null}
+                    {items.map((it) => {
+                      if (it.kind !== "result") return null;
+                      const isActive = it.flatIndex === active;
+                      return (
+                        <button
+                          key={`${collection}-${it.handle.uri}-${it.flatIndex}`}
+                          type="button"
+                          role="option"
+                          id={`rd-cmdk-row-${it.flatIndex}`}
+                          data-flat-index={it.flatIndex}
+                          data-cmdk-result
+                          data-cmdk-active={isActive || undefined}
+                          aria-selected={isActive}
+                          data-active={isActive || undefined}
+                          className="rd-cmdk__row"
+                          onMouseEnter={() => setActive(it.flatIndex)}
+                          onClick={(e) =>
+                            executeItem(it, e.metaKey || e.ctrlKey ? "secondary" : "primary")
+                          }
+                        >
+                          <span className="rd-cmdk__row-label">
+                            {it.handle.title || COLLECTION_LABELS[collection]}
+                            {it.handle.source ? (
+                              <span className="rd-cmdk__row-source">
+                                {it.handle.source}
+                              </span>
+                            ) : null}
+                          </span>
+                          {it.handle.snippet ? (
+                            <span className="rd-cmdk__row-snippet">{it.handle.snippet}</span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                    {result.count > items.length ? (
+                      <div className="rd-cmdk__row-more">
+                        + {result.count - items.length} more in {COLLECTION_LABELS[collection].toLowerCase()}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })
+            : null}
+
+          {/* Always render Commands group (acts as nav fallback) */}
+          {commandsBucket.length > 0 ? (
+            <div className="rd-cmdk__group" data-cmdk-group="commands">
+              <div className="rd-cmdk__group-label">Commands</div>
+              {commandsBucket.map((it) => {
+                if (it.kind !== "command") return null;
+                const isActive = it.flatIndex === active;
+                return (
+                  <button
+                    key={it.command.id}
+                    type="button"
+                    role="option"
+                    id={`rd-cmdk-row-${it.flatIndex}`}
+                    data-flat-index={it.flatIndex}
+                    data-cmdk-result
+                    data-cmdk-active={isActive || undefined}
+                    aria-selected={isActive}
+                    data-active={isActive || undefined}
+                    className="rd-cmdk__row"
+                    onMouseEnter={() => setActive(it.flatIndex)}
+                    onClick={() => executeItem(it, "primary")}
+                  >
+                    <span className="rd-cmdk__row-label">{it.command.label}</span>
+                    {it.command.hint ? (
+                      <span className="rd-cmdk__row-hint">{it.command.hint}</span>
+                    ) : null}
+                    {it.command.shortcut ? (
+                      <span className="rd-cmdk__row-kbd">
+                        {it.command.shortcut.split(" ").map((k, i) => (
+                          <kbd key={i}>{k}</kbd>
+                        ))}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {/* Empty + no recents */}
+          {!showSearchMode && recentsBucket.length === 0 && commandsBucket.length === 0 ? (
+            <div className="rd-cmdk__empty">
+              Try searching for an entity, report, or thread.
+            </div>
+          ) : null}
+
+          {/* Search mode + truly zero results */}
+          {showSearchMode &&
+          !isLoading &&
+          totalResults === 0 &&
+          commandsBucket.length === 0 ? (
+            <div className="rd-cmdk__empty">
+              0 results for "{query}"
+            </div>
+          ) : null}
         </div>
       </div>
     </div>
   );
 }
 
+/* -------------------------------------------------------------------------- */
+/* Sub-components                                                              */
+/* -------------------------------------------------------------------------- */
+
+function SkeletonGroups() {
+  return (
+    <div data-cmdk-skeleton>
+      {[0, 1, 2].map((g) => (
+        <div className="rd-cmdk__group" key={g} aria-hidden="true">
+          <div className="rd-cmdk__group-label">Loading...</div>
+          <div className="rd-cmdk__skeleton">
+            <div className="rd-cmdk__skeleton-line" style={{ width: "70%" }} />
+            <div className="rd-cmdk__skeleton-line" style={{ width: "55%" }} />
+            <div className="rd-cmdk__skeleton-line" style={{ width: "40%" }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function SearchIcon() {
   return (
-    <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <circle cx="11" cy="11" r="8" />
       <path d="m21 21-4.35-4.35" />
     </svg>
   );
 }
 
-/** Hook: wires Cmd+K / Ctrl+K to open the palette. Returns { open, setOpen }. */
+function isInTextInput(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable;
+}
+
+function buildLiveRegion(args: {
+  query: string;
+  isLoading: boolean;
+  error: Error | null;
+  data: FederatedSearchResponse | null;
+  totalRendered: number;
+}): string {
+  const { query, isLoading, error, data, totalRendered } = args;
+  if (!query.trim()) return "Empty query. Showing recent searches and commands.";
+  if (isLoading) return `Searching for ${query}.`;
+  if (error) return `Search failed: ${error.message}.`;
+  if (!data) return "";
+  const failed = data.collections.filter((c) => !c.ok).length;
+  const parts = [
+    `${data.total} ${data.total === 1 ? "result" : "results"} across ${data.collections.length} collections.`,
+  ];
+  if (failed > 0) parts.push(`${failed} collection${failed > 1 ? "s" : ""} failed.`);
+  if (totalRendered < data.total) {
+    parts.push(`${totalRendered} shown.`);
+  }
+  return parts.join(" ");
+}
+
+/* -------------------------------------------------------------------------- */
+/* Hook: wires Cmd+K / Ctrl+K to open the palette.                             */
+/* -------------------------------------------------------------------------- */
+
 export function useCommandPalette() {
   const [open, setOpen] = useState(false);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
-      const inField = target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable;
       if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
         e.preventDefault();
         setOpen((o) => !o);
         return;
-      }
-      // / opens palette when not typing in a field
-      if (e.key === "k" && !inField && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        // No-op — Cmd+K is the canonical trigger. Letter "k" is reserved for fuzzy navigation later.
       }
     };
     window.addEventListener("keydown", onKey);

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -2960,6 +2960,82 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   color: var(--rd-ink-soft);
 }
 
+/* ───────── Federated search additions ───────── */
+[data-redesign] .rd-cmdk__status {
+  padding: 6px 14px;
+  font-family: var(--rd-font-mono);
+  font-size: 10.5px;
+  color: var(--rd-ink-soft);
+  border-bottom: 1px solid var(--rd-line-faint);
+  background: var(--rd-paper-warm);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+[data-redesign] .rd-cmdk__status[data-tone="warn"] { color: var(--rd-ink); }
+[data-redesign] .rd-cmdk__group-error {
+  padding: 6px 12px 8px;
+  font-size: 11.5px;
+  color: var(--rd-ink-soft);
+  font-style: italic;
+}
+[data-redesign] .rd-cmdk__row-snippet {
+  font-size: 11.5px;
+  color: var(--rd-ink-soft);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  grid-column: 1 / -1;
+  margin-top: 2px;
+}
+[data-redesign] .rd-cmdk__row-source {
+  font-family: var(--rd-font-mono);
+  font-size: 9.5px;
+  color: var(--rd-ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 1px 5px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: 3px;
+  margin-left: 6px;
+  white-space: nowrap;
+}
+[data-redesign] .rd-cmdk__row-more {
+  font-size: 11.5px;
+  color: var(--rd-ink-soft);
+  padding: 4px 12px;
+  text-align: right;
+}
+[data-redesign] .rd-cmdk__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 12px;
+}
+[data-redesign] .rd-cmdk__skeleton-line {
+  height: 12px;
+  background: linear-gradient(
+    90deg,
+    var(--rd-line-faint) 25%,
+    var(--rd-paper-warm) 50%,
+    var(--rd-line-faint) 75%
+  );
+  background-size: 200% 100%;
+  animation: rd-cmdk-shimmer 1.4s infinite;
+  border-radius: 3px;
+  width: 80%;
+}
+@keyframes rd-cmdk-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-redesign] .rd-cmdk__skeleton-line { animation: none; }
+  [data-redesign] .rd-cmdk { animation: none; }
+  [data-redesign] .rd-cmdk__backdrop { animation: none; backdrop-filter: none; -webkit-backdrop-filter: none; }
+}
+
 /* ───────── ? Shortcuts overlay ───────── */
 [data-redesign] .rd-shortcuts__backdrop {
   position: fixed;

--- a/src/layouts/chrome/commandPalette/recentSearches.ts
+++ b/src/layouts/chrome/commandPalette/recentSearches.ts
@@ -1,0 +1,82 @@
+/**
+ * Cmd-K recent searches — localStorage CRUD with TTL + dedupe.
+ *
+ * Storage key: `nb_cmdk_recent_v1` (versioned for safe schema bumps).
+ * Cap: 10 entries. TTL: 30 days.
+ *
+ * Pattern: write-through cache. Every successful federated search query is
+ * pushed to the top; older instances of the same query are removed (so the
+ * list stays useful, not redundant).
+ *
+ * Reliability invariants (.claude/rules/agentic_reliability.md):
+ *   - BOUND: max 10 entries, never grows unbounded
+ *   - DETERMINISTIC: same query string always collides (case-sensitive intentional —
+ *     queries like "AAPL" vs "aapl" are user signal)
+ *
+ * NOT shared across devices — pure client-side. Out of scope for v1.
+ */
+
+const RECENT_KEY = "nb_cmdk_recent_v1";
+const MAX_RECENT = 10;
+const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export interface CmdkRecentSearch {
+  query: string;
+  timestamp: number;
+}
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && !!window.localStorage;
+}
+
+export function getRecentCmdkSearches(): CmdkRecentSearch[] {
+  if (!canUseStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(RECENT_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const now = Date.now();
+    const fresh = parsed
+      .filter(
+        (entry): entry is CmdkRecentSearch =>
+          !!entry &&
+          typeof entry.query === "string" &&
+          entry.query.trim().length > 0 &&
+          typeof entry.timestamp === "number" &&
+          now - entry.timestamp < TTL_MS,
+      )
+      .slice(0, MAX_RECENT);
+    return fresh;
+  } catch {
+    return [];
+  }
+}
+
+export function addRecentCmdkSearch(query: string): void {
+  if (!canUseStorage()) return;
+  const trimmed = query.trim();
+  if (!trimmed) return;
+  try {
+    const existing = getRecentCmdkSearches().filter(
+      (entry) => entry.query !== trimmed,
+    );
+    const next: CmdkRecentSearch[] = [
+      { query: trimmed, timestamp: Date.now() },
+      ...existing,
+    ].slice(0, MAX_RECENT);
+    window.localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  } catch {
+    // Storage may be full or disabled (private mode). Fail silent — recent
+    // searches are a convenience, not a correctness invariant.
+  }
+}
+
+export function clearRecentCmdkSearches(): void {
+  if (!canUseStorage()) return;
+  try {
+    window.localStorage.removeItem(RECENT_KEY);
+  } catch {
+    // Ignore.
+  }
+}

--- a/src/layouts/chrome/commandPalette/resolveResultAction.ts
+++ b/src/layouts/chrome/commandPalette/resolveResultAction.ts
@@ -1,0 +1,108 @@
+/**
+ * Resolves a federated-search FederatedHandle to concrete UI actions.
+ *
+ * Each handle has a stable `uri` like `entity://acme-ai`, `report://abc123`,
+ * etc. This module owns the mapping `uri -> route`.
+ *
+ * Two action surfaces:
+ *   - primary  (Enter)        — open the result in its native context
+ *   - secondary (Cmd+Enter)   — "ask about this" — pre-fill the chat composer
+ *
+ * Both return paths or query strings; the caller invokes navigate().
+ *
+ * Pattern: pure function, no React, no router. Easy to unit test.
+ */
+
+import type { FederatedHandle } from "./types";
+
+export interface ResolvedActions {
+  primaryPath: string;
+  secondaryPath: string;
+}
+
+/**
+ * Extract the slug or id from a uri like `entity://slug` or `report://abc123`.
+ * Returns the empty string if the URI is malformed.
+ */
+function uriBody(uri: string, scheme: string): string {
+  const prefix = `${scheme}://`;
+  if (!uri.startsWith(prefix)) return "";
+  return uri.slice(prefix.length);
+}
+
+/**
+ * Build a chat URL pre-filled with a question about this handle.
+ * Used for Cmd+Enter "ask about this".
+ */
+function askAbout(handle: FederatedHandle): string {
+  const subject = handle.title || handle.snippet || "this";
+  const trimmed = subject.replace(/\s+/g, " ").trim().slice(0, 240);
+  const q = encodeURIComponent(`Tell me about: ${trimmed}`);
+  return `/redesign/chat?q=${q}`;
+}
+
+export function resolveResultAction(handle: FederatedHandle): ResolvedActions {
+  switch (handle.type) {
+    case "nb_entities": {
+      const slug = uriBody(handle.uri, "entity");
+      return {
+        // Workspace surface scoped to the entity reads /redesign/workspace?entity=slug.
+        primaryPath: slug
+          ? `/redesign/workspace?entity=${encodeURIComponent(slug)}`
+          : "/redesign/workspace",
+        secondaryPath: askAbout(handle),
+      };
+    }
+    case "nb_reports": {
+      const id = uriBody(handle.uri, "report");
+      return {
+        primaryPath: id ? `/redesign/reports/${encodeURIComponent(id)}` : "/redesign/reports",
+        secondaryPath: askAbout(handle),
+      };
+    }
+    case "nb_notebook_blocks": {
+      // Blocks live under their parent report. Handle.uri is `block://id`,
+      // so fall back to opening the workspace + searching for the snippet.
+      return {
+        primaryPath: "/redesign/workspace?tab=notebook",
+        secondaryPath: askAbout(handle),
+      };
+    }
+    case "nb_claims": {
+      // Claims trace to a parent report (PR2 wires the actual report id).
+      // For PR1, surface the workspace + sources view.
+      return {
+        primaryPath: "/redesign/workspace?tab=sources",
+        secondaryPath: askAbout(handle),
+      };
+    }
+    case "nb_sources": {
+      // Sources have a real http(s) URL on `uri` when available.
+      const isHttp = handle.uri.startsWith("http://") || handle.uri.startsWith("https://");
+      return {
+        primaryPath: isHttp ? handle.uri : "/redesign/workspace?tab=sources",
+        secondaryPath: askAbout(handle),
+      };
+    }
+    case "nb_captures": {
+      return {
+        primaryPath: "/redesign/inbox?lane=captures",
+        secondaryPath: askAbout(handle),
+      };
+    }
+    case "nb_threads": {
+      const id = uriBody(handle.uri, "thread");
+      return {
+        primaryPath: id ? `/redesign/chat?thread=${encodeURIComponent(id)}` : "/redesign/chat",
+        secondaryPath: askAbout(handle),
+      };
+    }
+  }
+}
+
+/**
+ * True if the resolved path is an external http(s) URL (open in new tab).
+ */
+export function isExternalPath(path: string): boolean {
+  return path.startsWith("http://") || path.startsWith("https://");
+}

--- a/src/layouts/chrome/commandPalette/types.ts
+++ b/src/layouts/chrome/commandPalette/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared types for the Cmd-K palette federated-search consumer.
+ *
+ * Mirrors the action response shape from
+ * `convex/domains/search/federatedSearch.ts`. Re-declared here to:
+ *   1. Avoid pulling Convex's generated api types into UI code at build time.
+ *   2. Keep the UI compilable when the action's path moves.
+ *
+ * If federatedSearch's response shape changes, update both. The mismatch
+ * surface area is small (single hook) so keeping them in sync is cheap.
+ */
+
+export type FederatedCollection =
+  | "nb_entities"
+  | "nb_reports"
+  | "nb_notebook_blocks"
+  | "nb_claims"
+  | "nb_sources"
+  | "nb_captures"
+  | "nb_threads";
+
+export interface FederatedHandle {
+  type: FederatedCollection;
+  uri: string;
+  title: string;
+  snippet: string;
+  score: number;
+  source: string;
+  actions: string[];
+}
+
+export interface CollectionResult {
+  collection: FederatedCollection;
+  ok: boolean;
+  results: FederatedHandle[];
+  count: number;
+  error?: string;
+}
+
+export interface FederatedSearchResponse {
+  query: string;
+  collections: CollectionResult[];
+  total: number;
+  timedOut: boolean;
+  partial: boolean;
+  identityScope: "authenticated" | "anonymous";
+}
+
+/**
+ * Display order — drives left-to-right group rendering and Cmd+1..7 jump
+ * shortcuts. Stable across calls (DETERMINISTIC).
+ */
+export const COLLECTION_DISPLAY_ORDER: ReadonlyArray<FederatedCollection> = [
+  "nb_entities",
+  "nb_reports",
+  "nb_notebook_blocks",
+  "nb_claims",
+  "nb_sources",
+  "nb_captures",
+  "nb_threads",
+];
+
+/**
+ * Plain-language labels (per .claude/rules/reexamine_design_reduction.md —
+ * kill jargon). Used in group headers and aria-live announcements.
+ */
+export const COLLECTION_LABELS: Record<FederatedCollection, string> = {
+  nb_entities: "Entities",
+  nb_reports: "Reports",
+  nb_notebook_blocks: "Notebook blocks",
+  nb_claims: "Claims",
+  nb_sources: "Sources",
+  nb_captures: "Captures",
+  nb_threads: "Threads",
+};
+
+/** Per-group display cap (BOUND). Federated search action also caps server-side. */
+export const MAX_RESULTS_PER_GROUP = 5;
+/** Total cap across all groups in the palette (BOUND). */
+export const MAX_RESULTS_TOTAL = 35;
+/** Client-side abort budget: server is 3 s + 0.5 s buffer (TIMEOUT). */
+export const CLIENT_TIMEOUT_MS = 3500;
+/** Debounce window before firing federatedSearch on every keystroke. */
+export const SEARCH_DEBOUNCE_MS = 150;

--- a/src/layouts/chrome/commandPalette/useFederatedSearch.ts
+++ b/src/layouts/chrome/commandPalette/useFederatedSearch.ts
@@ -1,0 +1,125 @@
+/**
+ * useFederatedSearch — debounced consumer of the Convex federatedSearch action.
+ *
+ * Pattern: AbortController-style cancellation via stale-request rejection.
+ * The hook tracks an internal request id; only the latest in-flight request
+ * is allowed to update state. This avoids tearing when the user types quickly.
+ *
+ * Reliability invariants (.claude/rules/agentic_reliability.md):
+ *   - BOUND: only one in-flight request mutates state at a time
+ *   - HONEST_STATUS: errors return { error } — never silently rendered as 0
+ *   - TIMEOUT: client-side abort at CLIENT_TIMEOUT_MS (server is 3 s, buffer 0.5 s)
+ *   - DETERMINISTIC: same query + same data → same response order (server side)
+ *
+ * Returns:
+ *   - data: FederatedSearchResponse | null
+ *   - isLoading: boolean (true while a request is in flight for the current query)
+ *   - error: Error | null (set when the latest request fails)
+ *
+ * Empty / whitespace queries short-circuit to { data: null, isLoading: false }.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAction } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { getAnonymousProductSessionId } from "@/features/product/lib/productIdentity";
+import {
+  CLIENT_TIMEOUT_MS,
+  SEARCH_DEBOUNCE_MS,
+  type FederatedSearchResponse,
+} from "./types";
+
+interface UseFederatedSearchResult {
+  data: FederatedSearchResponse | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useFederatedSearch(query: string): UseFederatedSearchResult {
+  // Type the action loosely — the codegen path may not exist on first build,
+  // but the runtime resolves once federatedSearch.ts is deployed. The shape
+  // is asserted by the explicit return type cast below.
+  const federatedSearch = useAction(
+    (api as any).domains.search.federatedSearch.federatedSearch,
+  );
+
+  const [data, setData] = useState<FederatedSearchResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Monotonic request id — every fire bumps it. Only the latest may write state.
+  const requestIdRef = useRef(0);
+
+  const fire = useCallback(
+    async (q: string) => {
+      const trimmed = q.trim();
+      const myId = ++requestIdRef.current;
+
+      // Empty query — clear state and return early. Don't make a network round-trip.
+      if (!trimmed) {
+        setData(null);
+        setIsLoading(false);
+        setError(null);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      // Client-side timeout race. The server has its own 3 s budget; this is
+      // belt-and-suspenders for hung connections.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error("client_timeout"));
+        }, CLIENT_TIMEOUT_MS);
+      });
+
+      try {
+        const response = (await Promise.race([
+          federatedSearch({
+            q: trimmed,
+            anonymousSessionId: getAnonymousProductSessionId(),
+          }),
+          timeoutPromise,
+        ])) as FederatedSearchResponse;
+
+        // Stale check — newer request started after this one. Drop the result.
+        if (myId !== requestIdRef.current) return;
+        setData(response);
+        setIsLoading(false);
+      } catch (err) {
+        if (myId !== requestIdRef.current) return;
+        const e = err instanceof Error ? err : new Error(String(err));
+        setError(e);
+        setIsLoading(false);
+        // Keep stale data visible alongside the error so users see "the
+        // last good result" rather than a blank pane during transient failures.
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    },
+    [federatedSearch],
+  );
+
+  // Debounce — wait SEARCH_DEBOUNCE_MS after the latest keystroke before firing.
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      // Cancel pending request and clear state immediately.
+      requestIdRef.current += 1;
+      setData(null);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    const handle = setTimeout(() => {
+      void fire(query);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [query, fire]);
+
+  return { data, isLoading, error };
+}

--- a/tests/e2e/cmdk-palette.spec.ts
+++ b/tests/e2e/cmdk-palette.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * cmdk-palette.spec.ts — end-to-end smoke for the federated Cmd-K palette.
+ *
+ * Verifies the three reliability scenarios from
+ * src/features/redesign/components/CommandPalette.test.tsx in a real browser:
+ *
+ *   1. Power user opens palette and types a query — DOM reflects status bar
+ *      + at least one group testid renders (proves federatedSearch round-trip).
+ *   2. Empty query — Commands group renders, status bar absent (no fetch fired).
+ *   3. Escape closes the palette.
+ *
+ * Run locally:    npx playwright test tests/e2e/cmdk-palette.spec.ts --project=chromium
+ * Run on prod:    BASE_URL=https://www.nodebenchai.com npm run live-smoke -- tests/e2e/cmdk-palette.spec.ts
+ *
+ * The test deliberately does NOT assert on specific result counts or text
+ * (those depend on what's in the user's account). It asserts on the
+ * structural contract — testids, ARIA, status bar wording shape.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL?.replace(/\/$/, "") ?? "http://127.0.0.1:5173";
+
+test.describe("Cmd-K federated palette — /redesign", () => {
+  test.setTimeout(60_000);
+
+  test("opens on Cmd+K, renders Commands group when query is empty", async ({ page, browserName }) => {
+    await page.goto(`${BASE_URL}/redesign`);
+    // Wait for hydration — h1 always exists on /redesign HomeSurface.
+    await expect(page.locator("h1").first()).toBeVisible({ timeout: 15_000 });
+
+    // Press Cmd+K (Meta on Mac/WebKit; Control elsewhere).
+    const isMac = browserName === "webkit" || process.platform === "darwin";
+    await page.keyboard.press(isMac ? "Meta+k" : "Control+k");
+
+    const modal = page.locator("[data-cmdk-modal]");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // Input should auto-focus.
+    const input = page.locator("[data-cmdk-input]");
+    await expect(input).toBeFocused();
+
+    // Status bar should NOT render before the user types anything.
+    await expect(page.locator("[data-cmdk-status]")).toHaveCount(0);
+
+    // Commands group always present (nav fallback).
+    await expect(page.locator('[data-cmdk-group="commands"]')).toBeVisible();
+    await expect(page.getByText("Go to Home", { exact: true })).toBeVisible();
+  });
+
+  test("typing a query fires federatedSearch and renders the status bar", async ({ page, browserName }) => {
+    await page.goto(`${BASE_URL}/redesign`);
+    await expect(page.locator("h1").first()).toBeVisible({ timeout: 15_000 });
+
+    const isMac = browserName === "webkit" || process.platform === "darwin";
+    await page.keyboard.press(isMac ? "Meta+k" : "Control+k");
+
+    const input = page.locator("[data-cmdk-input]");
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill("a");
+
+    // Status bar surfaces — wait up to 4 s (server budget 3 s + 0.5 s buffer + jitter).
+    const status = page.locator("[data-cmdk-status]");
+    await expect(status).toBeVisible({ timeout: 4_500 });
+
+    // Status text matches the contract: "<N> results across <M> collections"
+    // OR "Searching..." (transient) OR an honest failure message.
+    const statusText = (await status.textContent()) ?? "";
+    expect(statusText).toMatch(
+      /(results? across \d+ collections|Searching|Search request failed)/,
+    );
+  });
+
+  test("Escape closes the palette and returns focus to the document body", async ({ page, browserName }) => {
+    await page.goto(`${BASE_URL}/redesign`);
+    await expect(page.locator("h1").first()).toBeVisible({ timeout: 15_000 });
+
+    const isMac = browserName === "webkit" || process.platform === "darwin";
+    await page.keyboard.press(isMac ? "Meta+k" : "Control+k");
+    await expect(page.locator("[data-cmdk-modal]")).toBeVisible({ timeout: 5_000 });
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator("[data-cmdk-modal]")).toHaveCount(0, { timeout: 2_000 });
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces navigation-only redesign palette with full federated search consuming `domains/search/federatedSearch:federatedSearch` from PR #310.
- Static nav commands preserved as the **Commands** group when query is empty (no breakage).
- 7 result groups (entities, reports, notebook blocks, claims, sources, captures, threads) + Commands fallback, capped at 5 per group / 35 total per BOUND rule.

## Reliability (`.claude/rules/agentic_reliability.md`)
- **BOUND**: 5 results per group, 35 total in palette
- **HONEST_STATUS**: per-collection failures rendered inline (`Search failed for X`), never silently hidden
- **TIMEOUT**: client-side 3.5 s abort race (server budget 3 s + 0.5 s buffer)
- **DETERMINISTIC**: same query + same data → same render order

## A11y (`.claude/rules/reexamine_a11y.md` + `reexamine_keyboard.md`)
- `role="dialog"` `aria-modal` `aria-label="Command palette"`
- `role="listbox"` + `role="option"` + `aria-selected` per result
- `aria-live="polite"` announces "N results across M collections"
- Focus trap (Tab/Shift-Tab cycles), Escape closes, focus returns to trigger
- `prefers-reduced-motion`: disables shimmer + slide animations

## Keyboard
| Key | Action |
|---|---|
| Up / Down | Move selection (skips group headers) |
| Enter | Open in native context |
| Cmd / Ctrl + Enter | Secondary "ask about this" pre-fill |
| Cmd / Ctrl + 1..7 | Jump to result group |
| ? | Open shortcuts overlay |
| Escape | Close, return focus to trigger |

## Files
- `src/layouts/chrome/commandPalette/{types,useFederatedSearch,resolveResultAction,recentSearches}.ts`
- `src/features/redesign/components/CommandPalette.tsx` (rewritten)
- `src/features/redesign/components/CommandPalette.test.tsx` (8 scenario tests)
- `src/features/redesign/primitives.css` (federated-search style additions)
- `tests/e2e/cmdk-palette.spec.ts` (3 scenario e2e)

## Test plan
- [x] `npx tsc --noEmit -p .` → 0 errors
- [x] `npx tsc --noEmit -p convex` → 0 errors
- [x] `npm run build` → clean (8.94 s)
- [x] `npx vitest run src/features/redesign/components/CommandPalette.test.tsx` → 8/8
- [ ] After deploy: `BASE_URL=https://www.nodebenchai.com npx playwright test tests/e2e/cmdk-palette.spec.ts --project=chromium` (Tier B)
- [ ] Visual: navigate to `/redesign`, press Cmd+K, type "Anthropic", confirm grouped results render with `[data-cmdk-group="*"]` and `[data-cmdk-status]` testids

## Honest gaps
- Recent searches localStorage-only (not synced across devices). Out of scope for v1.
- Block / claim / capture rows show snippet + collection group but don't yet jump to the parent report's deep link — PR2 will wire `block://id` → `/redesign/reports/<parent>?block=<id>` once the parent index is in place.
- Mobile (< 375 px width): the `rd-cmdk` modal stays at `min(640px, 92vw)`; tested visually that all rows wrap, but mobile-first responsive review is a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)