### PR TITLE
fix: close Home Pulse QA gaps

### DIFF
--- a/convex/domains/product/nudges.ts
+++ b/convex/domains/product/nudges.ts
@@ -216,6 +216,36 @@ export const completeNudge = mutation({
   },
 });
 
+export const createHomePulseFollowupNudge = mutation({
+  args: {
+    anonymousSessionId: v.optional(v.string()),
+    title: v.string(),
+    summary: v.string(),
+    actionLabel: v.optional(v.string()),
+    actionTargetSurface: v.optional(v.string()),
+    actionTargetId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await requireProductIdentity(ctx, args.anonymousSessionId);
+    const now = Date.now();
+    return await upsertOpenProductNudge(ctx, {
+      ownerKey: identity.ownerKey,
+      type: "follow_up_due",
+      title: args.title.trim().slice(0, 160) || "Home Pulse follow-up",
+      summary:
+        args.summary.trim().slice(0, 700) ||
+        "Review the latest Home Pulse and decide which report, notebook, or source trail needs a follow-up.",
+      priority: "medium",
+      dueAt: now + 24 * 60 * 60 * 1000,
+      actionLabel: args.actionLabel ?? "Open in Chat",
+      actionTargetSurface: args.actionTargetSurface ?? "chat",
+      actionTargetId: args.actionTargetId ?? "home-pulse",
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Internal: create a nudge (called by cron or other internal actions)
 // ---------------------------------------------------------------------------

--- a/convex/domains/research/editionQueries.ts
+++ b/convex/domains/research/editionQueries.ts
@@ -767,6 +767,10 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_WEEK_RE = /^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])$/;
 /** ISO YYYY-MM pattern (month 01-12). */
 const ISO_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+/** ISO YYYY-Qn pattern (quarter 1-4). */
+const ISO_QUARTER_RE = /^\d{4}-Q[1-4]$/;
+/** ISO YYYY pattern. */
+const ISO_YEAR_RE = /^\d{4}$/;
 
 function isValidDateKey(s: string): boolean {
   if (!ISO_DATE_RE.test(s)) return false;
@@ -805,6 +809,46 @@ function monthRange(monthKey: string): { startMs: number; endMs: number } | null
   const startMs = Date.UTC(year, month - 1, 1);
   const endMs = Date.UTC(year, month, 1) - 1;
   return { startMs, endMs };
+}
+
+function quarterRange(quarterKey: string): { startMs: number; endMs: number } | null {
+  if (!ISO_QUARTER_RE.test(quarterKey)) return null;
+  const [yearPart, quarterPart] = quarterKey.split("-Q");
+  const year = Number(yearPart);
+  const quarter = Number(quarterPart);
+  const startMonth = (quarter - 1) * 3;
+  return {
+    startMs: Date.UTC(year, startMonth, 1),
+    endMs: Date.UTC(year, startMonth + 3, 1) - 1,
+  };
+}
+
+function yearRange(yearKey: string): { startMs: number; endMs: number } | null {
+  if (!ISO_YEAR_RE.test(yearKey)) return null;
+  const year = Number(yearKey);
+  return {
+    startMs: Date.UTC(year, 0, 1),
+    endMs: Date.UTC(year + 1, 0, 1) - 1,
+  };
+}
+
+function longHorizonRange(
+  kind: "quarter" | "year",
+  periodKey: string,
+): { startMs: number; endMs: number } | null {
+  return kind === "quarter" ? quarterRange(periodKey) : yearRange(periodKey);
+}
+
+function sourceItemCount(snapshot: Doc<"dailyBriefSnapshots">): number {
+  const summary = snapshot.sourceSummary as any;
+  const candidates = [
+    summary?.totalItems,
+    summary?.itemCount,
+    summary?.sources,
+    Array.isArray(summary?.items) ? summary.items.length : undefined,
+  ];
+  const value = candidates.find((candidate) => typeof candidate === "number");
+  return Number.isFinite(value) ? Math.max(0, Number(value)) : 0;
 }
 
 /* ────────────────────────────────────────────────────────────────────
@@ -1358,6 +1402,140 @@ export const getMonthlyRetrospective = query({
       dailyHistogram,
       dayKeys,
       pulseSource,
+    };
+  },
+});
+
+export const getLongHorizonRetrospective = query({
+  args: {
+    kind: v.union(v.literal("quarter"), v.literal("year")),
+    periodKey: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const range = longHorizonRange(args.kind, args.periodKey);
+    if (!range) {
+      return {
+        available: false as const,
+        reason: "invalid_period" as const,
+        kind: args.kind,
+        periodKey: args.periodKey,
+        startDateKey: null as string | null,
+        endDateKey: null as string | null,
+      };
+    }
+
+    const { startMs, endMs } = range;
+    const startDateKey = dateKeyFromMs(startMs);
+    const endDateKey = dateKeyFromMs(endMs);
+    const snapshotCap = args.kind === "year" ? 420 : 120;
+    const snapshotsAll = await ctx.db
+      .query("dailyBriefSnapshots")
+      .withIndex("by_date_string")
+      .order("desc")
+      .take(snapshotCap);
+    const snapshots = snapshotsAll.filter((snapshot) => {
+      const t = Date.parse(`${snapshot.dateString}T00:00:00Z`);
+      return t >= startMs && t <= endMs;
+    });
+    snapshots.sort((left, right) => left.dateString.localeCompare(right.dateString));
+
+    const snapshotSummaries = snapshots
+      .map((snapshot) => ({
+        dateString: snapshot.dateString,
+        keyStatCount: snapshot.dashboardMetrics?.keyStats?.length ?? 0,
+        sourceItemCount: sourceItemCount(snapshot),
+      }))
+      .sort(
+        (left, right) =>
+          right.keyStatCount - left.keyStatCount ||
+          right.sourceItemCount - left.sourceItemCount ||
+          right.dateString.localeCompare(left.dateString),
+      )
+      .slice(0, 8);
+
+    const resolutions = await ctx.db
+      .query("forecastResolutions")
+      .order("desc")
+      .take(400);
+    const inWindowResolutions = resolutions.filter(
+      (resolution) => resolution.resolvedAt >= startMs && resolution.resolvedAt <= endMs,
+    );
+    const brierScores = inWindowResolutions
+      .map((resolution) => resolution.brierScore)
+      .filter((score): score is number => typeof score === "number" && Number.isFinite(score));
+    const meanBrier =
+      brierScores.length > 0
+        ? brierScores.reduce((sum, score) => sum + score, 0) / brierScores.length
+        : null;
+
+    const topResolved: Array<{
+      _id: Id<"forecastResolutions">;
+      forecastId: Id<"forecasts">;
+      question: string | null;
+      outcome: "yes" | "no" | "ambiguous";
+      finalProbability: number | null;
+      brierScore: number | null;
+      resolvedAt: number;
+    }> = [];
+    for (const resolution of inWindowResolutions.slice(0, 5)) {
+      const forecast = await ctx.db.get(resolution.forecastId);
+      topResolved.push({
+        _id: resolution._id,
+        forecastId: resolution.forecastId,
+        question: forecast?.question ?? null,
+        outcome: resolution.outcome,
+        finalProbability:
+          typeof forecast?.probability === "number" ? forecast.probability : null,
+        brierScore:
+          typeof resolution.brierScore === "number" ? resolution.brierScore : null,
+        resolvedAt: resolution.resolvedAt,
+      });
+    }
+
+    const recentUpdates = await ctx.db
+      .query("industryUpdates")
+      .withIndex("by_scanned_at")
+      .order("desc")
+      .take(500);
+    const sourceUpdateCount = recentUpdates.filter(
+      (update) => update.scannedAt >= startMs && update.scannedAt <= endMs,
+    ).length;
+
+    if (
+      snapshots.length === 0 &&
+      inWindowResolutions.length === 0 &&
+      sourceUpdateCount === 0
+    ) {
+      return {
+        available: false as const,
+        reason: "no_edition" as const,
+        kind: args.kind,
+        periodKey: args.periodKey,
+        startDateKey,
+        endDateKey,
+      };
+    }
+
+    return {
+      available: true as const,
+      kind: args.kind,
+      periodKey: args.periodKey,
+      startDateKey,
+      endDateKey,
+      snapshotCount: snapshots.length,
+      latestSnapshotDate: snapshots.length > 0 ? snapshots[snapshots.length - 1].dateString : null,
+      totalKeyStats: snapshots.reduce(
+        (total, snapshot) => total + (snapshot.dashboardMetrics?.keyStats?.length ?? 0),
+        0,
+      ),
+      sourceItemCount: snapshots.reduce(
+        (total, snapshot) => total + sourceItemCount(snapshot),
+        sourceUpdateCount,
+      ),
+      resolvedForecastCount: inWindowResolutions.length,
+      meanBrier,
+      topSnapshots: snapshotSummaries,
+      topResolved,
     };
   },
 });

--- a/convex/domains/search/federatedSearch.test.ts
+++ b/convex/domains/search/federatedSearch.test.ts
@@ -33,6 +33,7 @@ import {
   MAX_TOTAL_RESULTS,
   rrfMerge,
 } from "./federatedHelpers";
+import { isSourceArtifactVisibleToCaller } from "./federatedSearch";
 
 /* -------------------------------------------------------------------------- */
 /* Pure helpers                                                                */
@@ -678,5 +679,48 @@ describe("Scenario 7 — typo queries at scale (PR E)", () => {
       // DETERMINISTIC — same inputs MUST produce same output every iteration.
       expect(json).toBe(lastJson);
     }
+  });
+});
+
+describe("Scenario 9 — source artifact search privacy", () => {
+  /**
+   * Persona:    Anonymous visitor and two authenticated users
+   * Goal:       Search sources without leaking run-backed private artifacts
+   * Prior:      One public/system source, one source created by user A's run
+   * Actions:    Check visibility for anonymous, user B, and user A
+   * Expected:   Public source is visible to all; run-backed source only to owner
+   */
+  it("anonymous callers never see run-backed source artifacts", () => {
+    expect(
+      isSourceArtifactVisibleToCaller(
+        { runId: undefined },
+        { userId: null },
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      isSourceArtifactVisibleToCaller(
+        { runId: "run_user_a" },
+        { userId: null },
+        "user_a",
+      ),
+    ).toBe(false);
+  });
+
+  it("authenticated callers only see source artifacts from their own runs", () => {
+    expect(
+      isSourceArtifactVisibleToCaller(
+        { runId: "run_user_a" },
+        { userId: "user_b" },
+        "user_a",
+      ),
+    ).toBe(false);
+    expect(
+      isSourceArtifactVisibleToCaller(
+        { runId: "run_user_a" },
+        { userId: "user_a" },
+        "user_a",
+      ),
+    ).toBe(true);
   });
 });

--- a/convex/domains/search/federatedSearch.ts
+++ b/convex/domains/search/federatedSearch.ts
@@ -332,18 +332,29 @@ export const searchClaims = internalQuery({
   },
 });
 
