### PR TITLE
feat(search): backfill searchableText + patch-site hooks for live indexing

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1214,6 +1214,8 @@ import type * as domains_search_searchCache from "../domains/search/searchCache.
 import type * as domains_search_searchForecastGate from "../domains/search/searchForecastGate.js";
 import type * as domains_search_searchPipeline from "../domains/search/searchPipeline.js";
 import type * as domains_search_searchPipelineNode from "../domains/search/searchPipelineNode.js";
+import type * as domains_search_searchableTextBackfill from "../domains/search/searchableTextBackfill.js";
+import type * as domains_search_searchableTextRecompute from "../domains/search/searchableTextRecompute.js";
 import type * as domains_search_sharedCache from "../domains/search/sharedCache.js";
 import type * as domains_search_signalTaxonomy from "../domains/search/signalTaxonomy.js";
 import type * as domains_signals_index from "../domains/signals/index.js";
@@ -2709,6 +2711,8 @@ declare const fullApi: ApiFromModules<{
   "domains/search/searchForecastGate": typeof domains_search_searchForecastGate;
   "domains/search/searchPipeline": typeof domains_search_searchPipeline;
   "domains/search/searchPipelineNode": typeof domains_search_searchPipelineNode;
+  "domains/search/searchableTextBackfill": typeof domains_search_searchableTextBackfill;
+  "domains/search/searchableTextRecompute": typeof domains_search_searchableTextRecompute;
   "domains/search/sharedCache": typeof domains_search_sharedCache;
   "domains/search/signalTaxonomy": typeof domains_search_signalTaxonomy;
   "domains/signals/index": typeof domains_signals_index;

--- a/convex/domains/documents/artifacts/sourceArtifacts.ts
+++ b/convex/domains/documents/artifacts/sourceArtifacts.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { internalMutation, internalQuery } from "../../../_generated/server";
 import type { Doc } from "../../../_generated/dataModel";
+import { recomputeSourceSearchableText } from "../../search/searchableTextRecompute";
 
 async function sha256Hex(input: string): Promise<string> {
   const bytes = new TextEncoder().encode(input);
@@ -106,6 +107,14 @@ export const upsertSourceArtifact = internalMutation({
       sizeBytes: args.sizeBytes,
       title: args.title,
       extractedData: args.extractedData,
+      // PR D: populate searchableText for the federated `search_sources`
+      // index. Sources are de-facto public artifacts of crawled URLs, so
+      // both anonymous and authenticated callers can search them.
+      searchableText: recomputeSourceSearchableText({
+        title: args.title,
+        sourceUrl,
+        mimeType: args.mimeType,
+      }),
       fetchedAt,
       expiresAt: args.expiresAt,
     });

--- a/convex/domains/operations/bugLoop.ts
+++ b/convex/domains/operations/bugLoop.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { mutation, query, internalAction, internalQuery, internalMutation } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
 import { internal } from "../../_generated/api";
+import { recomputeSourceSearchableText } from "../search/searchableTextRecompute";
 
 type BugColumn =
   | "inbox"
@@ -173,6 +174,12 @@ export const reportClientError = mutation({
         sizeBytes: occurrenceRaw.length,
         title: `Bug occurrence ${signature}`,
         extractedData: occurrencePayload,
+        // PR D: populate searchableText for the federated `search_sources`.
+        searchableText: recomputeSourceSearchableText({
+          title: `Bug occurrence ${signature}`,
+          sourceUrl,
+          mimeType: "application/json",
+        }),
         fetchedAt: now,
         expiresAt: undefined,
       }));

--- a/convex/domains/product/blocks.ts
+++ b/convex/domains/product/blocks.ts
@@ -44,6 +44,7 @@ import {
   productBlockKindValidator,
   productBlockRelationKindValidator,
 } from "./schema";
+import { recomputeBlockSearchableText } from "../search/searchableTextRecompute";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Input-size guard — prevent a single oversized block from OOMing the function
@@ -1365,6 +1366,12 @@ export const appendBlock = mutation({
         sourceRefIds: args.sourceRefIds,
         attributes: args.attributes,
         revision: 1,
+        // PR D: populate searchableText for the federated `search_blocks`
+        // index. Inserts at PR #310 ship time were missing this.
+        searchableText: recomputeBlockSearchableText({
+          content: args.content,
+          deletedAt: undefined,
+        }),
         createdAt: now,
         updatedAt: now,
       });
@@ -1447,6 +1454,11 @@ export const insertBlockBetween = mutation({
       sourceRefIds: args.sourceRefIds,
       attributes: args.attributes,
       revision: 1,
+      // PR D: populate searchableText for the federated `search_blocks` index.
+      searchableText: recomputeBlockSearchableText({
+        content: args.content,
+        deletedAt: undefined,
+      }),
       createdAt: now,
       updatedAt: now,
     });
@@ -1528,13 +1540,23 @@ export const updateBlock = mutation({
         previousBlockId: existing.previousBlockId,
         revision: existing.revision,
         deletedAt: now,
+        // PR D: deleted snapshot row gets empty searchableText so it drops
+        // out of the federated `search_blocks` index immediately.
+        searchableText: "",
         createdAt: existing.createdAt,
         updatedAt: existing.updatedAt,
       });
     }
 
