### PR TITLE
chore(gitignore): ignore .claude/worktrees/ (agent isolation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ public/dogfood/scribe/userdata/
 
 # Overstory multi-agent orchestration
 .worktrees/
+.claude/worktrees/
 .overstory/engine/
 .overstory/worktrees/
 .overstory/overstory.db


### PR DESCRIPTION
Adds `.claude/worktrees/` to .gitignore so agents with `isolation: "worktree"` don't pollute git status. Supersedes #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)