### PR TITLE
fix(home): kill duplicate 'Every chat makes the next one faster' H2

### DIFF
--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -625,8 +625,8 @@ function NBPulseStrip({ liveEntities }: { liveEntities?: Array<any> | null }) {
     <section className="nb-pulse" data-layout="card-grid" data-scale="big" data-testid="exact-home-pulse-strip">
       <header className="nb-pulse-head">
         <div>
-          <div className="nb-kicker">Memory pulse</div>
-          <h2 className="nb-pulse-title">Every chat makes the next one faster.</h2>
+          <div className="nb-kicker">Today's signals</div>
+          <h2 className="nb-pulse-title">What changed across your watched entities.</h2>
           <p className="nb-pulse-sub">Public context compounds. Private notes stay private.</p>
         </div>
         <span className="nb-pulse-priv" title="Private notes never leak into public counters.">


### PR DESCRIPTION
## Summary

\`NBPulseStrip\` in \`ExactKit.tsx:629\` and \`MemoryPulse.tsx:54\` were both rendering the identical eyebrow + H2 on desktop Home — DOM had two back-to-back \"Memory pulse / Every chat makes the next one faster\" blocks. P2 from the dogfood scorecard (5 H1/H2/H3 listing).

\`MemoryPulse\` is the newer fully-styled component (PR3) and owns that copy. Differentiated the legacy strip:

- Kicker: \"Memory pulse\" → \"Today's signals\"
- H2: \"Every chat makes the next one faster.\" → \"What changed across your watched entities.\"

## Verification

2-line diff. No tests changed. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)