+    const nextContent = args.content ?? existing.content;
+    // PR D: refresh searchableText so the federated `search_blocks` index
+    // reflects the edited content. This is the hottest block write path.
+    const nextBlockSearchableText = recomputeBlockSearchableText({
+      content: nextContent,
+      deletedAt: undefined,
+    });
     await ctx.db.patch(args.blockId, {
-      content: args.content ?? existing.content,
+      content: nextContent,
       kind: args.kind ?? existing.kind,
       isChecked: args.isChecked ?? existing.isChecked,
       sourceRefIds: args.sourceRefIds ?? existing.sourceRefIds,
@@ -1543,6 +1565,7 @@ export const updateBlock = mutation({
       revision: existing.revision + 1,
       authorKind: args.editedByAuthorKind ?? existing.authorKind,
       authorId: args.editedByAuthorId ?? existing.authorId,
+      searchableText: nextBlockSearchableText,
       updatedAt: now,
     });
     return args.blockId;
@@ -1570,7 +1593,13 @@ export const deleteBlock = mutation({
     if (existing.accessMode !== "edit") {
       throw convexError({ code: "BLOCK_READ_ONLY", blockId: args.blockId });
     }
-    await ctx.db.patch(args.blockId, { deletedAt: Date.now(), updatedAt: Date.now() });
+    // PR D: clear searchableText on soft-delete so the federated
+    // `search_blocks` index drops the row from results immediately.
+    await ctx.db.patch(args.blockId, {
+      deletedAt: Date.now(),
+      searchableText: "",
+      updatedAt: Date.now(),
+    });
   },
 });
 
@@ -1922,6 +1951,9 @@ export const promoteLinkToEvidence = mutation({
     const pos = positionBetween(beforePos, afterPos);
 
     const now = Date.now();
+    const evidenceContent = [
+      { type: "link", value: args.label, url: args.url },
+    ];
     const evidenceBlockId = await ctx.db.insert("productBlocks", {
       ownerKey: citing.ownerKey,
       entityId: citing.entityId,
@@ -1929,12 +1961,17 @@ export const promoteLinkToEvidence = mutation({
       kind: "evidence",
       authorKind: "user",
       authorId: "user:promote",
-      content: [{ type: "link", value: args.label, url: args.url }],
+      content: evidenceContent,
       positionInt: pos.int,
       positionFrac: pos.frac,
       accessMode: "edit",
       isPublic: false,
       revision: 1,
+      // PR D: populate searchableText for the federated `search_blocks` index.
+      searchableText: recomputeBlockSearchableText({
+        content: evidenceContent,
+        deletedAt: undefined,
+      }),
       createdAt: now,
       updatedAt: now,
     });
@@ -2037,7 +2074,13 @@ export const backfillEntityBlocks = mutation({
         block.authorKind === "agent" ||
         (shouldResetPlaceholderBlocks && isPlaceholderNotebookBlock(block))
       ) {
-        await ctx.db.patch(block._id, { deletedAt: Date.now(), updatedAt: Date.now() });
+        // PR D: clear searchableText so the federated `search_blocks` index
+        // drops these soft-deleted rows immediately (no stale results).
+        await ctx.db.patch(block._id, {
+          deletedAt: Date.now(),
+          searchableText: "",
+          updatedAt: Date.now(),
+        });
         cleared += 1;
       }
     }
@@ -2119,6 +2162,7 @@ export const backfillEntityBlocks = mutation({
       const positions = positionsBetween(null, null, 1 + sectionCount * 2);
       let posIdx = 0;
 
+      const briefHeadingContent = [{ type: "text" as const, value: seedTitle }];
       const briefHeadingId = await ctx.db.insert("productBlocks", {
         ownerKey: entity.ownerKey,
         entityId: entity._id,
@@ -2126,13 +2170,18 @@ export const backfillEntityBlocks = mutation({
         kind: "heading_2",
         authorKind: "agent",
         authorId: seedAuthorId,
-        content: [{ type: "text", value: seedTitle }],
+        content: briefHeadingContent,
         positionInt: positions[posIdx].int,
         positionFrac: positions[posIdx].frac,
         accessMode: "edit",
         isPublic: false,
         sourceSessionId: seedSessionId,
         revision: 1,
+        // PR D: populate searchableText for the federated `search_blocks`.
+        searchableText: recomputeBlockSearchableText({
+          content: briefHeadingContent,
+          deletedAt: undefined,
+        }),
         createdAt: now,
         updatedAt: now,
       });
@@ -2140,6 +2189,9 @@ export const backfillEntityBlocks = mutation({
       inserted += 1;
 
       for (const section of seedSections) {
+        const sectionHeadingContent = [
+          { type: "text" as const, value: section.title },
+        ];
         const headingId = await ctx.db.insert("productBlocks", {
           ownerKey: entity.ownerKey,
           entityId: entity._id,
@@ -2147,19 +2199,27 @@ export const backfillEntityBlocks = mutation({
           kind: "heading_3",
           authorKind: "agent",
           authorId: seedAuthorId,
-          content: [{ type: "text", value: section.title }],
+          content: sectionHeadingContent,
           positionInt: positions[posIdx].int,
           positionFrac: positions[posIdx].frac,
           accessMode: "edit",
           isPublic: false,
           sourceSessionId: seedSessionId,
           revision: 1,
+          // PR D: populate searchableText for the federated `search_blocks`.
+          searchableText: recomputeBlockSearchableText({
+            content: sectionHeadingContent,
+            deletedAt: undefined,
+          }),
           createdAt: now,
           updatedAt: now,
         });
         posIdx += 1;
         inserted += 1;
 
+        const sectionBodyContent = [
+          { type: "text" as const, value: section.body },
+        ];
         await ctx.db.insert("productBlocks", {
           ownerKey: entity.ownerKey,
           entityId: entity._id,
@@ -2167,7 +2227,7 @@ export const backfillEntityBlocks = mutation({
           kind: "text",
           authorKind: "agent",
           authorId: seedAuthorId,
-          content: [{ type: "text", value: section.body }],
+          content: sectionBodyContent,
           positionInt: positions[posIdx].int,
           positionFrac: positions[posIdx].frac,
           accessMode: "edit",
@@ -2175,6 +2235,11 @@ export const backfillEntityBlocks = mutation({
           sourceSessionId: seedSessionId,
           sourceRefIds: section.sourceRefIds,
           revision: 1,
+          // PR D: populate searchableText for the federated `search_blocks`.
+          searchableText: recomputeBlockSearchableText({
+            content: sectionBodyContent,
+            deletedAt: undefined,
+          }),
           createdAt: now,
           updatedAt: now,
         });
@@ -2192,24 +2257,30 @@ export const backfillEntityBlocks = mutation({
       const positions = positionsBetween(null, null, evidenceItems.length);
       for (let i = 0; i < evidenceItems.length; i++) {
         const item = evidenceItems[i];
+        const evidenceLinkContent = [
+          {
+            type: "link" as const,
+            value: item.label,
+            url: item.sourceUrl,
+          },
+        ];
         await ctx.db.insert("productBlocks", {
           ownerKey: entity.ownerKey,
           entityId: entity._id,
           kind: "evidence",
           authorKind: "agent",
           authorId: "harness:evidence",
-          content: [
-            {
-              type: "link",
-              value: item.label,
-              url: item.sourceUrl,
-            },
-          ],
+          content: evidenceLinkContent,
           positionInt: positions[i].int,
           positionFrac: positions[i].frac,
           accessMode: "edit",
           isPublic: false,
           revision: 1,
+          // PR D: populate searchableText for the federated `search_blocks`.
+          searchableText: recomputeBlockSearchableText({
+            content: evidenceLinkContent,
+            deletedAt: undefined,
+          }),
           createdAt: now,
           updatedAt: now,
         });

--- a/convex/domains/product/bootstrap.ts
+++ b/convex/domains/product/bootstrap.ts
@@ -5,6 +5,10 @@ import type { Doc } from "../../_generated/dataModel";
 import { requireProductIdentity } from "./helpers";
 import { ensureEntityForReport, upsertEntityContextItem } from "./entities";
 import { upsertOpenProductNudge } from "./nudgeHelpers";
+import {
+  recomputeEntitySearchableText,
+  recomputeReportSearchableText,
+} from "../search/searchableTextRecompute";
 
 const PRODUCT_SCHEMA_VERSION = "2026-04-12-entity-v3";
 
@@ -362,6 +366,16 @@ export const ensureCanonicalProductBootstrap = mutation({
           evidenceItemIds,
           pinned: !!document.isFavorite,
           visibility: document.isPublic ? "public" : "private",
+          // PR D: populate searchableText for the federated `search_reports`
+          // index. Bootstrap migrates legacy documents into reports, so this
+          // makes those rows searchable from day one.
+          searchableText: recomputeReportSearchableText({
+            title: document.title,
+            summary,
+            query: document.title,
+            primaryEntity: document.title,
+            entitySlug: undefined,
+          }),
           createdAt: document._creationTime ?? now,
           updatedAt: document.lastModified ?? now,
           lastRefreshAt: document.lastModified ?? now,
@@ -443,13 +457,32 @@ export const ensureCanonicalProductBootstrap = mutation({
           now: report.updatedAt,
         });
 
+        // PR D: refresh searchableText since entitySlug is part of the
+        // composed search field for the federated `search_reports` index.
+        const nextReportSearchableText = recomputeReportSearchableText({
+          title: report.title,
+          summary: report.summary,
+          query: report.query,
+          primaryEntity: report.primaryEntity,
+          entitySlug: entityMeta.entitySlug,
+        });
         await ctx.db.patch(report._id, {
           entityId: entityMeta.entityId,
           entitySlug: entityMeta.entitySlug,
           revision: entityMeta.revision,
           previousReportId: entityMeta.previousReportId ?? undefined,
+          searchableText: nextReportSearchableText,
         });
 
+        // PR D: refresh searchableText for the federated `search_entities`
+        // index when the entity name/summary changes via legacy bootstrap.
+        const existingEntityForBootstrap = await ctx.db.get(entityMeta.entityId);
+        const nextEntitySearchableText = recomputeEntitySearchableText({
+          name: entityMeta.entityName,
+          slug: existingEntityForBootstrap?.slug ?? entityMeta.entitySlug,
+          summary: report.summary,
+          savedBecause: existingEntityForBootstrap?.savedBecause,
+        });
         await ctx.db.patch(entityMeta.entityId, {
           name: entityMeta.entityName,
           entityType: entityMeta.entityType,
@@ -458,6 +491,7 @@ export const ensureCanonicalProductBootstrap = mutation({
           latestReportUpdatedAt: report.updatedAt,
           latestRevision: entityMeta.revision,
           reportCount: entityMeta.revision,
+          searchableText: nextEntitySearchableText,
           updatedAt: report.updatedAt,
         });
 

--- a/convex/domains/product/chat.ts
+++ b/convex/domains/product/chat.ts
@@ -8,6 +8,10 @@ import { isProductRuntimeFlagEnabled } from "../../lib/featureFlags";
 import { deriveCanonicalReportSections } from "../../../shared/reportSections";
 import { buildPrepBriefTitle, deriveReportArtifactMode, type ReportArtifactMode } from "../../../shared/reportArtifacts";
 import { upsertOpenProductNudge } from "./nudgeHelpers";
+import {
+  recomputeEntitySearchableText,
+  recomputeReportSearchableText,
+} from "../search/searchableTextRecompute";
 import { syncGenericDiligenceProjectionDrafts, buildGenericDiligenceProjectionDrafts } from "./diligenceProjectionRuntime";
 import {
   buildProductProviderBudgetSummary,
@@ -1957,6 +1961,20 @@ export const completeSession = mutation({
         revision: entityMeta.revision,
         previousReportId: entityMeta.previousReportId ?? undefined,
         lastRefreshAt: now,
+        // PR D: populate searchableText so the federated `search_reports`
+        // index sees both the chat-driven insert AND any subsequent patch.
+        // This is the hottest report write path — every chat finalization
+        // flows through here.
+        searchableText: recomputeReportSearchableText({
+          title: reportTitle,
+          summary: reportSummary,
+          query: session.query,
+          primaryEntity:
+            typeof args.packet?.entityName === "string"
+              ? args.packet.entityName
+              : (resolution.entityName ?? undefined),
+          entitySlug: entityMeta.entitySlug ?? undefined,
+        }),
         updatedAt: now,
       };
 
@@ -2132,6 +2150,15 @@ export const completeSession = mutation({
     }
 
     if (entityMeta.entityId && reportId && effectiveArtifactState === "saved") {
+      // PR D: refresh searchableText on the entity row when chat saves a
+      // report (entity name/summary may have changed during finalization).
+      const existingEntityForChat = await ctx.db.get(entityMeta.entityId);
+      const nextEntitySearchableText = recomputeEntitySearchableText({
+        name: entityMeta.entityName,
+        slug: existingEntityForChat?.slug ?? entityMeta.entitySlug,
+        summary: reportSummary,
+        savedBecause: existingEntityForChat?.savedBecause,
+      });
       await ctx.db.patch(entityMeta.entityId, {
         name: entityMeta.entityName,
         entityType: entityMeta.entityType,
@@ -2140,6 +2167,7 @@ export const completeSession = mutation({
         latestReportUpdatedAt: now,
         latestRevision: entityMeta.revision,
         reportCount: entityMeta.reportCount,
+        searchableText: nextEntitySearchableText,
         updatedAt: now,
       });
 

--- a/convex/domains/product/entities.ts
+++ b/convex/domains/product/entities.ts
@@ -14,6 +14,10 @@ import {
 } from "./helpers";
 import { productNoteBlockValidator } from "./schema";
 import { composeSearchableText } from "../search/federatedHelpers";
+import {
+  recomputeEntitySearchableText,
+  recomputeReportSearchableText,
+} from "../search/searchableTextRecompute";
 import { getEntityMemoryDocumentWorkspace } from "./documents";
 import {
   buildEntityAliasKey,
@@ -1431,8 +1435,15 @@ export const updateEntitySavedBecause = mutation({
     }
 
     const nextValue = args.savedBecause.trim().slice(0, 120);
+    // Refresh searchableText so the federated `search_entities` index sees the
+    // updated savedBecause value (PR D — patch-site hook).
+    const nextSearchableText = recomputeEntitySearchableText({
+      ...entity,
+      savedBecause: nextValue,
+    });
     await ctx.db.patch(entity._id, {
       savedBecause: nextValue,
+      searchableText: nextSearchableText,
       updatedAt: Date.now(),
     });
 
@@ -1552,30 +1563,54 @@ export const ensureEntityBackfill = mutation({
         now: report.updatedAt,
       });
 
+      // PR D: refresh searchableText for the federated `search_reports`
+      // index — entitySlug is part of the composed string.
+      const nextReportSearchableText = recomputeReportSearchableText({
+        title: report.title,
+        summary: report.summary,
+        query: report.query,
+        primaryEntity: report.primaryEntity,
+        entitySlug: entityMeta.entitySlug,
+      });
       await ctx.db.patch(report._id, {
         entityId: entityMeta.entityId,
         entitySlug: entityMeta.entitySlug,
         revision: entityMeta.revision,
         previousReportId: entityMeta.previousReportId ?? undefined,
+        searchableText: nextReportSearchableText,
       });
 
       const existingEntity = await ctx.db.get(entityMeta.entityId);
+      const nextEntitySummary = summarizeText(
+        report.summary,
+        entityMeta.entityName,
+      );
+      const nextEntitySavedBecause =
+        existingEntity?.savedBecause ??
+        inferProductSavedBecause({
+          entityType: entityMeta.entityType,
+          title: report.title,
+          query: report.query,
+          lens: report.lens,
+        });
+      // Refresh searchableText so the federated `search_entities` index sees
+      // the renamed/retyped entity (PR D — patch-site hook).
+      const nextEntitySearchableText = recomputeEntitySearchableText({
+        name: entityMeta.entityName,
+        slug: existingEntity?.slug ?? entityMeta.entitySlug,
+        summary: nextEntitySummary,
+        savedBecause: nextEntitySavedBecause,
+      });
       await ctx.db.patch(entityMeta.entityId, {
         name: entityMeta.entityName,
         entityType: entityMeta.entityType,
-        summary: summarizeText(report.summary, entityMeta.entityName),
-        savedBecause:
-          existingEntity?.savedBecause ??
-          inferProductSavedBecause({
-            entityType: entityMeta.entityType,
-            title: report.title,
-            query: report.query,
-            lens: report.lens,
-          }),
+        summary: nextEntitySummary,
+        savedBecause: nextEntitySavedBecause,
         latestReportId: report._id,
         latestReportUpdatedAt: report.updatedAt,
         latestRevision: entityMeta.revision,
         reportCount: entityMeta.revision,
+        searchableText: nextEntitySearchableText,
         updatedAt: report.updatedAt,
       });
       await upsertEntityContextItem(ctx, {
@@ -1642,10 +1677,20 @@ export const repairEntityModelBackfill = mutation({
       });
 
       if (entity.name !== nextName || entity.entityType !== nextType) {
+        const nextSummary = entity.summary || report.summary;
+        // Refresh searchableText so the federated `search_entities` index sees
+        // the renamed entity (PR D — patch-site hook).
+        const nextSearchableText = recomputeEntitySearchableText({
+          name: nextName,
+          slug: entity.slug,
+          summary: nextSummary,
+          savedBecause: entity.savedBecause,
+        });
         await ctx.db.patch(entity._id, {
           name: nextName,
           entityType: nextType,
-          summary: entity.summary || report.summary,
+          summary: nextSummary,
+          searchableText: nextSearchableText,
           updatedAt: Date.now(),
         });
         repairedEntities += 1;

--- a/convex/domains/product/reports.ts
+++ b/convex/domains/product/reports.ts
@@ -12,6 +12,7 @@ import {
 import { insertProductActivity } from "./activity";
 import { upsertOpenProductNudge } from "./nudgeHelpers";
 import { productReportExportFormatValidator } from "./schema";
+import { recomputeReportSearchableText } from "../search/searchableTextRecompute";
 import {
   buildEntityAliasKey,
   chooseEntityDisplayName,
@@ -475,11 +476,13 @@ export const createDraftReport = mutation({
     const title = args.title.trim().slice(0, REPORT_DRAFT_TITLE_MAX);
     if (!title) throw new Error("Title is required");
     const now = Date.now();
+    const draftSummary = (args.summary ?? "").slice(0, 1000);
+    const draftQuery = (args.query ?? title).slice(0, 1000);
     const id = await ctx.db.insert("productReports", {
       ownerKey,
       title,
-      summary: (args.summary ?? "").slice(0, 1000),
-      query: (args.query ?? title).slice(0, 1000),
+      summary: draftSummary,
+      query: draftQuery,
       type: (args.type ?? "report").slice(0, 64),
       lens: "founder",
       status: "draft",
@@ -488,6 +491,16 @@ export const createDraftReport = mutation({
       sections: [],
       sources: [],
       evidenceItemIds: [],
+      // PR D: populate searchableText so the federated `search_reports` index
+      // sees this draft immediately. Schema docs the shape; this insert was
+      // missing it at PR #310 ship time.
+      searchableText: recomputeReportSearchableText({
+        title,
+        summary: draftSummary,
+        query: draftQuery,
+        primaryEntity: undefined,
+        entitySlug: undefined,
+      }),
       createdAt: now,
       updatedAt: now,
     });

--- a/convex/domains/product/wikiStagingMutations.ts
+++ b/convex/domains/product/wikiStagingMutations.ts
@@ -11,6 +11,7 @@
 import { v } from "convex/values";
 import { query, mutation, internalMutation, internalQuery } from "../../_generated/server";
 import type { Doc, Id } from "../../_generated/dataModel";
+import { recomputeReportSearchableText } from "../search/searchableTextRecompute";
 
 // ====================================================================
 // Constants
@@ -801,6 +802,7 @@ export const _createMockReport = internalMutation({
   handler: async (ctx, { ownerKey, entitySlug, title, summary, type, updatedAt }) => {
     const createdAt = updatedAt;
     
+    const queryStr = `Research on ${entitySlug}`;
     await ctx.db.insert("productReports", {
       ownerKey,
       entitySlug,
@@ -809,12 +811,21 @@ export const _createMockReport = internalMutation({
       type,
       status: "saved",
       lens: "founder",
-      query: `Research on ${entitySlug}`,
+      query: queryStr,
       sections: [],
       sources: [],
       evidenceItemIds: [],
       pinned: false,
       visibility: "private",
+      // PR D: populate searchableText so the federated `search_reports` index
+      // sees this mock report immediately.
+      searchableText: recomputeReportSearchableText({
+        title,
+        summary,
+        query: queryStr,
+        primaryEntity: undefined,
+        entitySlug,
+      }),
       createdAt,
       updatedAt,
     });
@@ -912,6 +923,7 @@ export const _batchInsertMockData = internalMutation({
     const inserted = { reports: 0, claims: 0, evidence: 0 };
 
     for (const report of reports) {
+      const queryStr = `Research on ${entitySlug}`;
       await ctx.db.insert("productReports", {
         ownerKey,
         entitySlug,
@@ -920,12 +932,21 @@ export const _batchInsertMockData = internalMutation({
         type: report.type,
         status: "saved",
         lens: "founder",
-        query: `Research on ${entitySlug}`,
+        query: queryStr,
         sections: [],
         sources: [],
         evidenceItemIds: [],
         pinned: false,
         visibility: "private",
+        // PR D: populate searchableText for the federated `search_reports`
+        // index. Backfill is also a thing — but new inserts should be live.
+        searchableText: recomputeReportSearchableText({
+          title: report.title,
+          summary: report.summary,
+          query: queryStr,
+          primaryEntity: undefined,
+          entitySlug,
+        }),
         createdAt: report.updatedAt,
         updatedAt: report.updatedAt,
       });

--- a/convex/domains/search/searchableTextBackfill.ts
+++ b/convex/domains/search/searchableTextBackfill.ts
@@ -1,0 +1,393 @@
+/**
+ * One-shot backfill mutations for `searchableText` across the 4 federated
+ * search collections that compose the field at write time.
+ *
+ * Why this exists (PR D)
+ * ----------------------
+ * PR #310 shipped Convex-native federated search but only POPULATED
+ * `searchableText` on the insert path. Existing rows (entities/reports/
+ * blocks/sources written before PR #310) are invisible to keyword search
+ * until they are touched by a mutation. This backfill makes every existing
+ * row searchable in one bounded pass.
+ *
+ * Per .claude/rules/agentic_reliability.md:
+ *   - BOUND: each call paginates 200 rows at a time, max 1000 pages per
+ *     invocation (200 000 rows / call). Idempotent — re-call to continue.
+ *   - HONEST_STATUS: returns { scanned, written, skipped, done, cursor }.
+ *     A `done: false` means more pages remain — caller re-invokes with
+ *     the returned cursor.
+ *   - HONEST_SCORES: `scanned` and `written` are real counters, not
+ *     synthetic estimates.
+ *   - DETERMINISTIC: re-running on the same data is a no-op because the
+ *     recompute helper is pure and we skip writes when the computed value
+ *     equals the stored value.
+ *   - TIMEOUT: Convex mutations have a 1-minute hard cap. 200 000 rows
+ *     comfortably fits — the recompute is local CPU only.
+ *
+ * Scope: 4 tables (entities, reports, blocks, sources). The other 3
+ * federated tables (productClaims, quickCaptures, chatThreadsStream)
+ * index a REQUIRED field directly, so existing rows are already
+ * searchable — no backfill needed.
+ *
+ * CLI: `npx convex run domains/search/searchableTextBackfill:backfillAll`
+ *      runs all 4 backfills serially, looping until each is `done`.
+ *
+ * Pattern: orchestrator-workers, where the action orchestrates and each
+ * per-collection internal mutation is a worker. Mirrors the federated
+ * search dispatch shape.
+ *
+ * Privacy: backfill runs server-side with internal-only mutations. No
+ * user identity is consulted — each row is reindexed in place.
+ *
+ * See: docs/architecture/CONVEX_FEDERATED_SEARCH.md
+ */
+
+import { v } from "convex/values";
+import {
+  internalMutation,
+  internalAction,
+} from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import {
+  recomputeEntitySearchableText,
+  recomputeReportSearchableText,
+  recomputeBlockSearchableText,
+  recomputeSourceSearchableText,
+} from "./searchableTextRecompute";
+
+/* -------------------------------------------------------------------------- */
+/* Pagination knobs                                                            */
+/* -------------------------------------------------------------------------- */
+
+/** BOUND: rows scanned per page. Tuned to stay under Convex's 8 MB read budget. */
+const ROWS_PER_PAGE = 200;
+/**
+ * BOUND: max pages per single call. 1000 pages × 200 rows = 200 000 rows
+ * per invocation, which fits in Convex's 60s mutation budget with margin.
+ * Callers re-invoke if `done: false` is returned with the next cursor.
+ */
+const MAX_PAGES_PER_CALL = 1000;
+
+/* -------------------------------------------------------------------------- */
+/* Shape                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export type BackfillResult = {
+  /** Total rows scanned this call. */
+  scanned: number;
+  /** Rows where the stored value differed and was rewritten. */
+  written: number;
+  /** Rows where the stored value already matched the recomputed value. */
+  skipped: number;
+  /** True if the full table has been processed (no more pages). */
+  done: boolean;
+  /** Continuation cursor if `done: false`. Pass back into the next call. */
+  cursor: string | null;
+  /** Per-call wall-clock duration. */
+  durationMs: number;
+};
+
+const BACKFILL_RESULT_SHAPE = {
+  scanned: v.number(),
+  written: v.number(),
+  skipped: v.number(),
+  done: v.boolean(),
+  cursor: v.union(v.string(), v.null()),
+  durationMs: v.number(),
+};
+
+const BACKFILL_ARGS = {
+  cursor: v.optional(v.union(v.string(), v.null())),
+};
+
+/* -------------------------------------------------------------------------- */
+/* Per-table workers                                                           */
+/* -------------------------------------------------------------------------- */
+
+export const backfillEntities = internalMutation({
+  args: BACKFILL_ARGS,
+  returns: v.object(BACKFILL_RESULT_SHAPE),
+  handler: async (ctx, args): Promise<BackfillResult> => {
+    const startedAt = Date.now();
+    let cursor: string | null = args.cursor ?? null;
+    let scanned = 0;
+    let written = 0;
+    let skipped = 0;
+    for (let page = 0; page < MAX_PAGES_PER_CALL; page += 1) {
+      const result = await ctx.db
+        .query("productEntities")
+        .paginate({ cursor, numItems: ROWS_PER_PAGE });
+      for (const row of result.page) {
+        scanned += 1;
+        const next = recomputeEntitySearchableText(row);
+        if (row.searchableText === next) {
+          skipped += 1;
+        } else {
+          await ctx.db.patch(row._id, { searchableText: next });
+          written += 1;
+        }
+      }
+      cursor = result.continueCursor;
+      if (result.isDone) {
+        return {
+          scanned,
+          written,
+          skipped,
+          done: true,
+          cursor: null,
+          durationMs: Date.now() - startedAt,
+        };
+      }
+    }
+    return {
+      scanned,
+      written,
+      skipped,
+      done: false,
+      cursor,
+      durationMs: Date.now() - startedAt,
+    };
+  },
+});
+
+export const backfillReports = internalMutation({
+  args: BACKFILL_ARGS,
+  returns: v.object(BACKFILL_RESULT_SHAPE),
+  handler: async (ctx, args): Promise<BackfillResult> => {
+    const startedAt = Date.now();
+    let cursor: string | null = args.cursor ?? null;
+    let scanned = 0;
+    let written = 0;
+    let skipped = 0;
+    for (let page = 0; page < MAX_PAGES_PER_CALL; page += 1) {
+      const result = await ctx.db
+        .query("productReports")
+        .paginate({ cursor, numItems: ROWS_PER_PAGE });
+      for (const row of result.page) {
+        scanned += 1;
+        const next = recomputeReportSearchableText(row);
+        if (row.searchableText === next) {
+          skipped += 1;
+        } else {
+          await ctx.db.patch(row._id, { searchableText: next });
+          written += 1;
+        }
+      }
+      cursor = result.continueCursor;
+      if (result.isDone) {
+        return {
+          scanned,
+          written,
+          skipped,
+          done: true,
+          cursor: null,
+          durationMs: Date.now() - startedAt,
+        };
+      }
+    }
+    return {
+      scanned,
+      written,
+      skipped,
+      done: false,
+      cursor,
+      durationMs: Date.now() - startedAt,
+    };
+  },
+});
+
+export const backfillBlocks = internalMutation({
+  args: BACKFILL_ARGS,
+  returns: v.object(BACKFILL_RESULT_SHAPE),
+  handler: async (ctx, args): Promise<BackfillResult> => {
+    const startedAt = Date.now();
+    let cursor: string | null = args.cursor ?? null;
+    let scanned = 0;
+    let written = 0;
+    let skipped = 0;
+    for (let page = 0; page < MAX_PAGES_PER_CALL; page += 1) {
+      const result = await ctx.db
+        .query("productBlocks")
+        .paginate({ cursor, numItems: ROWS_PER_PAGE });
+      for (const row of result.page) {
+        scanned += 1;
+        const next = recomputeBlockSearchableText(row);
+        if (row.searchableText === next) {
+          skipped += 1;
+        } else {
+          await ctx.db.patch(row._id, { searchableText: next });
+          written += 1;
+        }
+      }
+      cursor = result.continueCursor;
+      if (result.isDone) {
+        return {
+          scanned,
+          written,
+          skipped,
+          done: true,
+          cursor: null,
+          durationMs: Date.now() - startedAt,
+        };
+      }
+    }
+    return {
+      scanned,
+      written,
+      skipped,
+      done: false,
+      cursor,
+      durationMs: Date.now() - startedAt,
+    };
+  },
+});
+
+export const backfillSources = internalMutation({
+  args: BACKFILL_ARGS,
+  returns: v.object(BACKFILL_RESULT_SHAPE),
+  handler: async (ctx, args): Promise<BackfillResult> => {
+    const startedAt = Date.now();
+    let cursor: string | null = args.cursor ?? null;
+    let scanned = 0;
+    let written = 0;
+    let skipped = 0;
+    for (let page = 0; page < MAX_PAGES_PER_CALL; page += 1) {
+      const result = await ctx.db
+        .query("sourceArtifacts")
+        .paginate({ cursor, numItems: ROWS_PER_PAGE });
+      for (const row of result.page) {
+        scanned += 1;
+        const next = recomputeSourceSearchableText(row);
+        if (row.searchableText === next) {
+          skipped += 1;
+        } else {
+          await ctx.db.patch(row._id, { searchableText: next });
+          written += 1;
+        }
+      }
+      cursor = result.continueCursor;
+      if (result.isDone) {
+        return {
+          scanned,
+          written,
+          skipped,
+          done: true,
+          cursor: null,
+          durationMs: Date.now() - startedAt,
+        };
+      }
+    }
+    return {
+      scanned,
+      written,
+      skipped,
+      done: false,
+      cursor,
+      durationMs: Date.now() - startedAt,
+    };
+  },
+});
+
+/* -------------------------------------------------------------------------- */
+/* Orchestrator — runs all 4 backfills until each is done                      */
+/* -------------------------------------------------------------------------- */
+
+export type BackfillAllResult = {
+  entities: BackfillResult;
+  reports: BackfillResult;
+  blocks: BackfillResult;
+  sources: BackfillResult;
+  /** True only when every per-table backfill reported done. */
+  done: boolean;
+  /** Total wall-clock for the orchestrator (sum + overhead). */
+  totalDurationMs: number;
+};
+
+/**
+ * Runs the 4 backfills serially and loops each one until it reports done.
+ * Each loop iteration is a separate mutation call (idempotent — re-running
+ * is safe), so we stay within Convex's per-mutation budget even on giant
+ * tables.
+ *
+ * CLI: `npx convex run domains/search/searchableTextBackfill:backfillAll`
+ */
+export const backfillAll = internalAction({
+  args: {},
+  returns: v.object({
+    entities: v.object(BACKFILL_RESULT_SHAPE),
+    reports: v.object(BACKFILL_RESULT_SHAPE),
+    blocks: v.object(BACKFILL_RESULT_SHAPE),
+    sources: v.object(BACKFILL_RESULT_SHAPE),
+    done: v.boolean(),
+    totalDurationMs: v.number(),
+  }),
+  handler: async (ctx): Promise<BackfillAllResult> => {
+    const startedAt = Date.now();
+
+    type TableName = "entities" | "reports" | "blocks" | "sources";
+
+    async function runUntilDone(
+      table: TableName,
+    ): Promise<BackfillResult> {
+      let cursor: string | null = null;
+      let totalScanned = 0;
+      let totalWritten = 0;
+      let totalSkipped = 0;
+      let totalDuration = 0;
+      // Safety cap so a runaway loop can't run forever — 50 iterations ×
+      // 200 000 rows = 10M rows max. Far more than any production table.
+      for (let iter = 0; iter < 50; iter += 1) {
+        const ref =
+          table === "entities"
+            ? internal.domains.search.searchableTextBackfill.backfillEntities
+            : table === "reports"
+              ? internal.domains.search.searchableTextBackfill.backfillReports
+              : table === "blocks"
+                ? internal.domains.search.searchableTextBackfill.backfillBlocks
+                : internal.domains.search.searchableTextBackfill
+                    .backfillSources;
+        const result: BackfillResult = await ctx.runMutation(ref, { cursor });
+        totalScanned += result.scanned;
+        totalWritten += result.written;
+        totalSkipped += result.skipped;
+        totalDuration += result.durationMs;
+        if (result.done) {
+          return {
+            scanned: totalScanned,
+            written: totalWritten,
+            skipped: totalSkipped,
+            done: true,
+            cursor: null,
+            durationMs: totalDuration,
+          };
+        }
+        cursor = result.cursor;
+      }
+      // Hit the safety cap — return partial with done: false. Caller can
+      // re-invoke to continue.
+      return {
+        scanned: totalScanned,
+        written: totalWritten,
+        skipped: totalSkipped,
+        done: false,
+        cursor,
+        durationMs: totalDuration,
+      };
+    }
+
+    const entities = await runUntilDone("entities");
+    const reports = await runUntilDone("reports");
+    const blocks = await runUntilDone("blocks");
+    const sources = await runUntilDone("sources");
+
+    return {
+      entities,
+      reports,
+      blocks,
+      sources,
+      done:
+        entities.done && reports.done && blocks.done && sources.done,
+      totalDurationMs: Date.now() - startedAt,
+    };
+  },
+});

--- a/convex/domains/search/searchableTextRecompute.test.ts
+++ b/convex/domains/search/searchableTextRecompute.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Scenario tests for `searchableTextRecompute` helpers (PR D).
+ *
+ * Per .claude/rules/scenario_testing.md — every test names a persona,
+ * a goal, prior state, action sequence, scale, and duration. The helpers
+ * are pure functions, so we exercise them directly with realistic row
+ * shapes for each of the 4 backfilled collections.
+ *
+ * The helpers are the SINGLE SOURCE OF TRUTH for `searchableText` on
+ * every insert AND every patch. They must:
+ *   - Be deterministic (DETERMINISTIC rule) — same row → same string.
+ *   - Be idempotent under recompute — calling twice produces equal output.
+ *   - Cap output at MAX_SEARCHABLE_TEXT_BYTES (BOUND_READ rule).
+ *   - Skip empty parts so the search field stays compact.
+ *   - Treat soft-deleted blocks as having empty searchableText so the
+ *     federated index drops them immediately.
+ *
+ * These tests are the regression net for PR D — any patch site that
+ * forgets the hook will leave its row's searchableText stale, which is
+ * an unobservable correctness bug. The scenario tests in
+ * `federatedSearch.test.ts` exercise the fan-out shape; this file
+ * exercises the projection shape.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  recomputeEntitySearchableText,
+  recomputeReportSearchableText,
+  recomputeBlockSearchableText,
+  recomputeSourceSearchableText,
+} from "./searchableTextRecompute";
+import { MAX_SEARCHABLE_TEXT_BYTES } from "./federatedHelpers";
+
+/* -------------------------------------------------------------------------- */
+/* recomputeEntitySearchableText                                               */
+/* -------------------------------------------------------------------------- */
+
+describe("recomputeEntitySearchableText — entity projection", () => {
+  /**
+   * Persona:    Power user creates a new entity from a chat thread
+   * Goal:       Entity is immediately findable by name, slug, or summary
+   * Prior:      Empty workspace
+   * Actions:    Helper composes searchableText from entity fields
+   * Scale:      1 row
+   * Duration:   Single call (deterministic)
+   * Expected:   Joined string with name, slug, summary, savedBecause
+   */
+  it("composes name + slug + summary + savedBecause", () => {
+    const got = recomputeEntitySearchableText({
+      name: "Anthropic",
+      slug: "anthropic-ai", // distinct from name to avoid case-insensitive dedupe
+      summary: "AI safety company building Claude",
+      savedBecause: "founder briefing",
+    });
+    expect(got).toBe(
+      "Anthropic | anthropic-ai | AI safety company building Claude | founder briefing",
+    );
+  });
+
+  /**
+   * Persona:    Adversarial mutation patches savedBecause but leaves
+   *             searchableText stale.
+   * Goal:       Re-running recompute against the patched row produces a
+   *             different string (so the backfill / patch hook catches
+   *             the staleness).
+   * Expected:   recompute(after) !== recompute(before)
+   */
+  it("changes when any source field changes (HONEST_SCORES)", () => {
+    const before = recomputeEntitySearchableText({
+      name: "Acme",
+      slug: "acme",
+      summary: "Stealth",
+      savedBecause: "saved",
+    });
+    const after = recomputeEntitySearchableText({
+      name: "Acme",
+      slug: "acme",
+      summary: "Stealth AI infrastructure for satellites",
+      savedBecause: "saved",
+    });
+    expect(after).not.toBe(before);
+  });
+
+  it("handles missing optional savedBecause without crashing", () => {
+    const got = recomputeEntitySearchableText({
+      name: "OpenAI",
+      slug: "openai-corp", // distinct from name to avoid case-insensitive dedupe
+      summary: "ChatGPT and GPT-5",
+      savedBecause: undefined,
+    });
+    // savedBecause skipped — not "undefined" stringified. composeSearchableText
+    // dedupes case-insensitively so a slug equal to the name (lowercased)
+    // would collapse — that's by design.
+    expect(got).toBe("OpenAI | openai-corp | ChatGPT and GPT-5");
+    expect(got).not.toContain("undefined");
+  });
+
+  it("dedupes case-insensitively (slug matching lowered name collapses)", () => {
+    // This is a feature: the federated index doesn't waste bytes on the
+    // same token written twice in different cases.
+    const got = recomputeEntitySearchableText({
+      name: "OpenAI",
+      slug: "openai", // lowercased name → dedupe drops this
+      summary: "AI lab",
+      savedBecause: undefined,
+    });
+    expect(got).toBe("OpenAI | AI lab");
+  });
+
+  it("is deterministic across repeated calls (DETERMINISTIC rule)", () => {
+    const doc = {
+      name: "Stripe",
+      slug: "stripe",
+      summary: "Payments infrastructure",
+      savedBecause: "fintech-research",
+    };
+    const a = recomputeEntitySearchableText(doc);
+    const b = recomputeEntitySearchableText(doc);
+    expect(a).toBe(b);
+  });
+
+  it("caps oversized summaries at MAX_SEARCHABLE_TEXT_BYTES (BOUND_READ)", () => {
+    const huge = "Stripe " + "x".repeat(MAX_SEARCHABLE_TEXT_BYTES + 1000);
+    const got = recomputeEntitySearchableText({
+      name: "Stripe",
+      slug: "stripe",
+      summary: huge,
+      savedBecause: undefined,
+    });
+    expect(got.length).toBeLessThanOrEqual(MAX_SEARCHABLE_TEXT_BYTES);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* recomputeReportSearchableText                                               */
+/* -------------------------------------------------------------------------- */
+
+describe("recomputeReportSearchableText — report projection", () => {
+  /**
+   * Persona:    Power user finalizes a chat session into a saved report
+   * Goal:       Report is immediately findable by title, query, or entity
+   * Prior:      Existing entity, ongoing chat session
+   * Actions:    Helper composes searchableText from report fields
+   * Scale:      1 row
+   * Duration:   Single call
+   * Expected:   Joined string with title, summary, query, primaryEntity,
+   *             entitySlug
+   */
+  it("composes title + summary + query + primaryEntity + entitySlug", () => {
+    const got = recomputeReportSearchableText({
+      title: "Anthropic deep dive",
+      summary: "Claude 4.7 launch, $61B valuation",
+      query: "what's new at Anthropic",
+      primaryEntity: "Anthropic",
+      entitySlug: "anthropic-org", // distinct from primaryEntity
+    });
+    expect(got).toContain("Anthropic deep dive");
+    expect(got).toContain("Claude 4.7 launch");
+    expect(got).toContain("Anthropic"); // primaryEntity surfaces as a separate token
+    expect(got).toContain("anthropic-org"); // entitySlug surfaces too
+  });
+
+  it("dedupes case-insensitively so the same entity isn't doubled", () => {
+    const got = recomputeReportSearchableText({
+      title: "Orbital Labs",
+      summary: "satellites",
+      query: "Orbital Labs",
+      primaryEntity: "Orbital Labs",
+      entitySlug: "orbital-labs",
+    });
+    // "Orbital Labs" appears once at the top of the joined string —
+    // composeSearchableText drops the duplicate query + primaryEntity.
+    const occurrences = (got.match(/Orbital Labs/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it("survives all-optional row (draft with no entity yet)", () => {
+    const got = recomputeReportSearchableText({
+      title: "Untitled",
+      summary: "",
+      query: "",
+      primaryEntity: undefined,
+      entitySlug: undefined,
+    });
+    expect(got).toBe("Untitled");
+    expect(got).not.toContain("undefined");
+  });
+
+  /**
+   * Persona:    Backfill runs on a row that was just inserted by a
+   *             post-PR-D mutation.
+   * Goal:       Backfill detects no diff and skips the write.
+   * Expected:   recompute() with the SAME inputs returns the SAME string.
+   */
+  it("is idempotent — same inputs ⇒ same output (backfill skip path)", () => {
+    const inputs = {
+      title: "Stripe Q1 brief",
+      summary: "RPV up 23% YoY",
+      query: "stripe revenue",
+      primaryEntity: "Stripe",
+      entitySlug: "stripe",
+    };
+    const first = recomputeReportSearchableText(inputs);
+    const second = recomputeReportSearchableText(inputs);
+    expect(first).toBe(second);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* recomputeBlockSearchableText                                                */
+/* -------------------------------------------------------------------------- */
+
+describe("recomputeBlockSearchableText — block chip projection", () => {
+  /**
+   * Persona:    Agent appends a paragraph to an entity workspace
+   * Goal:       The paragraph text is searchable by any token it contains
+   * Prior:      Entity workspace exists
+   * Actions:    Helper flattens chip array to a single string
+   * Scale:      1 row
+   * Duration:   Single call
+   * Expected:   String contains every chip's `value` token, no chip type
+   *             labels leak into the field.
+   */
+  it("flattens chip array values", () => {
+    const got = recomputeBlockSearchableText({
+      content: [
+        { type: "text", value: "Anthropic raised $13B" },
+        { type: "text", value: "from Lightspeed" },
+      ],
+      deletedAt: undefined,
+    });
+    expect(got).toContain("Anthropic raised $13B");
+    expect(got).toContain("from Lightspeed");
+    expect(got).not.toContain("text"); // chip type label must not leak
+  });
+
+  /**
+   * Persona:    User pastes a hyperlink chip
+   * Goal:       Search "openai.com" finds the block, not just the visible
+   *             label.
+   * Expected:   The link's hostname is surfaced.
+   */
+  it("surfaces link hostnames so URL-based search works", () => {
+    const got = recomputeBlockSearchableText({
+      content: [
+        { type: "text", value: "See " },
+        {
+          type: "link",
+          value: "OpenAI blog",
+          url: "https://www.openai.com/research/gpt-5",
+        },
+      ],
+      deletedAt: undefined,
+    });
+    expect(got).toContain("OpenAI blog");
+    expect(got).toContain("openai.com");
+  });
+
+  /**
+   * Persona:    User soft-deletes a block via the trash UI
+   * Goal:       The soft-deleted row stops appearing in search results
+   * Expected:   recompute returns empty string for deletedAt rows so the
+   *             federated `search_blocks` index drops the row.
+   */
+  it("returns empty string for soft-deleted blocks (HONEST_STATUS)", () => {
+    const got = recomputeBlockSearchableText({
+      content: [{ type: "text", value: "secret note" }],
+      deletedAt: Date.now(),
+    });
+    expect(got).toBe("");
+  });
+
+  it("handles mention chips with mentionTarget", () => {
+    const got = recomputeBlockSearchableText({
+      content: [
+        { type: "text", value: "Asked " },
+        {
+          type: "mention",
+          value: "@homen",
+          mentionTrigger: "@",
+          mentionTarget: "user:homen",
+        },
+      ],
+      deletedAt: undefined,
+    });
+    expect(got).toContain("@homen");
+    expect(got).toContain("user:homen");
+  });
+
+  it("handles invalid link URLs gracefully (BOUND_READ)", () => {
+    const got = recomputeBlockSearchableText({
+      content: [
+        {
+          type: "link",
+          value: "Broken link",
+          url: "not-a-valid-url",
+        },
+      ],
+      deletedAt: undefined,
+    });
+    // value still surfaces; bad URL is silently dropped, no throw.
+    expect(got).toContain("Broken link");
+  });
+
+  it("returns empty for missing/non-array content", () => {
+    expect(
+      recomputeBlockSearchableText({
+        content: undefined as any,
+        deletedAt: undefined,
+      }),
+    ).toBe("");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* recomputeSourceSearchableText                                               */
+/* -------------------------------------------------------------------------- */
+
+describe("recomputeSourceSearchableText — source artifact projection", () => {
+  /**
+   * Persona:    Agent crawls a public URL during research
+   * Goal:       The fetched URL is findable by title or domain
+   * Prior:      Empty source corpus
+   * Actions:    Helper composes searchableText from source row
+   * Scale:      1 row
+   * Duration:   Single call
+   * Expected:   String contains title + URL + mimeType
+   */
+  it("composes title + sourceUrl + mimeType", () => {
+    const got = recomputeSourceSearchableText({
+      title: "Anthropic blog: Constitutional AI",
+      sourceUrl: "https://www.anthropic.com/research/constitutional-ai",
+      mimeType: "text/html",
+    });
+    expect(got).toContain("Constitutional AI");
+    expect(got).toContain(
+      "https://www.anthropic.com/research/constitutional-ai",
+    );
+    expect(got).toContain("text/html");
+  });
+
+  it("survives missing title (URL-only sources)", () => {
+    const got = recomputeSourceSearchableText({
+      title: undefined,
+      sourceUrl: "https://www.openai.com/news",
+      mimeType: "text/html",
+    });
+    expect(got).toContain("openai.com");
+    expect(got).not.toContain("undefined");
+  });
+
+  /**
+   * Persona:    Backfill on production sourceArtifacts corpus (100k+ rows)
+   * Goal:       Re-running the backfill is a no-op
+   * Expected:   Same inputs ⇒ same output
+   */
+  it("is idempotent (backfill no-op on second run)", () => {
+    const inputs = {
+      title: "OpenAI announces o3",
+      sourceUrl: "https://openai.com/o3",
+      mimeType: "text/html",
+    };
+    const a = recomputeSourceSearchableText(inputs);
+    const b = recomputeSourceSearchableText(inputs);
+    expect(a).toBe(b);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Long-running scenario — 1000 sequential recomputes don't drift              */
+/* -------------------------------------------------------------------------- */
+
+describe("Scenario — long-running recompute accumulation", () => {
+  /**
+   * Persona:    Backfill scans 1000+ rows in a single mutation
+   * Goal:       No state drift, no memory growth, no determinism break
+   * Prior:      1000 rows with mixed content
+   * Actions:    Recompute each row, collect outputs
+   * Scale:      1000 sequential calls in one process
+   * Duration:   Sustained CPU burst
+   * Expected:   All outputs stable; calling the helper N times on the same
+   *             input N times in a row produces N identical strings.
+   */
+  it("1000 sequential entity recomputes on the same row produce identical output", () => {
+    const doc = {
+      name: "Stripe",
+      slug: "stripe",
+      summary: "Payments infrastructure for the internet",
+      savedBecause: "fintech",
+    };
+    const golden = recomputeEntitySearchableText(doc);
+    for (let i = 0; i < 1000; i += 1) {
+      expect(recomputeEntitySearchableText(doc)).toBe(golden);
+    }
+  });
+
+  it("1000 different blocks each produce stable output", () => {
+    for (let i = 0; i < 1000; i += 1) {
+      const got = recomputeBlockSearchableText({
+        content: [{ type: "text", value: `Token ${i}` }],
+        deletedAt: undefined,
+      });
+      expect(got).toContain(`Token ${i}`);
+    }
+  });
+});

--- a/convex/domains/search/searchableTextRecompute.ts
+++ b/convex/domains/search/searchableTextRecompute.ts
@@ -1,0 +1,142 @@
+/**
+ * Per-table recompute helpers for the federated search `searchableText`
+ * field. Single source of truth — every insert path AND every patch hook
+ * MUST call the same helper so the field stays consistent.
+ *
+ * Pattern: deterministic projection (per .claude/rules/agentic_reliability.md
+ * `DETERMINISTIC`). Same row → same string, every time. Backfill compares
+ * the computed value to the existing field and skips writes when equal,
+ * so re-running the backfill is a no-op.
+ *
+ * Prior art:
+ *   - PR #310 inserts (entities/eventWorkspace) — these helpers extract the
+ *     same `composeSearchableText([...])` shape into one place.
+ *
+ * Why this file lives in `domains/search/` (not `domains/product/`):
+ *   - Avoids a circular import: `product/entities.ts` already imports
+ *     `composeSearchableText` from this folder. Putting the recompute
+ *     helpers here keeps the dependency arrow one-way.
+ *   - The 7 search-indexed collections cross domains (sourceArtifacts is
+ *     in `domains/documents/`, quickCaptures and chatThreadsStream are
+ *     top-level schema). Search owns the projection rules.
+ */
+
+import { composeSearchableText } from "./federatedHelpers";
+import type { Doc } from "../../_generated/dataModel";
+
+/* -------------------------------------------------------------------------- */
+/* productEntities                                                             */
+/*                                                                             */
+/* Source fields: name, slug, summary, savedBecause                            */
+/* Insert sites that already match: entities.ts:412, 653, 1734, 1814           */
+/* Insert sites that already match: eventWorkspace.ts:421                      */
+/* -------------------------------------------------------------------------- */
+
+export function recomputeEntitySearchableText(
+  doc: Pick<
+    Doc<"productEntities">,
+    "name" | "slug" | "summary" | "savedBecause"
+  >,
+): string {
+  return composeSearchableText([
+    doc.name,
+    doc.slug,
+    doc.summary,
+    doc.savedBecause,
+  ]);
+}
+
+/* -------------------------------------------------------------------------- */
+/* productReports                                                              */
+/*                                                                             */
+/* Source fields: title, summary, query, primaryEntity, entitySlug             */
+/* PR #310's schema docs the shape — but NO insert path actually populated     */
+/* the field at ship time. PR D fixes the 4 insert sites + adds the patch     */
+/* hook.                                                                       */
+/*                                                                             */
+/* Both `primaryEntity` (display name) and `entitySlug` (canonical) are        */
+/* included — composeSearchableText dedupes case-insensitively, so identical   */
+/* values collapse to one token without bloating the index.                    */
+/* -------------------------------------------------------------------------- */
+
+export function recomputeReportSearchableText(
+  doc: Pick<
+    Doc<"productReports">,
+    "title" | "summary" | "query" | "primaryEntity" | "entitySlug"
+  >,
+): string {
+  return composeSearchableText([
+    doc.title,
+    doc.summary,
+    doc.query,
+    doc.primaryEntity,
+    doc.entitySlug,
+  ]);
+}
+
+/* -------------------------------------------------------------------------- */
+/* productBlocks                                                               */
+/*                                                                             */
+/* Source field: content — an ARRAY of `{type, value, url?}` chips (text /     */
+/* mention / link / linebreak / image). We flatten by joining `value` from     */
+/* every chip plus URL hostnames from links so a search for "openai.com"       */
+/* finds blocks that link to it. `kind` is filterable on the index.            */
+/*                                                                             */
+/* Soft-deleted blocks (deletedAt set) get an empty searchableText so they     */
+/* drop out of the keyword search index immediately.                           */
+/* -------------------------------------------------------------------------- */
+
+type BlockChip = Doc<"productBlocks">["content"][number];
+
+function chipToSearchableTokens(chip: BlockChip): string[] {
+  const tokens: string[] = [];
+  if (chip.value && chip.value.trim().length > 0) tokens.push(chip.value);
+  // For link chips, surface the hostname so search hits the domain too.
+  if (chip.type === "link" && chip.url) {
+    try {
+      const hostname = new URL(chip.url).hostname.replace(/^www\./, "");
+      if (hostname) tokens.push(hostname);
+    } catch {
+      // Invalid URL — silently skip, the chip's `value` is still searchable.
+    }
+  }
+  if (chip.mentionTarget) tokens.push(chip.mentionTarget);
+  return tokens;
+}
+
+export function recomputeBlockSearchableText(
+  doc: Pick<Doc<"productBlocks">, "content" | "deletedAt">,
+): string {
+  if (doc.deletedAt) return "";
+  if (!Array.isArray(doc.content)) return "";
+  const allTokens = doc.content.flatMap(chipToSearchableTokens);
+  return composeSearchableText(allTokens);
+}
+
+/* -------------------------------------------------------------------------- */
+/* sourceArtifacts                                                             */
+/*                                                                             */
+/* Source fields: title, sourceUrl, mimeType. We deliberately exclude          */
+/* `rawContent` because it can be megabytes — the snippet from title + URL +   */
+/* mime is enough signal for search ranking; full content is reachable via the */
+/* row itself.                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export function recomputeSourceSearchableText(
+  doc: Pick<Doc<"sourceArtifacts">, "title" | "sourceUrl" | "mimeType">,
+): string {
+  return composeSearchableText([doc.title, doc.sourceUrl, doc.mimeType]);
+}
+
+/* -------------------------------------------------------------------------- */
+/* productClaims, quickCaptures, chatThreadsStream                             */
+/*                                                                             */
+/* These three tables index a REQUIRED field directly:                         */
+/*   - productClaims  → claimText (always populated on insert)                 */
+/*   - quickCaptures  → content   (always populated on insert)                 */
+/*   - chatThreadsStream → title  (always populated on insert)                 */
+/*                                                                             */
+/* So they need no `searchableText` projection or backfill — every existing    */
+/* row is already searchable. Patch sites that mutate the source field will    */
+/* automatically refresh the index because Convex re-indexes on patch.         */
+/* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
PR #310 shipped Convex-native federated search but only populated `searchableText` on the insert path. Rows edited before PR1 were invisible to keyword search, and patches that mutated source fields silently left `searchableText` stale. This PR closes those gaps via:
- Single-source-of-truth recompute helpers per table
- 7 patch-site hooks across entities/reports/blocks/chat/bootstrap
- 12 missing-insert backfills (4 reports + 8 blocks + 1 source)
- Paginated backfill (200 rows/page x 1000 pages/call, idempotent)
- CLI: `npx convex run domains/search/searchableTextBackfill:backfillAll`

`nb_sources` privacy: documented as intentionally public — crawled URLs are de-facto public artifacts and return for both anonymous and authenticated callers.

Per `.claude/rules/agentic_reliability.md`: BOUND, HONEST_STATUS, HONEST_SCORES, TIMEOUT, DETERMINISTIC all enforced.

## Test plan
- [x] `npx convex codegen` clean
- [x] `npx tsc --noEmit --pretty false` clean
- [x] `npx vitest run convex/domains/search/` — 586 passed (incl. 21 new + 20 existing scenario tests)
- [x] `npx vite build` clean
- [ ] Post-merge: `npx convex run domains/search/searchableTextBackfill:backfillAll` against prod
- [ ] Tier B: `npx convex run domains/search/federatedSearch:federatedSearch '{"q":"Anthropic"}'` returns non-zero results

Closes part of the "honest gaps" from PR #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)