+export function isSourceArtifactVisibleToCaller(
+  row: { runId?: string },
+  args: { userId?: string | null },
+  runOwnerUserId?: string | null,
+): boolean {
+  if (!row.runId) return true;
+  if (!args.userId) return false;
+  return runOwnerUserId === args.userId;
+}
+
 /**
- * Sources have NO ownerKey on the row (sourceArtifacts is system-fetched).
- * Privacy floor: only return rows whose `runId` traces to the user's
- * agentRuns (when authenticated) OR rows with no runId (system-fetched
- * public URLs) when anonymous.
+ * Sources have no ownerKey on the row. The access floor is therefore:
+ *   - rows with no runId are treated as public/system-fetched source refs
+ *   - run-backed rows are only visible to the user who owns that agentRun
  *
- * For PR1, we keep this simple: return all matching rows (sources are
- * already de-facto public artifacts of crawled URLs). PR2 wires the
- * runId → ownerKey filter once that mapping is hot.
+ * This is intentionally post-filtered after the search index read because
+ * `sourceArtifacts.search_sources` only has sourceType as an index filter.
  */
 export const searchSources = internalQuery({
-  args: SEARCH_QUERY_ARGS,
+  args: {
+    ...SEARCH_QUERY_ARGS,
+    userId: v.optional(v.id("users")),
+  },
   handler: async (ctx, args): Promise<FederatedHandle[]> => {
     const limit = clampLimit(args.limit);
     if (!args.q.trim()) return [];
@@ -352,16 +363,44 @@ export const searchSources = internalQuery({
       .withSearchIndex("search_sources", (q) =>
         q.search("searchableText", args.q),
       )
-      .take(limit);
-    return rows.map((row) => ({
-      type: "nb_sources" as const,
-      uri: row.sourceUrl ?? `source://${row._id}`,
-      title: row.title ?? row.sourceUrl ?? "Untitled source",
-      snippet: boundSnippet(row.searchableText ?? row.sourceUrl ?? ""),
-      score: 1,
-      source: row.sourceType,
-      actions: ["open_source", "fetch_artifact"],
-    }));
+      .take(Math.min(limit * 4, 100));
+
+    const visible: FederatedHandle[] = [];
+    const runOwnerCache = new Map<string, string | null>();
+    for (const row of rows) {
+      let runOwnerUserId: string | null = null;
+      if (row.runId) {
+        const runId = String(row.runId);
+        if (runOwnerCache.has(runId)) {
+          runOwnerUserId = runOwnerCache.get(runId) ?? null;
+        } else {
+          const run = await ctx.db.get(row.runId);
+          runOwnerUserId = run?.userId ? String(run.userId) : null;
+          runOwnerCache.set(runId, runOwnerUserId);
+        }
+      }
+      if (
+        !isSourceArtifactVisibleToCaller(
+          { runId: row.runId ? String(row.runId) : undefined },
+          { userId: args.userId ? String(args.userId) : null },
+          runOwnerUserId,
+        )
+      ) {
+        continue;
+      }
+      visible.push({
+        type: "nb_sources" as const,
+        uri: row.sourceUrl ?? `source://${row._id}`,
+        title: row.title ?? row.sourceUrl ?? "Untitled source",
+        snippet: boundSnippet(row.searchableText ?? row.sourceUrl ?? ""),
+        score: 1,
+        source: row.sourceType,
+        actions: ["open_source", "fetch_artifact"],
+        rowId: String(row._id),
+      });
+      if (visible.length >= limit) break;
+    }
+    return visible;
   },
 });
 
@@ -719,12 +758,13 @@ async function dispatchOne(
         ownerKey,
       });
     case "nb_sources":
-      // Sources are system-fetched and de-facto public; safe for both
-      // anonymous and authenticated callers. No vector index (yet).
+      // Run-backed sources are owner-scoped via agentRuns.userId. Rows
+      // without runId remain public/system-fetched source refs.
       return ctx.runQuery(internal.domains.search.federatedSearch.searchSources, {
         q,
         limit,
-        ownerKey: ownerKey ?? "anonymous",
+        ownerKey,
+        userId: userId ? (userId as any) : undefined,
       });
     case "nb_captures":
       // quickCaptures is auth-only; anonymous gets []. No vector index (yet).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:search-api-bundle && vite build",
     "build:search-api-bundle": "npx esbuild server/vercel/searchApp.ts --bundle --packages=external --platform=node --format=esm --target=node20 --outfile=api/_searchApp.bundle.mjs",
     "deploy:convex": "node scripts/deploy-convex-prod.mjs",
-    "deploy:prod": "bash scripts/deploy-prod.sh",
+    "deploy:prod": "node scripts/deploy-prod.mjs",
     "preflight": "node scripts/preflight-deploy.mjs",
     "preflight:production": "node scripts/preflight-deploy.mjs --target=production",
     "preflight:fast": "node scripts/preflight-deploy.mjs --skip=tsc-convex,search-api,size",

--- a/package.json
+++ b/package.json
@@ -291,6 +291,7 @@
     "fractional-indexing": "^3.2.0",
     "framer-motion": "^12.23.25",
     "googleapis": "^171.4.0",
+    "helmet": "^8.1.0",
     "install": "^0.13.0",
     "katex": "^0.16.28",
     "lexical": "^0.43.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:voice": "tsx --watch --env-file=.env.local server/index.ts",
     "build": "npm run build:search-api-bundle && vite build",
     "build:search-api-bundle": "npx esbuild server/vercel/searchApp.ts --bundle --packages=external --platform=node --format=esm --target=node20 --outfile=api/_searchApp.bundle.mjs",
-    "deploy:convex": "convex deploy -y --typecheck=enable",
+    "deploy:convex": "node scripts/deploy-convex-prod.mjs",
     "deploy:prod": "bash scripts/deploy-prod.sh",
     "preflight": "node scripts/preflight-deploy.mjs",
     "preflight:production": "node scripts/preflight-deploy.mjs --target=production",

--- a/scripts/deploy-convex-prod.mjs
+++ b/scripts/deploy-convex-prod.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const envFile = path.resolve(process.cwd(), ".env.production.local");
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function readEnvValue(filePath, key) {
+  if (!fs.existsSync(filePath)) return null;
+  const text = fs.readFileSync(filePath, "utf8");
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const idx = trimmed.indexOf("=");
+    if (idx === -1) continue;
+    const name = trimmed.slice(0, idx).trim();
+    if (name !== key) continue;
+    return unquote(trimmed.slice(idx + 1));
+  }
+  return null;
+}
+
+const env = { ...process.env };
+if (!env.CONVEX_DEPLOY_KEY) {
+  const deployKey = readEnvValue(envFile, "CONVEX_DEPLOY_KEY");
+  if (deployKey) {
+    env.CONVEX_DEPLOY_KEY = deployKey;
+    console.log("Loaded CONVEX_DEPLOY_KEY from .env.production.local");
+  }
+}
+
+if (!env.CONVEX_DEPLOY_KEY) {
+  console.error(
+    "CONVEX_DEPLOY_KEY is not set. Run `vercel env pull .env.production.local --environment=production` or export a deploy key.",
+  );
+  process.exit(1);
+}
+
+const child = spawn("npx convex deploy -y --typecheck=enable", {
+  env,
+  shell: true,
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    console.error(`convex deploy terminated by ${signal}`);
+    process.exit(1);
+  }
+  process.exit(code ?? 1);
+});

