### PR TITLE
fix(redesign): Notebook Cmd+F finder + /events/:eventId route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,12 @@ const UniversalWorkspacePage = lazy(() =>
 );
 const EmbedView = lazy(() => import("@/features/founder/views/EmbedView"));
 const FounderRouteResolver = lazy(() => import("@/features/founder/views/FounderRouteResolver"));
+// /events/:eventId — corpus explorer for one event. See viewRegistry "event-corpus" entry.
+const EventCorpusExplorer = lazy(() =>
+  import("@/features/events/views/EventCorpusExplorer").then((m) => ({
+    default: m.EventCorpusExplorer,
+  })),
+);
 // My Wiki — Phase 1 routes. See docs/architecture/ME_AGENT_DESIGN.md
 const WikiLandingRoute = lazy(() => import("@/features/me/components/wiki/WikiLandingRoute"));
 const WikiPageDetailRoute = lazy(() => import("@/features/me/components/wiki/WikiPageDetailRoute"));
@@ -382,6 +388,29 @@ function App() {
           <Suspense fallback={<ViewSkeleton />}>
             <div key="embed" className="route-fade-in">
               <EmbedView />
+            </div>
+          </Suspense>
+        </ErrorBoundary>
+      </ThemeProvider>
+    );
+  }
+
+  // /events/:eventId — corpus explorer for one event. Mounted as a top-level
+  // standalone route (NOT inside the cockpit) because the cockpit's path
+  // resolver does prefix-style longest-match and would happily swallow
+  // /events/* into "/" if no explicit branch ran first.
+  // See viewRegistry.ts "event-corpus" entry — that entry exists so Cmd-K
+  // and other discovery surfaces know about the route, but the actual
+  // rendering happens here.
+  const eventsRouteMatch = location.pathname.match(/^\/events\/([^/]+)\/?$/);
+  if (eventsRouteMatch) {
+    const eventId = decodeURIComponent(eventsRouteMatch[1] ?? "");
+    return (
+      <ThemeProvider>
+        <ErrorBoundary title="Event corpus failed to load">
+          <Suspense fallback={<ViewSkeleton />}>
+            <div key={`events-${eventId}`} className="route-fade-in">
+              <EventCorpusExplorer eventId={eventId} />
             </div>
           </Suspense>
         </ErrorBoundary>

--- a/src/features/events/views/EventCorpusExplorer.test.tsx
+++ b/src/features/events/views/EventCorpusExplorer.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { EventCorpusExplorer } from "./EventCorpusExplorer";
+import { resolvePathToView, resolvePathToCockpitState } from "@/lib/registry/viewRegistry";
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * Scenario: dogfooder pastes /events/test-event-id into a fresh tab. Before
+ * this PR, the cockpit's prefix matcher swallowed the slug and the page
+ * fell through to the home control-plane view. The route resolver MUST now
+ * recognize the event corpus path and surface the slug.
+ *
+ * User:       dogfooder / external partner with a shared event-corpus link
+ * Goal:       open the corpus surface for a specific event id
+ * Prior state: no auth, no cockpit query string
+ * Actions:    navigate to /events/test-event-id
+ * Scale:      single user
+ * Duration:   short — single render
+ * Expected:   resolvePathToView returns view: "event-corpus" with the slug
+ *             carried in entityName (same channel /entity/:slug uses);
+ *             EventCorpusExplorer renders the slug + the "no corpus yet"
+ *             honest empty state.
+ * Edge cases:  empty id → "No event id" + amber warning state;
+ *             very long id → bounded preview (no DoS surface).
+ */
+describe("EventCorpusExplorer + /events/:eventId route", () => {
+  it("Scenario: resolvePathToView recognizes /events/:eventId and lifts the slug into entityName", () => {
+    expect(resolvePathToView("/events/test-event-id")).toMatchObject({
+      view: "event-corpus",
+      entityName: "test-event-id",
+      isUnknownRoute: false,
+    });
+  });
+
+  it("Scenario: resolvePathToCockpitState routes /events/* to the packets surface", () => {
+    // The cockpit resolver maps view → surface via VIEW_MAP. The event-corpus
+    // view is registered under packets in viewRegistry, so a deep link should
+    // land on the Reports surface in the cockpit (alongside other dynamic
+    // /entity/:slug-style routes).
+    expect(resolvePathToCockpitState("/events/founder-summit-2026")).toMatchObject({
+      surfaceId: "packets",
+      view: "event-corpus",
+      entityName: "founder-summit-2026",
+    });
+  });
+
+  it("Scenario: /events alone (no slug) does NOT resolve to event-corpus — it's a missing-id case", () => {
+    // The startsWith("/events/") branch in the resolver requires the slash.
+    // Bare /events has no event id; the rest of the resolver decides where it
+    // lands (longest-path-wins). We just make sure it does NOT return a fake
+    // event-corpus result with entityName=null.
+    const resolved = resolvePathToView("/events");
+    // Either the bare /events path matches the registry entry (view = "event-corpus",
+    // entityName = null) OR it falls through. Either way, entityName is null —
+    // the contract is "no fake slug".
+    if (resolved.view === "event-corpus") {
+      expect(resolved.entityName).toBeNull();
+    } else {
+      // Tolerated alternative — the resolver doesn't promote a bare /events
+      // path to event-corpus.
+      expect(resolved.entityName).toBeNull();
+    }
+  });
+
+  it("Scenario: component renders the slug verbatim when present", () => {
+    render(<EventCorpusExplorer eventId="test-event-id" />);
+    expect(screen.getByTestId("event-corpus-explorer")).toBeTruthy();
+    expect(screen.getByTestId("event-corpus-explorer").getAttribute("data-event-id")).toBe(
+      "test-event-id",
+    );
+    // Honest empty state — no fake corpus data.
+    expect(screen.getByTestId("event-corpus-explorer-empty")).toBeTruthy();
+  });
+
+  it("Scenario (sad path): missing eventId renders honest 'no id' warning, not a home fallthrough", () => {
+    render(<EventCorpusExplorer eventId={null} />);
+    // The warning is the surface contract — it must be visible to the user
+    // and to screen readers. No silent rendering of home content.
+    const missing = screen.getByTestId("event-corpus-explorer-missing-id");
+    expect(missing).toBeTruthy();
+    expect(missing.textContent ?? "").toMatch(/missing/i);
+  });
+
+  it("Scenario (adversarial): pathological 1000-char id is bounded — no DoS surface", () => {
+    const huge = "x".repeat(1000);
+    render(<EventCorpusExplorer eventId={huge} />);
+    const host = screen.getByTestId("event-corpus-explorer");
+    const rendered = host.getAttribute("data-event-id") ?? "";
+    // The id is sanitized to <= 240 chars + the truncation glyph (sanitize() in component).
+    expect(rendered.length).toBeLessThanOrEqual(241);
+    expect(rendered.endsWith("…")).toBe(true);
+  });
+
+  it("Scenario (long-running): 10 distinct slugs route in sequence without bleed-over", () => {
+    // Catch a regression where the resolver caches the last slug into module
+    // state. Each call must be a fresh resolution.
+    for (const slug of [
+      "a",
+      "b-slug",
+      "Founder-Summit_2026",
+      "with%20space",
+      "trailing-",
+      "-leading",
+      "double--dash",
+      "UPPER",
+      "mixed-CaSe-123",
+      "very-very-long-event-slug-name-that-keeps-going-and-going",
+    ]) {
+      const res = resolvePathToView(`/events/${slug}`);
+      expect(res.view).toBe("event-corpus");
+      expect(res.entityName).toBe(decodeURIComponent(slug));
+    }
+  });
+});

--- a/src/features/events/views/EventCorpusExplorer.tsx
+++ b/src/features/events/views/EventCorpusExplorer.tsx
@@ -1,0 +1,135 @@
+/**
+ * EventCorpusExplorer — landing surface for /events/:eventId.
+ *
+ * V1 scope (this PR closes the routing gap, not the data plane):
+ *   - Renders the event id passed via the URL so a dogfood user can
+ *     verify routing works end-to-end (i.e. /events/test-event-id no
+ *     longer falls through to home).
+ *   - Provides a stable data-testid="event-corpus-explorer" surface so
+ *     the live-smoke + Playwright suites can assert presence.
+ *   - Leaves a clearly-labelled `Empty state` for the real corpus once
+ *     the productEvents → searchableText pipeline lands. We render
+ *     "No corpus rows yet for {eventId}" rather than a generic placeholder
+ *     so reviewers can see at a glance which event id was resolved.
+ *
+ * Honest-status (.claude/rules/agentic_reliability.md):
+ *   - This route never returns 200 with fake data. If the route resolver
+ *     hands us an empty eventId, we render the "no event id" state and
+ *     announce it via aria-live so screen readers and tests see the truth.
+ *   - There is NO hardcoded passing score / verdict here. The "ready"
+ *     surface is the route resolving and the eventId being readable —
+ *     nothing more.
+ *
+ * Accessibility (.claude/rules/reexamine_a11y.md):
+ *   - role="region" + aria-label so this section is a discoverable
+ *     landmark.
+ *   - The eventId is rendered in a <code> element for visual scanability
+ *     and uses font-mono for screen contrast in dark mode.
+ */
+import { useMemo } from "react";
+
+export interface EventCorpusExplorerProps {
+  /**
+   * Resolved event id from the URL. App.tsx pulls this from the path
+   * regex; viewRegistry.ts exposes it as `entityName` in the cockpit
+   * surface state (same plumbing channel as /entity/:slug).
+   */
+  eventId: string | null;
+  /** Test-id override; default matches the smoke contract. */
+  testId?: string;
+}
+
+function sanitize(id: string | null): string | null {
+  if (!id) return null;
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  // Bound the rendered id to a sane length so an attacker can't fill the
+  // surface with a 10K-char path segment. (BOUND_READ analog.)
+  return trimmed.length > 240 ? `${trimmed.slice(0, 240)}…` : trimmed;
+}
+
+export function EventCorpusExplorer({
+  eventId,
+  testId = "event-corpus-explorer",
+}: EventCorpusExplorerProps) {
+  const resolvedId = useMemo(() => sanitize(eventId), [eventId]);
+
+  return (
+    <section
+      data-testid={testId}
+      data-event-id={resolvedId ?? ""}
+      role="region"
+      aria-label="Event corpus"
+      className="mx-auto flex min-h-[480px] max-w-[960px] flex-col gap-4 px-6 py-8"
+    >
+      <header className="flex items-baseline justify-between gap-4 border-b border-black/[0.08] pb-4 dark:border-white/[0.08]">
+        <div>
+          <div className="text-[11px] uppercase tracking-[0.2em] text-gray-500 dark:text-gray-400">
+            Event corpus
+          </div>
+          <h1 className="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            {resolvedId ? (
+              <code className="font-mono text-xl text-[#ad5f45] dark:text-[#f0b39a]">
+                {resolvedId}
+              </code>
+            ) : (
+              "No event id"
+            )}
+          </h1>
+        </div>
+        <a
+          href="/?surface=reports"
+          className="text-xs text-gray-500 hover:text-[#ad5f45] dark:text-gray-400 dark:hover:text-[#f0b39a]"
+        >
+          ← Reports
+        </a>
+      </header>
+
+      {resolvedId ? (
+        <div className="flex flex-1 flex-col gap-3" data-testid={`${testId}-empty`}>
+          <p
+            role="status"
+            aria-live="polite"
+            className="rounded-md border border-black/[0.06] bg-white/[0.02] p-4 text-sm text-gray-600 dark:border-white/[0.06] dark:text-gray-300"
+          >
+            No corpus rows yet for <code className="font-mono">{resolvedId}</code>.
+            The /events/:eventId route is wired — the productEvents
+            corpus reader is the next PR.
+          </p>
+          <ul className="grid grid-cols-1 gap-2 text-sm text-gray-500 dark:text-gray-400 sm:grid-cols-3">
+            <li className="rounded-md border border-black/[0.06] p-3 dark:border-white/[0.06]">
+              <strong className="block text-xs uppercase tracking-[0.18em] text-gray-400">
+                Sources
+              </strong>
+              <span>—</span>
+            </li>
+            <li className="rounded-md border border-black/[0.06] p-3 dark:border-white/[0.06]">
+              <strong className="block text-xs uppercase tracking-[0.18em] text-gray-400">
+                Mentions
+              </strong>
+              <span>—</span>
+            </li>
+            <li className="rounded-md border border-black/[0.06] p-3 dark:border-white/[0.06]">
+              <strong className="block text-xs uppercase tracking-[0.18em] text-gray-400">
+                Linked entities
+              </strong>
+              <span>—</span>
+            </li>
+          </ul>
+        </div>
+      ) : (
+        <p
+          role="status"
+          aria-live="polite"
+          data-testid={`${testId}-missing-id`}
+          className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-200"
+        >
+          The event id is missing from the URL. Open this surface via
+          /events/:eventId — the route resolver passes the slug here.
+        </p>
+      )}
+    </section>
+  );
+}
+
+export default EventCorpusExplorer;

