### PR TITLE
perf(agents): Anthropic prompt caching on reasoning adapter (system + tool catalog)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as crons_sloCalculation from "../crons/sloCalculation.js";
 import type * as dataAudit from "../dataAudit.js";
 import type * as debugEnv from "../debugEnv.js";
 import type * as domains_agents_adapters_anthropic_anthropicReasoningAdapter from "../domains/agents/adapters/anthropic/anthropicReasoningAdapter.js";
+import type * as domains_agents_adapters_anthropic_promptCacheHelpers from "../domains/agents/adapters/anthropic/promptCacheHelpers.js";
 import type * as domains_agents_adapters_convex_convexAgentAdapter from "../domains/agents/adapters/convex/convexAgentAdapter.js";
 import type * as domains_agents_adapters_google_googleInteractionsAdapter from "../domains/agents/adapters/google/googleInteractionsAdapter.js";
 import type * as domains_agents_adapters_handoffBridge from "../domains/agents/adapters/handoffBridge.js";
@@ -1530,6 +1531,7 @@ declare const fullApi: ApiFromModules<{
   dataAudit: typeof dataAudit;
   debugEnv: typeof debugEnv;
   "domains/agents/adapters/anthropic/anthropicReasoningAdapter": typeof domains_agents_adapters_anthropic_anthropicReasoningAdapter;
+  "domains/agents/adapters/anthropic/promptCacheHelpers": typeof domains_agents_adapters_anthropic_promptCacheHelpers;
   "domains/agents/adapters/convex/convexAgentAdapter": typeof domains_agents_adapters_convex_convexAgentAdapter;
   "domains/agents/adapters/google/googleInteractionsAdapter": typeof domains_agents_adapters_google_googleInteractionsAdapter;
   "domains/agents/adapters/handoffBridge": typeof domains_agents_adapters_handoffBridge;

--- a/convex/domains/agents/adapters/anthropic/anthropicReasoningAdapter.ts
+++ b/convex/domains/agents/adapters/anthropic/anthropicReasoningAdapter.ts
@@ -22,6 +22,12 @@ import type {
   SDKConfig,
 } from "../types";
 import { DEFAULT_SDK_CONFIG } from "../types";
+import {
+  buildCachedSystem,
+  buildCachedTools,
+  extractCacheStats,
+  type AnthropicCacheStats,
+} from "./promptCacheHelpers";
 
 function resolveAnthropicSdkModelId(model: string): string {
   const approved = resolveModelAlias(model);
@@ -130,10 +136,14 @@ export function createAnthropicReasoningAdapter(
           messages,
         };
 
-        // Add system prompt if provided
-        if (systemPrompt) {
-          requestParams.system = systemPrompt;
-        }
+        // Add system prompt — wrap in cache_control when above the 1024-token
+        // floor so prefix-stable sub-agent runs (DeepReasoning, CodeAnalysis,
+        // any custom adapter with the same role) hit the cache on subsequent
+        // calls within the 5-min ephemeral window.  Below the floor the helper
+        // returns the plain string so we don't waste request bytes on a
+        // marker the API would silently drop.
+        const cachedSystem = buildCachedSystem(systemPrompt);
+        let systemCacheAttached = cachedSystem.attached;
 
         // Add extended thinking if enabled
         if (thinking.enabled) {
@@ -143,13 +153,21 @@ export function createAnthropicReasoningAdapter(
           };
         }
 
-        // Add tools if provided
+        // Add tools — same gating logic.  Tools are typically the largest
+        // stable block (10+ tools × full JSON schema = thousands of tokens),
+        // so caching them is the highest-leverage move on any agent that
+        // uses runWithTools or repeated single-turn `execute()` calls.
+        let toolsCacheAttached = false;
+        let preparedTools: Array<Anthropic.Tool> | undefined;
         if (tools.length > 0) {
-          requestParams.tools = tools.map((t) => ({
+          const rawTools = tools.map((t) => ({
             name: t.name,
             description: t.description,
             input_schema: zodToJsonSchema(t.inputSchema),
           }));
+          const cachedTools = buildCachedTools(rawTools);
+          toolsCacheAttached = cachedTools.attached;
+          preparedTools = cachedTools.tools as Anthropic.Tool[] | undefined;
         }
 
         // Execute the request - build non-streaming params properly
@@ -159,14 +177,27 @@ export function createAnthropicReasoningAdapter(
           messages: requestParams.messages as Anthropic.MessageParam[],
         };
 
-        if (requestParams.system) {
-          nonStreamingParams.system = requestParams.system as string;
+        if (cachedSystem.system !== undefined) {
+          // SDK accepts both `string` and `TextBlockParam[]`; the cast covers
+          // the structured-blocks branch produced when caching is attached.
+          nonStreamingParams.system =
+            cachedSystem.system as Anthropic.MessageCreateParamsNonStreaming["system"];
         }
-        if (requestParams.tools) {
-          nonStreamingParams.tools = requestParams.tools as Anthropic.Tool[];
+        if (preparedTools) {
+          nonStreamingParams.tools = preparedTools;
         }
 
         const response = await anthropic.messages.create(nonStreamingParams);
+
+        // HONEST_SCORES — record real cache stats from the API response.  No
+        // fabricated floors: if the marker was dropped (e.g. the prompt
+        // estimator was too generous) the stats will show
+        // cacheControlAttached=true with cacheReadInputTokens=0 on first
+        // call, which is exactly the signal the operator dashboard needs.
+        const cacheStats: AnthropicCacheStats = extractCacheStats(
+          response.usage,
+          systemCacheAttached || toolsCacheAttached,
+        );
 
         // Parse response blocks
         let thinkingContent = "";
@@ -196,6 +227,20 @@ export function createAnthropicReasoningAdapter(
           tokenUsage: {
             input: response.usage.input_tokens,
             output: response.usage.output_tokens,
+            // HONEST_SCORES — only emit `cache` when we actually attempted
+            // caching.  Downstream consumers can treat absence as "feature
+            // off" and presence with read=0 as "first call, expect hits next".
+            ...(cacheStats.cacheControlAttached
+              ? {
+                  cache: {
+                    cacheControlAttached: cacheStats.cacheControlAttached,
+                    cacheCreationInputTokens:
+                      cacheStats.cacheCreationInputTokens,
+                    cacheReadInputTokens: cacheStats.cacheReadInputTokens,
+                    cacheHitRate: cacheStats.cacheHitRate,
+                  },
+                }
+              : {}),
           },
         };
       } catch (error) {
@@ -288,16 +333,27 @@ export async function runWithTools(config: {
   const currentMessages: Anthropic.MessageParam[] = [{ role: "user", content: query }];
   let iteration = 0;
 
+  // Build the tools array ONCE outside the loop and attach a cache_control
+  // marker to the last tool when the catalog clears the 1024-token floor.
+  // Inside a tool-loop the catalog is byte-identical across every iteration,
+  // so the second iteration onward gets a cache hit on the entire schema
+  // block (~90% discount on tool tokens).  This is the highest-leverage
+  // single change in the file — multi-iteration tool loops were paying full
+  // price for the same schema 5–10× per agent run.
+  const rawTools = tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: zodToJsonSchema(t.inputSchema),
+  }));
+  const cachedTools = buildCachedTools(rawTools);
+  const preparedTools = (cachedTools.tools as Anthropic.Tool[] | undefined) ?? [];
+
   while (iteration < maxIterations) {
     const response = await anthropic.messages.create({
       model,
       max_tokens: maxTokens,
       messages: currentMessages,
-      tools: tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        input_schema: zodToJsonSchema(t.inputSchema),
-      })),
+      tools: preparedTools,
     });
 
     // Check for tool use

--- a/convex/domains/agents/adapters/anthropic/promptCacheHelpers.test.ts
+++ b/convex/domains/agents/adapters/anthropic/promptCacheHelpers.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Scenario-based tests for Anthropic prompt-cache helpers.
+ *
+ * Per .claude/rules/scenario_testing.md every test must declare:
+ *   Who (persona) · What (goal) · How (action) · Scale · Duration · Failure
+ *
+ * Personas exercised here:
+ *   - "DeepReasoning sub-agent run" — single-turn execute() with a small
+ *     system prompt (below cache floor — must NOT attach a marker).
+ *   - "CodeAnalysis sub-agent run" — single-turn execute() with a long
+ *     system prompt (above cache floor — must attach a marker on system).
+ *   - "MultiToolAgent runWithTools loop" — 5-iteration loop with a 12-tool
+ *     catalog (above cache floor — marker must land on the LAST tool, no
+ *     mutation of the input array).
+ *   - "Agent with no tools" — catalog is empty, tools cache MUST stay off.
+ *   - "Agent with 1 tiny tool" — catalog far below floor, tools cache MUST
+ *     stay off (no wasted bytes on a no-op marker).
+ *   - "Operator dashboard" — extractCacheStats produces honest stats whether
+ *     the API returns the cache fields, returns nulls, or omits them.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ANTHROPIC_CACHE_MIN_TOKENS,
+  buildCachedSystem,
+  buildCachedTools,
+  estimateTokens,
+  extractCacheStats,
+} from "./promptCacheHelpers";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers — produce realistic-shaped test inputs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Synthesize a system prompt of approximately `targetTokens` tokens. */
+function makeSystemPrompt(targetTokens: number): string {
+  // ~4 chars per token is what the helper assumes; produce slightly more so
+  // the estimator sees us above the floor.
+  const chars = targetTokens * 4 + 8;
+  return "S".repeat(chars);
+}
+
+/** Synthesize N tools each with a chunky JSON schema description. */
+function makeTools(count: number, descriptionTokens = 100) {
+  const desc = "D".repeat(descriptionTokens * 4);
+  return Array.from({ length: count }, (_, i) => ({
+    name: `tool_${i}`,
+    description: desc,
+    input_schema: { type: "object", properties: { x: { type: "string" } } },
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("estimateTokens", () => {
+  it("returns 0 for empty string (defensive — avoids NaN downstream)", () => {
+    expect(estimateTokens("")).toBe(0);
+    expect(estimateTokens(undefined as unknown as string)).toBe(0);
+  });
+
+  it("rounds up so a 1-char string still costs 1 token (caller never undercounts)", () => {
+    expect(estimateTokens("x")).toBe(1);
+    expect(estimateTokens("xxxx")).toBe(1);
+    expect(estimateTokens("xxxxx")).toBe(2);
+  });
+});
+
+describe("buildCachedSystem — small prompt persona (DeepReasoning sub-agent)", () => {
+  it("returns the original string when systemPrompt is below the 1024-token floor", () => {
+    const small = "You are a helpful assistant.";
+    const result = buildCachedSystem(small);
+    expect(result.attached).toBe(false);
+    expect(result.system).toBe(small);
+  });
+
+  it("returns undefined and attached=false when systemPrompt is undefined", () => {
+    const result = buildCachedSystem(undefined);
+    expect(result.attached).toBe(false);
+    expect(result.system).toBeUndefined();
+  });
+
+  it("does NOT attach a marker just below the floor (estimator must gate before the API)", () => {
+    // Build a prompt the estimator will see strictly below the floor by
+    // requesting (floor - 100) tokens worth of chars. The +8 pad in
+    // makeSystemPrompt is below the per-token rounding noise here.
+    const justBelow = makeSystemPrompt(ANTHROPIC_CACHE_MIN_TOKENS - 100);
+    const result = buildCachedSystem(justBelow);
+    expect(result.attached).toBe(false);
+    expect(typeof result.system).toBe("string");
+  });
+});
+
+describe("buildCachedSystem — large prompt persona (CodeAnalysis sub-agent)", () => {
+  it("attaches cache_control on a system prompt above the floor", () => {
+    const large = makeSystemPrompt(ANTHROPIC_CACHE_MIN_TOKENS + 100);
+    const result = buildCachedSystem(large);
+    expect(result.attached).toBe(true);
+    expect(Array.isArray(result.system)).toBe(true);
+    if (Array.isArray(result.system)) {
+      expect(result.system).toHaveLength(1);
+      expect(result.system[0].type).toBe("text");
+      expect(result.system[0].text).toBe(large);
+      expect(result.system[0].cache_control).toEqual({ type: "ephemeral" });
+    }
+  });
+});
+
+describe("buildCachedTools — empty / tiny catalog persona (no-op cases)", () => {
+  it("returns an empty array unchanged when no tools are provided", () => {
+    const result = buildCachedTools([]);
+    expect(result.attached).toBe(false);
+    expect(result.tools).toEqual([]);
+  });
+
+  it("returns undefined unchanged when tools is undefined", () => {
+    const result = buildCachedTools(undefined);
+    expect(result.attached).toBe(false);
+    expect(result.tools).toBeUndefined();
+  });
+
+  it("does NOT attach a marker on a single tiny tool (would be a wasted no-op)", () => {
+    const tools = [
+      {
+        name: "ping",
+        description: "tiny",
+        input_schema: { type: "object" },
+      },
+    ];
+    const result = buildCachedTools(tools);
+    expect(result.attached).toBe(false);
+    // Returned array should be the same reference (no copy when not caching)
+    expect(result.tools).toBe(tools);
+    expect(result.tools?.[0]).not.toHaveProperty("cache_control");
+  });
+});
+
+describe("buildCachedTools — large catalog persona (MultiToolAgent)", () => {
+  it("attaches cache_control to the LAST tool only when the catalog is large", () => {
+    const tools = makeTools(12, 100); // 12 tools × ~100 token desc each = ~1200 tokens
+    const result = buildCachedTools(tools);
+    expect(result.attached).toBe(true);
+    expect(result.tools).toHaveLength(12);
+    // First N-1 tools must NOT carry the marker.
+    for (let i = 0; i < 11; i++) {
+      expect(result.tools?.[i]).not.toHaveProperty("cache_control");
+    }
+    // The last tool MUST carry it.
+    expect(result.tools?.[11]).toMatchObject({
+      cache_control: { type: "ephemeral" },
+    });
+  });
+
+  it("does not mutate the input array (DETERMINISTIC — re-running yields same shape)", () => {
+    const tools = makeTools(12, 100);
+    const snapshot = JSON.stringify(tools);
+    const first = buildCachedTools(tools);
+    const second = buildCachedTools(tools);
+    // Original untouched
+    expect(JSON.stringify(tools)).toBe(snapshot);
+    expect(tools[11]).not.toHaveProperty("cache_control");
+    // Two runs produce structurally identical output (no Math.random etc.)
+    expect(JSON.stringify(first.tools)).toBe(JSON.stringify(second.tools));
+  });
+});
+
+describe("extractCacheStats — operator dashboard persona", () => {
+  it("returns honest zeros when usage is undefined and no marker was attached", () => {
+    const stats = extractCacheStats(undefined, false);
+    expect(stats).toEqual({
+      cacheControlAttached: false,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      inputTokens: 0,
+      cacheHitRate: 0,
+    });
+  });
+
+  it("reports cacheControlAttached=true even when the API returned no cache fields (first call)", () => {
+    // Simulates the first request after attaching a marker — API hasn't built
+    // the cache yet, so cache_read=0 and cache_creation reflects writes.
+    const usage = {
+      input_tokens: 200,
+      cache_creation_input_tokens: 1500,
+      cache_read_input_tokens: 0,
+      output_tokens: 300,
+    } as unknown as Parameters<typeof extractCacheStats>[0];
+    const stats = extractCacheStats(usage, true);
+    expect(stats.cacheControlAttached).toBe(true);
+    expect(stats.cacheCreationInputTokens).toBe(1500);
+    expect(stats.cacheReadInputTokens).toBe(0);
+    expect(stats.cacheHitRate).toBe(0);
+  });
+
+  it("computes hit rate correctly on a warm-cache call (cache_read > 0)", () => {
+    const usage = {
+      input_tokens: 200,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 1500,
+      output_tokens: 300,
+    } as unknown as Parameters<typeof extractCacheStats>[0];
+    const stats = extractCacheStats(usage, true);
+    // hit rate = 1500 / (200 + 0 + 1500) = ~0.882
+    expect(stats.cacheHitRate).toBeCloseTo(0.882, 2);
+  });
+
+  it("clamps cacheHitRate to [0,1] even when API returns absurd values (defensive)", () => {
+    const usage = {
+      input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 99999,
+      output_tokens: 0,
+    } as unknown as Parameters<typeof extractCacheStats>[0];
+    const stats = extractCacheStats(usage, true);
+    // Even though numerator > denominator nominally, we accept the API's
+    // reported counts and clamp to 1 so dashboards don't render >100%.
+    expect(stats.cacheHitRate).toBeLessThanOrEqual(1);
+    expect(stats.cacheHitRate).toBeGreaterThanOrEqual(0);
+  });
+
+  it("treats null cache fields as 0 (some SDK versions emit null instead of omitting)", () => {
+    const usage = {
+      input_tokens: 100,
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+      output_tokens: 50,
+    } as unknown as Parameters<typeof extractCacheStats>[0];
+    const stats = extractCacheStats(usage, true);
+    expect(stats.cacheCreationInputTokens).toBe(0);
+    expect(stats.cacheReadInputTokens).toBe(0);
+  });
+});
+
+describe("scale + duration scenario — sustained tool-loop cache hits", () => {
+  it("repeated buildCachedTools calls produce the SAME shape (no per-call drift)", () => {
+    // Simulates a long-running agent that invokes runWithTools 1000 times in
+    // a session — the helper must not accumulate state, mutate inputs, or
+    // produce different cache placement across calls.
+    const tools = makeTools(15, 80);
+    const shapes = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      const r = buildCachedTools(tools);
+      shapes.add(JSON.stringify(r.tools));
+    }
+    expect(shapes.size).toBe(1);
+  });
+
+  it("estimateTokens is pure under repeated invocation (no entropy)", () => {
+    const sample = makeSystemPrompt(2048);
+    const first = estimateTokens(sample);
+    for (let i = 0; i < 100; i++) {
+      expect(estimateTokens(sample)).toBe(first);
+    }
+  });
+});

--- a/convex/domains/agents/adapters/anthropic/promptCacheHelpers.ts
+++ b/convex/domains/agents/adapters/anthropic/promptCacheHelpers.ts
@@ -1,0 +1,180 @@
+/**
+ * Anthropic prompt-caching helpers for the reasoning adapter.
+ *
+ * Wraps system prompts and tool catalogs in `cache_control: { type: "ephemeral" }`
+ * markers when they cross Anthropic's 1024-token cache floor, and produces
+ * stable hit/miss stats for the operator dashboard.
+ *
+ * Pattern: prompt caching (5-minute ephemeral)
+ * Prior art:
+ *   - Anthropic prompt caching guide (2025)
+ *     https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+ *   - convex/domains/agents/mcp_tools/models/promptCaching.ts (existing
+ *     general-purpose helpers; this file is the adapter-side wiring)
+ *
+ * See: .claude/rules/agentic_reliability.md (HONEST_SCORES + DETERMINISTIC)
+ *
+ * Why a new file: the existing `promptCaching.ts` defines opaque shapes but
+ * no production call site uses them. The reasoning adapter has two distinct
+ * call shapes (single-turn `execute()` and multi-iteration `runWithTools()`).
+ * A focused helper avoids forcing that shared module to know about Anthropic
+ * SDK types directly, which would couple it to `@anthropic-ai/sdk`.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Anthropic cache breakpoint floor (per docs as of 2025-2026).
+ * Below this size the API silently ignores the cache_control marker.
+ */
+export const ANTHROPIC_CACHE_MIN_TOKENS = 1024;
+
+/**
+ * Conservative chars-per-token used for the threshold check.  Real BPE is
+ * ~3.5–4.5 chars/tok for English; we use 4.0 so we don't flip the marker on
+ * borderline prompts that won't actually clear the floor server-side.
+ */
+const CHARS_PER_TOKEN_ESTIMATE = 4.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Per-call cache statistics — surfaced on `AdapterResult.tokenUsage`.
+ *
+ * HONEST_SCORES: every field is the literal value reported by Anthropic's
+ * API (or 0 when the field is absent).  No fabricated floors.
+ */
+export interface AnthropicCacheStats {
+  /** Whether cache_control markers were attached at request time. */
+  cacheControlAttached: boolean;
+  /** Tokens written to cache on this request (1.25× normal price). */
+  cacheCreationInputTokens: number;
+  /** Tokens served from cache on this request (0.10× normal price). */
+  cacheReadInputTokens: number;
+  /** Total input tokens for the request, per Anthropic. */
+  inputTokens: number;
+  /** cache_read / input — clamped to [0, 1].  0 when input is 0. */
+  cacheHitRate: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers — DETERMINISTIC: same input → same output, no I/O.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Conservative token estimate.  Used only to gate whether we attach a
+ * cache_control marker; never reported back to the caller as a measurement.
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / CHARS_PER_TOKEN_ESTIMATE);
+}
+
+/**
+ * Build a cache-aware Anthropic `system` parameter.
+ *
+ * - When `systemPrompt` is undefined or below the cache floor, returns the
+ *   original string (or undefined) so behavior is byte-identical to the
+ *   uncached path.
+ * - When the prompt clears the floor, returns the structured-blocks form
+ *   with one `cache_control: ephemeral` marker on the (single) system block.
+ *
+ * The `attached` flag is what the adapter records into telemetry, so we never
+ * lie about whether a marker was sent.
+ */
+export function buildCachedSystem(
+  systemPrompt: string | undefined,
+): { system: string | Array<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }> | undefined; attached: boolean } {
+  if (!systemPrompt) return { system: undefined, attached: false };
+  const tokens = estimateTokens(systemPrompt);
+  if (tokens < ANTHROPIC_CACHE_MIN_TOKENS) {
+    // Below the floor — cache_control would be silently dropped by the API.
+    // Return the plain string so we don't waste request bytes on a no-op.
+    return { system: systemPrompt, attached: false };
+  }
+  return {
+    system: [
+      {
+        type: "text",
+        text: systemPrompt,
+        cache_control: { type: "ephemeral" },
+      },
+    ],
+    attached: true,
+  };
+}
+
+/**
+ * Build a cache-aware Anthropic `tools` array.
+ *
+ * - When `tools` is empty or the serialized catalog is below the cache floor,
+ *   returns the input array as-is.
+ * - When the catalog clears the floor, attaches `cache_control: ephemeral`
+ *   to the LAST tool only.  Anthropic caches the prefix up to and including
+ *   any block carrying a marker; tagging the last tool means the entire
+ *   catalog is cached.  Tagging earlier tools would cache only a partial
+ *   prefix and lose the savings.
+ *
+ * The input array is not mutated.
+ */
+export function buildCachedTools<T extends { name: string; description?: string; input_schema: unknown }>(
+  tools: T[] | undefined,
+): { tools: (T & { cache_control?: { type: "ephemeral" } })[] | undefined; attached: boolean } {
+  if (!tools || tools.length === 0) return { tools, attached: false };
+
+  // Estimate over the serialized catalog — schemas dominate the byte count.
+  const serialized = JSON.stringify(tools);
+  const tokens = estimateTokens(serialized);
+  if (tokens < ANTHROPIC_CACHE_MIN_TOKENS) {
+    return { tools, attached: false };
+  }
+
+  const out = tools.slice() as (T & { cache_control?: { type: "ephemeral" } })[];
+  const last = out.length - 1;
+  out[last] = { ...out[last], cache_control: { type: "ephemeral" } };
+  return { tools: out, attached: true };
+}
+
+/**
+ * Extract cache stats from an Anthropic message response.
+ *
+ * Reads the optional `cache_creation_input_tokens` and
+ * `cache_read_input_tokens` fields the SDK now exposes on `usage`.  When the
+ * caller never attached a marker, `cacheControlAttached` is false and the
+ * other fields will be 0 — useful for distinguishing "we didn't try" from
+ * "we tried but missed".
+ */
+export function extractCacheStats(
+  usage: Anthropic.Usage | undefined,
+  cacheControlAttached: boolean,
+): AnthropicCacheStats {
+  const inputTokens = usage?.input_tokens ?? 0;
+  // SDK types the optional fields as `number | null`; coerce defensively.
+  const cacheCreationInputTokens =
+    typeof usage?.cache_creation_input_tokens === "number"
+      ? usage.cache_creation_input_tokens
+      : 0;
+  const cacheReadInputTokens =
+    typeof usage?.cache_read_input_tokens === "number"
+      ? usage.cache_read_input_tokens
+      : 0;
+  const totalInputAccountedFor =
+    inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
+  const cacheHitRate =
+    totalInputAccountedFor > 0
+      ? Math.min(1, Math.max(0, cacheReadInputTokens / totalInputAccountedFor))
+      : 0;
+  return {
+    cacheControlAttached,
+    cacheCreationInputTokens,
+    cacheReadInputTokens,
+    inputTokens,
+    cacheHitRate,
+  };
+}

--- a/convex/domains/agents/adapters/types.ts
+++ b/convex/domains/agents/adapters/types.ts
@@ -128,6 +128,26 @@ export interface AdapterResult<T = unknown> {
     input: number;
     output: number;
     thinking?: number; // For Anthropic extended thinking
+    /**
+     * Anthropic prompt-cache stats — populated when the adapter attaches a
+     * `cache_control` marker (system prompt or tool catalog ≥ 1024 tokens).
+     * All four fields are the literal Anthropic API values; absent caching
+     * support means the field is undefined, never zero (HONEST_SCORES).
+     *
+     * - cacheCreationInputTokens: tokens written to cache (~1.25× normal cost)
+     * - cacheReadInputTokens: tokens served from cache (~0.10× normal cost)
+     * - cacheControlAttached: true if the adapter sent a marker, regardless
+     *   of whether the API actually cached. Lets dashboards distinguish
+     *   "we didn't try" from "we tried, missed, expect a hit on retry".
+     * - cacheHitRate: cache_read / (input + cache_read + cache_creation),
+     *   clamped to [0,1].
+     */
+    cache?: {
+      cacheControlAttached: boolean;
+      cacheCreationInputTokens: number;
+      cacheReadInputTokens: number;
+      cacheHitRate: number;
+    };
   };
   /** If handoff occurred, target agent name */
   handoffTarget?: string;


### PR DESCRIPTION
Per analyst-diagnostic of LLM cache audit: anthropic reasoning adapter uses 800-tok system + 3000-tok tool catalog with zero cache_control today. With cache_control breakpoints, second-pass and tool-loop calls drop from $0.0645 → $0.0263 (59% reduction). Estimated ~$57/mo at current call volume.

Files:
- promptCacheHelpers.ts (new, pure helpers)
- promptCacheHelpers.test.ts (18 scenario tests, 6 personas)
- anthropicReasoningAdapter.ts (wired execute() and runWithTools())
- adapters/types.ts (extended tokenUsage with optional cache stats)

Verification: 18/18 helper tests pass, 93/93 adapter test surface unchanged, tsc/codegen/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)