### PR TITLE
fix(cockpit): add event-corpus to intel mode

### DIFF
--- a/src/layouts/cockpitModes.ts
+++ b/src/layouts/cockpitModes.ts
@@ -48,6 +48,7 @@ export const MODES: ModeConfig[] = [
       "watchlists",
       "entity",
       "entity-pulse",
+      "event-corpus",
       "report-detail",
       "report-detail-workspace",
       "role-lens-output",


### PR DESCRIPTION
PR #321 registered the `event-corpus` view in viewRegistry but didn't add it to any cockpit MODE. `useCockpitMode.test.tsx` asserts every registered view maps to exactly one mode — the absence caused a pre-existing test failure on main. event-corpus is a research surface, slotting it into the intel mode.

1-line addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)