--- a/src/features/notebook/components/NotebookBlockFinder.tsx
+++ b/src/features/notebook/components/NotebookBlockFinder.tsx
@@ -1,0 +1,222 @@
+/**
+ * NotebookBlockFinder — in-notebook find UI.
+ *
+ * Mount surface: an overlay opened by Cmd/Ctrl+F when the parent editor (or any
+ * descendant of `containerRef`) has focus. Scoped per-report via `reportId`,
+ * which is used both as the storage key for the most recent query and as the
+ * filter context for any future server-backed expansion
+ * (e.g. `filterBy: "report_id:=${reportId}"`).
+ *
+ * V1 behavior (this PR):
+ *   - Pure in-document search across the editor's prosemirror text content.
+ *   - No Convex / federated-search dependency — the finder is reliable even
+ *     when the editor is offline and even before `productBlocks` rows are
+ *     indexed (PR #310's backfill is in progress).
+ *   - The component still emits `reportId` on its root and stores recent
+ *     queries under `nb_finder_recent.<reportId>` so a future server-backed
+ *     expansion can swap the body without changing the contract.
+ *
+ * Accessibility (.claude/rules/reexamine_a11y.md):
+ *   - role="dialog" + aria-modal + aria-label
+ *   - aria-live="polite" status row announces match count
+ *   - Escape closes; focus returns to the editor element
+ *   - Input is the initial focus target
+ *
+ * Reliability invariants (.claude/rules/agentic_reliability.md):
+ *   - BOUND        — match list capped at MAX_MATCHES (200); query trimmed
+ *                    to MAX_QUERY (200 chars)
+ *   - HONEST_STATUS — "0 matches" rendered as plain text, never suppressed
+ *   - DETERMINISTIC — match scan walks the DOM in document order; same input
+ *                    + same content → same match list
+ */
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+
+const MAX_QUERY = 200;
+const MAX_MATCHES = 200;
+
+export interface NotebookBlockFinderProps {
+  /** The report whose notebook this finder is scoped to. Used for storage + future server-backed filter. */
+  reportId: string;
+  /** The editor host. The finder reads textContent from inside this element. */
+  containerRef: React.RefObject<HTMLElement | null>;
+  /** Called when the finder should close (Escape / dismiss). */
+  onClose: () => void;
+  /** Optional test id override. Default: "notebook-block-finder". */
+  testId?: string;
+}
+
+interface Match {
+  /** 0-based index of the match within the flattened text. */
+  index: number;
+  /** A short context window (preview) surrounding the match. */
+  preview: string;
+}
+
+function recentKey(reportId: string) {
+  return `nb_finder_recent.${reportId}`;
+}
+
+function readRecent(reportId: string): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(recentKey(reportId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((s): s is string => typeof s === "string").slice(0, 5)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function pushRecent(reportId: string, q: string) {
+  if (!q.trim() || typeof window === "undefined") return;
+  const list = readRecent(reportId);
+  const next = [q, ...list.filter((s) => s !== q)].slice(0, 5);
+  try {
+    window.localStorage.setItem(recentKey(reportId), JSON.stringify(next));
+  } catch {
+    /* localStorage may be unavailable in private sessions — non-fatal. */
+  }
+}
+
+function findMatches(container: HTMLElement | null, query: string): Match[] {
+  if (!container || !query) return [];
+  const haystack = container.textContent ?? "";
+  if (!haystack) return [];
+  const needle = query.toLowerCase();
+  const flatLower = haystack.toLowerCase();
+  const out: Match[] = [];
+  let cursor = 0;
+  // Deterministic forward scan; bounded by MAX_MATCHES to keep the panel cheap.
+  while (cursor < flatLower.length && out.length < MAX_MATCHES) {
+    const hit = flatLower.indexOf(needle, cursor);
+    if (hit === -1) break;
+    const start = Math.max(0, hit - 24);
+    const end = Math.min(haystack.length, hit + needle.length + 24);
+    out.push({
+      index: hit,
+      preview: `${start > 0 ? "…" : ""}${haystack.slice(start, end)}${end < haystack.length ? "…" : ""}`,
+    });
+    cursor = hit + needle.length;
+  }
+  return out;
+}
+
+export function NotebookBlockFinder({
+  reportId,
+  containerRef,
+  onClose,
+  testId = "notebook-block-finder",
+}: NotebookBlockFinderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const titleId = useId();
+  const [query, setQueryRaw] = useState("");
+  const [recent, setRecent] = useState<string[]>(() => readRecent(reportId));
+
+  // Bound the query length up-front so the rest of the component can assume
+  // a fixed-size string. This pairs with BOUND in the file header.
+  const setQuery = (next: string) => {
+    setQueryRaw(next.length > MAX_QUERY ? next.slice(0, MAX_QUERY) : next);
+  };
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const matches = useMemo(
+    () => findMatches(containerRef.current ?? null, query.trim()),
+    // containerRef.current changes do not trigger memo invalidation by themselves
+    // (React intentionally omits refs from deps), but query changes do — which is
+    // when matches need to be recomputed in this finder's V1 design.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [query, containerRef],
+  );
+
+  // Persist recent query when the user pauses typing (debounced via blur).
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    pushRecent(reportId, query.trim());
+    setRecent(readRecent(reportId));
+  };
+
+  return (
+    <div
+      data-testid={testId}
+      data-report-id={reportId}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      className="absolute right-3 top-3 z-30 w-[320px] rounded-lg border border-black/[0.08] bg-white p-3 shadow-lg dark:border-white/[0.08] dark:bg-[#1b1815]"
+    >
+      <form onSubmit={handleSubmit} className="flex items-center gap-2">
+        <label className="sr-only" htmlFor={`${titleId}-input`}>
+          Find in notebook
+        </label>
+        <span id={titleId} className="text-[11px] uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
+          Find in notebook
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close finder"
+          className="ml-auto rounded px-1.5 py-0.5 text-xs text-gray-500 hover:bg-black/[0.04] dark:text-gray-400 dark:hover:bg-white/[0.06]"
+        >
+          Esc
+        </button>
+      </form>
+      <input
+        id={`${titleId}-input`}
+        ref={inputRef}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search blocks…"
+        maxLength={MAX_QUERY}
+        data-testid={`${testId}-input`}
+        className="mt-2 w-full rounded-md border border-black/[0.08] bg-white px-2 py-1.5 text-sm text-gray-800 outline-none focus:border-[#d97757] dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-gray-100"
+      />
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid={`${testId}-status`}
+        className="mt-2 text-[11px] text-gray-500 dark:text-gray-400"
+      >
+        {query.trim().length === 0
+          ? recent.length > 0
+            ? `Recent: ${recent.join(" · ")}`
+            : "Type to search the open notebook"
+          : `${matches.length}${matches.length === MAX_MATCHES ? "+" : ""} match${matches.length === 1 ? "" : "es"}`}
+      </div>
+      {matches.length > 0 ? (
+        <ul
+          data-testid={`${testId}-results`}
+          className="mt-2 max-h-[280px] overflow-y-auto rounded-md border border-black/[0.06] dark:border-white/[0.08]"
+        >
+          {matches.slice(0, 50).map((m) => (
+            <li
+              key={m.index}
+              className="border-b border-black/[0.04] px-2 py-1.5 text-xs text-gray-700 last:border-b-0 dark:border-white/[0.06] dark:text-gray-200"
+            >
+              {m.preview}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export default NotebookBlockFinder;

--- a/src/features/notebook/components/RichNotebookEditor.finder.test.tsx
+++ b/src/features/notebook/components/RichNotebookEditor.finder.test.tsx
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, act } from "@testing-library/react";
+
+import { RichNotebookEditor } from "./RichNotebookEditor";
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+/**
+ * Scenario: power-user opens the in-notebook finder via Cmd+F while the
+ * editor has focus. This is the keystroke-shortcut analog of the existing
+ * AI proposals / claims tests — same test harness, but driven by the
+ * keyboard rather than seeded data.
+ *
+ * User:        power-user editing a report notebook
+ * Goal:        find "founder" inside a notebook with many blocks
+ * Prior state: editor mounted with reportId="r1"
+ * Actions:     focus editor → press Cmd+F → type "founder"
+ * Scale:       single user
+ * Duration:    short — keystroke + 2s waitFor for lazy mount
+ * Expected:    finder dialog mounts, carries data-report-id, browser's
+ *              native Find does NOT also fire (preventDefault).
+ * Edge cases:  Cmd+F WITHOUT reportId is a no-op (graceful);
+ *              Cmd+F when focus is OUTSIDE the editor article is a no-op;
+ *              Escape closes the finder and returns focus to the editor.
+ */
+describe("RichNotebookEditor — Cmd+F finder (in-notebook find)", () => {
+  function dispatchCmdF(target: HTMLElement) {
+    // Match the editor-side handler: capture-phase keydown on `document`,
+    // listening for `e.key === "f" || "F"` with metaKey OR ctrlKey.
+    const e = new KeyboardEvent("keydown", {
+      key: "f",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(e);
+    return e;
+  }
+
+  it("Scenario: Cmd+F opens NotebookBlockFinder scoped to the reportId", async () => {
+    render(
+      <RichNotebookEditor
+        initialContent="<p>founder bio here</p>"
+        reportId="r1"
+        testId="rne"
+      />,
+    );
+
+    // Wait for TipTap to actually mount its contenteditable host.
+    const editable = await waitFor(() => {
+      const el = document.querySelector('[data-testid="rne"] [contenteditable="true"]');
+      if (!el) throw new Error("editor not mounted");
+      return el as HTMLElement;
+    });
+    editable.focus();
+    expect(document.activeElement).toBe(editable);
+
+    // Browser's native Find returns a preventDefault-capable event; we assert
+    // the editor cancels the default (so the page-level Find dialog never opens).
+    const event = await act(async () => dispatchCmdF(editable));
+    expect(event.defaultPrevented).toBe(true);
+
+    // The lazy NotebookBlockFinder should mount after the Suspense resolves.
+    const finder = await screen.findByTestId("notebook-block-finder");
+    expect(finder.getAttribute("data-report-id")).toBe("r1");
+    // The status pill renders the empty-query helper text.
+    expect(screen.getByTestId("notebook-block-finder-status")).toBeTruthy();
+  });
+
+  it("Scenario: Cmd+F WITHOUT reportId is a no-op — finder does not mount, browser default proceeds", async () => {
+    render(
+      <RichNotebookEditor
+        initialContent="<p>baseline body</p>"
+        testId="rne-no-report"
+      />,
+    );
+
+    const editable = await waitFor(() => {
+      const el = document.querySelector(
+        '[data-testid="rne-no-report"] [contenteditable="true"]',
+      );
+      if (!el) throw new Error("editor not mounted");
+      return el as HTMLElement;
+    });
+    editable.focus();
+
+    const event = await act(async () => dispatchCmdF(editable));
+    // Without reportId, the editor does not register the listener — the
+    // browser's native Find runs unmodified.
+    expect(event.defaultPrevented).toBe(false);
+
+    // Finder never mounts.
+    expect(screen.queryByTestId("notebook-block-finder")).toBeNull();
+  });
+
+  it("Scenario: Cmd+F dispatched while focus is OUTSIDE the editor does NOT open the finder", async () => {
+    // Mount an external focus target alongside the editor.
+    const outside = document.createElement("input");
+    outside.setAttribute("data-testid", "outside-input");
+    document.body.appendChild(outside);
+    try {
+      render(
+        <RichNotebookEditor
+          initialContent="<p>scope test</p>"
+          reportId="r2"
+          testId="rne-scope"
+        />,
+      );
+
+      await waitFor(() => {
+        const el = document.querySelector('[data-testid="rne-scope"] [contenteditable="true"]');
+        if (!el) throw new Error("editor not mounted");
+        return el;
+      });
+
+      // Focus the OUTSIDE input, then dispatch Cmd+F. The editor's handler
+      // should bail out of the focus-guard branch without preventDefault.
+      outside.focus();
+      expect(document.activeElement).toBe(outside);
+
+      const event = await act(async () => dispatchCmdF(outside));
+      expect(event.defaultPrevented).toBe(false);
+      // 100ms grace for any spurious Suspense mounts.
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 100));
+      });
+      expect(screen.queryByTestId("notebook-block-finder")).toBeNull();
+    } finally {
+      outside.remove();
+    }
+  });
+
+  it("Scenario: opening the finder with reportId='other' keeps the data-report-id in sync", async () => {
+    render(
+      <RichNotebookEditor
+        initialContent="<p>cross-report check</p>"
+        reportId="other"
+        testId="rne-other"
+      />,
+    );
+
+    const editable = await waitFor(() => {
+      const el = document.querySelector('[data-testid="rne-other"] [contenteditable="true"]');
+      if (!el) throw new Error("editor not mounted");
+      return el as HTMLElement;
+    });
+    editable.focus();
+
+    await act(async () => dispatchCmdF(editable));
+    const finder = await screen.findByTestId("notebook-block-finder");
+    expect(finder.getAttribute("data-report-id")).toBe("other");
+  });
+
+  it("Scenario: Escape closes the finder (a11y contract)", async () => {
+    render(
+      <RichNotebookEditor
+        initialContent="<p>escape me</p>"
+        reportId="r3"
+        testId="rne-esc"
+      />,
+    );
+
+    const editable = await waitFor(() => {
+      const el = document.querySelector('[data-testid="rne-esc"] [contenteditable="true"]');
+      if (!el) throw new Error("editor not mounted");
+      return el as HTMLElement;
+    });
+    editable.focus();
+    await act(async () => dispatchCmdF(editable));
+
+    const finder = await screen.findByTestId("notebook-block-finder");
+    expect(finder).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("notebook-block-finder")).toBeNull();
+    });
+  });
+
+  // Long-running sentinel: confirm 100 rapid Cmd+F bursts do not stack listeners
+  // or leak finder instances. Catches the regression where capture-phase
+  // listeners accumulate on every prop change.
+  it("Scenario (sustained): 100 rapid Cmd+F bursts produce exactly one finder, no listener leak", async () => {
+    const onChangeSpy = vi.fn();
+    render(
+      <RichNotebookEditor
+        initialContent="<p>burst test</p>"
+        reportId="burst"
+        testId="rne-burst"
+        onChange={onChangeSpy}
+      />,
+    );
+
+    const editable = await waitFor(() => {
+      const el = document.querySelector('[data-testid="rne-burst"] [contenteditable="true"]');
+      if (!el) throw new Error("editor not mounted");
+      return el as HTMLElement;
+    });
+    editable.focus();
+
+    for (let i = 0; i < 100; i += 1) {
+      await act(async () => dispatchCmdF(editable));
+    }
+    await screen.findByTestId("notebook-block-finder");
+    // Exactly one finder is mounted regardless of how many times Cmd+F fires.
+    expect(screen.getAllByTestId("notebook-block-finder")).toHaveLength(1);
+  });
+});

--- a/src/features/notebook/components/RichNotebookEditor.tsx
+++ b/src/features/notebook/components/RichNotebookEditor.tsx
@@ -14,7 +14,7 @@
  * proposals[] or claims[] array. When those arrays are provided, they
  * are seeded into the editor document on first mount.
  */
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import {
@@ -35,6 +35,12 @@ import { NbClaim, type ClaimAttrs } from "../extensions/nbClaim";
 import { createSlashCommandExtension } from "../extensions/slashCommand";
 import { createSlashRenderer } from "../extensions/slashMenuRenderer";
 import "../styles/notebook.css";
+
+// Lazy-loaded so the finder bundle (~3KB) only ships when a caller passes a
+// reportId. Older callers (no reportId → no Cmd+F binding) pay nothing.
+const NotebookBlockFinder = lazy(() =>
+  import("./NotebookBlockFinder").then((m) => ({ default: m.NotebookBlockFinder })),
+);
 
 export type NotebookProposal = Omit<ProposalAttrs, "state"> & {
   state?: ProposalAttrs["state"];
@@ -65,6 +71,15 @@ type RichNotebookEditorProps = {
   saveDebounceMs?: number;
   /** Show the save-state indicator pill (default true). */
   showSaveState?: boolean;
+  /**
+   * Optional report id. When present:
+   *   - Cmd/Ctrl+F (while focus is inside this editor) opens the
+   *     NotebookBlockFinder, scoped to this reportId.
+   *   - The browser's native Find is preempted (`preventDefault`).
+   * When absent, Cmd+F is a no-op for this component (browser's native Find
+   * runs as usual).
+   */
+  reportId?: string;
 };
 
 type ToolbarButton = {
@@ -145,6 +160,7 @@ export function RichNotebookEditor({
   claims,
   saveDebounceMs = 900,
   showSaveState = true,
+  reportId,
 }: RichNotebookEditorProps) {
   const content = useMemo(
     () => buildSeedHtml(readStoredNotebook(storageKey, initialContent), proposals, claims),
@@ -157,6 +173,18 @@ export function RichNotebookEditor({
   const [saveState, setSaveState] = useState<"saved" | "saving">("saved");
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastAppendRequestIdRef = useRef<string | null>(null);
+  const rootRef = useRef<HTMLElement | null>(null);
+  const editorContainerRef = useRef<HTMLDivElement | null>(null);
+  const [finderOpen, setFinderOpen] = useState(false);
+  const closeFinder = useCallback(() => {
+    setFinderOpen(false);
+    // After closing, return focus to the editor host so the user can keep typing.
+    // ProseMirror's contenteditable is inside editorContainerRef.
+    const editable = editorContainerRef.current?.querySelector<HTMLElement>(
+      '[contenteditable="true"]',
+    );
+    editable?.focus();
+  }, []);
 
   const slashExtension = useMemo(
     () =>
@@ -202,6 +230,32 @@ export function RichNotebookEditor({
     lastAppendRequestIdRef.current = appendRequest.id;
     editor.chain().focus().insertContent(appendRequest.html).run();
   }, [appendRequest, editor]);
+
+  // Editor-scoped Cmd/Ctrl+F binding. Only fires when focus is inside the
+  // editor article (so the browser's native Find still works elsewhere on the
+  // page). No-op when `reportId` is undefined — older callers see no change.
+  useEffect(() => {
+    if (!reportId) return;
+    function onKeyDown(e: KeyboardEvent) {
+      // Cmd on macOS, Ctrl elsewhere — match the platform's Find shortcut.
+      const isCmdF =
+        (e.key === "f" || e.key === "F") && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey;
+      if (!isCmdF) return;
+      // Only intercept when focus is inside this editor. Browser-native Find
+      // continues to work everywhere else on the page.
+      const active = document.activeElement;
+      const host = rootRef.current;
+      if (!host || !active || !host.contains(active)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setFinderOpen(true);
+    }
+    // Keydown on document with focus guard — same as TipTap's own shortcut path.
+    // Capture phase so we beat the browser's native handler, which honors
+    // `preventDefault` only on the *first* listener to call it.
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [reportId]);
 
   const buttons: ToolbarButton[] = editor
     ? [
@@ -258,8 +312,9 @@ export function RichNotebookEditor({
 
   return (
     <article
+      ref={rootRef}
       className={cn(
-        "rounded-md border border-black/[0.08] bg-[#fffcf6] p-4 shadow-sm dark:border-white/[0.08] dark:bg-[#15130f]",
+        "relative rounded-md border border-black/[0.08] bg-[#fffcf6] p-4 shadow-sm dark:border-white/[0.08] dark:bg-[#15130f]",
         className,
       )}
     >
@@ -313,7 +368,7 @@ export function RichNotebookEditor({
           </div>
         ) : null}
       </div>
-      <div className="border-l-2 border-[#d97757] pl-5">
+      <div ref={editorContainerRef} className="border-l-2 border-[#d97757] pl-5">
         {editor ? (
           <EditorContent editor={editor} data-testid={testId} />
         ) : (
@@ -324,6 +379,15 @@ export function RichNotebookEditor({
         <div className="mt-4 border-t border-black/[0.05] pt-3 dark:border-white/[0.05]">
           {footer}
         </div>
+      ) : null}
+      {reportId && finderOpen ? (
+        <Suspense fallback={null}>
+          <NotebookBlockFinder
+            reportId={reportId}
+            containerRef={editorContainerRef}
+            onClose={closeFinder}
+          />
+        </Suspense>
       ) : null}
     </article>
   );

--- a/src/features/reports/views/ReportNotebookDetail.tsx
+++ b/src/features/reports/views/ReportNotebookDetail.tsx
@@ -817,6 +817,7 @@ export function ReportNotebookDetail() {
             className="min-h-[560px] p-5"
             onChange={onEditorChange}
             appendRequest={appendRequest}
+            reportId={reportId}
             footer={
               <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] uppercase tracking-[0.18em] text-gray-400">
                 <span>

--- a/src/lib/registry/viewRegistry.ts
+++ b/src/lib/registry/viewRegistry.ts
@@ -49,7 +49,8 @@ export type MainView =
   | "entity-compare"
   | "benchmark-comparison"
   | "role-lens-output"
-  | "homes-hub-session";
+  | "homes-hub-session"
+  | "event-corpus";
 
 export type ResearchTab = "overview" | "signals" | "briefing" | "deals" | "changes" | "changelog";
 
@@ -608,6 +609,31 @@ export const VIEW_REGISTRY: ViewRegistryEntry[] = [
     commandPaletteVisible: false,
   },
 
+  // ── Event Corpus Explorer ───────────────────────────────────────────────
+  // Dynamic route /events/:eventId — corpus of sources, mentions, and linked
+  // entities for a single event. The active rendering lives in App.tsx's
+  // top-level routing block; this entry exists so resolveViewFromPath +
+  // Cmd-K know the route is real (otherwise the cockpit resolver short-
+  // circuits to control-plane / "isUnknownRoute: true"). The cockpit-state
+  // resolver also extracts the eventId into `entityName` — same channel
+  // /entity/:slug uses.
+  {
+    id: "event-corpus",
+    title: "Event Corpus",
+    subtitle: "Sources, mentions, and linked entities for one event",
+    path: "/events",
+    component: lazyView(() =>
+      import("@/features/events/views/EventCorpusExplorer").then((m) => ({
+        default: m.EventCorpusExplorer,
+      })),
+    ),
+    dynamic: true,
+    group: "nested",
+    navVisible: false,
+    surfaceId: "packets",
+    commandPaletteVisible: false,
+  },
+
   // ── Entity Compare ──────────────────────────────────────────────────────
   {
     id: "entity-compare",
@@ -1081,6 +1107,16 @@ export function resolvePathToView(rawPathname: string): {
     const match = (rawPathname || "").match(/^\/report[\\/](.+)$/i);
     const reportId = match ? decodeURIComponent(match[1]) : null;
     return { view: "report-detail", entityName: reportId, spreadsheetId: null, researchTab: "overview", isUnknownRoute: false };
+  }
+
+  // /events/:eventId — event corpus explorer. Same channel as /entity/:slug:
+  // the slug rides in `entityName`. Without this branch, the generic
+  // candidates loop below would resolve "/events" via prefix match but drop
+  // the slug, leaving the cockpit unable to tell which event was requested.
+  if (pathname.startsWith("/events/")) {
+    const match = (rawPathname || "").match(/^\/events[\\/](.+)$/i);
+    const eventId = match ? decodeURIComponent(match[1]) : null;
+    return { view: "event-corpus", entityName: eventId, spreadsheetId: null, researchTab: "overview", isUnknownRoute: false };
   }
 
   // General matching: longest path wins. Never let "/" swallow all routes.


### PR DESCRIPTION
## Summary

Two redesign P1s from dogfood QA:

1. **Notebook Cmd+F doesn't fire** — \`RichNotebookEditor\` now accepts \`reportId?\` prop, capture-phase Cmd+F handler with focus guard opens \`NotebookBlockFinder\` overlay (new 185 LOC component). \`ReportNotebookDetail.tsx:820\` forwards \`reportId\`.
2. **\`/events/:eventId\` falls through to home** — New \`EventCorpusExplorer\` component, \`App.tsx\` regex match, \`viewRegistry.ts\` resolver branch lifts the slug into \`entityName\`.

## Verification

- \`npx tsc --noEmit --pretty false\` 0 errors
- \`npx vitest run src/features/notebook/ src/features/search/ src/features/events/ src/lib/registry/\` 56/56 passed (10 files)

## Test plan

- [ ] Focus notebook editor on \`/reports/:id/notebook\`, hit Cmd+F → finder opens with \`data-testid=\"notebook-block-finder\"\`
- [ ] Focus outside editor + Cmd+F → browser's native Find fires (surgical scope honored)
- [ ] Navigate to \`/events/test-id\` → \`EventCorpusExplorer\` mounts (not home)
- [ ] Missing slug → honest amber warning, not silent fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)