--- a/scripts/deploy-prod.mjs
+++ b/scripts/deploy-prod.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Canonical production deploy wrapper for nodebenchai.com.
+ *
+ * Default path: cloud build via `vercel deploy --prod --yes`.
+ * This uses Vercel's Linux builder, project env, and linked Convex
+ * deploy key, avoiding Windows local-build bugs in @vercel/static-build.
+ *
+ * Optional local prebuilt path:
+ *   NODEBENCH_PREBUILT_DEPLOY=1 npm run deploy:prod
+ *
+ * The Node wrapper avoids the Windows -> WSL `bash` path, where
+ * `/usr/bin/node` can be too old for the current Vercel CLI ESM entrypoint.
+ */
+
+import { spawn } from "node:child_process";
+
+const NPX_BIN = process.platform === "win32" ? "npx.cmd" : "npx";
+
+function runVercel(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(NPX_BIN, ["vercel", ...args], {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`vercel ${args.join(" ")} failed with ${signal ?? code}`));
+    });
+  });
+}
+
+async function main() {
+  console.log("==> Pulling Vercel project settings and production env");
+  await runVercel(["pull", "--yes", "--environment=production"]);
+
+  if (process.env.NODEBENCH_PREBUILT_DEPLOY === "1") {
+    console.log("==> Pulling root Vite env for local prebuilt deploy");
+    await runVercel(["env", "pull", ".env.production.local", "--environment=production"]);
+
+    console.log("==> Building with prod env (Vite inlines VITE_*)");
+    await runVercel(["build", "--prod"]);
+
+    console.log("==> Deploying prebuilt artifact to production");
+    await runVercel(["deploy", "--prebuilt", "--prod"]);
+  } else {
+    console.log("==> Deploying with Vercel cloud build");
+    await runVercel(["deploy", "--prod", "--yes"]);
+  }
+
+  console.log("==> Done. Run scripts/verify-live.ts to confirm the live HTML.");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/features/redesign/components/edition/EditionSelector.tsx
+++ b/src/features/redesign/components/edition/EditionSelector.tsx
@@ -1,8 +1,8 @@
 /**
  * EditionSelector — temporal chip group above the §1 header.
  *
- * Renders five affordances:
- *   Today | Yesterday | This week | This month | Archive (date picker)
+ * Renders seven affordances:
+ *   Today | Yesterday | This week | This month | This quarter | This year | Archive
  *
  * Mobile (< 480px) collapses to: Today | 7d | 30d | →
  *
@@ -32,7 +32,9 @@ export type EditionSelection =
   | { kind: "today" }
   | { kind: "day"; dateKey: string }
   | { kind: "week"; weekKey: string }
-  | { kind: "month"; monthKey: string };
+  | { kind: "month"; monthKey: string }
+  | { kind: "quarter"; quarterKey: string }
+  | { kind: "year"; yearKey: string };
 
 interface Props {
   /** The currently-active selection, parsed by the surface. */
@@ -74,6 +76,16 @@ function currentWeekKey(): string {
 function currentMonthKey(): string {
   const now = todayUtc();
   return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function currentQuarterKey(): string {
+  const now = todayUtc();
+  const quarter = Math.floor(now.getUTCMonth() / 3) + 1;
+  return `${now.getUTCFullYear()}-Q${quarter}`;
+}
+
+function currentYearKey(): string {
+  return `${todayUtc().getUTCFullYear()}`;
 }
 
 /* ─── Chip styles ────────────────────────────────────────────────── */
@@ -128,10 +140,15 @@ export function EditionSelector({ selection, earliestDateKey }: Props) {
   const isDay = selection.kind === "day";
   const isWeek = selection.kind === "week";
   const isMonth = selection.kind === "month";
+  const isQuarter = selection.kind === "quarter";
+  const isYear = selection.kind === "year";
   const yKey = yesterdayKey();
   const isYesterday = isDay && selection.dateKey === yKey;
   const isThisWeek = isWeek && selection.weekKey === currentWeekKey();
   const isThisMonth = isMonth && selection.monthKey === currentMonthKey();
+  const isThisQuarter =
+    isQuarter && selection.quarterKey === currentQuarterKey();
+  const isThisYear = isYear && selection.yearKey === currentYearKey();
 
   const onPickDate = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -202,11 +219,33 @@ export function EditionSelector({ selection, earliestDateKey }: Props) {
       </button>
       <button
         type="button"
+        data-edition-chip="quarter"
+        aria-pressed={isThisQuarter}
+        style={isThisQuarter ? activeChipStyle : baseChipStyle}
+        onClick={() => setEdition(`quarter:${currentQuarterKey()}`)}
+      >
+        <span className="rd-edition-chip__full">This quarter</span>
+        <span className="rd-edition-chip__short">QTD</span>
+      </button>
+      <button
+        type="button"
+        data-edition-chip="year"
+        aria-pressed={isThisYear}
+        style={isThisYear ? activeChipStyle : baseChipStyle}
+        onClick={() => setEdition(`year:${currentYearKey()}`)}
+      >
+        <span className="rd-edition-chip__full">This year</span>
+        <span className="rd-edition-chip__short">YTD</span>
+      </button>
+      <button
+        type="button"
         data-edition-chip="archive"
         aria-pressed={
           (isDay && !isYesterday) ||
           (isMonth && !isThisMonth) ||
-          (isWeek && !isThisWeek)
+          (isWeek && !isThisWeek) ||
+          (isQuarter && !isThisQuarter) ||
+          (isYear && !isThisYear)
         }
         aria-expanded={pickerOpen}
         style={baseChipStyle}

--- a/src/features/redesign/components/edition/EditionTOC.tsx
+++ b/src/features/redesign/components/edition/EditionTOC.tsx
@@ -1,8 +1,8 @@
 /**
  * EditionTOC — desktop-only sticky table-of-contents rail for the
  * editorial home (Phase 7b).  Shown to the right of the 720px center
- * column on viewports >= 1024px; hidden entirely on mobile so the
- * single-column reading flow is preserved.
+ * column on viewports >= 1440px; hidden entirely on mobile and
+ * medium desktop widths so the single-column reading flow is preserved.
  *
  * Behavior:
  *   - Lists every visible section in document order.
@@ -43,7 +43,7 @@ function prefersReducedMotion(): boolean {
 }
 
 export function EditionTOC({ entries }: Props) {
-  // Watch viewport — only render at >= 1024px.  We mount the
+  // Watch viewport — only render at >= 1440px.  We mount the
   // observer hook unconditionally so React's hook order stays
   // stable; the rail JSX itself is gated on the `isDesktop` flag.
   const ids = entries.map((e) => e.id);
@@ -52,7 +52,7 @@ export function EditionTOC({ entries }: Props) {
   const [isDesktop, setIsDesktop] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     try {
-      return window.matchMedia("(min-width: 1024px)").matches;
+      return window.matchMedia("(min-width: 1440px)").matches;
     } catch {
       return false;
     }
@@ -60,7 +60,7 @@ export function EditionTOC({ entries }: Props) {
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.matchMedia) return;
-    const mq = window.matchMedia("(min-width: 1024px)");
+    const mq = window.matchMedia("(min-width: 1440px)");
     const onChange = () => setIsDesktop(mq.matches);
     mq.addEventListener?.("change", onChange);
     return () => mq.removeEventListener?.("change", onChange);

--- a/src/features/redesign/components/edition/edition.css
+++ b/src/features/redesign/components/edition/edition.css
@@ -481,19 +481,23 @@
 }
 
 /* ─── Phase 7b: Edition TOC (right-rail scroll-spy) ─────────────── */
-/* Hidden on mobile + narrow desktops (single column rules); shown
-   on >=1200px as a fixed rail that doesn't overlap the 720px center
-   column.
-   Math: center column right edge at viewport vw is (vw+720)/2.  TOC
-   left edge is vw-24-180 = vw-204.  Non-overlap requires
-   vw-204 >= (vw+720)/2 → vw >= 1128.  Round up to 1200 to leave a
-   visible gap.  Hot-fix 2026-05-11: was 1024, which caused
-   14-52px overlap on viewports 1024-1180px (analyst_diagnostic). */
+/* Hidden on mobile + medium desktops (single column rules); shown
+   on >=1440px as a fixed rail that doesn't overlap the 720px article
+   column inside the app shell.
+   Math: the raw viewport formula is not sufficient because the
+   article is centered inside the app content pane after the left
+   chrome. The 1440px breakpoint keeps the rail hidden until there is
+   real clearance.  Hot-fix 2026-05-11: was 1024, which caused
+   14-52px overlap on viewports 1024-1180px. Follow-up: the app shell
+   shifts the article right, so 1200px still overlapped in production. */
 [data-redesign] [data-edition] .rd-edition-toc {
   display: none;
 }
 
-@media (min-width: 1200px) {
+/* Production shell guard: the app chrome shifts the article column right, so
+   the rail remains hidden until 1440px and then uses a wider right offset. */
+
+@media (min-width: 1440px) {
   [data-redesign] [data-edition] .rd-edition-toc {
     display: block;
     position: fixed;
@@ -510,10 +514,10 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1440px) {
   [data-redesign] [data-edition] .rd-edition-toc {
     /* On wide viewports, push the rail farther from the column. */
-    right: max(24px, calc((100vw - 720px) / 2 - 240px));
+    right: max(24px, calc((100vw - 720px) / 2 - 360px));
   }
 }
 
@@ -702,6 +706,51 @@
 [data-redesign] [data-edition] .rd-offline-banner strong {
   color: var(--rd-ink-strong);
   font-weight: 600;
+}
+
+[data-redesign] [data-edition] .rd-coordinator-trace {
+  border-top: 1px solid var(--rd-edition-rule);
+  border-bottom: 1px solid var(--rd-edition-rule);
+  padding: 10px 0;
+  margin: 0 0 12px;
+}
+
+[data-redesign] [data-edition] .rd-coordinator-trace__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+[data-redesign] [data-edition] .rd-coordinator-trace__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(124px, 1fr));
+  gap: 6px;
+}
+
+[data-redesign] [data-edition] .rd-coordinator-trace__cell {
+  min-height: 34px;
+  border: 1px solid var(--rd-edition-rule);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 11.5px;
+  color: var(--rd-ink-mute);
+  background: var(--rd-surface, transparent);
+}
+
+[data-redesign] [data-edition] .rd-coordinator-trace__cell strong {
+  color: var(--rd-ink-strong);
+  font-weight: 700;
+}
+
+[data-redesign] [data-edition] .rd-coordinator-trace__cell[data-status="loading"] {
+  opacity: 0.72;
+}
+
+[data-redesign] [data-edition] .rd-coordinator-trace__cell[data-status="empty"] {
+  border-style: dashed;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/features/redesign/hooks/editionSession.ts
+++ b/src/features/redesign/hooks/editionSession.ts
@@ -1,17 +1,37 @@
 /**
  * Local helper for the editorial home — read the same anonymous
- * session ID the rest of the app uses so guest pulses route to the
- * same owner.  Mirrors useAnonymousSession's storage contract; we
- * intentionally do *not* generate a new ID here (avoid double-create).
+ * session ID the rest of the product uses so guest pulses, reports,
+ * nudges, and Inbox rows route to the same owner. We intentionally do
+ * not generate a new ID here because read-only edition queries should
+ * not create identity as a side effect.
  */
 
-const STORAGE_KEY = "nodebench:anonymous:sessionId";
+const PRODUCT_STORAGE_KEY = "nodebench:product-anon-session";
+const LEGACY_STORAGE_KEY = "nodebench:anonymous:sessionId";
+const PRODUCT_COOKIE_KEY = "nodebench_product_anon_session";
+
+function readCookieSessionId(): string | undefined {
+  if (typeof document === "undefined" || typeof document.cookie !== "string") {
+    return undefined;
+  }
+  const prefix = `${PRODUCT_COOKIE_KEY}=`;
+  const match = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+  return match ? decodeURIComponent(match.slice(prefix.length)) : undefined;
+}
 
 export function getStoredAnonymousSessionId(): string | undefined {
   if (typeof window === "undefined") return undefined;
   try {
-    const v = localStorage.getItem(STORAGE_KEY);
-    return v ?? undefined;
+    return (
+      localStorage.getItem(PRODUCT_STORAGE_KEY) ??
+      sessionStorage.getItem(PRODUCT_STORAGE_KEY) ??
+      readCookieSessionId() ??
+      localStorage.getItem(LEGACY_STORAGE_KEY) ??
+      undefined
+    );
   } catch {
     return undefined;
   }

--- a/src/features/redesign/hooks/useEditionView.ts
+++ b/src/features/redesign/hooks/useEditionView.ts
@@ -21,6 +21,8 @@ import type { EditionSelection } from "../components/edition/EditionSelector";
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_WEEK_RE = /^week:(\d{4}-W(?:0[1-9]|[1-4]\d|5[0-3]))$/;
 const ISO_MONTH_RE = /^month:(\d{4}-(?:0[1-9]|1[0-2]))$/;
+const ISO_QUARTER_RE = /^quarter:(\d{4}-Q[1-4])$/;
+const ISO_YEAR_RE = /^year:(\d{4})$/;
 
 function isValidDateKey(s: string): boolean {
   if (!ISO_DATE_RE.test(s)) return false;
@@ -43,6 +45,14 @@ export function parseEditionParam(value: string | null): EditionSelection {
   const mMatch = value.match(ISO_MONTH_RE);
   if (mMatch) {
     return { kind: "month", monthKey: mMatch[1] };
+  }
+  const qMatch = value.match(ISO_QUARTER_RE);
+  if (qMatch) {
+    return { kind: "quarter", quarterKey: qMatch[1] };
+  }
+  const yMatch = value.match(ISO_YEAR_RE);
+  if (yMatch) {
+    return { kind: "year", yearKey: yMatch[1] };
   }
   // ERROR_BOUNDARY: malformed → fall back to today; never throw.
   return { kind: "today" };

--- a/src/features/redesign/hooks/useInboxLive.ts
+++ b/src/features/redesign/hooks/useInboxLive.ts
@@ -9,6 +9,7 @@
 import { useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import type { InboxItem } from "../fixtures";
+import { getAnonymousProductSessionId } from "../../product/lib/productIdentity";
 
 interface PipelineRun {
   _id: string;
@@ -22,6 +23,24 @@ interface PipelineRun {
   errorMessage?: string;
 }
 
+interface ProductNudge {
+  _id: string;
+  type: string;
+  title: string;
+  summary: string;
+  priority: "low" | "medium" | "high";
+  bucket?: "action_required" | "update";
+  actionLabel?: string;
+  actionTargetSurface?: string;
+  actionTargetId?: string;
+  linkedReportTitle?: string;
+  updatedAt: number;
+}
+
+interface ProductNudgeSnapshot {
+  nudges: ProductNudge[];
+}
+
 function timeAgo(at: number): string {
   const delta = Math.max(0, Date.now() - at);
   const m = Math.floor(delta / 60_000);
@@ -31,6 +50,39 @@ function timeAgo(at: number): string {
   if (h < 24) return `${h}h ago`;
   const d = Math.floor(h / 24);
   return `${d}d ago`;
+}
+
+function nudgeToInbox(nudge: ProductNudge): InboxItem {
+  const toneMap: Record<ProductNudge["priority"], NonNullable<InboxItem["whyTone"]>> = {
+    high: "amber",
+    medium: "accent",
+    low: "blue",
+  };
+  const lane =
+    nudge.bucket === "action_required" ||
+    nudge.type === "follow_up_due" ||
+    nudge.type === "refresh_recommended"
+      ? "agent_suggestions"
+      : "watchlist";
+  const title = nudge.linkedReportTitle
+    ? `${nudge.title} - ${nudge.linkedReportTitle}`
+    : nudge.title;
+  return {
+    id: `nudge_${nudge._id}`,
+    lane,
+    category: lane === "watchlist" ? "watchlist" : "automation",
+    whyHere:
+      nudge.type === "follow_up_due"
+        ? "FOLLOW-UP"
+        : nudge.type === "refresh_recommended"
+          ? "REFRESH"
+          : "NUDGE",
+    whyTone: toneMap[nudge.priority] ?? "accent",
+    title,
+    body: nudge.summary,
+    meta: `${timeAgo(nudge.updatedAt)} - ${nudge.actionLabel ?? "Open"}`,
+    confidence: nudge.priority === "high" ? 0.82 : nudge.priority === "medium" ? 0.7 : 0.58,
+  };
 }
 
 function pipelineToInbox(run: PipelineRun): InboxItem {
@@ -62,23 +114,31 @@ export interface UseInboxLiveResult {
 }
 
 export function useInboxLive(): UseInboxLiveResult {
+  const anonymousSessionId = getAnonymousProductSessionId();
   const livePipeline = useQuery(
     (api as unknown as { domains: { pipelines: { pipelineRunsQueries: { listRecentRuns: unknown } } } })
       .domains.pipelines.pipelineRunsQueries.listRecentRuns as Parameters<typeof useQuery>[0],
     { limit: 20 } as Parameters<typeof useQuery>[1],
   ) as PipelineRun[] | undefined;
+  const nudgeSnapshot = useQuery(
+    (api as unknown as { domains: { product: { nudges: { getNudgesSnapshot: unknown } } } })
+      .domains.product.nudges.getNudgesSnapshot as Parameters<typeof useQuery>[0],
+    { anonymousSessionId } as Parameters<typeof useQuery>[1],
+  ) as ProductNudgeSnapshot | undefined;
 
-  if (livePipeline === undefined) {
+  if (livePipeline === undefined && nudgeSnapshot === undefined) {
     return { items: [], isLive: false, isLoading: true, liveCount: 0 };
   }
 
-  const liveItems = livePipeline
+  const liveItems = (livePipeline ?? [])
     .filter((run) => run.verdict === "needs_review" || run.verdict === "failed")
     .map(pipelineToInbox);
+  const nudgeItems = (nudgeSnapshot?.nudges ?? []).map(nudgeToInbox);
+  const items = [...nudgeItems, ...liveItems];
 
-  if (liveItems.length === 0) {
+  if (items.length === 0) {
     return { items: [], isLive: false, isLoading: false, liveCount: 0 };
   }
 
-  return { items: liveItems, isLive: true, isLoading: false, liveCount: liveItems.length };
+  return { items, isLive: true, isLoading: false, liveCount: items.length };
 }

--- a/src/features/redesign/hooks/useLongHorizonRetrospectiveSwr.ts
+++ b/src/features/redesign/hooks/useLongHorizonRetrospectiveSwr.ts
@@ -1,0 +1,27 @@
+import {
+  useLongHorizonRetrospective,
+  type LongHorizonRetrospectiveResult,
+} from "./useTemporalEdition";
+import {
+  useStaleWhileRevalidate,
+  type SwrResult,
+} from "../../../lib/performance/useStaleWhileRevalidate";
+
+export interface LongHorizonRetrospectiveSwr {
+  data: LongHorizonRetrospectiveResult | undefined;
+  swr: Omit<SwrResult<LongHorizonRetrospectiveResult>, "data">;
+}
+
+export function useLongHorizonRetrospectiveSwr(
+  kind: "quarter" | "year" | null,
+  periodKey: string | null,
+): LongHorizonRetrospectiveSwr {
+  const live = useLongHorizonRetrospective(kind, periodKey);
+  const swr = useStaleWhileRevalidate<LongHorizonRetrospectiveResult>(
+    "editorial.longHorizonRetrospective",
+    { kind, periodKey },
+    live,
+  );
+  const { data, ...meta } = swr;
+  return { data, swr: meta };
+}

--- a/src/features/redesign/hooks/useTemporalEdition.ts
+++ b/src/features/redesign/hooks/useTemporalEdition.ts
@@ -122,6 +122,19 @@ export type MonthlyRetrospectiveResult =
       }>;
       resolvedForecastCount: number;
       meanBrier: number | null;
+      topResolved?: Array<{
+        _id: string;
+        forecastId: string;
+        question: string | null;
+        outcome: "yes" | "no" | "ambiguous";
+        finalProbability: number | null;
+        brierScore: number | null;
+        resolvedAt: number;
+      }>;
+      weeklyPulseTotals?: Array<{ weekKey: string; materialChanges: number }>;
+      dailyHistogram?: number[];
+      dayKeys?: string[];
+      pulseSource?: "user" | "public-trending" | "none";
     }
   | {
       available: false;
@@ -132,9 +145,60 @@ export type MonthlyRetrospectiveResult =
 export function useMonthlyRetrospective(
   monthKey: string | null,
 ): MonthlyRetrospectiveResult | undefined {
+  const sessionId = getStoredAnonymousSessionId();
   const data = useQuery(
     api.domains.research.editionQueries.getMonthlyRetrospective,
-    monthKey ? { monthKey } : "skip",
+    monthKey ? { monthKey, anonymousSessionId: sessionId } : "skip",
   );
   return data as MonthlyRetrospectiveResult | undefined;
+}
+
+/* --- Quarter / year retrospective --------------------------------------- */
+
+export type LongHorizonRetrospectiveResult =
+  | {
+      available: true;
+      kind: "quarter" | "year";
+      periodKey: string;
+      startDateKey: string;
+      endDateKey: string;
+      snapshotCount: number;
+      latestSnapshotDate: string | null;
+      totalKeyStats: number;
+      sourceItemCount: number;
+      resolvedForecastCount: number;
+      meanBrier: number | null;
+      topSnapshots: Array<{
+        dateString: string;
+        keyStatCount: number;
+        sourceItemCount: number;
+      }>;
+      topResolved: Array<{
+        _id: string;
+        forecastId: string;
+        question: string | null;
+        outcome: "yes" | "no" | "ambiguous";
+        finalProbability: number | null;
+        brierScore: number | null;
+        resolvedAt: number;
+      }>;
+    }
+  | {
+      available: false;
+      reason: "invalid_period" | "no_edition";
+      kind: "quarter" | "year";
+      periodKey: string;
+      startDateKey: string | null;
+      endDateKey: string | null;
+    };
+
+export function useLongHorizonRetrospective(
+  kind: "quarter" | "year" | null,
+  periodKey: string | null,
+): LongHorizonRetrospectiveResult | undefined {
+  const data = useQuery(
+    api.domains.research.editionQueries.getLongHorizonRetrospective,
+    kind && periodKey ? { kind, periodKey } : "skip",
+  );
+  return data as LongHorizonRetrospectiveResult | undefined;
 }

--- a/src/features/redesign/pages/EditionPrintPage.tsx
+++ b/src/features/redesign/pages/EditionPrintPage.tsx
@@ -38,6 +38,13 @@ import { useActiveHypotheses } from "../hooks/useActiveHypotheses";
 import { useTopForecasts } from "../hooks/useTopForecasts";
 import { useLatestDailyBriefSnapshot } from "../hooks/useLatestDailyBriefSnapshot";
 import { useEditionFootnotes } from "../hooks/useEditionFootnotes";
+import {
+  getForecastReviewSummary,
+  getHypothesisReviewSummary,
+  getHypothesisReviewTitle,
+  HOME_AUDIENCE_RELEVANCE_SECTION,
+  HOME_EVIDENCE_WATCHLIST_SECTION,
+} from "../surfaces/EditorialHomeAudienceRelevance";
 import "../components/edition/edition.css";
 import "../components/edition/edition-print.css";
 
@@ -107,14 +114,14 @@ export function EditionPrintPage() {
   if (Array.isArray(hypotheses) && hypotheses.length > 0) {
     visibleSections.push({
       id: "competing-explanations",
-      kicker: "Hypotheses under test",
-      heading: "The competing explanations",
+      kicker: HOME_AUDIENCE_RELEVANCE_SECTION.kicker,
+      heading: HOME_AUDIENCE_RELEVANCE_SECTION.heading,
     });
   }
   visibleSections.push({
     id: "what-to-look-at",
-    kicker: "Forecasts in motion",
-    heading: "What to look at this week",
+    kicker: HOME_EVIDENCE_WATCHLIST_SECTION.kicker,
+    heading: HOME_EVIDENCE_WATCHLIST_SECTION.heading,
   });
   visibleSections.push({
     id: "scoreboard",
@@ -192,25 +199,31 @@ export function EditionPrintPage() {
           <EditionErrorBoundary label="print-hypotheses">
             <section
               role="region"
-              aria-label="The competing explanations"
+              aria-label="Audience relevance and evidence review queue"
               className="rd-edition-section"
               data-section="competing-explanations"
               data-section-number={numberFor(visibleSections.findIndex((s) => s.id === "competing-explanations"))}
-              data-section-kicker="Hypotheses under test"
+              data-section-kicker={HOME_AUDIENCE_RELEVANCE_SECTION.kicker}
             >
               <header>
                 <p className="rd-edition-section__eyebrow">
-                  {numberFor(visibleSections.findIndex((s) => s.id === "competing-explanations"))} · Hypotheses under test
+                  {numberFor(visibleSections.findIndex((s) => s.id === "competing-explanations"))} · {HOME_AUDIENCE_RELEVANCE_SECTION.kicker}
                 </p>
-                <h2 className="rd-edition-section__h2">The competing explanations</h2>
+                <h2 className="rd-edition-section__h2">
+                  {HOME_AUDIENCE_RELEVANCE_SECTION.heading}
+                </h2>
               </header>
               {hypotheses.map((h) => (
                 <article key={h._id} className="rd-edition-hypothesis">
                   <div className="rd-edition-hypothesis__head">
                     <span className="rd-edition-hypothesis__label">{h.label}</span>
-                    <h3 className="rd-edition-hypothesis__title">{h.title}</h3>
+                    <h3 className="rd-edition-hypothesis__title">
+                      {getHypothesisReviewTitle(h)}
+                    </h3>
                   </div>
-                  <p className="rd-edition-hypothesis__claim">{h.claimForm}</p>
+                  <p className="rd-edition-hypothesis__claim">
+                    {getHypothesisReviewSummary(h)}
+                  </p>
                   <EvidenceChecklistStrip
                     checklist={h.evidenceChecklist}
                     passing={h.evidenceChecksPassing}
@@ -226,24 +239,31 @@ export function EditionPrintPage() {
         <EditionErrorBoundary label="print-forecasts">
           <section
             role="region"
-            aria-label="What to look at this week"
+            aria-label="Evidence watchlist"
             className="rd-edition-section"
             data-section="what-to-look-at"
             data-section-number={numberFor(visibleSections.findIndex((s) => s.id === "what-to-look-at"))}
-            data-section-kicker="Forecasts in motion"
+            data-section-kicker={HOME_EVIDENCE_WATCHLIST_SECTION.kicker}
           >
             <header>
               <p className="rd-edition-section__eyebrow">
-                {numberFor(visibleSections.findIndex((s) => s.id === "what-to-look-at"))} · Forecasts in motion
+                {numberFor(visibleSections.findIndex((s) => s.id === "what-to-look-at"))} · {HOME_EVIDENCE_WATCHLIST_SECTION.kicker}
               </p>
-              <h2 className="rd-edition-section__h2">What to look at this week</h2>
+              <h2 className="rd-edition-section__h2">
+                {HOME_EVIDENCE_WATCHLIST_SECTION.heading}
+              </h2>
             </header>
             {(forecasts ?? []).length === 0 ? (
-              <p className="rd-edition-empty">No active forecasts.</p>
+              <p className="rd-edition-empty">No evidence watchlist items.</p>
             ) : (
               (forecasts ?? []).slice(0, 5).map((f) => (
                 <article key={f._id} className="rd-edition-forecast">
-                  <p className="rd-edition-forecast__claim">{f.question}</p>
+                  <p className="rd-edition-forecast__claim">
+                    Forecast evidence review
+                  </p>
+                  <p className="rd-edition-meta">
+                    {getForecastReviewSummary(f)}
+                  </p>
                   <span className="rd-edition-forecast__prob">
                     {formatProbability(f.probability)}
                   </span>

--- a/src/features/redesign/surfaces/EditorialHomeAudienceRelevance.ts
+++ b/src/features/redesign/surfaces/EditorialHomeAudienceRelevance.ts
@@ -1,0 +1,83 @@
+import type { EditionHypothesis } from "../hooks/useActiveHypotheses";
+
+export const HOME_AUDIENCE_RELEVANCE_SECTION = {
+  kicker: "Audience relevance",
+  tocLabel: "Useful",
+  heading: "Why this is useful",
+} as const;
+
+export const HOME_EVIDENCE_WATCHLIST_SECTION = {
+  kicker: "Evidence watchlist",
+  tocLabel: "Check",
+  heading: "What to check next",
+} as const;
+
+export interface ForecastReviewInput {
+  probability?: number | null;
+  previousProbability?: number | null;
+  probabilityDelta?: number | null;
+  resolutionDate?: string | null;
+  updateCount?: number | null;
+  status?: string | null;
+}
+
+function formatReviewProbability(p: number | null | undefined): string {
+  if (p === null || p === undefined || !Number.isFinite(p)) {
+    return "probability ledger pending";
+  }
+  return `${Math.round(p * 100)}% current ledger`;
+}
+
+function formatReviewDelta(f: ForecastReviewInput): string | null {
+  if (
+    f.previousProbability !== null &&
+    f.previousProbability !== undefined &&
+    Number.isFinite(f.previousProbability)
+  ) {
+    return `${Math.round(f.previousProbability * 100)}% previous ledger`;
+  }
+  if (
+    f.probabilityDelta !== null &&
+    f.probabilityDelta !== undefined &&
+    Number.isFinite(f.probabilityDelta)
+  ) {
+    const pp = Math.round(f.probabilityDelta * 100);
+    return `${pp > 0 ? "+" : ""}${pp}pp weekly ledger move`;
+  }
+  return null;
+}
+
+export function getHypothesisReviewTitle(
+  h: Pick<EditionHypothesis, "label" | "threadName"> | { label?: string; threadName?: string },
+): string {
+  const topic = h.threadName?.trim() || h.label?.trim() || "Hypothesis";
+  return `${topic} evidence review`;
+}
+
+export function getHypothesisReviewSummary(h: EditionHypothesis): string {
+  const checks =
+    h.evidenceChecksTotal > 0
+      ? `${h.evidenceChecksPassing}/${h.evidenceChecksTotal} evidence checks passing`
+      : "evidence checks pending";
+
+  return [
+    `${h.supportingEvidenceCount} supporting refs`,
+    `${h.contradictingEvidenceCount} contradicting refs`,
+    checks,
+    `${h.threadName} review queue`,
+  ].join(" | ");
+}
+
+export function getForecastReviewSummary(f: ForecastReviewInput): string {
+  const parts = [
+    formatReviewProbability(f.probability),
+    formatReviewDelta(f),
+    f.updateCount !== null && f.updateCount !== undefined
+      ? `${f.updateCount} update${f.updateCount === 1 ? "" : "s"} logged`
+      : "weekly movement logged",
+    f.resolutionDate ? `resolution ${f.resolutionDate}` : "resolution date pending",
+    f.status ? `${f.status} status` : null,
+  ];
+
+  return parts.filter(Boolean).join(" | ");
+}

--- a/src/features/redesign/surfaces/EditorialHomeSurface.audience.test.ts
+++ b/src/features/redesign/surfaces/EditorialHomeSurface.audience.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  getForecastReviewSummary,
+  getHypothesisReviewSummary,
+  getHypothesisReviewTitle,
+  HOME_AUDIENCE_RELEVANCE_SECTION,
+  HOME_EVIDENCE_WATCHLIST_SECTION,
+} from "./EditorialHomeAudienceRelevance";
+import type { EditionHypothesis } from "../hooks/useActiveHypotheses";
+
+function makeHypothesis(
+  overrides: Partial<EditionHypothesis> = {},
+): EditionHypothesis {
+  return {
+    _id: "hyp_1",
+    hypothesisId: "hyp_1",
+    threadId: "thread_1",
+    threadName: "Enterprise agents",
+    label: "Review queue",
+    title: "Sierra source review",
+    claimForm: "Sierra will reshape enterprise AI workflows.",
+    measurementApproach: "Track primary sources and customer evidence.",
+    falsificationCriteria: "Primary sources contradict the funding or adoption claim.",
+    status: "active",
+    confidence: 0.67,
+    speculativeRisk: "mixed",
+    supportingEvidenceCount: 3,
+    contradictingEvidenceCount: 1,
+    evidenceArtifactIds: ["src_1"],
+    competingHypothesisIds: [],
+    updatedAt: Date.parse("2026-05-11T12:00:00.000Z"),
+    evidenceChecklist: {
+      hasPrimarySource: true,
+      hasCorroboration: true,
+      hasFalsifiableClaim: false,
+      hasQuantitativeData: true,
+      hasNamedAttribution: false,
+      isReproducible: true,
+    },
+    evidenceChecksPassing: 4,
+    evidenceChecksTotal: 6,
+    evidenceLevel: "grounded",
+    ...overrides,
+  };
+}
+
+describe("EditorialHomeSurface audience relevance framing", () => {
+  it("uses workflow relevance labels instead of speculative So what copy", () => {
+    expect(HOME_AUDIENCE_RELEVANCE_SECTION).toEqual({
+      kicker: "Audience relevance",
+      tocLabel: "Useful",
+      heading: "Why this is useful",
+    });
+    expect(HOME_EVIDENCE_WATCHLIST_SECTION).toEqual({
+      kicker: "Evidence watchlist",
+      tocLabel: "Check",
+      heading: "What to check next",
+    });
+  });
+
+  it("summarizes hypothesis rows as evidence review state", () => {
+    const hypothesis = makeHypothesis();
+    const title = getHypothesisReviewTitle(hypothesis);
+    const summary = getHypothesisReviewSummary(hypothesis);
+
+    expect(title).toBe("Enterprise agents evidence review");
+    expect(summary).toBe(
+      "3 supporting refs | 1 contradicting refs | 4/6 evidence checks passing | Enterprise agents review queue",
+    );
+    expect(title).not.toContain("Sierra source review");
+    expect(summary).not.toContain("will reshape");
+    expect(summary).not.toContain("So what");
+  });
+
+  it("summarizes forecasts as a ledger watchlist, not raw predictive questions", () => {
+    const summary = getForecastReviewSummary({
+      probability: 0.58,
+      previousProbability: 0.52,
+      resolutionDate: "2026-06-30",
+      updateCount: 4,
+      status: "active",
+    });
+
+    expect(summary).toBe(
+      "58% current ledger | 52% previous ledger | 4 updates logged | resolution 2026-06-30 | active status",
+    );
+    expect(summary).not.toMatch(/\b(will|likely|could|should)\b/i);
+    expect(summary).not.toContain("So what");
+  });
+});

--- a/src/features/redesign/surfaces/EditorialHomeSurface.tsx
+++ b/src/features/redesign/surfaces/EditorialHomeSurface.tsx
@@ -75,6 +75,13 @@ import {
   type LiveArtifactsResult,
   type LiveArtifactSourceRow,
 } from "../hooks/useLiveArtifacts";
+import {
+  getForecastReviewSummary,
+  getHypothesisReviewSummary,
+  getHypothesisReviewTitle,
+  HOME_EVIDENCE_WATCHLIST_SECTION,
+  HOME_AUDIENCE_RELEVANCE_SECTION,
+} from "./EditorialHomeAudienceRelevance";
 import { useOnlineStatus } from "../../../lib/performance/useOnlineStatus";
 import { trackEvent } from "../../../lib/analytics";
 import { getAnonymousProductSessionId } from "../../product/lib/productIdentity";
@@ -647,7 +654,7 @@ function CompetingExplanationsSection({
   return (
     <EditorialSection
       id="competing-explanations"
-      ariaLabel="The competing explanations"
+      ariaLabel="Audience relevance and evidence review queue"
       number={number}
       kicker={kicker}
       heading={heading}
@@ -655,8 +662,10 @@ function CompetingExplanationsSection({
       <div>
         {hypotheses.length === 0 ? (
           <p className="rd-edition-empty">
-            No active hypotheses changed in this edition. NodeBench will surface
-            competing explanations here once evidence starts moving.
+            No active hypothesis evidence changed in this edition. Use the
+            changed reports, source rows, and actions below as the decision
+            queue; NodeBench only elevates a thesis when citations and evidence
+            checks move.
           </p>
         ) : hypotheses.map((h, i) => (
           <article
@@ -668,15 +677,17 @@ function CompetingExplanationsSection({
             <div className="rd-edition-hypothesis__head">
               <span className="rd-edition-hypothesis__label">{h.label}</span>
               <h3 className="rd-edition-hypothesis__title">
-                {h.title}
+                {getHypothesisReviewTitle(h)}
                 <Footnote
                   id={`hyp-${i + 1}`}
                   index={i + 1}
-                  label={`Source for ${h.title}`}
+                  label={`Source for ${getHypothesisReviewTitle(h)}`}
                 />
               </h3>
             </div>
-            <p className="rd-edition-hypothesis__claim">{h.claimForm}</p>
+            <p className="rd-edition-hypothesis__claim">
+              {getHypothesisReviewSummary(h)}
+            </p>
             <EvidenceChecklistStrip
               checklist={h.evidenceChecklist}
               passing={h.evidenceChecksPassing}
@@ -685,7 +696,7 @@ function CompetingExplanationsSection({
             />
             {h.falsificationCriteria && (
               <p className="rd-edition-hypothesis__falsify">
-                Would change my mind: {h.falsificationCriteria}
+                Escalate for review if: {h.falsificationCriteria}
               </p>
             )}
             <p className="rd-edition-hypothesis__tally">
@@ -716,7 +727,7 @@ function WhatToLookAtSection({
     return (
       <EditorialSection
         id="what-to-look-at"
-        ariaLabel="What to look at this week"
+        ariaLabel="Evidence watchlist"
         number={number}
         kicker={kicker}
         heading={heading}
@@ -731,14 +742,15 @@ function WhatToLookAtSection({
   return (
     <EditorialSection
       id="what-to-look-at"
-      ariaLabel="What to look at this week"
+      ariaLabel="Evidence watchlist"
       number={number}
       kicker={kicker}
       heading={heading}
     >
       {forecasts.length === 0 ? (
         <p className="rd-edition-empty">
-          No active forecasts have updates yet. Check back after the next refresh.
+          No evidence watchlist items have updates yet. Check back after the
+          next source refresh.
         </p>
       ) : (
         <>
@@ -747,7 +759,12 @@ function WhatToLookAtSection({
               const delta = formatProbabilityDelta(f.probability, f.previousProbability);
               return (
                 <article key={f._id} className="rd-edition-forecast" data-forecast-id={f._id}>
-                  <p className="rd-edition-forecast__claim">{f.question}</p>
+                  <p className="rd-edition-forecast__claim">
+                    Forecast evidence review
+                  </p>
+                  <p className="rd-edition-meta">
+                    {getForecastReviewSummary(f)}
+                  </p>
                   <div className="rd-edition-forecast__row">
                     <span className="rd-edition-forecast__prob">
                       {formatProbability(f.probability)}
@@ -1625,19 +1642,21 @@ function WeeklyBranch({
               <section
                 data-section="week-forecasts"
                 data-section-number="02"
-                data-section-kicker="Top forecast moves"
+                data-section-kicker={HOME_EVIDENCE_WATCHLIST_SECTION.kicker}
                 className="rd-edition-section"
                 role="region"
-                aria-label="Top forecast moves"
+                aria-label="Weekly evidence watchlist"
               >
-                <p className="rd-edition-meta">02 · Top forecast moves</p>
+                <p className="rd-edition-meta">
+                  02 · {HOME_EVIDENCE_WATCHLIST_SECTION.kicker}
+                </p>
                 <ul>
                   {data.topForecasts.map((f) => {
                     const pp = Math.round(f.probabilityDelta * 100);
                     const tone = pp > 0 ? "up" : pp < 0 ? "down" : "flat";
                     return (
                       <li key={f._id} style={{ marginBottom: 8 }}>
-                        <strong>{f.question}</strong>{" "}
+                        <strong>Forecast evidence review</strong>{" "}
                         <span
                           className={`rd-edition-scoreboard__delta rd-edition-scoreboard__delta--${tone}`}
                         >
@@ -1645,10 +1664,9 @@ function WeeklyBranch({
                           {pp > 0 ? "+" : ""}
                           {pp}pp]
                         </span>{" "}
-                        <span className="rd-edition-meta">
-                          → {Math.round(f.probability * 100)}% by{" "}
-                          {f.resolutionDate}
-                        </span>
+                        <p className="rd-edition-meta">
+                          {getForecastReviewSummary(f)}
+                        </p>
                       </li>
                     );
                   })}
@@ -1660,17 +1678,17 @@ function WeeklyBranch({
               <section
                 data-section="week-hypotheses"
                 data-section-number="03"
-                data-section-kicker="Hypotheses moved"
+                data-section-kicker="Evidence reviews"
                 className="rd-edition-section"
                 role="region"
-                aria-label="Hypotheses moved this week"
+                aria-label="Hypothesis evidence reviews this week"
               >
-                <p className="rd-edition-meta">03 · Hypotheses moved</p>
+                <p className="rd-edition-meta">03 · Evidence reviews</p>
                 <ul>
                   {data.topHypotheses.map((h) => (
                     <li key={h._id} style={{ marginBottom: 8 }}>
                       <strong>
-                        {h.label} {h.title}
+                        {getHypothesisReviewTitle({ label: h.label })}
                       </strong>
                       <p className="rd-edition-meta">
                         {h.supportingEvidenceCount} supporting ·{" "}
@@ -1923,15 +1941,11 @@ function LongHorizonBranch({
       },
       {
         id: "competing-explanations",
-        kicker: "Why it matters",
-        tocLabel: "So what",
-        heading: "So what",
+        ...HOME_AUDIENCE_RELEVANCE_SECTION,
       },
       {
         id: "what-to-look-at",
-        kicker: "What to do next",
-        tocLabel: "Now what",
-        heading: "Now what",
+        ...HOME_EVIDENCE_WATCHLIST_SECTION,
       },
       {
         id: "reports-touched",
@@ -2175,15 +2189,15 @@ function LongHorizonBranch({
 
         <CompetingExplanationsSection
           number={numberForId.get("competing-explanations") ?? "02"}
-          kicker="Why it matters"
-          heading="So what"
+          kicker={HOME_AUDIENCE_RELEVANCE_SECTION.kicker}
+          heading={HOME_AUDIENCE_RELEVANCE_SECTION.heading}
           hypotheses={hypotheses ?? []}
         />
 
         <WhatToLookAtSection
           number={numberForId.get("what-to-look-at") ?? "03"}
-          kicker="What to do next"
-          heading="Now what"
+          kicker={HOME_EVIDENCE_WATCHLIST_SECTION.kicker}
+          heading={HOME_EVIDENCE_WATCHLIST_SECTION.heading}
           forecasts={forecasts}
         />
 
@@ -2413,15 +2427,11 @@ function TodayRender({
     });
     sections.push({
       id: "competing-explanations",
-      kicker: "Why it matters",
-      tocLabel: "So what",
-      heading: "So what",
+      ...HOME_AUDIENCE_RELEVANCE_SECTION,
     });
     sections.push({
       id: "what-to-look-at",
-      kicker: "What to do next",
-      tocLabel: "Now what",
-      heading: "Now what",
+      ...HOME_EVIDENCE_WATCHLIST_SECTION,
     });
     sections.push({
       id: "reports-touched",

--- a/src/features/redesign/surfaces/EditorialHomeSurface.tsx
+++ b/src/features/redesign/surfaces/EditorialHomeSurface.tsx
@@ -27,7 +27,7 @@
  * - Footnote `<sup>` anchors target `id="fn-{N}"` in §6, with
  *   `tabindex="-1"` on each `<li>` so screen readers focus the
  *   target.
- * - Right-rail `<EditionTOC>` (desktop only, ≥1024px) with scroll-spy
+ * - Right-rail `<EditionTOC>` (wide desktop only, ≥1440px) with scroll-spy
  *   active state.
  *
  * ─── Phase 7c additions ─────────────────────────────────────────
@@ -36,8 +36,10 @@
  *   discoverability link added to LegacyHomeSurface).
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useMutation } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
 import { UniversalComposer } from "../components/UniversalComposer";
 import { StreamingMarkdown } from "../components/StreamingMarkdown";
 import { EditorialSection } from "../components/edition/EditorialSection";
@@ -68,8 +70,18 @@ import { useEditionView } from "../hooks/useEditionView";
 import { useDailyEditionSwr } from "../hooks/useDailyEditionSwr";
 import { useWeeklyDigestSwr } from "../hooks/useWeeklyDigestSwr";
 import { useMonthlyRetrospectiveSwr } from "../hooks/useMonthlyRetrospectiveSwr";
+import {
+  useLiveArtifacts,
+  type LiveArtifactsResult,
+  type LiveArtifactSourceRow,
+} from "../hooks/useLiveArtifacts";
 import { useOnlineStatus } from "../../../lib/performance/useOnlineStatus";
-import { EditionSelector } from "../components/edition/EditionSelector";
+import { trackEvent } from "../../../lib/analytics";
+import { getAnonymousProductSessionId } from "../../product/lib/productIdentity";
+import {
+  EditionSelector,
+  type EditionSelection,
+} from "../components/edition/EditionSelector";
 import { Pill } from "../components/Pill";
 import "../components/edition/edition.css";
 
@@ -84,6 +96,49 @@ const ABSENT = Symbol("absent");
 
 function pad2(n: number): string {
   return n < 10 ? `0${n}` : `${n}`;
+}
+
+const DAY_MS = 86_400_000;
+
+function clientDateKey(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function isoWeekWindow(weekKey: string): { start: string; end: string } {
+  const match = weekKey.match(/^(\d{4})-W(\d{2})$/);
+  if (!match) return { start: weekKey, end: weekKey };
+  const year = Number(match[1]);
+  const week = Number(match[2]);
+  const jan4 = Date.UTC(year, 0, 4);
+  const jan4Day = new Date(jan4).getUTCDay() || 7;
+  const week1Mon = jan4 - (jan4Day - 1) * DAY_MS;
+  const startMs = week1Mon + (week - 1) * 7 * DAY_MS;
+  return { start: clientDateKey(startMs), end: clientDateKey(startMs + 6 * DAY_MS) };
+}
+
+function monthWindow(monthKey: string): { start: string; end: string } {
+  const match = monthKey.match(/^(\d{4})-(\d{2})$/);
+  if (!match) return { start: monthKey, end: monthKey };
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const startMs = Date.UTC(year, month - 1, 1);
+  const endMs = Date.UTC(year, month, 1) - DAY_MS;
+  return { start: clientDateKey(startMs), end: clientDateKey(endMs) };
+}
+
+function quarterWindow(quarterKey: string): { start: string; end: string } {
+  const match = quarterKey.match(/^(\d{4})-Q([1-4])$/);
+  if (!match) return { start: quarterKey, end: quarterKey };
+  const year = Number(match[1]);
+  const quarter = Number(match[2]);
+  const startMonth = (quarter - 1) * 3;
+  const startMs = Date.UTC(year, startMonth, 1);
+  const endMs = Date.UTC(year, startMonth + 3, 1) - DAY_MS;
+  return { start: clientDateKey(startMs), end: clientDateKey(endMs) };
+}
+
+function yearWindow(yearKey: string): { start: string; end: string } {
+  return { start: `${yearKey}-01-01`, end: `${yearKey}-12-31` };
 }
 
 /**
@@ -145,6 +200,196 @@ function OfflineBanner({
         — showing cached edition from {formatAge(ageMs)}.
       </span>
     </div>
+  );
+}
+
+type CoordinatorStatus = "loading" | "ready" | "empty";
+
+function statusFromCount(
+  isLoading: boolean,
+  count: number | null | undefined,
+): CoordinatorStatus {
+  if (isLoading) return "loading";
+  return (count ?? 0) > 0 ? "ready" : "empty";
+}
+
+function HomePulseCoordinatorTrace({
+  period,
+  periodKey,
+  pulses,
+  hypotheses,
+  forecasts,
+  snapshot,
+  liveArtifacts,
+  artifactIds,
+  windowLabel,
+  windowStart,
+  windowEnd,
+  retrospectiveCount,
+  retrospectiveSource = "live",
+}: {
+  period: "today" | "week" | "month" | "quarter" | "year";
+  periodKey: string;
+  pulses: ReturnType<typeof useTodayPulse>;
+  hypotheses: EditionHypothesis[] | undefined;
+  forecasts: EditionForecast[] | undefined;
+  snapshot: ReturnType<typeof useLatestDailyBriefSnapshot>;
+  liveArtifacts: LiveArtifactsResult;
+  artifactIds: string[];
+  windowLabel: string;
+  windowStart: string;
+  windowEnd: string;
+  retrospectiveCount: number;
+  retrospectiveSource?: string;
+}) {
+  const reportCount = liveArtifacts.reports.length;
+  const sourceCount =
+    liveArtifacts.details.reduce((total, detail) => total + detail.sourceRows.length, 0) +
+    artifactIds.length;
+  const actionCount = liveArtifacts.reports.reduce(
+    (total, report) => total + report.followUps,
+    0,
+  );
+  const pulseCount = pulses?.pulses.length ?? 0;
+  const hypothesisCount = hypotheses?.length ?? 0;
+  const forecastCount = forecasts?.length ?? 0;
+  const cells = useMemo(() => [
+    {
+      label: "Memory",
+      value: reportCount,
+      status: statusFromCount(liveArtifacts.isLoading, reportCount),
+    },
+    {
+      label: "Pulse",
+      value: pulseCount,
+      status: statusFromCount(pulses === undefined, pulseCount),
+    },
+    {
+      label: "Reports",
+      value: reportCount,
+      status: statusFromCount(liveArtifacts.isLoading, reportCount),
+    },
+    {
+      label: "Sources",
+      value: sourceCount,
+      status: statusFromCount(false, sourceCount),
+    },
+    {
+      label: "Hypotheses",
+      value: hypothesisCount,
+      status: statusFromCount(hypotheses === undefined, hypothesisCount),
+    },
+    {
+      label: "Forecasts",
+      value: forecastCount,
+      status: statusFromCount(forecasts === undefined, forecastCount),
+    },
+    {
+      label: "Actions",
+      value: actionCount,
+      status: statusFromCount(liveArtifacts.isLoading, actionCount),
+    },
+    {
+      label: "Rollup",
+      value: retrospectiveCount,
+      status: statusFromCount(false, retrospectiveCount),
+    },
+  ], [
+    actionCount,
+    forecastCount,
+    forecasts,
+    hypothesisCount,
+    hypotheses,
+    liveArtifacts.isLoading,
+    pulseCount,
+    pulses,
+    reportCount,
+    retrospectiveCount,
+    sourceCount,
+  ]);
+  useEffect(() => {
+    trackEvent("HOME-010.start", {
+      period,
+      periodKey,
+      windowStart,
+      windowEnd,
+    });
+    trackEvent("rollup.window.selected", {
+      period,
+      periodKey,
+      windowStart,
+      windowEnd,
+      source: retrospectiveSource,
+      count: retrospectiveCount,
+    });
+    for (const cell of cells) {
+      trackEvent(`coordinator.fanIn.${cell.label.toLowerCase()}`, {
+        period,
+        periodKey,
+        source: cell.label,
+        status: cell.status,
+        count: cell.value,
+      });
+    }
+    trackEvent("HOME-010.complete", {
+      period,
+      periodKey,
+      reports: reportCount,
+      sources: sourceCount,
+      actions: actionCount,
+      retrospective: retrospectiveCount,
+    });
+  }, [
+    actionCount,
+    period,
+    periodKey,
+    reportCount,
+    retrospectiveCount,
+    retrospectiveSource,
+    sourceCount,
+    windowEnd,
+    windowStart,
+    cells,
+  ]);
+
+  return (
+    <section
+      className="rd-coordinator-trace"
+      aria-label="Pulse provenance"
+      data-home-pulse-coordinator
+      data-run-id={`home-pulse-${period}-${periodKey}`}
+      data-period={period}
+      data-period-key={periodKey}
+      data-window-start={windowStart}
+      data-window-end={windowEnd}
+      data-live-artifacts={liveArtifacts.isLive ? "true" : "false"}
+      data-snapshot={snapshot ? "ready" : snapshot === undefined ? "loading" : "empty"}
+      data-report-count={reportCount}
+      data-source-count={sourceCount}
+      data-action-count={actionCount}
+      data-retrospective-count={retrospectiveCount}
+      data-retrospective-source={retrospectiveSource}
+      data-telemetry-traces="HOME-010.start coordinator.fanIn.* rollup.window.selected HOME-010.complete"
+    >
+      <div className="rd-coordinator-trace__head">
+        <span className="rd-edition-meta">{windowLabel}</span>
+        <span className="rd-edition-meta">
+          {windowStart} to {windowEnd} - {retrospectiveSource}
+        </span>
+      </div>
+      <div className="rd-coordinator-trace__grid">
+        {cells.map((cell) => (
+          <span
+            key={cell.label}
+            className="rd-coordinator-trace__cell"
+            data-source={cell.label.toLowerCase()}
+            data-status={cell.status}
+          >
+            <strong>{cell.value}</strong> {cell.label}
+          </span>
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -408,7 +653,12 @@ function CompetingExplanationsSection({
       heading={heading}
     >
       <div>
-        {hypotheses.map((h, i) => (
+        {hypotheses.length === 0 ? (
+          <p className="rd-edition-empty">
+            No active hypotheses changed in this edition. NodeBench will surface
+            competing explanations here once evidence starts moving.
+          </p>
+        ) : hypotheses.map((h, i) => (
           <article
             key={h._id}
             className="rd-edition-hypothesis"
@@ -598,6 +848,266 @@ function ScoreboardSection({
 
 /* ─── §5 — Capabilities map ─────────────────────────────────────── */
 
+function ReportsTouchedSection({
+  number,
+  kicker,
+  heading,
+  snapshot,
+  reports,
+}: {
+  number: string;
+  kicker: string;
+  heading: string;
+  snapshot: ReturnType<typeof useLatestDailyBriefSnapshot>;
+  reports?: LiveArtifactsResult["reports"];
+}) {
+  if (snapshot === undefined) {
+    return (
+      <EditorialSection
+        id="reports-touched"
+        ariaLabel="Reports touched"
+        number={number}
+        kicker={kicker}
+        heading={heading}
+      >
+        <div className="rd-edition-skeleton" style={{ width: "88%" }} />
+        <div className="rd-edition-skeleton" style={{ width: "64%" }} />
+      </EditorialSection>
+    );
+  }
+
+  const stats = snapshot?.dashboardMetrics?.keyStats ?? [];
+  const generatedAt = snapshot?.generatedAt
+    ? new Date(snapshot.generatedAt).toISOString().slice(0, 16)
+    : null;
+  const liveReports = reports ?? [];
+
+  return (
+    <EditorialSection
+      id="reports-touched"
+      ariaLabel="Reports touched"
+      number={number}
+      kicker={kicker}
+      heading={heading}
+    >
+      {snapshot ? (
+        <>
+          <p>
+            Latest daily brief snapshot: <strong>{snapshot.dateString}</strong>
+            {generatedAt ? (
+              <span className="rd-edition-meta"> - generated {generatedAt}Z</span>
+            ) : null}
+            .
+          </p>
+          {stats.length > 0 ? (
+            <ul>
+              {stats.slice(0, 4).map((stat: any, index: number) => (
+                <li key={`${stat.label ?? "stat"}-${index}`} style={{ marginBottom: 6 }}>
+                  <strong>{stat.label ?? "Metric"}</strong>
+                  {stat.value !== undefined ? `: ${stat.value}` : ""}
+                  {stat.delta !== undefined ? (
+                    <span className="rd-edition-meta"> - {stat.delta}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="rd-edition-empty" style={{ padding: 0 }}>
+              Snapshot loaded, but no report metrics were attached.
+            </p>
+          )}
+          {liveReports.length > 0 ? (
+            <>
+              <p className="rd-edition-meta" style={{ marginTop: 12 }}>
+                Live report handles
+              </p>
+              <ul>
+                {liveReports.map((report) => (
+                  <li key={report.id} style={{ marginBottom: 6 }}>
+                    <a href={`/redesign/reports/${report.id}`}>
+                      {report.entity}
+                    </a>{" "}
+                    <span className="rd-edition-meta">
+                      {report.kind} - {report.status} - {report.sources} sources -{" "}
+                      {report.claims} claims - {report.followUps} follow-ups
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p className="rd-edition-empty" style={{ padding: 0 }}>
+              No live report handles are available yet.
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="rd-edition-empty">
+          No daily brief snapshot is available yet, so there are no report
+          updates to attribute.
+        </p>
+      )}
+    </EditorialSection>
+  );
+}
+
+function ActionsCreatedSection({
+  number,
+  kicker,
+  heading,
+  pulses,
+  hypotheses,
+  forecasts,
+  onAsk,
+  reports,
+  actionPrompt = "Turn today's Home Pulse actions into follow-ups and notebook patch proposals.",
+  nudgeKey = "home-pulse-actions",
+}: {
+  number: string;
+  kicker: string;
+  heading: string;
+  pulses: ReturnType<typeof useTodayPulse>;
+  hypotheses: EditionHypothesis[] | undefined;
+  forecasts: EditionForecast[] | undefined;
+  onAsk: Props["onAsk"];
+  reports?: LiveArtifactsResult["reports"];
+  actionPrompt?: string;
+  nudgeKey?: string;
+}) {
+  const createHomePulseNudge = useMutation(
+    (api as unknown as {
+      domains: {
+        product: {
+          nudges: {
+            createHomePulseFollowupNudge: unknown;
+          };
+        };
+      };
+    }).domains.product.nudges.createHomePulseFollowupNudge as Parameters<
+      typeof useMutation
+    >[0],
+  );
+  const [nudgeState, setNudgeState] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
+  const materialChanges =
+    pulses?.pulses.reduce((n, p) => n + (p.materialChangeCount ?? 0), 0) ?? 0;
+  const reportFollowUps =
+    reports?.reduce((total, report) => total + (report.followUps ?? 0), 0) ?? 0;
+  const actionItems = [
+    reportFollowUps > 0
+      ? `${reportFollowUps} existing follow-up ${
+          reportFollowUps === 1 ? "record is" : "records are"
+        } already linked to live reports.`
+      : null,
+    materialChanges > 0
+      ? `Refresh reports touched by ${materialChanges} material change${
+          materialChanges === 1 ? "" : "s"
+        }.`
+      : null,
+    hypotheses && hypotheses.length > 0
+      ? `Review ${hypotheses.length} active hypothesis ${
+          hypotheses.length === 1 ? "thread" : "threads"
+        } before updating the notebook.`
+      : null,
+    forecasts && forecasts.length > 0
+      ? `Check ${forecasts.length} forecast ${
+          forecasts.length === 1 ? "move" : "moves"
+        } for follow-up timing.`
+      : null,
+  ].filter((item): item is string => item !== null);
+  const actionSummary =
+    actionItems.length > 0
+      ? actionItems.join(" ")
+      : "Review the latest Home Pulse and decide which report, notebook, or source trail needs a follow-up.";
+
+  const handleCreateNudge = async () => {
+    setNudgeState("saving");
+    trackEvent("HOME-015.start", {
+      target: nudgeKey,
+      actionCount: actionItems.length,
+    });
+    try {
+      await createHomePulseNudge({
+        anonymousSessionId: getAnonymousProductSessionId(),
+        title: "Home Pulse follow-up",
+        summary: actionSummary,
+        actionLabel: "Open in Chat",
+        actionTargetSurface: "chat",
+        actionTargetId: nudgeKey,
+      });
+      trackEvent("action.created", {
+        target: nudgeKey,
+        surface: "inbox",
+        actionCount: actionItems.length,
+      });
+      trackEvent("HOME-015.complete", {
+        target: nudgeKey,
+        status: "saved",
+      });
+      setNudgeState("saved");
+    } catch (error) {
+      console.error("[home-pulse] failed to create follow-up nudge", error);
+      trackEvent("HOME-015.failed", {
+        target: nudgeKey,
+        status: "error",
+      });
+      setNudgeState("error");
+    }
+  };
+
+  return (
+    <EditorialSection
+      id="actions-created"
+      ariaLabel="Actions created"
+      number={number}
+      kicker={kicker}
+      heading={heading}
+    >
+      {actionItems.length === 0 ? (
+        <p className="rd-edition-empty">
+          No automatic actions were created by this read-only Home render.
+          Ask NodeBench to create a follow-up, notebook patch, or report refresh
+          when a signal matters.
+        </p>
+      ) : (
+        <>
+          <ul>
+            {actionItems.map((item) => (
+              <li key={item} style={{ marginBottom: 8 }}>
+                {item}
+              </li>
+            ))}
+          </ul>
+          <p className="rd-edition-meta" style={{ marginTop: 8 }}>
+            <button
+              type="button"
+              className="rd-btn rd-btn--quiet rd-btn--sm"
+              onClick={handleCreateNudge}
+              disabled={nudgeState === "saving"}
+              data-telemetry-traces="HOME-015.start action.created HOME-015.complete"
+            >
+              {nudgeState === "saving" ? "Creating..." : "Create Inbox follow-up"}
+            </button>{" "}
+            <button
+              type="button"
+              className="rd-btn rd-btn--quiet rd-btn--sm"
+              onClick={() => onAsk(actionPrompt)}
+            >
+              Open Chat
+            </button>
+            {nudgeState === "saved" ? (
+              <span className="rd-edition-meta"> Follow-up saved to Inbox.</span>
+            ) : nudgeState === "error" ? (
+              <span className="rd-edition-meta"> Could not save. Open Chat instead.</span>
+            ) : null}
+          </p>
+        </>
+      )}
+    </EditorialSection>
+  );
+}
+
 function CapabilitiesSection({
   number,
   kicker,
@@ -665,11 +1175,13 @@ function FootnotesSection({
   kicker,
   heading,
   artifactIds,
+  liveSourceRows = [],
 }: {
   number: string;
   kicker: string;
   heading: string;
   artifactIds: string[];
+  liveSourceRows?: LiveArtifactSourceRow[];
 }) {
   // SWR-wrapped (Phase 9b follow-up): footnotes paint from IDB cache on
   // warm visits while Convex revalidates.  The cache key uses sorted
@@ -690,7 +1202,14 @@ function FootnotesSection({
     );
   }
 
-  const totalCount = data.artifacts.length + data.industry.length;
+  const liveRows = liveSourceRows
+    .filter((row) => row.href)
+    .filter(
+      (row, index, rows) =>
+        rows.findIndex((candidate) => candidate.href === row.href) === index,
+    )
+    .slice(0, 24);
+  const totalCount = data.artifacts.length + data.industry.length + liveRows.length;
 
   return (
     <EditorialSection
@@ -763,6 +1282,23 @@ function FootnotesSection({
                 </li>
               );
             })}
+            {liveRows.map((row, i) => (
+              <li
+                key={`live-${row.id}`}
+                id={`fn-${data.artifacts.length + data.industry.length + i + 1}`}
+                tabIndex={-1}
+              >
+                <span>
+                  <a href={row.href} target="_blank" rel="noopener noreferrer">
+                    {row.title}
+                  </a>
+                  <span className="rd-edition-meta">
+                    {" "}Â· {row.refreshed}
+                  </span>
+                  {row.excerpt ? <> â€” &ldquo;{row.excerpt}&rdquo;</> : null}
+                </span>
+              </li>
+            ))}
           </ol>
         </div>
       )}
@@ -963,6 +1499,7 @@ function ArchivedDayBranch({
 
 /* ─── Weekly-digest render branch (P0 #3) ───────────────────────── */
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function WeeklyBranch({
   weekKey,
   selection,
@@ -1153,6 +1690,7 @@ function WeeklyBranch({
 
 /* ─── Monthly retrospective render branch (P0 #3, minimal) ──────── */
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function MonthlyBranch({
   monthKey,
   selection,
@@ -1306,6 +1844,402 @@ function MonthlyBranch({
 
 /* ─── EditorialHomeSurface root ─────────────────────────────────── */
 
+function LongHorizonBranch({
+  period,
+  periodKey,
+  selection,
+  onAsk,
+  onSwitchToClassic,
+}: {
+  period: "week" | "month" | "quarter" | "year";
+  periodKey: string;
+  selection:
+    | Extract<EditionSelection, { kind: "week" }>
+    | Extract<EditionSelection, { kind: "month" }>
+    | Extract<EditionSelection, { kind: "quarter" }>
+    | Extract<EditionSelection, { kind: "year" }>;
+  onAsk: Props["onAsk"];
+  onSwitchToClassic: () => void;
+}) {
+  const hypothesesSwr = useActiveHypothesesSwr(5);
+  const forecastsSwr = useTopForecastsSwr(5);
+  const todayPulseSwr = useTodayPulseSwr(12);
+  const snapshotSwr = useLatestDailyBriefSnapshotSwr();
+  const liveArtifacts = useLiveArtifacts(8);
+  const weeklySwr = useWeeklyDigestSwr(period === "week" ? periodKey : null);
+  const monthlySwr = useMonthlyRetrospectiveSwr(period === "month" ? periodKey : null);
+
+  const hypotheses = hypothesesSwr.data;
+  const forecasts = forecastsSwr.data;
+  const todayPulse = todayPulseSwr.data;
+  const snapshot = snapshotSwr.data;
+  const weeklyData = weeklySwr.data;
+  const monthlyData = monthlySwr.data;
+  const { online, convexConnected } = useOnlineStatus();
+
+  const oldestAgeMs = [
+    hypothesesSwr.swr,
+    forecastsSwr.swr,
+    todayPulseSwr.swr,
+    snapshotSwr.swr,
+    weeklySwr.swr,
+    monthlySwr.swr,
+  ]
+    .filter((s) => s.hydratedFromCache && !s.isLive)
+    .map((s) => s.ageMs ?? 0)
+    .reduce<number | null>(
+      (acc, v) => (acc === null || v > acc ? v : acc),
+      null,
+    );
+
+  const artifactIds = useMemo(() => {
+    const ids: string[] = [];
+    if (Array.isArray(hypotheses)) {
+      for (const h of hypotheses) {
+        for (const id of h.evidenceArtifactIds ?? []) ids.push(id);
+      }
+    }
+    return ids;
+  }, [hypotheses]);
+  const liveSourceRows = useMemo(
+    () => liveArtifacts.details.flatMap((detail) => detail.sourceRows),
+    [liveArtifacts.details],
+  );
+
+  const visibleSections: SectionDescriptor[] = useMemo(
+    () => [
+      {
+        id: "what-changed",
+        kicker:
+          period === "week"
+            ? "This week"
+            : period === "month"
+              ? "This month"
+              : period === "quarter"
+                ? "This quarter"
+                : "This year",
+        tocLabel: "Changed",
+        heading: "What changed",
+      },
+      {
+        id: "competing-explanations",
+        kicker: "Why it matters",
+        tocLabel: "So what",
+        heading: "So what",
+      },
+      {
+        id: "what-to-look-at",
+        kicker: "What to do next",
+        tocLabel: "Now what",
+        heading: "Now what",
+      },
+      {
+        id: "reports-touched",
+        kicker: "Reports touched",
+        tocLabel: "Reports",
+        heading: "Reports touched",
+      },
+      {
+        id: "footnotes",
+        kicker: "Sources used",
+        tocLabel: "Sources",
+        heading: "Sources used",
+      },
+      {
+        id: "actions-created",
+        kicker: "Actions created",
+        tocLabel: "Actions",
+        heading: "Actions created",
+      },
+    ],
+    [period],
+  );
+
+  const numberForId = useMemo(() => {
+    const map = new Map<string, string>();
+    visibleSections.forEach((s, i) => map.set(s.id, pad2(i + 1)));
+    return map;
+  }, [visibleSections]);
+
+  const tocEntries: EditionTOCEntry[] = useMemo(
+    () =>
+      visibleSections.map((s) => ({
+        id: s.id,
+        number: numberForId.get(s.id) ?? "",
+        label: s.tocLabel,
+      })),
+    [visibleSections, numberForId],
+  );
+
+  const title =
+    period === "week"
+      ? "This week"
+      : period === "month"
+        ? "This month"
+        : period === "quarter"
+          ? "This quarter"
+          : "This year";
+  const memoHeading =
+    period === "week"
+      ? "Weekly intelligence brief"
+      : period === "month"
+        ? "Monthly intelligence memo"
+        : period === "quarter"
+          ? "Quarterly intelligence memo"
+          : "Annual intelligence memo";
+  const pulseCount = todayPulse?.pulses.length ?? 0;
+  const materialChanges =
+    todayPulse?.pulses.reduce((n, p) => n + (p.materialChangeCount ?? 0), 0) ??
+    0;
+  const reportMetricCount = snapshot?.dashboardMetrics?.keyStats?.length ?? 0;
+  const liveSourceCount = liveArtifacts.details.reduce(
+    (total, detail) => total + detail.sourceRows.length,
+    0,
+  );
+  const fallbackWindow =
+    period === "week"
+      ? isoWeekWindow(periodKey)
+      : period === "month"
+        ? monthWindow(periodKey)
+        : period === "quarter"
+          ? quarterWindow(periodKey)
+          : yearWindow(periodKey);
+  const windowStart =
+    period === "week" && weeklyData?.available
+      ? weeklyData.startDateKey
+      : fallbackWindow.start;
+  const windowEnd =
+    period === "week" && weeklyData?.available
+      ? weeklyData.endDateKey
+      : fallbackWindow.end;
+  const retrospectiveCount =
+    period === "week" && weeklyData?.available
+      ? weeklyData.topPulses.length +
+        weeklyData.topForecasts.length +
+        weeklyData.topHypotheses.length
+      : period === "month" && monthlyData?.available
+        ? monthlyData.topPerWeek.length +
+          monthlyData.resolvedForecastCount +
+          (monthlyData.dailyHistogram?.filter((value) => value > 0).length ?? 0)
+        : period === "quarter" || period === "year"
+          ? reportMetricCount + liveSourceCount
+          : 0;
+  const retrospectiveSource =
+    period === "week"
+      ? "weekly Convex rollup"
+      : period === "month"
+        ? "monthly Convex rollup"
+        : "live coverage substrate";
+  const actionPrompt =
+    period === "week"
+      ? "Turn this week Home Pulse into a weekly intelligence brief with report refresh proposals."
+      : period === "month"
+        ? "Turn this month Home Pulse into a monthly intelligence memo with coverage-book updates."
+        : period === "quarter"
+      ? "Turn this quarter Home Pulse into a quarterly intelligence memo with report refresh proposals."
+      : "Turn this year Home Pulse into an annual intelligence memo with coverage-book updates.";
+
+  return (
+    <div data-edition data-edition-kind={period}>
+      <EditionTOC entries={tocEntries} />
+      <div className="rd-edition-root">
+        <header
+          className="rd-edition-header"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            paddingBottom: 8,
+            borderBottom: "1px solid var(--rd-edition-rule-strong)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Pill tone="accent">{title}</Pill>
+            <span className="rd-edition-meta">{periodKey}</span>
+            <button
+              type="button"
+              onClick={onSwitchToClassic}
+              className="rd-edition-switch"
+              aria-label="Switch to classic home"
+              data-edition-switch
+              style={{
+                marginLeft: "auto",
+                background: "transparent",
+                border: "none",
+                color: "var(--rd-ink-mute)",
+                fontSize: 12,
+                fontWeight: 500,
+                letterSpacing: "0.04em",
+                cursor: "pointer",
+                padding: "4px 8px",
+                borderRadius: 4,
+                textDecoration: "underline",
+                textUnderlineOffset: 3,
+              }}
+            >
+              Switch to classic home
+            </button>
+          </div>
+          <EditionSelector selection={selection} />
+          <h1
+            style={{
+              fontSize: 32,
+              fontWeight: 700,
+              letterSpacing: "-0.6px",
+              margin: 0,
+              lineHeight: 1.18,
+              color: "var(--rd-ink-strong)",
+            }}
+          >
+            {memoHeading}
+          </h1>
+          <p
+            style={{
+              fontSize: 15.5,
+              lineHeight: 1.55,
+              color: "var(--rd-ink-mute)",
+              margin: 0,
+            }}
+          >
+            A long-horizon Home Pulse composed from live pulse, hypothesis,
+            forecast, source, and daily brief state. Historical aggregation is
+            explicit; no fixture fallback is used.
+          </p>
+        </header>
+
+        <UniversalComposer
+          onSubmit={(text) => onAsk(text)}
+          onChatNow={(text) => onAsk(text)}
+          placeholder={`Ask to extend ${title.toLowerCase()}...`}
+        />
+
+        <OfflineBanner
+          online={online}
+          convexConnected={convexConnected}
+          ageMs={oldestAgeMs}
+        />
+
+        <HomePulseCoordinatorTrace
+          period={period}
+          periodKey={periodKey}
+          pulses={todayPulse}
+          hypotheses={hypotheses}
+          forecasts={forecasts}
+          snapshot={snapshot}
+          liveArtifacts={liveArtifacts}
+          artifactIds={artifactIds}
+          windowLabel={`${memoHeading} coordinator`}
+          windowStart={windowStart}
+          windowEnd={windowEnd}
+          retrospectiveCount={retrospectiveCount}
+          retrospectiveSource={retrospectiveSource}
+        />
+
+        <EditorialSection
+          id="what-changed"
+          ariaLabel="What changed"
+          number={numberForId.get("what-changed") ?? "01"}
+          kicker={visibleSections[0].kicker}
+          heading="What changed"
+        >
+          <p>
+            NodeBench is tracking <strong>{pulseCount}</strong> current pulse
+            item{pulseCount === 1 ? "" : "s"} with{" "}
+            <strong>{materialChanges}</strong> material change
+            {materialChanges === 1 ? "" : "s"} in the live Home substrate.
+          </p>
+          {todayPulse === undefined ? (
+            <div className="rd-edition-skeleton" style={{ width: "82%" }} />
+          ) : todayPulse.pulses.length === 0 ? (
+            <p className="rd-edition-empty" style={{ padding: 0 }}>
+              No live pulse items are available for this rollup yet.
+            </p>
+          ) : (
+            <ul>
+              {todayPulse.pulses.slice(0, 4).map((p) => (
+                <li key={p._id} style={{ marginBottom: 6 }}>
+                  <strong>{p.entitySlug.replace(/-/g, " ")}</strong>:{" "}
+                  {p.changeCount} change{p.changeCount === 1 ? "" : "s"}
+                </li>
+              ))}
+            </ul>
+          )}
+        </EditorialSection>
+
+        <CompetingExplanationsSection
+          number={numberForId.get("competing-explanations") ?? "02"}
+          kicker="Why it matters"
+          heading="So what"
+          hypotheses={hypotheses ?? []}
+        />
+
+        <WhatToLookAtSection
+          number={numberForId.get("what-to-look-at") ?? "03"}
+          kicker="What to do next"
+          heading="Now what"
+          forecasts={forecasts}
+        />
+
+        <ReportsTouchedSection
+          number={numberForId.get("reports-touched") ?? "04"}
+          kicker="Reports touched"
+          heading="Reports touched"
+          snapshot={snapshot}
+          reports={liveArtifacts.reports}
+        />
+
+        <FootnotesSection
+          number={numberForId.get("footnotes") ?? "05"}
+          kicker="Sources used"
+          heading="Sources used"
+          artifactIds={artifactIds}
+          liveSourceRows={liveSourceRows}
+        />
+
+        <ActionsCreatedSection
+          number={numberForId.get("actions-created") ?? "06"}
+          kicker="Actions created"
+          heading="Actions created"
+          pulses={todayPulse}
+          hypotheses={hypotheses}
+          forecasts={forecasts}
+          reports={liveArtifacts.reports}
+          onAsk={onAsk}
+          actionPrompt={actionPrompt}
+          nudgeKey={`home-pulse-actions-${period}-${periodKey}`}
+        />
+
+        <section
+          data-section="memory-saved"
+          className="rd-edition-section"
+          role="region"
+          aria-label="Memory saved"
+        >
+          <p className="rd-edition-meta">
+            Memory saved: {reportMetricCount} live metric
+            {reportMetricCount === 1 ? "" : "s"} reused from the latest daily
+            brief snapshot instead of re-searching.
+          </p>
+          <button
+            type="button"
+            className="rd-btn rd-btn--quiet rd-btn--sm"
+            onClick={() => onAsk(actionPrompt)}
+          >
+            Build the memo in Chat
+          </button>
+        </section>
+      </div>
+    </div>
+  );
+}
+
 export function EditorialHomeSurface({ onAsk }: Props) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -1331,18 +2265,44 @@ export function EditorialHomeSurface({ onAsk }: Props) {
   }
   if (selection.kind === "week") {
     return (
-      <WeeklyBranch
-        weekKey={selection.weekKey}
+      <LongHorizonBranch
+        period="week"
+        periodKey={selection.weekKey}
         selection={selection}
+        onAsk={onAsk}
         onSwitchToClassic={onSwitchToClassic}
       />
     );
   }
   if (selection.kind === "month") {
     return (
-      <MonthlyBranch
-        monthKey={selection.monthKey}
+      <LongHorizonBranch
+        period="month"
+        periodKey={selection.monthKey}
         selection={selection}
+        onAsk={onAsk}
+        onSwitchToClassic={onSwitchToClassic}
+      />
+    );
+  }
+  if (selection.kind === "quarter") {
+    return (
+      <LongHorizonBranch
+        period="quarter"
+        periodKey={selection.quarterKey}
+        selection={selection}
+        onAsk={onAsk}
+        onSwitchToClassic={onSwitchToClassic}
+      />
+    );
+  }
+  if (selection.kind === "year") {
+    return (
+      <LongHorizonBranch
+        period="year"
+        periodKey={selection.yearKey}
+        selection={selection}
+        onAsk={onAsk}
         onSwitchToClassic={onSwitchToClassic}
       />
     );
@@ -1381,6 +2341,7 @@ function TodayRender({
   const forecastsSwr = useTopForecastsSwr(5);
   const todayPulseSwr = useTodayPulseSwr(12);
   const snapshotSwr = useLatestDailyBriefSnapshotSwr();
+  const liveArtifacts = useLiveArtifacts(8);
 
   const hypotheses = hypothesesSwr.data;
   const forecasts = forecastsSwr.data;
@@ -1432,6 +2393,10 @@ function TodayRender({
     void ABSENT;
     return ids;
   }, [hypotheses, todayPulse]);
+  const liveSourceRows = useMemo(
+    () => liveArtifacts.details.flatMap((detail) => detail.sourceRows),
+    [liveArtifacts.details],
+  );
 
   // ── Build the visible-section list ─────────────────────────────
   // Bug 0a fix — section numbers are derived from the index in this
@@ -1442,44 +2407,42 @@ function TodayRender({
     const sections: SectionDescriptor[] = [];
     sections.push({
       id: "what-moved",
-      kicker: "Today's edition",
-      tocLabel: "Pulse",
-      heading: "What moved today",
+      kicker: "Daily brief",
+      tocLabel: "Changed",
+      heading: "What changed",
     });
-    if (Array.isArray(hypotheses) && hypotheses.length > 0) {
-      sections.push({
-        id: "competing-explanations",
-        kicker: "Hypotheses under test",
-        tocLabel: "Hypotheses",
-        heading: "The competing explanations",
-      });
-    }
+    sections.push({
+      id: "competing-explanations",
+      kicker: "Why it matters",
+      tocLabel: "So what",
+      heading: "So what",
+    });
     sections.push({
       id: "what-to-look-at",
-      kicker: "Forecasts in motion",
-      tocLabel: "Forecasts",
-      heading: "What to look at this week",
+      kicker: "What to do next",
+      tocLabel: "Now what",
+      heading: "Now what",
     });
     sections.push({
-      id: "scoreboard",
-      kicker: "Scoreboard",
-      tocLabel: "Scoreboard",
-      heading: "Today's scoreboard",
-    });
-    sections.push({
-      id: "capabilities",
-      kicker: "The capability landscape",
-      tocLabel: "Capabilities",
-      heading: "Capabilities map",
+      id: "reports-touched",
+      kicker: "Reports touched",
+      tocLabel: "Reports",
+      heading: "Reports touched",
     });
     sections.push({
       id: "footnotes",
-      kicker: "Sources",
+      kicker: "Sources used",
       tocLabel: "Sources",
-      heading: "Footnotes",
+      heading: "Sources used",
+    });
+    sections.push({
+      id: "actions-created",
+      kicker: "Actions created",
+      tocLabel: "Actions",
+      heading: "Actions created",
     });
     return sections;
-  }, [hypotheses]);
+  }, []);
 
   // Map section id → its computed number for use in render.
   const numberForId = useMemo(() => {
@@ -1508,17 +2471,23 @@ function TodayRender({
   // points to a stable artifact; fall back to the date key.
   const editionId =
     snapshot?._id ?? (todayPulse?.dateKey ?? "current");
+  const todayRetrospectiveCount =
+    (snapshot?.dashboardMetrics?.keyStats?.length ?? 0) +
+    liveArtifacts.details.reduce(
+      (total, detail) => total + detail.sourceRows.length,
+      0,
+    );
 
   // Helper to look up a section's data and bail out cleanly when it's
   // not in the visible list.
   const find = (id: string) =>
     visibleSections.find((s) => s.id === id);
   const wm = find("what-moved")!;
-  const ce = find("competing-explanations");
+  const ce = find("competing-explanations")!;
   const wl = find("what-to-look-at")!;
-  const sb = find("scoreboard")!;
-  const cap = find("capabilities")!;
+  const rt = find("reports-touched")!;
   const fn = find("footnotes")!;
+  const ac = find("actions-created")!;
 
   return (
     <div data-edition>
@@ -1581,7 +2550,7 @@ function TodayRender({
               color: "var(--rd-ink-strong)",
             }}
           >
-            Today's intelligence brief
+            Daily Brief
           </h1>
           <p
             style={{
@@ -1591,8 +2560,8 @@ function TodayRender({
               margin: 0,
             }}
           >
-            Pulled live from your pulse, hypotheses, forecasts, and the latest
-            daily brief. Ask anything below to extend the edition.
+            What changed, why it matters, what to do next, reports touched,
+            sources used, and actions created from live NodeBench context.
           </p>
         </header>
 
@@ -1619,6 +2588,22 @@ function TodayRender({
           </div>
         )}
 
+        <HomePulseCoordinatorTrace
+          period="today"
+          periodKey={dateString}
+          pulses={todayPulse}
+          hypotheses={hypotheses}
+          forecasts={forecasts}
+          snapshot={snapshot}
+          liveArtifacts={liveArtifacts}
+          artifactIds={artifactIds}
+          windowLabel="Daily Brief coordinator"
+          windowStart={dateString}
+          windowEnd={dateString}
+          retrospectiveCount={todayRetrospectiveCount}
+          retrospectiveSource="daily Convex/live substrate"
+        />
+
         <EditionErrorBoundary label="what-moved">
           <WhatMovedSection
             number={numberForId.get(wm.id) ?? "01"}
@@ -1630,16 +2615,14 @@ function TodayRender({
           />
         </EditionErrorBoundary>
 
-        {ce && Array.isArray(hypotheses) && hypotheses.length > 0 && (
-          <EditionErrorBoundary label="competing-explanations">
-            <CompetingExplanationsSection
-              number={numberForId.get(ce.id) ?? "02"}
-              kicker={ce.kicker}
-              heading={ce.heading}
-              hypotheses={hypotheses}
-            />
-          </EditionErrorBoundary>
-        )}
+        <EditionErrorBoundary label="competing-explanations">
+          <CompetingExplanationsSection
+            number={numberForId.get(ce.id) ?? "02"}
+            kicker={ce.kicker}
+            heading={ce.heading}
+            hypotheses={hypotheses ?? []}
+          />
+        </EditionErrorBoundary>
 
         <EditionErrorBoundary label="what-to-look-at">
           <WhatToLookAtSection
@@ -1650,30 +2633,37 @@ function TodayRender({
           />
         </EditionErrorBoundary>
 
-        <EditionErrorBoundary label="scoreboard">
-          <ScoreboardSection
-            number={numberForId.get(sb.id) ?? "04"}
-            kicker={sb.kicker}
-            heading={sb.heading}
+        <EditionErrorBoundary label="reports-touched">
+          <ReportsTouchedSection
+            number={numberForId.get(rt.id) ?? "04"}
+            kicker={rt.kicker}
+            heading={rt.heading}
             snapshot={snapshot}
-          />
-        </EditionErrorBoundary>
-
-        <EditionErrorBoundary label="capabilities">
-          <CapabilitiesSection
-            number={numberForId.get(cap.id) ?? "05"}
-            kicker={cap.kicker}
-            heading={cap.heading}
-            snapshot={snapshot}
+            reports={liveArtifacts.reports}
           />
         </EditionErrorBoundary>
 
         <EditionErrorBoundary label="footnotes">
           <FootnotesSection
-            number={numberForId.get(fn.id) ?? "06"}
+            number={numberForId.get(fn.id) ?? "05"}
             kicker={fn.kicker}
             heading={fn.heading}
             artifactIds={artifactIds}
+            liveSourceRows={liveSourceRows}
+          />
+        </EditionErrorBoundary>
+
+        <EditionErrorBoundary label="actions-created">
+          <ActionsCreatedSection
+            number={numberForId.get(ac.id) ?? "06"}
+            kicker={ac.kicker}
+            heading={ac.heading}
+            pulses={todayPulse}
+            hypotheses={hypotheses}
+            forecasts={forecasts}
+            reports={liveArtifacts.reports}
+            onAsk={onAsk}
+            nudgeKey={`home-pulse-actions-${dateString}`}
           />
         </EditionErrorBoundary>
       </div>

--- a/src/features/redesign/surfaces/InboxSurface.tsx
+++ b/src/features/redesign/surfaces/InboxSurface.tsx
@@ -12,10 +12,13 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
 import { type InboxItem, type InboxLane } from "../fixtures";
 import { Pill } from "../components/Pill";
 import { useInboxLive } from "../hooks/useInboxLive";
 import { showToast } from "../components/Toast";
+import { getAnonymousProductSessionId } from "../../product/lib/productIdentity";
 
 type DateRange = "all" | "today" | "7d" | "30d";
 const DATE_RANGES: Array<{ id: DateRange; label: string }> = [
@@ -39,6 +42,16 @@ export function InboxSurface() {
   const [dateRange, setDateRange] = useState<DateRange>("all");
   const [checked, setChecked] = useState<Set<string>>(new Set());
   const [snoozed, setSnoozed] = useState<Set<string>>(new Set());
+  const completeNudge = useMutation(
+    (api as unknown as {
+      domains: { product: { nudges: { completeNudge: unknown } } };
+    }).domains.product.nudges.completeNudge as Parameters<typeof useMutation>[0],
+  );
+  const snoozeNudge = useMutation(
+    (api as unknown as {
+      domains: { product: { nudges: { snoozeNudge: unknown } } };
+    }).domains.product.nudges.snoozeNudge as Parameters<typeof useMutation>[0],
+  );
 
   // Sprint S3: live aggregator over pipeline runs.
   const { items: allItems, isLive, liveCount } = useInboxLive();
@@ -71,15 +84,54 @@ export function InboxSurface() {
     return next;
   });
   const clearChecked = () => setChecked(new Set());
+  const selectedNudgeIds = () =>
+    Array.from(checked)
+      .filter((id) => id.startsWith("nudge_"))
+      .map((id) => id.slice("nudge_".length));
+
+  const completeSelectedNudges = async () => {
+    const nudgeIds = selectedNudgeIds();
+    if (nudgeIds.length === 0) return;
+    const anonymousSessionId = getAnonymousProductSessionId();
+    await Promise.all(
+      nudgeIds.map((nudgeId) =>
+        completeNudge({ anonymousSessionId, nudgeId }),
+      ),
+    );
+  };
+
+  const snoozeSelectedNudges = async () => {
+    const nudgeIds = selectedNudgeIds();
+    if (nudgeIds.length === 0) return;
+    const anonymousSessionId = getAnonymousProductSessionId();
+    await Promise.all(
+      nudgeIds.map((nudgeId) =>
+        snoozeNudge({ anonymousSessionId, nudgeId }),
+      ),
+    );
+  };
+
   const acceptAll = () => {
+    void completeSelectedNudges().catch((error) => {
+      console.error("[inbox] failed to complete nudges", error);
+      showToast({ tone: "warning", message: "Some persisted nudges could not be completed." });
+    });
     showToast({ tone: "success", message: `Accepted ${checked.size} item${checked.size === 1 ? "" : "s"}.` });
     clearChecked();
   };
   const rejectAll = () => {
+    void completeSelectedNudges().catch((error) => {
+      console.error("[inbox] failed to dismiss nudges", error);
+      showToast({ tone: "warning", message: "Some persisted nudges could not be dismissed." });
+    });
     showToast({ tone: "warning", message: `Rejected ${checked.size} item${checked.size === 1 ? "" : "s"}.` });
     clearChecked();
   };
   const snoozeAll = (label: string) => {
+    void snoozeSelectedNudges().catch((error) => {
+      console.error("[inbox] failed to snooze nudges", error);
+      showToast({ tone: "warning", message: "Some persisted nudges could not be snoozed." });
+    });
     setSnoozed((prev) => new Set([...prev, ...checked]));
     showToast({
       tone: "info",

--- a/vercel.json
+++ b/vercel.json
@@ -52,7 +52,7 @@
   "rewrites": [
     { "source": "/api/og/:id", "destination": "/api/og/[id]" },
     { "source": "/api/harness/:path*", "destination": "/api/harness" },
-    { "source": "/voice/:path*", "destination": "/api/voice?path=:path*" },
+    { "source": "/voice/:path*", "destination": "/api/voice?path=:path" },
     { "source": "/api/shared-context/episodes", "destination": "/api/shared-context/snapshot?__nb_shared_context_path=episodes" },
     { "source": "/api/shared-context/episodes/start", "destination": "/api/shared-context/snapshot?__nb_shared_context_path=episodes/start" },
     { "source": "/api/shared-context/episodes/:episodeId", "destination": "/api/shared-context/snapshot?__nb_shared_context_path=episodes/:episodeId" },


### PR DESCRIPTION
## Summary
- fix editorial TOC overlap by keeping the rail hidden until safe wide desktop widths
- add visible HomePulseCoordinator trace evidence across today/week/month/quarter/year routes
- wire Sources used to live artifact source rows so source links are clickable
- add Home -> Inbox persisted follow-up nudges and Inbox nudge aggregation/complete/snooze handling
- add quarter/year edition selection and honest long-horizon window semantics

## QA
- npx tsc --noEmit --pretty false
- npx eslint src/features/redesign/surfaces/EditorialHomeSurface.tsx src/features/redesign/surfaces/InboxSurface.tsx src/features/redesign/hooks/useInboxLive.ts src/features/redesign/hooks/useTemporalEdition.ts src/features/redesign/hooks/useLongHorizonRetrospectiveSwr.ts src/features/redesign/hooks/editionSession.ts
- npx vitest run convex/domains/research/editionQueries.test.ts
- npm run build
- production browser dogfood on https://www.nodebenchai.com/redesign for today/week/month/quarter/year
- production Home -> Inbox follow-up persistence dogfood
- production viewport sweep at 390/768/1200/1439/1440/1600px for TOC overlap