### PR TITLE
feat(redesign): mount VoiceCostBadge in chat right rail

### DIFF
--- a/src/features/redesign/components/RightInspector.tsx
+++ b/src/features/redesign/components/RightInspector.tsx
@@ -2,10 +2,24 @@
  * RightInspector — chat-page right rail.
  *
  * Spec: active entity card · graph preview · sources · prior threads · report status.
+ *
+ * Mounted widgets (top → bottom):
+ *   - Report status
+ *   - VoiceCostBadge (signed-in only — daily voice spend + tier-fallback
+ *     transparency. The widget shape — `<section>` with rounded border +
+ *     padding — matches the existing `rd-card` cadence. Mounted here per
+ *     the design pattern: sticky widgets in the right rail. HONEST_STATUS:
+ *     the badge is suppressed entirely for signed-out viewers (no fake
+ *     userId), and renders its own loading skeleton when Convex query
+ *     is undefined.)
+ *   - Active entity card
+ *   - Graph preview · sources · prior threads
  */
 
 import { Pill } from "./Pill";
 import { useLiveArtifacts, type LiveArtifactDetail } from "../hooks/useLiveArtifacts";
+import { VoiceCostBadge } from "@/features/voice";
+import { useCurrentUserId } from "@/hooks/useCurrentUser";
 
 export function RightInspector() {
   const liveArtifacts = useLiveArtifacts(12);
@@ -14,6 +28,9 @@ export function RightInspector() {
   const summary = detail?.summary ?? "Ask a question, capture a note, or open a live artifact to hydrate this inspector.";
   const sources = detail?.sourceRows.slice(0, 4) ?? [];
   const nodes = detail?.nodes.slice(0, 5) ?? [];
+  // HONEST_STATUS — only mount VoiceCostBadge for signed-in viewers.
+  // `null` = signed out (skip), `undefined` = loading auth (skip until known).
+  const userId = useCurrentUserId();
 
   return (
     <aside className="rd-pane rd-pane--right" style={{ padding: "20px 18px", gap: 16 }}>
@@ -30,6 +47,11 @@ export function RightInspector() {
           <span>{detail?.followUps ?? 0} follow-ups</span>
         </div>
       </section>
+
+      {/* Voice cost badge — signed-in only. Reuses the existing widget
+          shipped in PR #312 (was tree-shaken because nothing imported it).
+          See module header for HONEST_STATUS rationale. */}
+      {userId && <VoiceCostBadge userId={userId} />}
 
       {/* Active entity card */}
       <section className="rd-card rd-card__pad" style={{ display: "flex", flexDirection: "column", gap: 10 }}>

--- a/src/features/voice/components/VoiceAuditFeed.tsx
+++ b/src/features/voice/components/VoiceAuditFeed.tsx
@@ -17,7 +17,7 @@ import { useQuery } from "convex/react";
 import { useMemo } from "react";
 // The api object has the new realtimeAudit module after PR #274's codegen.
 // Until codegen runs in CI, fall back to a relaxed lookup so tsc passes.
-import { api } from "@/convex/_generated/api";
+import { api } from "../../../../convex/_generated/api";
 
 type AuditGate =
   | "anonymous_no_persist"

--- a/src/features/voice/components/VoiceCostBadge.tsx
+++ b/src/features/voice/components/VoiceCostBadge.tsx
@@ -37,7 +37,7 @@
 
 import { useState } from "react";
 import { useQuery } from "convex/react";
-import { api } from "@/convex/_generated/api";
+import { api } from "../../../../convex/_generated/api";
 
 interface VoiceCostBadgeProps {
   userId: string; // user's Convex id

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,0 +1,41 @@
+/**
+ * useCurrentUser / useCurrentUserId — typed hooks for the viewer identity.
+ *
+ * Wraps the existing `api.domains.auth.auth.loggedInUser` Convex query that
+ * was already used ad-hoc across many call sites (calendar, documents,
+ * notification panel, sync provenance badge, etc). Centralizing gives us:
+ *
+ *   - One auth-coupling per surface (drop the badge in any tree without
+ *     reinventing the query call)
+ *   - HONEST_STATUS — `useCurrentUserId()` returns `null` for guests and
+ *     `undefined` while loading. Callers MUST handle both, never pass an
+ *     empty string downstream (Convex queries that key on `userId` would
+ *     otherwise return data for "no such user" or error).
+ *
+ * Pattern: Read-through hook — mirrors the `loggedInUser` shape.
+ *
+ * See: convex/domains/auth/auth.ts (loggedInUser query)
+ *      .claude/rules/agentic_reliability.md (HONEST_STATUS)
+ */
+
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+
+/** Full user doc, or `null` (signed out), or `undefined` (loading). */
+export function useCurrentUser() {
+  return useQuery(api.domains.auth.auth.loggedInUser);
+}
+
+/**
+ * Just the viewer's Convex `_id`, or `null` (signed out), or `undefined`
+ * (loading). Use this when you only need the id (e.g. to scope a child
+ * query). Never coerce to an empty string — see HONEST_STATUS in module
+ * header.
+ */
+export function useCurrentUserId(): Id<"users"> | null | undefined {
+  const user = useCurrentUser();
+  if (user === undefined) return undefined;
+  if (user === null) return null;
+  return user._id as Id<"users">;
+}


### PR DESCRIPTION
## Summary

- Mounts the `VoiceCostBadge` from PR #312 into `RightInspector` (chat-surface right rail) — the natural design-pattern fit since the rail is a vertical stack of `<section className=\"rd-card\">` widgets and the badge is a `<section>` widget.
- Fixes a P0 latent bug: the badge was in the bundle in name only. It imported `@/convex/_generated/api` which the bundler cannot resolve. Tree-shaking hid the broken path because nothing imported the component. The moment `RightInspector` references it, the resolver activates and the path breaks the build. Switched both `voice/components/*` files to the relative `../../../../convex/_generated/api` pattern that 100% of other `src/` files already use.
- Adds `useCurrentUser` / `useCurrentUserId` (`src/hooks/useCurrentUser.ts`) wrapping `api.domains.auth.auth.loggedInUser` — centralizes the ad-hoc pattern already used by ~10 surfaces.

## HONEST_STATUS

`useCurrentUserId()` returns `null` for signed-out viewers and `undefined` while auth is loading. The badge is suppressed entirely until a real `Id<\"users\">` is known. **No empty-string userId is ever passed to the `checkCap` query.**

```tsx
{userId && <VoiceCostBadge userId={userId} />}
```

## Test plan

- [x] `npx tsc --noEmit --pretty false` clean
- [x] `npx vite build` clean (`RedesignShell-*.js` chunk now contains the badge)
- [x] `TopNav.test.tsx` 5/5 pass (no regression)
- [ ] Anonymous incognito visit to `/redesign?surface=chat` → badge NOT visible
- [ ] Signed-in visit → "Voice spend today" `<section>` rendered between "Report status" and "Active entity card"
- [ ] `[data-testid=\"voice-fallback-chip\"]` only present when authed AND fallback active

🤖 Generated with [Claude Code](https://claude.com/claude-code)