### PR TITLE
feat(cockpit-chat): @entity autocomplete in ExactComposer

### DIFF
--- a/src/features/designKit/exact/ExactComposer.entityMentions.test.tsx
+++ b/src/features/designKit/exact/ExactComposer.entityMentions.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * ExactComposer — scenario tests for the @entity autocomplete popup.
+ *
+ * Per .claude/rules/scenario_testing.md, every test starts from a real
+ * user persona, executes a realistic action sequence, and verifies system
+ * behavior including HONEST_STATUS error reporting and bounded results.
+ *
+ * Personas covered:
+ *
+ *   1. Banker disambiguating "Orbital" — types "@Or", picks the autocomplete
+ *      hit via mouse, confirms `@orbital-labs` is inserted at the caret.
+ *
+ *   2. Keyboard power user — arrow-key navigation through results, Enter
+ *      selects, Escape dismisses. Verifies aria-activedescendant follows
+ *      the active option (combobox a11y pattern).
+ *
+ *   3. Degraded backend — useFederatedSearch surfaces an error. The popup
+ *      must show "Entity lookup temporarily unavailable" (HONEST_STATUS),
+ *      not silently swallow the failure.
+ *
+ *   4. Empty result — server returns 0 hits for the prefix. The popup shows
+ *      "No matches" (not a blank rectangle that confuses users).
+ *
+ *   5. Email-like text — typing "foo@bar.com" must NOT open the popup, so
+ *      day-to-day chat text is not interrupted by spurious lookups.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { ExactComposer } from "./ExactComposer";
+import type { FederatedSearchResponse } from "@/layouts/chrome/commandPalette/types";
+
+/* -------------------------------------------------------------------------- */
+/* Mocks                                                                       */
+/* -------------------------------------------------------------------------- */
+
+// useFederatedSearch is the dependency we control. Mock at the module level
+// so the @entity hook resolves to controlled hits / errors / empty states.
+type MockResult = {
+  data: FederatedSearchResponse | null;
+  isLoading: boolean;
+  error: Error | null;
+};
+
+let mockResult: MockResult = { data: null, isLoading: false, error: null };
+
+vi.mock("@/layouts/chrome/commandPalette/useFederatedSearch", () => ({
+  useFederatedSearch: () => mockResult,
+}));
+
+function setEntityHits(
+  hits: Array<{ slug: string; title: string; source?: string; snippet?: string }>,
+  extra?: Partial<MockResult>,
+) {
+  mockResult = {
+    data: {
+      query: "Or",
+      collections: [
+        {
+          collection: "nb_entities",
+          ok: true,
+          count: hits.length,
+          results: hits.map((h) => ({
+            type: "nb_entities" as const,
+            uri: `entity://${h.slug}`,
+            title: h.title,
+            snippet: h.snippet ?? "",
+            source: h.source ?? "company",
+            score: 1,
+            actions: [],
+          })),
+        },
+      ],
+      total: hits.length,
+      timedOut: false,
+      partial: false,
+      identityScope: "anonymous",
+    },
+    isLoading: false,
+    error: null,
+    ...extra,
+  };
+}
+
+function setEntityError(message = "kaboom") {
+  mockResult = {
+    data: null,
+    isLoading: false,
+    error: new Error(message),
+  };
+}
+
+function setEntityEmpty() {
+  mockResult = {
+    data: {
+      query: "Xz",
+      collections: [
+        { collection: "nb_entities", ok: true, count: 0, results: [] },
+      ],
+      total: 0,
+      timedOut: false,
+      partial: false,
+      identityScope: "anonymous",
+    },
+    isLoading: false,
+    error: null,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Test harness                                                                */
+/* -------------------------------------------------------------------------- */
+
+function Harness(props: { initial?: string }) {
+  const [value, setValue] = useState(props.initial ?? "");
+  return (
+    <ExactComposer
+      value={value}
+      onValueChange={setValue}
+      onSubmit={() => {}}
+      placeholder="Ask anything"
+      ariaLabel="Chat composer"
+      inputTestId="composer-input"
+      enableEntityMentions
+    />
+  );
+}
+
+async function typeIntoComposer(user: ReturnType<typeof userEvent.setup>, text: string) {
+  const input = screen.getByTestId("composer-input") as HTMLTextAreaElement;
+  input.focus();
+  await user.type(input, text);
+  return input;
+}
+
+beforeEach(() => {
+  mockResult = { data: null, isLoading: false, error: null };
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/* -------------------------------------------------------------------------- */
+/* Scenarios                                                                   */
+/* -------------------------------------------------------------------------- */
+
+describe("ExactComposer @entity autocomplete", () => {
+  it("opens popup when typing @<prefix> at a whitespace boundary", async () => {
+    setEntityHits([
+      { slug: "orbital-labs", title: "Orbital Labs", source: "Company" },
+      { slug: "orion-energy", title: "Orion Energy", source: "Company" },
+    ]);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(<Harness />);
+    await typeIntoComposer(user, "@Or");
+    // Flush debounce (100 ms).
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.getByRole("listbox", { name: /entity suggestions/i })).toBeInTheDocument();
+    expect(screen.getByTestId("exact-composer-mention-option-orbital-labs")).toBeInTheDocument();
+    expect(screen.getByTestId("exact-composer-mention-option-orion-energy")).toBeInTheDocument();
+
+    const input = screen.getByTestId("composer-input");
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+  });
+
+  it("inserts @<slug> on click and emits onEntityMention", async () => {
+    setEntityHits([{ slug: "orbital-labs", title: "Orbital Labs", source: "Company" }]);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onMention = vi.fn();
+
+    function Wired() {
+      const [v, setV] = useState("");
+      return (
+        <ExactComposer
+          value={v}
+          onValueChange={setV}
+          onSubmit={() => {}}
+          placeholder="Ask"
+          ariaLabel="Chat composer"
+          inputTestId="composer-input"
+          enableEntityMentions
+          onEntityMention={onMention}
+        />
+      );
+    }
+    render(<Wired />);
+    await typeIntoComposer(user, "Hi @Or");
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+
+    const opt = await screen.findByTestId("exact-composer-mention-option-orbital-labs");
+    // Popup uses onMouseDown — fire that, not click, to match production path.
+    await user.pointer({ keys: "[MouseLeft>]", target: opt });
+    await user.pointer({ keys: "[/MouseLeft]", target: opt });
+
+    const input = screen.getByTestId("composer-input") as HTMLTextAreaElement;
+    expect(input.value).toContain("@orbital-labs");
+    expect(onMention).toHaveBeenCalledWith({ slug: "orbital-labs", title: "Orbital Labs" });
+  });
+
+  it("arrow-down moves aria-activedescendant; Enter selects", async () => {
+    setEntityHits([
+      { slug: "orbital-labs", title: "Orbital Labs" },
+      { slug: "orion-energy", title: "Orion Energy" },
+    ]);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Harness />);
+
+    const input = (await typeIntoComposer(user, "@Or")) as HTMLTextAreaElement;
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-0$/);
+
+    await user.keyboard("{ArrowDown}");
+    expect(input.getAttribute("aria-activedescendant")).toMatch(/-1$/);
+
+    await user.keyboard("{Enter}");
+    expect(input.value).toContain("@orion-energy");
+  });
+
+  it("Escape closes the popup without inserting", async () => {
+    setEntityHits([{ slug: "orbital-labs", title: "Orbital Labs" }]);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Harness />);
+
+    await typeIntoComposer(user, "@Or");
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(screen.queryByRole("listbox")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    const input = screen.getByTestId("composer-input") as HTMLTextAreaElement;
+    expect(input.value).toBe("@Or");
+    expect(input.value).not.toContain("orbital-labs");
+  });
+
+  it("surfaces honest error when useEntitySuggest reports a failure", async () => {
+    setEntityError("backend_down");
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Harness />);
+
+    await typeIntoComposer(user, "@An");
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.getByTestId("exact-composer-mention-error")).toHaveTextContent(
+      /entity lookup temporarily unavailable/i,
+    );
+  });
+
+  it("renders 'No matches' empty state when server returns 0 hits", async () => {
+    setEntityEmpty();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Harness />);
+
+    await typeIntoComposer(user, "@Xz");
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.getByTestId("exact-composer-mention-empty")).toHaveTextContent(/no matches/i);
+  });
+
+  it("does NOT open the popup for inline email-like text (foo@bar)", async () => {
+    setEntityHits([{ slug: "orbital-labs", title: "Orbital Labs" }]);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<Harness />);
+
+    await typeIntoComposer(user, "email me at foo@bar");
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.queryByRole("listbox", { name: /entity suggestions/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/designKit/exact/ExactComposer.tsx
+++ b/src/features/designKit/exact/ExactComposer.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { ChevronRight, Loader2, Plus, X } from "lucide-react";
+import { useEntitySuggest, type EntitySuggestHit } from "./useEntitySuggest";
 
 export type ExactComposerPin = {
   kind: string;
@@ -61,7 +62,22 @@ type ExactComposerProps = {
   footerMeta?: string;
   suggestions?: string[];
   onSuggestion?: (suggestion: string) => void;
+  /**
+   * Enable @entity autocomplete popup. When true, typing `@<prefix>` after a
+   * whitespace boundary fires a debounced entity lookup and renders a popup
+   * (combobox pattern). On select, the literal `@${slug}` token is inserted
+   * at the caret position.
+   *
+   * Defaults to false — existing call sites stay unchanged. Cockpit chat
+   * (`?surface=chat`) sets this to true so bankers can disambiguate
+   * "@Orbital" → "@orbital-labs".
+   */
+  enableEntityMentions?: boolean;
+  /** Optional callback fired when the user picks an entity. */
+  onEntityMention?: (hit: { slug: string; title: string }) => void;
 };
+
+const MENTION_DEBOUNCE_MS = 100;
 
 export function ExactComposer({
   as = "div",
@@ -100,6 +116,8 @@ export function ExactComposer({
   footerMeta,
   suggestions = [],
   onSuggestion,
+  enableEntityMentions = false,
+  onEntityMention,
 }: ExactComposerProps) {
   const disabledSubmit = Boolean(submitDisabled || submitting || disabled);
   const hasModelSelect = Boolean(modelOptions?.length && modelValue && onModelValueChange);
@@ -108,6 +126,252 @@ export function ExactComposer({
     if (disabledSubmit) return;
     onSubmit();
   };
+
+  // -- @entity mention state -------------------------------------------------
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const popupId = useId();
+  const optionIdPrefix = `${popupId}-opt`;
+  // `mentionPrefix` is the text typed after the trailing `@` at the caret.
+  // It is debounced before being passed to useEntitySuggest so we do not
+  // hammer the federated-search action on every keystroke (100 ms window
+  // — short enough to feel live, long enough to dedup bursts).
+  const [mentionPrefix, setMentionPrefix] = useState("");
+  const [debouncedPrefix, setDebouncedPrefix] = useState("");
+  const [mentionOpen, setMentionOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [mentionAtIndex, setMentionAtIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!enableEntityMentions || !mentionOpen) {
+      setDebouncedPrefix("");
+      return;
+    }
+    const handle = setTimeout(() => {
+      setDebouncedPrefix(mentionPrefix);
+    }, MENTION_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [mentionPrefix, mentionOpen, enableEntityMentions]);
+
+  const { hits, isLoading: hitsLoading, error: hitsError } = useEntitySuggest({
+    prefix: enableEntityMentions && mentionOpen ? debouncedPrefix : "",
+    collection: "nb_entities",
+    limit: 8,
+  });
+
+  // Detect `@<prefix>` at the caret. Only opens when the `@` follows a
+  // whitespace boundary or is the first character, so email-looking text
+  // like "foo@bar.com" does NOT trigger the popup.
+  const detectMention = useCallback(
+    (text: string, caret: number) => {
+      if (!enableEntityMentions) return;
+      const before = text.slice(0, caret);
+      const match = before.match(/(?:^|\s)@([\w-]*)$/);
+      if (match) {
+        const atIdx = caret - match[1].length - 1;
+        setMentionAtIndex(atIdx);
+        setMentionPrefix(match[1]);
+        setMentionOpen(true);
+        setActiveIndex(0);
+      } else {
+        setMentionOpen(false);
+        setMentionAtIndex(null);
+      }
+    },
+    [enableEntityMentions],
+  );
+
+  const closeMention = useCallback(() => {
+    setMentionOpen(false);
+    setMentionAtIndex(null);
+    setMentionPrefix("");
+  }, []);
+
+  const insertMention = useCallback(
+    (hit: EntitySuggestHit) => {
+      const ta = textareaRef.current;
+      const caret = ta?.selectionStart ?? value.length;
+      const atIdx = mentionAtIndex ?? value.slice(0, caret).lastIndexOf("@");
+      if (atIdx < 0) {
+        closeMention();
+        return;
+      }
+      const before = value.slice(0, atIdx);
+      const after = value.slice(caret);
+      const token = `@${hit.slug}`;
+      const next = `${before}${token} ${after}`;
+      onValueChange(next);
+      onEntityMention?.({ slug: hit.slug, title: hit.title });
+      closeMention();
+      // Restore caret after React applies the new value. requestAnimationFrame
+      // keeps this off the synchronous render path.
+      requestAnimationFrame(() => {
+        const ta2 = textareaRef.current;
+        if (!ta2) return;
+        const pos = before.length + token.length + 1;
+        ta2.focus();
+        try {
+          ta2.setSelectionRange(pos, pos);
+        } catch {
+          // ignore — some browsers throw when the element is detached
+        }
+      });
+    },
+    [value, mentionAtIndex, onValueChange, onEntityMention, closeMention],
+  );
+
+  // Clamp the active index whenever the result set shrinks (e.g. user types
+  // a more-specific prefix). DETERMINISTIC: never points past the array.
+  useEffect(() => {
+    if (activeIndex >= hits.length && hits.length > 0) {
+      setActiveIndex(hits.length - 1);
+    } else if (hits.length === 0 && activeIndex !== 0) {
+      setActiveIndex(0);
+    }
+  }, [hits.length, activeIndex]);
+
+  const popupOpen = enableEntityMentions && mentionOpen;
+  const showError = popupOpen && Boolean(hitsError);
+  const showEmpty = popupOpen && !hitsLoading && !hitsError && hits.length === 0 && debouncedPrefix.length > 0;
+  const activeOptionId = popupOpen && hits.length > 0 ? `${optionIdPrefix}-${activeIndex}` : undefined;
+
+  const handleTextareaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const next = event.target.value;
+    onValueChange(next);
+    if (enableEntityMentions) {
+      detectMention(next, event.target.selectionStart ?? next.length);
+    }
+  };
+
+  const handleTextareaKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (popupOpen && hits.length > 0) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((idx) => (idx + 1) % hits.length);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((idx) => (idx - 1 + hits.length) % hits.length);
+        return;
+      }
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        insertMention(hits[activeIndex]);
+        return;
+      }
+      if (event.key === "Tab") {
+        event.preventDefault();
+        insertMention(hits[activeIndex]);
+        return;
+      }
+    }
+    if (popupOpen && event.key === "Escape") {
+      event.preventDefault();
+      closeMention();
+      return;
+    }
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const popup = useMemo(() => {
+    if (!popupOpen) return null;
+    return (
+      <div
+        id={popupId}
+        role="listbox"
+        aria-label="Entity suggestions"
+        data-exact-composer-mention-popup="true"
+        className="nb-composer-mention-popup"
+        style={{
+          position: "absolute",
+          left: 8,
+          right: 8,
+          bottom: "100%",
+          marginBottom: 4,
+          zIndex: 50,
+          maxHeight: 240,
+          overflowY: "auto",
+          borderRadius: 8,
+          border: "1px solid var(--nb-edge, rgba(255,255,255,0.08))",
+          background: "var(--nb-surface, rgba(20,20,19,0.96))",
+          backdropFilter: "blur(8px)",
+          boxShadow: "0 8px 24px rgba(0,0,0,0.32)",
+        }}
+      >
+        {showError ? (
+          <div
+            role="status"
+            aria-live="polite"
+            data-testid="exact-composer-mention-error"
+            style={{ padding: "8px 12px", fontSize: 12, color: "#f0a070" }}
+          >
+            Entity lookup temporarily unavailable
+          </div>
+        ) : hitsLoading && hits.length === 0 ? (
+          <div
+            role="status"
+            aria-live="polite"
+            style={{ padding: "8px 12px", fontSize: 12, opacity: 0.7 }}
+          >
+            Searching...
+          </div>
+        ) : showEmpty ? (
+          <div
+            role="status"
+            aria-live="polite"
+            data-testid="exact-composer-mention-empty"
+            style={{ padding: "8px 12px", fontSize: 12, opacity: 0.7 }}
+          >
+            No matches
+          </div>
+        ) : (
+          hits.map((hit, idx) => {
+            const active = idx === activeIndex;
+            return (
+              <button
+                type="button"
+                key={hit.slug}
+                id={`${optionIdPrefix}-${idx}`}
+                role="option"
+                aria-selected={active}
+                data-testid={`exact-composer-mention-option-${hit.slug}`}
+                onMouseDown={(e) => {
+                  // Use onMouseDown so the click fires before the textarea
+                  // blur handler can close the popup.
+                  e.preventDefault();
+                  insertMention(hit);
+                }}
+                onMouseEnter={() => setActiveIndex(idx)}
+                style={{
+                  display: "flex",
+                  width: "100%",
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                  gap: 2,
+                  padding: "6px 12px",
+                  fontSize: 12,
+                  textAlign: "left",
+                  background: active ? "rgba(217,119,87,0.14)" : "transparent",
+                  color: "inherit",
+                  border: "none",
+                  cursor: "pointer",
+                }}
+              >
+                <span style={{ fontWeight: 500 }}>{hit.title}</span>
+                <span style={{ opacity: 0.65, fontSize: 11 }}>
+                  @{hit.slug}
+                  {hit.subtitle ? ` - ${hit.subtitle}` : ""}
+                </span>
+              </button>
+            );
+          })
+        )}
+      </div>
+    );
+  }, [popupOpen, popupId, optionIdPrefix, hits, activeIndex, hitsLoading, showError, showEmpty, insertMention]);
   const cardContents = (
     <>
       {(pins.length > 0 || onAddPin) ? (
@@ -158,22 +422,34 @@ export function ExactComposer({
           ) : null}
         </div>
       ) : null}
-      <textarea
-        data-testid={inputTestId}
-        className={`nb-composer-input${inputClassName ? ` ${inputClassName}` : ""}`}
-        value={value}
-        onChange={(event) => onValueChange(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" && !event.shiftKey) {
-            event.preventDefault();
-            handleSubmit();
-          }
-        }}
-        placeholder={placeholder}
-        aria-label={ariaLabel}
-        disabled={disabled}
-        maxLength={maxLength}
-      />
+      <div style={{ position: "relative" }}>
+        {popup}
+        <textarea
+          ref={textareaRef}
+          data-testid={inputTestId}
+          className={`nb-composer-input${inputClassName ? ` ${inputClassName}` : ""}`}
+          value={value}
+          onChange={handleTextareaChange}
+          onKeyDown={handleTextareaKeyDown}
+          onBlur={() => {
+            // Delay close so a popup click (mousedown) can take effect first.
+            setTimeout(() => closeMention(), 120);
+          }}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          disabled={disabled}
+          maxLength={maxLength}
+          {...(enableEntityMentions
+            ? {
+                role: "combobox",
+                "aria-autocomplete": "list" as const,
+                "aria-expanded": popupOpen,
+                "aria-controls": popupOpen ? popupId : undefined,
+                "aria-activedescendant": activeOptionId,
+              }
+            : {})}
+        />
+      </div>
       {options}
       <div className="nb-composer-footer">
         <div className="nb-composer-tools">

--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -2853,8 +2853,9 @@ export function ExactChatSurface() {
                 value={composer}
                 onValueChange={setComposer}
                 onSubmit={() => sendTurn(composer)}
-                placeholder="Ask, capture, paste, upload, or record..."
+                placeholder="Ask, capture, paste, upload, or record... (@ to mention an entity)"
                 ariaLabel="Chat composer"
+                enableEntityMentions
                 pins={pins.map((pin) => ({ ...pin, removable: true }))}
                 onRemovePin={(index) => setPins((prev) => prev.filter((_, idx) => idx !== index))}
                 addPinLabel="Add context"

--- a/src/features/designKit/exact/useEntitySuggest.ts
+++ b/src/features/designKit/exact/useEntitySuggest.ts
@@ -1,0 +1,106 @@
+/**
+ * useEntitySuggest — focused @mention autocomplete for entity slugs.
+ *
+ * Wraps the existing `useFederatedSearch` hook
+ * (src/layouts/chrome/commandPalette/useFederatedSearch.ts) and surfaces
+ * only the `nb_entities` collection. Used by `ExactComposer` to power
+ * @mention autocomplete in the cockpit chat surface.
+ *
+ * Pattern: thin adapter over the federated-search action. Inherits the
+ * underlying hook's debounce, abort, and stale-request semantics, so this
+ * file stays small and the reliability invariants stay in one place.
+ *
+ * Prior art:
+ *   - useFederatedSearch (this repo) — debounced reactive consumer
+ *   - GitHub / Notion @mention popups — combobox + slug emit
+ *
+ * Reliability invariants (.claude/rules/agentic_reliability.md):
+ *   - HONEST_STATUS: surfaces { error } from underlying action — never
+ *     silently renders an empty popup on transient failure.
+ *   - BOUND: caller clamps `limit` (default 8). Server caps at 25.
+ *   - DETERMINISTIC: same prefix + same data → same shape (server-side).
+ *
+ * Returns:
+ *   - hits: EntitySuggestHit[]   — slug-shaped results ready for insertion
+ *   - isLoading: boolean         — true while a request is in flight
+ *   - error: Error | null        — set when the latest request failed
+ *
+ * Empty / whitespace prefix short-circuits to { hits: [], isLoading: false }.
+ *
+ * See: src/features/designKit/exact/ExactComposer.tsx (consumer)
+ */
+
+import { useMemo } from "react";
+import { useFederatedSearch } from "@/layouts/chrome/commandPalette/useFederatedSearch";
+import type { FederatedHandle } from "@/layouts/chrome/commandPalette/types";
+
+export interface EntitySuggestHit {
+  /** Stable slug, e.g. "orbital-labs". Used as the @ token in composer text. */
+  slug: string;
+  /** Display title shown as the primary line in the popup. */
+  title: string;
+  /** Optional subtitle (entityType or snippet). Empty string when absent. */
+  subtitle: string;
+}
+
+export interface UseEntitySuggestArgs {
+  /** Substring after the trailing `@` in the composer. Empty disables. */
+  prefix: string;
+  /** Target collection — caller pins to "nb_entities" for entity mentions. */
+  collection: "nb_entities";
+  /** Max popup rows. Defaults to 8 (BOUND). */
+  limit?: number;
+}
+
+export interface UseEntitySuggestResult {
+  hits: EntitySuggestHit[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Parse an entity URI ("entity://orbital-labs") into a slug. Returns the
+ * empty string when the URI shape is unexpected — callers treat empty
+ * slugs as not-insertable and skip them.
+ */
+function slugFromUri(uri: string): string {
+  const prefix = "entity://";
+  if (!uri.startsWith(prefix)) return "";
+  return uri.slice(prefix.length).trim();
+}
+
+export function useEntitySuggest({
+  prefix,
+  collection,
+  limit = 8,
+}: UseEntitySuggestArgs): UseEntitySuggestResult {
+  // Reuse the federated-search hook end-to-end. It already debounces,
+  // aborts stale in-flight requests, and surfaces errors honestly.
+  const { data, isLoading, error } = useFederatedSearch(prefix);
+
+  const hits = useMemo<EntitySuggestHit[]>(() => {
+    if (!data) return [];
+    const target = data.collections.find((c) => c.collection === collection);
+    if (!target || !target.ok) return [];
+    const rows: FederatedHandle[] = target.results ?? [];
+    const seen = new Set<string>();
+    const shaped: EntitySuggestHit[] = [];
+    for (const row of rows) {
+      const slug = slugFromUri(row.uri);
+      if (!slug) continue;
+      if (seen.has(slug)) continue;
+      seen.add(slug);
+      shaped.push({
+        slug,
+        title: row.title || slug,
+        subtitle: row.source || row.snippet || "",
+      });
+      if (shaped.length >= limit) break;
+    }
+    return shaped;
+  }, [data, collection, limit]);
+
+  return { hits, isLoading, error };
+}
+
+export default useEntitySuggest;


### PR DESCRIPTION
## Summary

Closes the cockpit-chat @entity autocomplete gap from prior dogfood QA. FastAgentPanel already had it; ExactComposer (the surface=chat composer) didn't.

## Analyst note
The prior session's audit claimed \"PR3 added \`useSuggest({ collection: \\\"nb_entities\\\" })\` and \`useTypesenseSearch\`\" — those don't exist on main. What DOES exist is the Convex \`federatedSearch\` action (#310) + \`useFederatedSearch\` hook (#313). Built \`useEntitySuggest\` as a thin adapter over that.

## Changes

- New \`src/features/designKit/exact/useEntitySuggest.ts\` adapter
- \`ExactComposer.tsx\`: \`enableEntityMentions\` + \`onEntityMention\` props, mention state hooks, popup with full combobox a11y (\`role=listbox\` / \`role=option\` / \`aria-activedescendant\`), 100ms debounce, whitespace-anchored \`@<prefix>\` regex
- \`ExactKit.tsx:2856-2858\` flips the flag for the cockpit chat composer
- 7 scenario tests (mouse pick, ArrowDown+Enter, Escape, backend error, empty results, email-guard, slug insertion)

## Verification

- \`npx tsc --noEmit --pretty false\` 0 errors
- \`npx vitest run src/features/designKit/\` 7/7 passed

## Test plan

- [ ] Type \`@Or\` in cockpit chat → popup shows real entity hits scoped to ownerKey
- [ ] Arrow keys + Enter pick → token becomes \`@orbital-labs\`
- [ ] Convex 502 → \"Entity lookup temporarily unavailable\" inline (HONEST_STATUS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)