### PR TITLE
Ship home v2 parity runtime

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1180,6 +1180,7 @@ import type * as domains_search_embedRowOnUpdate from "../domains/search/embedRo
 import type * as domains_search_embedSearchableText from "../domains/search/embedSearchableText.js";
 import type * as domains_search_federatedHelpers from "../domains/search/federatedHelpers.js";
 import type * as domains_search_federatedSearch from "../domains/search/federatedSearch.js";
+import type * as domains_search_federatedSearchCache from "../domains/search/federatedSearchCache.js";
 import type * as domains_search_fusion_actions from "../domains/search/fusion/actions.js";
 import type * as domains_search_fusion_adapters_arxivAdapter from "../domains/search/fusion/adapters/arxivAdapter.js";
 import type * as domains_search_fusion_adapters_braveAdapter from "../domains/search/fusion/adapters/braveAdapter.js";
@@ -2682,6 +2683,7 @@ declare const fullApi: ApiFromModules<{
   "domains/search/embedSearchableText": typeof domains_search_embedSearchableText;
   "domains/search/federatedHelpers": typeof domains_search_federatedHelpers;
   "domains/search/federatedSearch": typeof domains_search_federatedSearch;
+  "domains/search/federatedSearchCache": typeof domains_search_federatedSearchCache;
   "domains/search/fusion/actions": typeof domains_search_fusion_actions;
   "domains/search/fusion/adapters/arxivAdapter": typeof domains_search_fusion_adapters_arxivAdapter;
   "domains/search/fusion/adapters/braveAdapter": typeof domains_search_fusion_adapters_braveAdapter;

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -24,7 +24,8 @@
  * proposeMemoryPatch on inline correction, source-URL substring
  * validation, production load polish.
  *
- * Auth-gated: anonymous users still get the showcase fixture path.
+ * Anonymous-safe: userId is attached when auth is present, but guests still
+ * exercise the real Convex-backed run pipeline.
  */
 
 import { v } from "convex/values";
@@ -58,6 +59,16 @@ interface AnswerPacket {
   fromMemory: boolean;
   trace: TraceRow[];
 }
+
+type PlannerArtifact = {
+  id: string;
+  label: string;
+  status: "selected" | "candidate" | "deferred" | "pending" | "complete" | "blocked";
+  detail: string;
+  confidence?: number;
+  riskTier?: "low" | "medium" | "high";
+  costUsd?: number;
+};
 
 // ───────── Constants ─────────
 
@@ -204,6 +215,109 @@ function classifyPrompt(prompt: string): { kind: string; entity?: string } {
   if (lower.includes(" vs ") || lower.includes(" compare ")) return { kind: "competitor", entity };
   if (entity && entity.length > 2) return { kind: "company_search", entity };
   return { kind: "general" };
+}
+
+function buildBoardState(args: {
+  runId: string;
+  prompt: string;
+  tier: string;
+  model: string;
+  contextRef?: string;
+  classification: { kind: string; entity?: string };
+}): {
+  boardState: Record<string, unknown>;
+  contextCandidates: PlannerArtifact[];
+  toolDecisions: PlannerArtifact[];
+} {
+  const entityLabel = args.classification.entity ?? "unresolved entity";
+  const hasReportContext = Boolean(args.contextRef);
+  const contextCandidates: PlannerArtifact[] = [
+    {
+      id: "user_prompt",
+      label: "User prompt",
+      status: "selected",
+      confidence: 1,
+      detail: clipText(args.prompt, 180),
+    },
+    {
+      id: "active_report",
+      label: hasReportContext ? `Active report ${args.contextRef}` : "Active report",
+      status: hasReportContext ? "selected" : "deferred",
+      confidence: hasReportContext ? 0.86 : 0,
+      detail: hasReportContext
+        ? "Composer supplied a live report/context reference."
+        : "No active report reference was supplied, so the run stays answer-first.",
+    },
+    {
+      id: "entity_mention",
+      label: entityLabel,
+      status: args.classification.entity ? "candidate" : "deferred",
+      confidence: args.classification.entity ? 0.72 : 0,
+      detail: args.classification.entity
+        ? `Classifier detected ${args.classification.kind}.`
+        : "Prompt did not expose a stable entity name.",
+    },
+  ];
+
+  const toolDecisions: PlannerArtifact[] = [
+    {
+      id: "search_memory",
+      label: "search_memory",
+      status: hasReportContext ? "selected" : "deferred",
+      riskTier: "low",
+      costUsd: 0,
+      detail: hasReportContext
+        ? "Use the selected live report as memory context before live grounding."
+        : "No report context to search in this anonymous/public run.",
+    },
+    {
+      id: "google_search_grounding",
+      label: "google_search grounding",
+      status: "selected",
+      riskTier: "medium",
+      detail: "Fresh external evidence is needed, so Gemini grounded search is enabled.",
+    },
+    {
+      id: "verify_sources",
+      label: "verify_sources",
+      status: "pending",
+      riskTier: "low",
+      costUsd: 0,
+      detail: "Source URL substring validation is scheduled after packet assembly.",
+    },
+    {
+      id: "patch_notebook",
+      label: "patch_notebook",
+      status: "deferred",
+      riskTier: "medium",
+      costUsd: 0,
+      detail: "Notebook writes require an explicit user action from the answer packet.",
+    },
+  ];
+
+  return {
+    boardState: {
+      runId: args.runId,
+      surface: "redesign_chat",
+      goal: "answer_with_cited_research_and_action_trace",
+      status: "running",
+      promptKind: args.classification.kind,
+      entity: args.classification.entity ?? null,
+      tier: args.tier,
+      model: args.model,
+      targetReport: args.contextRef ?? null,
+      successCriteria: [
+        "classify intent",
+        "select available memory/context",
+        "ground answer in sources",
+        "bind evidence rows",
+        "schedule source validation",
+        "emit cost and latency",
+      ],
+    },
+    contextCandidates,
+    toolDecisions,
+  };
 }
 
 interface ParsedMemo {
@@ -539,6 +653,21 @@ export const runStreamingChat = internalAction({
       trace.push(tr1);
       await append("tool_call", tr1);
       await append("stage", { stage: "classified", classification });
+      const planner = buildBoardState({
+        runId: args.runId,
+        prompt: args.prompt,
+        tier: args.tier,
+        model: args.model,
+        contextRef: args.contextRef,
+        classification,
+      });
+      await append("board_state", planner.boardState);
+      for (const candidate of planner.contextCandidates) {
+        await append("context_candidate", candidate);
+      }
+      for (const decision of planner.toolDecisions) {
+        await append("tool_decision", decision);
+      }
 
       // Stage 2 — context
       const t2 = Date.now();
@@ -597,6 +726,7 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
       }> = [];
       let inputTokens = 0;
       let outputTokens = 0;
+      let firstSourceAt: number | undefined;
 
       try {
         // Use streamGenerateContent (alt=sse) for token-level streaming
@@ -647,6 +777,7 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
                   const uri = chunk?.web?.uri;
                   if (uri && !seenChunkUris.has(uri)) {
                     seenChunkUris.add(uri);
+                    firstSourceAt ??= Date.now();
                     await append("grounding_chunk", {
                       idx: groundingChunks.length + 1,
                       url: uri,
@@ -694,6 +825,7 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
         const fallback = await runFallbackSourceSearch(args.prompt);
         fallbackSources = fallback.snippets;
         for (const [i, source] of fallbackSources.entries()) {
+          firstSourceAt ??= Date.now();
           await append("grounding_chunk", {
             idx: i + 1,
             url: source.url,
@@ -743,6 +875,15 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
       };
       trace.push(tr4);
       await append("tool_call", tr4);
+      for (const row of evidence) {
+        await append("claim_check", {
+          idx: row.idx,
+          status: "pending_source_validation",
+          method: "url_substring_validation",
+          source: row.source,
+          detail: "Evidence row bound; background validator will confirm quote support.",
+        });
+      }
 
       // Section commits
       await append("section", { name: "short_answer", text: parsed.shortAnswer });
@@ -764,7 +905,46 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
         evidenceUrls: evidence.map((e) => e.source),
       });
 
-      const packet: AnswerPacket = {
+      const runtime = {
+        boardState: {
+          ...planner.boardState,
+          status: "complete",
+        },
+        contextCandidates: planner.contextCandidates,
+        toolDecisions: planner.toolDecisions.map((decision) =>
+          decision.id === "verify_sources" ? { ...decision, status: "pending" as const } : decision,
+        ),
+        claimChecks: evidence.map((row) => ({
+          idx: row.idx,
+          status: "pending_source_validation",
+          method: "url_substring_validation",
+          source: row.source,
+          detail: "Evidence row bound; background validator will confirm quote support.",
+        })),
+        metrics: {
+          runId: args.runId,
+          totalLatencyMs,
+          totalTokens,
+          estimatedCostUsd,
+          paidCalls: 1,
+          sourceCount: evidence.length,
+          toolCallCount: trace.length,
+          liveSearchCalls: 1,
+          memoryHitRate: args.contextRef ? 1 : 0,
+          sourceCacheHitRate: 0,
+          timeToFirstSourceMs: firstSourceAt ? firstSourceAt - t0 : null,
+          timeToFinalMs: totalLatencyMs,
+        },
+        actionOutputs: [
+          {
+            id: "next_action",
+            label: "Recommended next action",
+            status: "local_only_recommendation",
+            detail: parsed.nextAction,
+          },
+        ],
+      };
+      const packet: AnswerPacket & { runtime: typeof runtime } = {
         shortAnswer: parsed.shortAnswer,
         whyItMatters: parsed.whyItMatters,
         evidence,
@@ -774,6 +954,7 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
         paidCalls: 1,
         fromMemory: false,
         trace,
+        runtime,
       };
 
       await ctx.runMutation(internal.domains.redesign.chatRuns.finalizeRun, {
@@ -783,6 +964,20 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
         totalLatencyMs,
         totalTokens,
         estimatedCostUsd,
+      });
+      await append("run_metrics", {
+        runId: args.runId,
+        totalLatencyMs,
+        totalTokens,
+        estimatedCostUsd,
+        paidCalls: 1,
+        sourceCount: evidence.length,
+        toolCallCount: trace.length,
+        liveSearchCalls: 1,
+        memoryHitRate: args.contextRef ? 1 : 0,
+        sourceCacheHitRate: 0,
+        timeToFirstSourceMs: firstSourceAt ? firstSourceAt - t0 : null,
+        timeToFinalMs: totalLatencyMs,
       });
       await append("packet_complete", { hash, totalLatencyMs, totalTokens, estimatedCostUsd });
 
@@ -922,6 +1117,19 @@ export const validateRunSources = internalAction({
       verifications: updates,
     });
     const verifiedCount = updates.filter((u) => u.verified).length;
+    for (const update of updates) {
+      await ctx.runMutation(internal.domains.redesign.chatRuns.appendEvent, {
+        runId: args.runId,
+        eventType: "claim_check",
+        payload: {
+          idx: update.idx,
+          status: update.verified ? "source_validation_passed" : "source_validation_failed",
+          method: "url_substring_validation",
+          verified: update.verified,
+          validationError: update.validationError,
+        } as any,
+      });
+    }
     await ctx.runMutation(internal.domains.redesign.chatRuns.appendEvent, {
       runId: args.runId,
       eventType: "sources_validated",
@@ -967,12 +1175,32 @@ export const patchEvidenceVerification = internalMutation({
       return { ...e, verified: u.verified, verifiedAt: Date.now(), validationError: u.validationError };
     });
     const verifiedCount = evidence.filter((e: any) => e.verified).length;
+    const runtime = row.packet.runtime
+      ? {
+          ...row.packet.runtime,
+          claimChecks: evidence.map((e: any) => ({
+            idx: e.idx,
+            status: e.verified ? "source_validation_passed" : "source_validation_failed",
+            method: "url_substring_validation",
+            source: e.source,
+            verified: e.verified,
+            validationError: e.validationError,
+            detail: e.verified ? "Quote substring confirmed in source body." : "Quote substring was not confirmed in source body.",
+          })),
+          metrics: {
+            ...(row.packet.runtime.metrics ?? {}),
+            sourceCount: evidence.length,
+            verifiedSourceCount: verifiedCount,
+          },
+        }
+      : undefined;
     await ctx.db.patch(row._id, {
       packet: {
         ...row.packet,
         evidence,
         sourceCount: evidence.length,
         verifiedSourceCount: verifiedCount,
+        ...(runtime ? { runtime } : {}),
       },
     });
   },

--- a/docs/runbooks/GOAL_MODE_RELEASE_AUTOPILOT.md
+++ b/docs/runbooks/GOAL_MODE_RELEASE_AUTOPILOT.md
@@ -1,0 +1,149 @@
+# Goal-Mode Release Autopilot
+
+Use this runbook when a task needs a long-running agent loop with a concrete definition of done.
+
+The goal is not a normal prompt. It is the stop condition. Keep implementation details in the task thread and durable project rules in `AGENTS.md` or the relevant runbook. Put only observable completion criteria in `/goal`.
+
+## Tool Support
+
+Claude Code:
+
+- `/goal` was introduced in Claude Code `v2.1.139`.
+- It sets one active session-scoped completion condition.
+- Claude keeps taking turns until an evaluator model decides the surfaced evidence satisfies the condition.
+- The evaluator does not run commands or inspect files itself, so the agent must report command output, browser evidence, and remaining risks.
+- Pair with auto mode when the loop should continue without per-turn prompts.
+
+Reference:
+- https://code.claude.com/docs/en/goal
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.139
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.140
+
+Codex CLI:
+
+- `/goal` is experimental and requires `features.goals = true`.
+- It is attached to the active CLI thread and does not override sandbox, approval, policy, or network limits.
+
+Reference:
+- https://developers.openai.com/codex/cli/slash-commands
+- https://developers.openai.com/codex/guides/agents-md
+
+## Usage
+
+Claude Code:
+
+```bash
+claude --permission-mode auto
+/goal <paste the release goal>
+```
+
+Codex CLI:
+
+```toml
+# ~/.codex/config.toml
+[features]
+goals = true
+```
+
+```bash
+codex --sandbox workspace-write --ask-for-approval on-request
+/goal <paste the release goal>
+```
+
+In Codex Desktop, emulate the same contract by treating the goal text as the active acceptance checklist and continuing the local fix, verify, and evidence loop until every gate is satisfied.
+
+## Goal Template
+
+```text
+/goal NodeBench <scope> is ACTUALLY done when:
+
+1. The work starts from the intended prod-parity branch or worktree, not a stale dirty branch, and any pre-existing user changes are preserved.
+
+2. The shipped behavior matches the named product target across all relevant routes, states, and breakpoints. For UI work, verify desktop, narrow desktop, and mobile.
+
+3. Live runtime flows remain intact. Production routes must not silently fall back to fixtures, fake data, or disabled backend wiring.
+
+4. The important user workflows are dogfooded end to end in the browser, including navigation, primary actions, empty/loading/error states, and any cross-panel synchronization.
+
+5. Required checks pass:
+   - npx tsc --noEmit --pretty false
+   - targeted Vitest for touched surfaces
+   - targeted Playwright or browser automation for changed workflows
+   - npm run build
+
+6. Release artifacts are updated when applicable:
+   - QA matrix rows include status, evidence, and remaining risk
+   - runbooks or AGENTS.md are updated for new operational behavior
+   - screenshots or trace artifacts are captured for changed views
+
+7. Any failure is root-caused and fixed, not waived. If the same failure repeats three times, change strategy by instrumenting, isolating, rolling back the risky slice, or reducing scope.
+
+8. Done means the final answer lists exact evidence: commands run, browser views verified, files changed, matrix rows updated, residual risks, and explicitly deferred items with rationale.
+```
+
+## Home-v2 Product Release Goal
+
+Use this for the current home-v2 parity and release-readiness loop.
+
+```text
+/goal NodeBench home-v2/product-release parity is ACTUALLY done when all of the following are true:
+
+1. The implementation starts from origin/main/prod-parity, not stale dirty branches, and preserves live Convex-backed runtime flows with no silent production fixture fallback.
+
+2. /redesign?qa=home-v2-implementation visually matches the latest home-v2.html target across Home, Reports, Chat, Inbox, and Me at desktop 1440x900, desktop 1280x720, and mobile 390x844.
+
+3. Web navigation remains exactly Home, Reports, Chat, Inbox, Me. Workspace stays a separate deployed surface, not a sixth web tab.
+
+4. Reports entity-card selection updates the selected card, left rail, center context, right coverage rail, score, signals, related entities, drawer toggle, and composer placeholder.
+
+5. Chat includes the rich product flow: report banner, checkpoints, structured answer packet, entity pills, evidence table, risks or open questions, next actions, tool or source chips, composer controls, and switching right-rail tabs.
+
+6. Inbox and Me match the intended richer product surfaces: ranked queue, actions, expanded rows for Inbox, and memory, integrations, settings, and session controls for Me.
+
+7. Landing and Home copy avoids unsupported predictive claims. It reads as an editorial intelligence brief: what changed, why it matters to the user, what to do next, reports touched, sources used, and actions created.
+
+8. The release QA matrix CSV is updated with pass/fail/evidence for every row touched or verified.
+
+9. Required checks pass:
+   - npx tsc --noEmit --pretty false
+   - targeted Vitest for touched surfaces
+   - BASE_URL=http://127.0.0.1:5180 npx playwright test tests/e2e/home-v2-parity.spec.ts
+   - npm run build
+
+10. Browser screenshots are captured and inspected for every changed view. Any console, runtime, or layout failure is root-caused and fixed, not waived.
+
+11. Done means the final answer lists exact evidence: commands run, screenshots or views verified, CSV updated, residual risks, and any explicitly deferred item with rationale. If any gate fails, continue fixing.
+```
+
+## Runtime-Trace Release Goal
+
+Use this when the home-v2 shell already renders but the question is whether the product is actually live-wired end to end.
+
+```text
+/goal NodeBench redesign runtime-readiness is ACTUALLY done when:
+
+1. /redesign/chat starts a real Convex-backed run for anonymous and signed-in users without inserting showcase answers.
+
+2. Every visible answer packet exposes a Runtime board with context candidates, tool decisions, claim/source checks, and cost/latency metrics. If the deployed backend predates first-class runtime events, the frontend must show an honest compatibility projection from the persisted run row and trace rather than hiding the missing data.
+
+3. The packet and stream contract include durable event names for board_state, context_candidate, tool_decision, claim_check, run_metrics, and packet_complete.
+
+4. Active-looking actions are either durable or explicitly labeled as local-only / preview-only.
+
+5. Required checks pass: tsc, targeted Vitest, home-v2 Playwright, npm run build, and browser dogfood of /redesign/chat?q=<probe> with the Runtime board visible.
+
+6. The QA matrix records PASS/NEEDS_RUN/NEEDS_FIX with evidence and remaining gaps for runtime observability, production proof, action durability, responsive parity, and console cleanliness.
+```
+
+## Execution Rule
+
+Before declaring success, surface enough evidence for the evaluator or reviewer to independently judge the goal:
+
+- exact commands and pass/fail state
+- exact routes and viewport sizes inspected
+- changed files
+- QA matrix rows updated
+- deployment target or local URL
+- known residual risks
+
+If the agent cannot complete a gate directly, it must engineer a workaround, reduce the task to a verifiable slice, or clearly mark the gate as failed. Do not call an unverified gate done.

--- a/docs/runbooks/PROD_PARITY_UI_KIT_WORKFLOW.md
+++ b/docs/runbooks/PROD_PARITY_UI_KIT_WORKFLOW.md
@@ -120,3 +120,9 @@ Do not use hotfix/workspace-routing-export or old parity/design worktrees as imp
 
 Inspect the newly provided UI kit packet, compare it against the current prod-parity app, list visual/runtime deltas, implement only the needed delta, and verify with screenshots plus typecheck/build/tests.
 ```
+
+## Goal-Mode Autopilot
+
+For long UI parity or release-readiness loops, use `docs/runbooks/GOAL_MODE_RELEASE_AUTOPILOT.md`.
+
+The `/goal` prompt is the stop condition, not the implementation plan. It should name the exact views, workflows, checks, browser evidence, QA matrix updates, and residual-risk reporting required before an agent can call the task done.

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -23,21 +23,30 @@ import "./primitives.css";
 
 import { Rail } from "./components/Rail";
 import { RightInspector } from "./components/RightInspector";
+import { AgentRail } from "./components/AgentRail";
 import { MobileShell } from "./components/MobileShell";
 import { TopNav } from "./components/TopNav";
 import { ReportNotebookView } from "./components/ReportNotebookView";
 import { CommandPalette, useCommandPalette } from "./components/CommandPalette";
 import { ShortcutsOverlay } from "./components/ShortcutsOverlay";
 import { ToastViewport } from "./components/Toast";
-import { HomeSurface } from "./surfaces/HomeSurface";
+import {
+  HomeV2BriefingRail,
+  HomeV2EditionRail,
+  HomeV2Surface,
+  PrototypeV2Center,
+  PrototypeV2LeftRail,
+  PrototypeV2RightRail,
+  type PrototypeSurface,
+} from "./surfaces/HomeV2PrototypeSurface";
 import { ReportsSurface } from "./surfaces/ReportsSurface";
 import { ChatSurface } from "./surfaces/ChatSurface";
 import { InboxSurface } from "./surfaces/InboxSurface";
 import { MeSurface } from "./surfaces/MeSurface";
 import { WorkspaceSurface } from "./surfaces/WorkspaceSurface";
 import { ReproducibleChatPage } from "./pages/ReproducibleChatPage";
-import { useLiveArtifacts } from "./hooks/useLiveArtifacts";
-import type { SurfaceId } from "./fixtures";
+import { useLiveArtifacts, type LiveArtifactDetail } from "./hooks/useLiveArtifacts";
+import type { ReportCardData, SurfaceId } from "./fixtures";
 
 const PATH_TO_SURFACE: Record<string, SurfaceId | "workspace"> = {
   "": "home",
@@ -64,6 +73,15 @@ function pathToChatHash(pathname: string): string | null {
   // /redesign/chat/r/<hash> → <hash> (Phase 3 reproducibility URL)
   const match = pathname.match(/^\/redesign\/chat\/r\/([A-Za-z0-9_-]+)/);
   return match?.[1] ?? null;
+}
+
+function queryPrompt(search: string): string {
+  const params = new URLSearchParams(search);
+  return params.get("q")?.trim() ?? "";
+}
+
+function normalizeEntityKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
 }
 
 type WorkspaceTab = "brief" | "cards" | "notebook" | "sources" | "chat" | "map";
@@ -95,16 +113,38 @@ export default function RedesignShell() {
   const reportId = useMemo(() => pathToReportId(location.pathname), [location.pathname]);
   const chatHash = useMemo(() => pathToChatHash(location.pathname), [location.pathname]);
   const workspace = useMemo(() => workspaceParams(location.search), [location.search]);
-  const shellLiveArtifacts = useLiveArtifacts(24);
+  const initialChatPrompt = useMemo(() => queryPrompt(location.search), [location.search]);
+  const isPrototypeKit = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get("qa") === "home-v2-implementation";
+  }, [location.search]);
+  const shellLiveArtifacts = useLiveArtifacts(24, { enabled: !isPrototypeKit });
+  const [selectedReport, setSelectedReport] = useState<ReportCardData | null>(null);
+  const [prototypeEntity, setPrototypeEntity] = useState("Anthropic");
+  const [activeChatDetail, setActiveChatDetail] = useState<LiveArtifactDetail | null>(null);
   const railStats = useMemo(() => ({
     entities: shellLiveArtifacts.publicResearch.length,
     reports: shellLiveArtifacts.reports.length,
     followUps: shellLiveArtifacts.reports.reduce((total, report) => total + report.followUps, 0),
   }), [shellLiveArtifacts.publicResearch.length, shellLiveArtifacts.reports]);
   const goSurface = (id: SurfaceId) => {
-    navigate(id === "home" ? "/redesign" : `/redesign/${id}`);
+    if (id !== "reports") setSelectedReport(null);
+    const path = id === "home" ? "/redesign" : `/redesign/${id}`;
+    navigate(isPrototypeKit ? `${path}?qa=home-v2-implementation` : path);
   };
   const goWorkspace = () => navigate("/redesign/workspace");
+  const sendPromptToChat = (prompt: string) => {
+    const query = isPrototypeKit
+      ? `qa=home-v2-implementation&q=${encodeURIComponent(prompt)}`
+      : `q=${encodeURIComponent(prompt)}`;
+    navigate(`/redesign/chat?${query}`);
+  };
+  const selectRelatedReport = (entity: string) => {
+    const key = normalizeEntityKey(entity);
+    const next = shellLiveArtifacts.reports.find((report) => normalizeEntityKey(report.entity) === key);
+    if (next) setSelectedReport(next);
+    else sendPromptToChat(`Find or create coverage context for ${entity}.`);
+  };
 
   // Optionally lock body scroll while shell is mounted
   useEffect(() => {
@@ -132,16 +172,16 @@ export default function RedesignShell() {
     })();
 
   // Mobile path overrides everything except /redesign/workspace (which keeps its own surface).
-  if (isMobile && surface !== "workspace") {
+  if (isMobile && surface !== "workspace" && !isPrototypeKit) {
     const mobileSurface: SurfaceId = (surface === "workspace" ? "reports" : surface) as SurfaceId;
     // Edition flag bypasses MobileShell at the home surface so the
     // single-column editorial layout stays responsive at any width.
     if (isEditionFlag && mobileSurface === "home") {
       return (
         <div data-redesign data-redesign-theme={theme} style={{ minHeight: "100dvh", overflow: "auto" }}>
-          <HomeSurface
+          <HomeV2Surface
             onAsk={(text) => navigate(`/redesign/chat?q=${encodeURIComponent(text)}`)}
-            onOpenReport={(id) => navigate(`/redesign/reports/${id}`)}
+            liveArtifacts={shellLiveArtifacts}
           />
           {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
           {showQaChrome && <ViewportFab forceMobile={forceMobile} setForceMobile={setForceMobile} />}
@@ -179,11 +219,15 @@ export default function RedesignShell() {
     );
   }
 
-  // Single-pane surfaces (Home, Reports, Inbox, Me) → no right rail
-  // Two-pane surfaces (Chat) → right inspector visible
-  // Phase 3 — /redesign/chat/r/{hash} is a chat sub-route but renders a
-  // standalone reproducible answer page; suppress the right inspector.
-  const showInspector = surface === "chat" && !chatHash;
+  // Phase 3 chat hashes and report detail pages own the full width. Other
+  // desktop surfaces keep a right-side agent rail so the center can stay calm.
+  const prototypeSurface = surface as PrototypeSurface;
+  const isHomeV2 = surface === "home" || isPrototypeKit;
+  const suppressRightRail =
+    !isPrototypeKit &&
+    ((surface === "chat" && Boolean(chatHash)) ||
+      (surface === "reports" && Boolean(reportId)) ||
+      surface === "me");
 
   return (
     <div
@@ -202,36 +246,56 @@ export default function RedesignShell() {
         onOpenPalette={() => cmdk.setOpen(true)}
         theme={theme}
         onToggleTheme={() => setTheme(theme === "light" ? "dark" : "light")}
+        prototypeMode={isPrototypeKit}
       />
       <div
-        className={`rd-shell ${showInspector ? "" : "rd-shell--single"}`}
+        className={`rd-shell ${isHomeV2 ? "rd-shell--home-v2" : ""} ${suppressRightRail ? "rd-shell--single" : ""}`}
         style={{ flex: 1, minHeight: 0 }}
       >
-        <Rail
-          active={surface as SurfaceId}
-          onChange={(id) => goSurface(id)}
-          onOpenWorkspace={goWorkspace}
-          liveStats={railStats}
-        />
-
-        {showInspector ? (
-          <div className="rd-shell__main">
-            <main id="main-content" data-main-content className="rd-pane" style={{ borderRight: "1px solid var(--rd-line-faint)" }}>
-              <ChatSurface />
-            </main>
-            <RightInspector />
-          </div>
+        {isPrototypeKit ? (
+          <PrototypeV2LeftRail
+            surface={prototypeSurface}
+            selectedEntity={prototypeEntity}
+            onSelectEntity={setPrototypeEntity}
+          />
+        ) : isHomeV2 ? (
+          <HomeV2EditionRail liveArtifacts={shellLiveArtifacts} />
         ) : (
+          <Rail
+            active={surface as SurfaceId}
+            onChange={(id) => goSurface(id)}
+            onOpenWorkspace={goWorkspace}
+            liveStats={railStats}
+          />
+        )}
+
+        {suppressRightRail ? (
           <main id="main-content" data-main-content className="rd-pane" style={{ borderRight: "none" }}>
-            {/* Phase 3 — /redesign/chat/r/{hash} renders the immutable cached run. */}
             {surface === "chat" && chatHash && <ReproducibleChatPage hash={chatHash} />}
-            {surface === "home" && (
-              <HomeSurface
-                onAsk={() => goSurface("chat")}
-                onOpenReport={(id) => navigate(`/redesign/workspace?report=${id}`)}
-              />
-            )}
-            {surface === "reports" && !reportId && (
+            {surface === "reports" && reportId && <ReportDetailRoute reportId={reportId} />}
+            {surface === "me" && <MeSurface />}
+          </main>
+        ) : (
+          <div className="rd-shell__main">
+            <main id="main-content" data-main-content className="rd-pane">
+              {isPrototypeKit && (
+                <PrototypeV2Center
+                  surface={prototypeSurface}
+                  onAsk={sendPromptToChat}
+                  selectedEntity={prototypeEntity}
+                  onSelectEntity={setPrototypeEntity}
+                />
+              )}
+              {!isPrototypeKit && surface === "chat" && (
+                <ChatSurface
+                  initialPrompt={initialChatPrompt}
+                  onActiveContextChange={setActiveChatDetail}
+                />
+              )}
+              {!isPrototypeKit && surface === "home" && (
+                <HomeV2Surface onAsk={sendPromptToChat} liveArtifacts={shellLiveArtifacts} />
+              )}
+            {!isPrototypeKit && surface === "reports" && !reportId && (
               <ReportsSurface
                 onOpen={(id, tab) => {
                   if (id.startsWith("li_") || id.startsWith("daily_") || id.startsWith("run_")) {
@@ -242,12 +306,34 @@ export default function RedesignShell() {
                   if (tab === "brief") navigate(`/redesign/reports/${id}`);
                   else navigate(`/redesign/workspace?report=${id}&tab=${tab}`);
                 }}
+                inspectedReportId={selectedReport?.id ?? null}
+                onSelectReport={setSelectedReport}
               />
             )}
-            {surface === "reports" && reportId && <ReportDetailRoute reportId={reportId} />}
-            {surface === "inbox" && <InboxSurface />}
-            {surface === "me" && <MeSurface />}
-          </main>
+            {!isPrototypeKit && surface === "reports" && reportId && <ReportDetailRoute reportId={reportId} />}
+            {!isPrototypeKit && surface === "inbox" && <InboxSurface />}
+            {!isPrototypeKit && surface === "me" && <MeSurface />}
+            </main>
+            {isPrototypeKit ? (
+              <PrototypeV2RightRail
+                surface={prototypeSurface}
+                onAsk={sendPromptToChat}
+                selectedEntity={prototypeEntity}
+                onSelectEntity={setPrototypeEntity}
+              />
+            ) : surface === "home" ? (
+              <HomeV2BriefingRail onAsk={sendPromptToChat} liveArtifacts={shellLiveArtifacts} />
+            ) : surface === "chat" ? (
+              <RightInspector activeLiveArtifactDetail={activeChatDetail ?? undefined} />
+            ) : (
+              <AgentRail
+                surface={surface as SurfaceId}
+                selectedReport={surface === "reports" ? selectedReport : null}
+                onSelectRelated={selectRelatedReport}
+                onSendPrompt={sendPromptToChat}
+              />
+            )}
+          </div>
         )}
       </div>
 

--- a/src/features/redesign/components/AgentRail.tsx
+++ b/src/features/redesign/components/AgentRail.tsx
@@ -1,0 +1,261 @@
+import { useMemo, useState } from "react";
+import type { ReportCardData, SurfaceId } from "../fixtures";
+import { Pill } from "./Pill";
+
+interface AgentRailProps {
+  surface: SurfaceId;
+  selectedReport?: ReportCardData | null;
+  onSelectRelated?: (entity: string) => void;
+  onSendPrompt?: (prompt: string) => void;
+}
+
+interface EntityDetail {
+  title: string;
+  score: number;
+  scoreLabel: string;
+  statusTone: "green" | "blue" | "amber";
+  sources: number;
+  claims: number;
+  followUps: number;
+  signals: Array<{ label: string; value: number; tone: "green" | "blue" | "amber" }>;
+  related: string[];
+  nextAction: string;
+  trace: string[];
+}
+
+const SURFACE_LABEL: Record<SurfaceId, string> = {
+  home: "Daily brief",
+  reports: "Coverage",
+  chat: "Chat",
+  inbox: "Inbox",
+  me: "Personal memory",
+};
+
+export function AgentRail({ surface, selectedReport, onSelectRelated, onSendPrompt }: AgentRailProps) {
+  const detail = useMemo(() => selectedReport ? buildEntityDetail(selectedReport) : null, [selectedReport]);
+  const [draft, setDraft] = useState("");
+  const label = detail ? "Coverage agent" : `${SURFACE_LABEL[surface]} agent`;
+  const prompt = draft.trim();
+
+  const submit = () => {
+    if (!prompt) return;
+    onSendPrompt?.(prompt);
+    setDraft("");
+  };
+
+  return (
+    <aside className="rd-pane rd-pane--right rd-agent-rail" data-testid="redesign-right-rail" aria-label={`${label} context`}>
+      <header className="rd-agent-rail__header">
+        <div>
+          <div className="rd-eyebrow">{label}</div>
+          <h2 className="rd-agent-rail__title">
+            {detail?.title ?? defaultRailTitle(surface)}
+          </h2>
+        </div>
+        {detail ? (
+          <Pill tone={detail.statusTone}>Score {detail.score}</Pill>
+        ) : (
+          <Pill tone="accent">Ready</Pill>
+        )}
+      </header>
+
+      <div className="rd-agent-rail__pills" aria-label="Current context">
+        <Pill>{SURFACE_LABEL[surface]}</Pill>
+        {detail ? (
+          <>
+            <Pill>{detail.sources} sources</Pill>
+            <Pill>{detail.claims} claims</Pill>
+            <Pill tone={detail.followUps > 0 ? "amber" : "green"}>{detail.followUps} follow-ups</Pill>
+          </>
+        ) : (
+          <>
+            <Pill>Memory-first</Pill>
+            <Pill>Notebook-ready</Pill>
+          </>
+        )}
+      </div>
+
+      {detail ? (
+        <>
+          <section className="rd-agent-card rd-agent-score" aria-label={`${detail.title} coverage score`}>
+            <div className="rd-agent-score__number">{detail.score}</div>
+            <div className="rd-stack" style={{ gap: 6 }}>
+              <div className="rd-agent-score__label">{detail.scoreLabel}</div>
+              <p className="rd-agent-rail__copy">
+                The selected report is now the active entity context. The rail shows what the agent would use before
+                opening notebook, graph, sources, or chat.
+              </p>
+            </div>
+          </section>
+
+          <section className="rd-agent-card" aria-label="Coverage dimensions">
+            <div className="rd-row--between">
+              <div className="rd-eyebrow">Signals</div>
+              <span className="rd-mono rd-agent-rail__muted">{detail.trace.length} trace steps</span>
+            </div>
+            <div className="rd-agent-bars">
+              {detail.signals.map((signal) => (
+                <div className="rd-agent-bar" key={signal.label}>
+                  <div className="rd-row--between">
+                    <span>{signal.label}</span>
+                    <span className="rd-mono">{signal.value}</span>
+                  </div>
+                  <div className="rd-agent-bar__track">
+                    <span data-tone={signal.tone} style={{ width: `${signal.value}%` }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rd-agent-card">
+            <div className="rd-eyebrow">Next best action</div>
+            <p className="rd-agent-rail__next">{detail.nextAction}</p>
+            <div className="rd-row" style={{ gap: 6, flexWrap: "wrap" }}>
+              <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={() => onSendPrompt?.(`Open the notebook context for ${detail.title}.`)}>
+                Open notebook
+              </button>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => onSendPrompt?.(`Check sources and unresolved claims for ${detail.title}.`)}>
+                Verify claims
+              </button>
+            </div>
+          </section>
+
+          <section className="rd-agent-card">
+            <div className="rd-eyebrow">Related entities</div>
+            <div className="rd-agent-related">
+              {detail.related.map((entity) => (
+                <button key={entity} type="button" className="rd-agent-related__item" onClick={() => onSelectRelated?.(entity)}>
+                  <span>{entity}</span>
+                  <span aria-hidden="true">-&gt;</span>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <details className="rd-agent-card rd-agent-trace">
+            <summary>Context trace</summary>
+            <ol>
+              {detail.trace.map((step) => <li key={step}>{step}</li>)}
+            </ol>
+          </details>
+        </>
+      ) : (
+        <DefaultRail surface={surface} />
+      )}
+
+      <section className="rd-agent-composer" aria-label="Agent composer">
+        <div className="rd-agent-composer__chips">
+          <span>+ Context</span>
+          <span>@ Reference</span>
+          <span>/ Command</span>
+          <span>Attach</span>
+        </div>
+        <textarea
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+              event.preventDefault();
+              submit();
+            }
+          }}
+          placeholder={detail ? `Ask about ${detail.title}...` : "Ask the agent to inspect this surface..."}
+          rows={3}
+        />
+        <div className="rd-row--between">
+          <span className="rd-mono rd-agent-rail__muted">Memory first, sources before claims</span>
+          <button className="rd-btn rd-btn--primary rd-btn--sm" disabled={!prompt} onClick={submit}>
+            Send
+          </button>
+        </div>
+      </section>
+    </aside>
+  );
+}
+
+function DefaultRail({ surface }: { surface: SurfaceId }) {
+  const items = surface === "home"
+    ? ["What changed", "So what", "Now what", "Reports touched"]
+    : surface === "inbox"
+      ? ["Needs approval", "Can batch", "Waiting", "Archive"]
+      : surface === "me"
+        ? ["User memory", "Preferences", "Watchlist", "Export rules"]
+        : ["Select a report", "Inspect sources", "Open notebook", "Ask in chat"];
+
+  return (
+    <section className="rd-agent-card">
+      <div className="rd-eyebrow">What this rail keeps visible</div>
+      <ul className="rd-agent-list">
+        {items.map((item) => (
+          <li key={item}>
+            <span className="rd-agent-list__dot" aria-hidden="true" />
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="rd-agent-rail__copy">
+        The center stays readable while the rail carries agent state, approval points, and handoffs.
+      </p>
+    </section>
+  );
+}
+
+function buildEntityDetail(report: ReportCardData): EntityDetail {
+  const evidence = clampScore(44 + report.sources * 2 + report.claims);
+  const freshness = report.updatedAt.includes("m") || report.updatedAt.includes("h") ? 88 : report.updatedAt.toLowerCase().includes("yesterday") ? 72 : 62;
+  const actionability = clampScore(50 + report.followUps * 8 + (report.status === "review" ? 10 : 0));
+  const graph = clampScore(54 + report.claims * 2 + report.sources);
+  const score = Math.round((evidence + freshness + actionability + graph) / 4);
+
+  return {
+    title: report.entity,
+    score,
+    scoreLabel: report.status === "verified" ? "Verified coverage" : report.status === "watching" ? "Active watch" : "Needs review",
+    statusTone: report.status === "verified" ? "green" : report.status === "watching" ? "blue" : "amber",
+    sources: report.sources,
+    claims: report.claims,
+    followUps: report.followUps,
+    signals: [
+      { label: "Evidence", value: evidence, tone: evidence > 78 ? "green" : "blue" },
+      { label: "Freshness", value: freshness, tone: freshness > 80 ? "green" : "amber" },
+      { label: "Actionability", value: actionability, tone: actionability > 82 ? "green" : "amber" },
+      { label: "Graph fit", value: graph, tone: graph > 80 ? "green" : "blue" },
+    ],
+    related: relatedEntities(report),
+    nextAction: report.status === "review"
+      ? `Review unsupported claims in ${report.entity} before exporting or promoting notebook patches.`
+      : report.followUps > 0
+        ? `Clear ${report.followUps} follow-up${report.followUps === 1 ? "" : "s"} tied to ${report.entity}.`
+        : `Open the notebook and reuse ${report.entity} as verified context.`,
+    trace: [
+      "Resolved selected report card",
+      `${report.sources} sources and ${report.claims} claims loaded`,
+      report.followUps > 0 ? "Follow-ups require action routing" : "No open follow-up pressure",
+      "Ready for notebook, graph, sources, or chat handoff",
+    ],
+  };
+}
+
+function relatedEntities(report: ReportCardData): string[] {
+  const base = report.kind === "Event"
+    ? ["Event captures", "Follow-ups", "Shared context"]
+    : report.kind === "Theme"
+      ? ["Adjacent companies", "Claims needing review", "Market map"]
+      : report.kind === "Coverage"
+        ? ["Competitors", "Product lines", "Enterprise buyers"]
+        : ["People", "Sources", "Similar companies"];
+  return [report.entity, ...base].slice(0, 4);
+}
+
+function clampScore(value: number): number {
+  return Math.max(42, Math.min(96, Math.round(value)));
+}
+
+function defaultRailTitle(surface: SurfaceId): string {
+  if (surface === "reports") return "Select a report";
+  if (surface === "home") return "Pulse context";
+  if (surface === "inbox") return "Decision queue";
+  if (surface === "me") return "Operator context";
+  return "Agent context";
+}

--- a/src/features/redesign/components/RightInspector.tsx
+++ b/src/features/redesign/components/RightInspector.tsx
@@ -1,117 +1,317 @@
 /**
- * RightInspector — chat-page right rail.
+ * RightInspector - chat-page right rail.
  *
- * Spec: active entity card · graph preview · sources · prior threads · report status.
- *
- * Mounted widgets (top → bottom):
- *   - Report status
- *   - VoiceCostBadge (signed-in only — daily voice spend + tier-fallback
- *     transparency. The widget shape — `<section>` with rounded border +
- *     padding — matches the existing `rd-card` cadence. Mounted here per
- *     the design pattern: sticky widgets in the right rail. HONEST_STATUS:
- *     the badge is suppressed entirely for signed-out viewers (no fake
- *     userId), and renders its own loading skeleton when Convex query
- *     is undefined.)
- *   - Active entity card
- *   - Graph preview · sources · prior threads
+ * The rail can be driven by an explicit active live artifact from Chat. When
+ * no prop is passed, it falls back to the live Convex-backed artifact list.
  */
 
+import { useState } from "react";
 import { Pill } from "./Pill";
 import { useLiveArtifacts, type LiveArtifactDetail } from "../hooks/useLiveArtifacts";
 import { VoiceCostBadge } from "@/features/voice";
 import { useCurrentUserId } from "@/hooks/useCurrentUser";
 
-export function RightInspector() {
+const utilityTabs = [
+  { id: "entity", label: "Entity" },
+  { id: "graph", label: "Graph" },
+  { id: "sources", label: "Sources" },
+  { id: "threads", label: "Threads" },
+  { id: "notebook", label: "Notebook" },
+  { id: "report", label: "Report" },
+] as const;
+
+type UtilityTab = typeof utilityTabs[number]["id"];
+
+interface RightInspectorProps {
+  activeLiveArtifactDetail?: LiveArtifactDetail | null;
+}
+
+export function RightInspector({ activeLiveArtifactDetail }: RightInspectorProps = {}) {
+  const [activeTab, setActiveTab] = useState<UtilityTab>("entity");
   const liveArtifacts = useLiveArtifacts(12);
-  const detail = liveArtifacts.details[0];
+  const detail = activeLiveArtifactDetail === undefined
+    ? liveArtifacts.details[0]
+    : activeLiveArtifactDetail ?? undefined;
   const title = detail?.title ?? "Current report";
   const summary = detail?.summary ?? "Ask a question, capture a note, or open a live artifact to hydrate this inspector.";
-  const sources = detail?.sourceRows.slice(0, 4) ?? [];
+  const sources = detail?.sourceRows.slice(0, 6) ?? [];
   const nodes = detail?.nodes.slice(0, 5) ?? [];
-  // HONEST_STATUS — only mount VoiceCostBadge for signed-in viewers.
+  // HONEST_STATUS: only mount VoiceCostBadge for signed-in viewers.
   // `null` = signed out (skip), `undefined` = loading auth (skip until known).
   const userId = useCurrentUserId();
 
   return (
-    <aside className="rd-pane rd-pane--right" style={{ padding: "20px 18px", gap: 16 }}>
-      {/* Report status */}
-      <section className="rd-card rd-card__pad-tight">
-        <div className="rd-eyebrow">Report status</div>
-        <div className="rd-row--between" style={{ marginTop: 8 }}>
-          <span className="rd-h3">{title}</span>
-          <Pill tone="green"><span className="rd-dot rd-dot--live" />{detail ? `Updated ${detail.updatedAt}` : "Ready"}</Pill>
-        </div>
-        <div className="rd-row" style={{ gap: 12, fontSize: 11, color: "var(--rd-ink-soft)", marginTop: 8 }}>
-          <span>{detail?.sourceCount ?? 0} sources</span>
-          <span>{detail?.claimCount ?? 0} claims</span>
-          <span>{detail?.followUps ?? 0} follow-ups</span>
-        </div>
-      </section>
-
-      {/* Voice cost badge — signed-in only. Reuses the existing widget
-          shipped in PR #312 (was tree-shaken because nothing imported it).
-          See module header for HONEST_STATUS rationale. */}
+    <aside className="rd-pane rd-pane--right" data-testid="right-inspector" style={{ padding: "20px 18px", gap: 16 }}>
       {userId && <VoiceCostBadge userId={userId} />}
 
-      {/* Active entity card */}
-      <section className="rd-card rd-card__pad" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-        <div className="rd-eyebrow">{detail ? "Active live artifact" : "Active context"}</div>
-        <h3 className="rd-h2" style={{ fontSize: 16 }}>{title}</h3>
-        <p className="rd-mono" style={{ fontSize: 10.5, color: "var(--rd-ink-soft)", margin: 0 }}>
-          {detail?.kind ?? "No live artifact selected"}
-        </p>
-        <p className="rd-body" style={{ fontSize: 12.5, color: "var(--rd-ink-mute)", margin: 0 }}>{summary}</p>
-        <div className="rd-row" style={{ gap: 4, flexWrap: "wrap", marginTop: 4 }}>
-          {(detail?.tags ?? ["Ask", "Capture", "Report"]).slice(0, 4).map((tag, i) => <Pill key={`${tag}-${i}`} tone={i === 0 ? "accent" : undefined}>{tag}</Pill>)}
-        </div>
-      </section>
-
-      {/* Graph preview */}
-      <section className="rd-card rd-card__pad-tight">
-        <div className="rd-row--between">
-          <div className="rd-eyebrow">Graph preview</div>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm" style={{ padding: "1px 6px", fontSize: 10 }}>Open Map</button>
-        </div>
-        <svg viewBox="0 0 240 120" width="100%" height={120} style={{ marginTop: 8 }}>
-          <GraphPreview detail={detail} nodes={nodes} />
-        </svg>
-      </section>
-
-      {/* Sources */}
-      <section className="rd-card rd-card__pad-tight">
-        <div className="rd-eyebrow">Sources used ({sources.length} / {detail?.sourceCount ?? 0})</div>
-        <ul className="rd-stack" style={{ gap: 6, listStyle: "none", padding: 0, margin: "8px 0 0" }}>
-          {(sources.length ? sources.map((source) => source.title) : ["Open a live artifact to hydrate source rows"]).map((s, i) => (
-            <li key={i} className="rd-row" style={{ gap: 8, fontSize: 12 }}>
-              <span className="rd-mono" style={{
-                fontSize: 10, background: "var(--rd-accent-soft)", color: "var(--rd-accent-strong)",
-                padding: "1px 5px", borderRadius: 3,
-              }}>[{i + 1}]</span>
-              <span style={{ flex: 1, color: "var(--rd-ink-mute)" }}>{s}</span>
-            </li>
+      <section className="rd-card rd-card__pad-tight" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div
+          className="rd-tabs"
+          role="tablist"
+          aria-label="Chat utility panels"
+          style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", width: "100%" }}
+        >
+          {utilityTabs.map((tab) => (
+            <button
+              key={tab.id}
+              id={`right-inspector-tab-${tab.id}`}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              aria-controls={`right-inspector-panel-${tab.id}`}
+              className="rd-tab"
+              style={{ minHeight: 30, padding: "6px 4px", fontSize: 11 }}
+              onClick={() => setActiveTab(tab.id)}
+            >
+              {tab.label}
+            </button>
           ))}
-        </ul>
-      </section>
+        </div>
 
-      {/* Prior threads */}
-      <section className="rd-card rd-card__pad-tight">
-        <div className="rd-eyebrow">Prior threads</div>
-        <ul className="rd-stack" style={{ gap: 4, listStyle: "none", padding: 0, margin: "8px 0 0" }}>
-          {[
-            { title: detail ? `Review ${detail.kind.toLowerCase()} claims` : "Start a research thread", when: detail?.updatedAt ?? "now" },
-            { title: detail ? "Open notebook handoff" : "Attach sources", when: "next" },
-            { title: detail ? "Export reusable memory" : "Create report", when: "later" },
-          ].map((t, i) => (
-            <li key={i}>
-              <button className="rd-btn rd-btn--quiet" style={{ width: "100%", justifyContent: "flex-start", padding: "5px 8px" }}>
-                <span style={{ flex: 1, textAlign: "left", fontSize: 12 }}>{t.title}</span>
-                <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>{t.when}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
+        <div>
+          <div
+            id="right-inspector-panel-entity"
+            role="tabpanel"
+            aria-labelledby="right-inspector-tab-entity"
+            hidden={activeTab !== "entity"}
+          >
+            <EntityPanel detail={detail} title={title} summary={summary} />
+          </div>
+          <div
+            id="right-inspector-panel-graph"
+            role="tabpanel"
+            aria-labelledby="right-inspector-tab-graph"
+            hidden={activeTab !== "graph"}
+          >
+            <GraphPanel detail={detail} nodes={nodes} />
+          </div>
+          <div
+            id="right-inspector-panel-sources"
+            role="tabpanel"
+            aria-labelledby="right-inspector-tab-sources"
+            hidden={activeTab !== "sources"}
+          >
+            <SourcesPanel detail={detail} sources={sources} />
+          </div>
+          <div
+            id="right-inspector-panel-threads"
+            role="tabpanel"
+            aria-labelledby="right-inspector-tab-threads"
+            hidden={activeTab !== "threads"}
+          >
+            <ThreadsPanel detail={detail} />
+          </div>
+          <div
+            id="right-inspector-panel-notebook"
+            role="tabpanel"
+            aria-labelledby="right-inspector-tab-notebook"
+            hidden={activeTab !== "notebook"}
+          >
+            <NotebookPanel detail={detail} />
+          </div>
+          <div
+            id="right-inspector-panel-report"
+            role="tabpanel"
+            aria-labelledby="right-inspector-tab-report"
+            hidden={activeTab !== "report"}
+          >
+            <ReportPanel detail={detail} title={title} />
+          </div>
+        </div>
       </section>
     </aside>
+  );
+}
+
+function EntityPanel({ detail, title, summary }: { detail?: LiveArtifactDetail; title: string; summary: string }) {
+  return (
+    <div className="rd-stack" style={{ gap: 10 }}>
+      <div className="rd-eyebrow">{detail ? "Active live artifact" : "Active context"}</div>
+      <h3 className="rd-h2" style={{ fontSize: 16 }}>{title}</h3>
+      <p className="rd-mono" style={{ fontSize: 10.5, color: "var(--rd-ink-soft)", margin: 0 }}>
+        {detail?.kind ?? "No live artifact selected"}
+      </p>
+      <p className="rd-body" style={{ fontSize: 12.5, color: "var(--rd-ink-mute)", margin: 0 }}>{summary}</p>
+      <div className="rd-row" style={{ gap: 4, flexWrap: "wrap", marginTop: 4 }}>
+        {(detail?.tags ?? ["Ask", "Capture", "Report"]).slice(0, 4).map((tag, i) => (
+          <Pill key={`${tag}-${i}`} tone={i === 0 ? "accent" : undefined}>{tag}</Pill>
+        ))}
+      </div>
+      <div className="rd-row" style={{ gap: 8 }}>
+        <MetricTile label="Claims" value={detail?.claimCount ?? 0} />
+        <MetricTile label="Sources" value={detail?.sourceCount ?? 0} />
+        <MetricTile label="Follow-ups" value={detail?.followUps ?? 0} />
+      </div>
+    </div>
+  );
+}
+
+function GraphPanel({ detail, nodes }: { detail?: LiveArtifactDetail; nodes: Array<{ title: string }> }) {
+  return (
+    <div className="rd-stack" style={{ gap: 10 }}>
+      <div className="rd-row--between">
+        <div className="rd-eyebrow">Graph preview</div>
+        <button className="rd-btn rd-btn--quiet rd-btn--sm" style={{ padding: "1px 6px", fontSize: 10 }}>Open Map</button>
+      </div>
+      <svg viewBox="0 0 240 120" width="100%" height={120}>
+        <GraphPreview detail={detail} nodes={nodes} />
+      </svg>
+      <p className="rd-body" style={{ fontSize: 12, color: "var(--rd-ink-mute)", margin: 0 }}>
+        {detail ? `${detail.nodes.length} nodes and ${detail.edges.length} relationships are attached to this artifact.` : "Pin or open a live artifact to hydrate first-ring relationships."}
+      </p>
+    </div>
+  );
+}
+
+function SourcesPanel({ detail, sources }: { detail?: LiveArtifactDetail; sources: LiveArtifactDetail["sourceRows"] }) {
+  return (
+    <div className="rd-stack" style={{ gap: 10 }}>
+      <div className="rd-eyebrow">Sources used ({sources.length} / {detail?.sourceCount ?? 0})</div>
+      {sources.length ? (
+        <ul className="rd-stack" style={{ gap: 6, listStyle: "none", padding: 0, margin: 0 }}>
+          {sources.map((source, i) => (
+            <li key={source.id || i} className="rd-row" style={{ alignItems: "flex-start", gap: 8, fontSize: 12 }}>
+              <span className="rd-mono" style={{
+                fontSize: 10,
+                background: "var(--rd-accent-soft)",
+                color: "var(--rd-accent-strong)",
+                padding: "1px 5px",
+                borderRadius: 3,
+              }}>[{i + 1}]</span>
+              <span style={{ flex: 1, minWidth: 0, color: "var(--rd-ink-mute)" }}>
+                <span style={{ display: "block", color: "var(--rd-ink)", fontWeight: 590 }}>{source.title}</span>
+                <span className="rd-mono" style={{ display: "block", marginTop: 2, fontSize: 10, color: "var(--rd-ink-soft)" }}>
+                  {source.type} - {source.refreshed}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <EmptyPanel message="Open a live artifact to hydrate source rows." />
+      )}
+    </div>
+  );
+}
+
+function ThreadsPanel({ detail }: { detail?: LiveArtifactDetail }) {
+  const threads = [
+    { title: detail ? `Review ${detail.kind.toLowerCase()} claims` : "Start a research thread", when: detail?.updatedAt ?? "now" },
+    { title: detail ? "Open notebook handoff" : "Attach sources", when: "next" },
+    { title: detail ? "Export reusable memory" : "Create report", when: "later" },
+  ];
+
+  return (
+    <div className="rd-stack" style={{ gap: 10 }}>
+      <div className="rd-eyebrow">Prior threads</div>
+      <ul className="rd-stack" style={{ gap: 4, listStyle: "none", padding: 0, margin: 0 }}>
+        {threads.map((thread, i) => (
+          <li key={i}>
+            <button className="rd-btn rd-btn--quiet" style={{ width: "100%", justifyContent: "flex-start", padding: "5px 8px" }}>
+              <span style={{ flex: 1, textAlign: "left", fontSize: 12 }}>{thread.title}</span>
+              <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>{thread.when}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function NotebookPanel({ detail }: { detail?: LiveArtifactDetail }) {
+  const sections = detail?.sections.slice(0, 3) ?? [];
+
+  return (
+    <div className="rd-stack" style={{ gap: 10 }}>
+      <div className="rd-row--between">
+        <div className="rd-eyebrow">Notebook</div>
+        <Pill tone={detail?.notebookHtml ? "green" : undefined}>{detail?.notebookHtml ? "Draft" : "Empty"}</Pill>
+      </div>
+      {detail ? (
+        <>
+          <p className="rd-body" style={{ fontSize: 12.5, color: "var(--rd-ink-mute)", margin: 0 }}>
+            {detail.primaryAction}
+          </p>
+          {sections.length ? (
+            <ul className="rd-stack" style={{ gap: 6, listStyle: "none", padding: 0, margin: 0 }}>
+              {sections.map((section) => (
+                <li
+                  key={section.title}
+                  style={{
+                    border: "1px solid var(--rd-line)",
+                    borderRadius: 6,
+                    padding: 10,
+                    background: "var(--rd-muted)",
+                  }}
+                >
+                  <div className="rd-h3" style={{ fontSize: 12 }}>{section.title}</div>
+                  <p className="rd-body" style={{ margin: "4px 0 0", fontSize: 11.5, color: "var(--rd-ink-mute)" }}>{section.body}</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyPanel message="No notebook sections are attached yet." />
+          )}
+        </>
+      ) : (
+        <EmptyPanel message="Create or open a live artifact to prepare a notebook handoff." />
+      )}
+    </div>
+  );
+}
+
+function ReportPanel({ detail, title }: { detail?: LiveArtifactDetail; title: string }) {
+  return (
+    <div className="rd-stack" style={{ gap: 10 }}>
+      <div className="rd-eyebrow">Report status</div>
+      <div className="rd-row--between">
+        <span className="rd-h3">{title}</span>
+        <Pill tone="green"><span className="rd-dot rd-dot--live" />{detail ? `Updated ${detail.updatedAt}` : "Ready"}</Pill>
+      </div>
+      <div className="rd-row" style={{ gap: 8 }}>
+        <MetricTile label="Sources" value={detail?.sourceCount ?? 0} />
+        <MetricTile label="Claims" value={detail?.claimCount ?? 0} />
+        <MetricTile label="Follow-ups" value={detail?.followUps ?? 0} />
+      </div>
+      <button className="rd-btn rd-btn--quiet rd-btn--sm" style={{ width: "100%", justifyContent: "center" }}>
+        Open report notebook
+      </button>
+    </div>
+  );
+}
+
+function MetricTile({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        minWidth: 0,
+        border: "1px solid var(--rd-line)",
+        borderRadius: 6,
+        padding: "8px 10px",
+        background: "var(--rd-muted)",
+      }}
+    >
+      <div className="rd-h3" style={{ fontSize: 14 }}>{value}</div>
+      <div className="rd-mono" style={{ marginTop: 2, fontSize: 9.5, color: "var(--rd-ink-soft)" }}>{label}</div>
+    </div>
+  );
+}
+
+function EmptyPanel({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--rd-line)",
+        borderRadius: 6,
+        padding: 10,
+        background: "var(--rd-muted)",
+        color: "var(--rd-ink-mute)",
+        fontSize: 12,
+      }}
+    >
+      {message}
+    </div>
   );
 }
 
@@ -138,7 +338,7 @@ function GraphPreview({ detail, nodes }: { detail?: LiveArtifactDetail; nodes: A
       </g>
       <circle cx={120} cy={60} r={18} fill="var(--rd-accent-soft)" stroke="var(--rd-accent)" strokeWidth={1.2} />
       <text x={120} y={64} textAnchor="middle" fontSize={9} fontWeight={590} fill="var(--rd-accent-strong)">Root</text>
-      {outer.map((node, i) => <NodeDot key={node.title} cx={positions[i].cx} cy={positions[i].cy} label={node.title.slice(0, 10)} />)}
+      {outer.map((node, i) => <NodeDot key={`${node.title}-${i}`} cx={positions[i].cx} cy={positions[i].cy} label={node.title.slice(0, 10)} />)}
     </>
   );
 }

--- a/src/features/redesign/components/TopNav.test.tsx
+++ b/src/features/redesign/components/TopNav.test.tsx
@@ -10,7 +10,7 @@
  *          editorial token system.
  * What:    They expect to see (a) the brand mark, (b) all 5 surface tabs
  *          with the active one highlighted, (c) a search chip with the
- *          K keyboard hint, (d) a theme toggle, (e) a profile/sign-in
+ *          Ctrl K keyboard hint, (d) a theme toggle, (e) a profile/sign-in
  *          slot.  They expect aria-current on the active tab and Alt+1..5
  *          to jump between surfaces.
  * Scale:   Single-component render.  At production scale this nav
@@ -18,7 +18,7 @@
  *          standalone workspace; correctness here is rendered on
  *          every page load.
  * Duration: Short-running.  No state accumulation.
- * Failure mode covered: missing tab, wrong active state, missing K
+ * Failure mode covered: missing tab, wrong active state, missing Ctrl K
  *          shortcut chip, palette-trigger callback silently dropped.
  */
 import { describe, expect, it, vi } from "vitest";
@@ -78,7 +78,7 @@ describe("TopNav — unified top horizontal nav (Bug 2)", () => {
     expect(current[0].textContent?.trim()).toBe("Reports");
   });
 
-  it("exposes the K shortcut chip on the search button", () => {
+  it("exposes the Ctrl K shortcut chip on the search button", () => {
     const { container } = renderTopNav();
     const searchBtn = container.querySelector(
       "[data-rd-topnav-search]",
@@ -86,7 +86,7 @@ describe("TopNav — unified top horizontal nav (Bug 2)", () => {
     expect(searchBtn).not.toBeNull();
     expect(searchBtn?.getAttribute("aria-keyshortcuts")).toMatch(/K/);
     const kbd = container.querySelector("[data-rd-topnav-kbd]");
-    expect(kbd?.textContent?.trim()).toBe("K");
+    expect(kbd?.textContent?.trim()).toBe("Ctrl K");
   });
 
   it("invokes onOpenPalette when the search button is clicked", () => {

--- a/src/features/redesign/components/TopNav.tsx
+++ b/src/features/redesign/components/TopNav.tsx
@@ -35,6 +35,7 @@ interface TopNavProps {
   onOpenPalette: () => void;
   theme: "light" | "dark";
   onToggleTheme: () => void;
+  prototypeMode?: boolean;
 }
 
 interface NavItem {
@@ -58,6 +59,7 @@ export function TopNav({
   onOpenPalette,
   theme,
   onToggleTheme,
+  prototypeMode = false,
 }: TopNavProps) {
   const { isAuthenticated, isLoading } = useConvexAuth();
   const { signIn } = useAuthActions();
@@ -88,6 +90,7 @@ export function TopNav({
     // RightInspector / MeSurface own the full identity story.
     return "NB";
   }, [isAuthenticated]);
+  const showAccountSlot = !prototypeMode && active !== "home";
 
   const onSignIn = () => {
     void signIn("anonymous").catch(() => undefined);
@@ -101,11 +104,12 @@ export function TopNav({
         display: "flex",
         alignItems: "center",
         gap: 16,
-        padding: "10px 20px",
-        height: 52,
+        padding: "8px 28px",
+        height: 46,
         borderBottom: "1px solid var(--rd-line-faint)",
         background: "var(--rd-paper)",
         flexShrink: 0,
+        zIndex: 20,
       }}
     >
       <button
@@ -116,41 +120,23 @@ export function TopNav({
         style={{
           display: "inline-flex",
           alignItems: "center",
-          gap: 9,
-          padding: "4px 8px",
+          gap: 0,
+          padding: 0,
           minWidth: 0,
+          flexShrink: 0,
           background: "transparent",
         }}
       >
         <span
-          aria-hidden="true"
           style={{
-            width: 24,
-            height: 24,
-            borderRadius: 6,
-            background: "var(--rd-accent)",
-            display: "grid",
-            placeItems: "center",
-            fontFamily: "var(--rd-font-mono)",
-            fontSize: 12,
+            fontSize: 15,
             fontWeight: 700,
-            color: "#fff",
-            lineHeight: 1,
-          }}
-        >
-          N
-        </span>
-        <span
-          style={{
-            fontSize: 13.5,
-            fontWeight: 590,
-            letterSpacing: "-0.01em",
+            letterSpacing: "-0.3px",
             color: "var(--rd-ink-strong)",
             whiteSpace: "nowrap",
           }}
         >
-          NodeBench{" "}
-          <span style={{ color: "var(--rd-accent-strong)" }}>AI</span>
+          Node<span style={{ color: "var(--rd-accent)" }}>Bench</span>
         </span>
       </button>
 
@@ -160,9 +146,9 @@ export function TopNav({
           display: "flex",
           alignItems: "center",
           gap: 2,
-          padding: 3,
+          padding: 0,
           borderRadius: "var(--rd-r-pill)",
-          background: "var(--rd-muted)",
+          background: "transparent",
         }}
       >
         {NAV.map((item) => {
@@ -177,14 +163,14 @@ export function TopNav({
               title={`${item.label} (Alt+${item.slot})`}
               className="rd-btn rd-btn--quiet"
               style={{
-                padding: "5px 12px",
-                minHeight: 28,
+                padding: "5px 10px",
+                minHeight: 26,
                 borderRadius: "var(--rd-r-pill)",
                 fontSize: 13,
-                fontWeight: isActive ? 590 : 510,
-                background: isActive ? "var(--rd-panel)" : "transparent",
-                color: isActive ? "var(--rd-ink-strong)" : "var(--rd-ink-mute)",
-                boxShadow: isActive ? "var(--rd-shadow-xs)" : "none",
+                fontWeight: isActive ? 590 : 500,
+                background: isActive ? "var(--rd-accent-soft)" : "transparent",
+                color: isActive ? "var(--rd-accent-strong)" : "var(--rd-ink-soft)",
+                boxShadow: "none",
               }}
             >
               {item.label}
@@ -193,44 +179,29 @@ export function TopNav({
         })}
       </nav>
 
-      <div style={{ flex: 1, display: "flex", justifyContent: "center", minWidth: 0 }}>
+      <div style={{ marginLeft: "auto", display: "flex", justifyContent: "flex-end", minWidth: 0 }}>
         <button
           type="button"
           onClick={onOpenPalette}
-          aria-label="Search reports, entities, inbox"
+          aria-label="Find a person, company, or action"
           aria-keyshortcuts="Meta+K Control+K"
           className="rd-btn rd-btn--quiet"
           data-rd-topnav-search
           style={{
             display: "inline-flex",
             alignItems: "center",
-            gap: 8,
-            padding: "5px 10px 5px 12px",
-            minHeight: 30,
-            maxWidth: 420,
-            width: "100%",
-            borderRadius: "var(--rd-r-md)",
+            gap: 6,
+            padding: "5px 12px",
+            minHeight: 28,
+            width: prototypeMode ? 276 : 270,
+            borderRadius: "var(--rd-r-pill)",
             border: "1px solid var(--rd-line)",
             background: "var(--rd-panel)",
-            color: "var(--rd-ink-soft)",
-            fontSize: 12.5,
+            color: "var(--rd-ink-faint)",
+            fontSize: prototypeMode ? 11.5 : 12,
             justifyContent: "flex-start",
           }}
         >
-          <svg
-            width={14}
-            height={14}
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={1.7}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <circle cx="11" cy="11" r="8" />
-            <path d="m21 21-4.35-4.35" />
-          </svg>
           <span
             style={{
               flex: 1,
@@ -240,7 +211,7 @@ export function TopNav({
               whiteSpace: "nowrap",
             }}
           >
-            Search reports, entities, inbox…
+            Find a person, company, or action
           </span>
           <kbd
             data-rd-topnav-kbd
@@ -255,12 +226,12 @@ export function TopNav({
               background: "var(--rd-muted)",
               border: "1px solid var(--rd-line-faint)",
               borderRadius: 4,
-              minWidth: 18,
-              justifyContent: "center",
-              lineHeight: 1.4,
-            }}
-          >
-            K
+            minWidth: 18,
+            justifyContent: "center",
+            lineHeight: 1.4,
+          }}
+        >
+            Ctrl K
           </kbd>
         </button>
       </div>
@@ -282,10 +253,12 @@ export function TopNav({
           title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
           className="rd-btn rd-btn--quiet"
           style={{
-            width: 30,
-            height: 30,
+            width: 28,
+            height: 28,
             padding: 0,
-            borderRadius: 8,
+            borderRadius: "50%",
+            border: "1px solid var(--rd-line)",
+            background: "var(--rd-panel)",
             display: "grid",
             placeItems: "center",
             color: "var(--rd-ink-mute)",
@@ -303,7 +276,7 @@ export function TopNav({
           )}
         </button>
 
-        {isLoading ? (
+        {showAccountSlot && isLoading ? (
           <div
             aria-hidden="true"
             style={{
@@ -313,7 +286,7 @@ export function TopNav({
               background: "var(--rd-muted)",
             }}
           />
-        ) : initials ? (
+        ) : showAccountSlot && initials ? (
           <button
             type="button"
             aria-label="Account menu"
@@ -335,7 +308,7 @@ export function TopNav({
           >
             {initials}
           </button>
-        ) : (
+        ) : showAccountSlot ? (
           <button
             type="button"
             onClick={onSignIn}
@@ -349,7 +322,7 @@ export function TopNav({
           >
             Sign in
           </button>
-        )}
+        ) : null}
       </div>
     </header>
   );

--- a/src/features/redesign/fixtures.ts
+++ b/src/features/redesign/fixtures.ts
@@ -329,6 +329,50 @@ export interface ChatTrace {
   durationMs?: number;
 }
 
+export interface ChatRuntimeArtifact {
+  id: string;
+  label: string;
+  status: string;
+  detail: string;
+  confidence?: number;
+  riskTier?: "low" | "medium" | "high";
+  costUsd?: number;
+}
+
+export interface ChatClaimCheck {
+  idx: number;
+  status: string;
+  method?: string;
+  source?: string;
+  detail?: string;
+  verified?: boolean;
+  validationError?: string;
+}
+
+export interface ChatRunMetrics {
+  runId?: string;
+  totalLatencyMs?: number;
+  totalTokens?: number;
+  estimatedCostUsd?: number;
+  paidCalls?: number;
+  sourceCount?: number;
+  verifiedSourceCount?: number;
+  toolCallCount?: number;
+  liveSearchCalls?: number;
+  memoryHitRate?: number;
+  sourceCacheHitRate?: number;
+  timeToFirstSourceMs?: number | null;
+  timeToFinalMs?: number;
+}
+
+export interface ChatRuntimeTrace {
+  boardState?: Record<string, unknown>;
+  contextCandidates?: ChatRuntimeArtifact[];
+  toolDecisions?: ChatRuntimeArtifact[];
+  claimChecks?: ChatClaimCheck[];
+  metrics?: ChatRunMetrics;
+}
+
 export interface ChatAnswer {
   shortAnswer: string;
   whyItMatters: string;
@@ -339,6 +383,7 @@ export interface ChatAnswer {
   paidCalls: number;
   fromMemory: boolean;
   trace: ChatTrace[];
+  runtime?: ChatRuntimeTrace;
 }
 
 export const sampleAnswer: ChatAnswer = {

--- a/src/features/redesign/hooks/useLiveArtifacts.ts
+++ b/src/features/redesign/hooks/useLiveArtifacts.ts
@@ -70,6 +70,19 @@ export interface LiveArtifactsResult {
   briefFeatureCount: number;
 }
 
+const EMPTY_LIVE_ARTIFACTS: LiveArtifactsResult = {
+  isLoading: false,
+  isLive: false,
+  sourceLabel: "Live artifacts disabled",
+  metrics: [],
+  pulse: [],
+  publicResearch: [],
+  reports: [],
+  details: [],
+  archiveCount: 0,
+  briefFeatureCount: 0,
+};
+
 export interface LiveArtifactSourceRow {
   id: string;
   type: string;
@@ -913,23 +926,25 @@ function buildMetrics(stats: ArchiveStats | null, memory: DailyBriefMemory | nul
   ];
 }
 
-export function useLiveArtifacts(limit = 24): LiveArtifactsResult {
+export function useLiveArtifacts(limit = 24, options: { enabled?: boolean } = {}): LiveArtifactsResult {
+  const enabled = options.enabled ?? true;
   const archive = useQuery(
     liveArtifactApi.domains.social.linkedinArchiveQueries.getArchivedPosts,
-    { limit, dedupe: true } as Parameters<typeof useQuery>[1],
+    enabled ? ({ limit, dedupe: true } as Parameters<typeof useQuery>[1]) : "skip",
   ) as ArchivePostsResult | undefined;
 
   const archiveStats = useQuery(
     liveArtifactApi.domains.social.linkedinArchiveQueries.getArchiveStats,
-    { dedupe: true } as Parameters<typeof useQuery>[1],
+    enabled ? ({ dedupe: true } as Parameters<typeof useQuery>[1]) : "skip",
   ) as ArchiveStats | undefined;
 
   const latestMemory = useQuery(
     liveArtifactApi.domains.research.dailyBriefMemoryQueries.getLatestMemory,
-    {} as Parameters<typeof useQuery>[1],
+    enabled ? ({} as Parameters<typeof useQuery>[1]) : "skip",
   ) as DailyBriefMemory | null | undefined;
 
   return useMemo(() => {
+    if (!enabled) return EMPTY_LIVE_ARTIFACTS;
     const isLoading = archive === undefined || archiveStats === undefined || latestMemory === undefined;
     const posts = archive?.posts ?? [];
     const memory = latestMemory ?? null;
@@ -963,5 +978,5 @@ export function useLiveArtifacts(limit = 24): LiveArtifactsResult {
       archiveCount,
       briefFeatureCount,
     };
-  }, [archive, archiveStats, latestMemory, limit]);
+  }, [archive, archiveStats, enabled, latestMemory, limit]);
 }

--- a/src/features/redesign/hooks/useRedesignChatRun.ts
+++ b/src/features/redesign/hooks/useRedesignChatRun.ts
@@ -10,8 +10,9 @@
  * Convex re-runs both whenever the underlying tables change → live
  * progress without any HTTP SSE plumbing.
  *
- * Auth-gated: state.available=false when unauthenticated; caller falls
- * back to fixture path.
+ * Anonymous-safe: the Convex mutation accepts anonymous runs and records
+ * userId only when auth is present. state.available=false only while auth
+ * is still loading, so guests can still exercise the real run pipeline.
  */
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { useMutation, useQuery, useConvexAuth } from "convex/react";
@@ -30,6 +31,123 @@ export function normalizeRouterTierForChatRun(tier: RouterTier): ChatRunTier {
 type EvidenceRow = ChatAnswer["evidence"][number];
 type TraceRow = ChatAnswer["trace"][number];
 
+export type PlannerArtifactStatus = "selected" | "candidate" | "deferred" | "pending" | "complete" | "blocked";
+
+export interface PlannerArtifact {
+  id: string;
+  label: string;
+  status: PlannerArtifactStatus;
+  detail: string;
+  confidence?: number;
+  riskTier?: "low" | "medium" | "high";
+  costUsd?: number;
+}
+
+export interface RuntimeMetrics {
+  runId?: string;
+  totalLatencyMs?: number;
+  totalTokens?: number;
+  estimatedCostUsd?: number;
+  paidCalls?: number;
+  sourceCount?: number;
+  verifiedSourceCount?: number;
+  toolCallCount?: number;
+  liveSearchCalls?: number;
+  memoryHitRate?: number;
+  sourceCacheHitRate?: number;
+  timeToFirstSourceMs?: number | null;
+  timeToFinalMs?: number;
+}
+
+export interface ClaimCheck {
+  idx: number;
+  status: string;
+  method?: string;
+  source?: string;
+  detail?: string;
+  verified?: boolean;
+  validationError?: string;
+}
+
+export interface RuntimeTrace {
+  boardState?: Record<string, unknown>;
+  contextCandidates: PlannerArtifact[];
+  toolDecisions: PlannerArtifact[];
+  claimChecks: ClaimCheck[];
+  metrics?: RuntimeMetrics;
+}
+
+function inferEntity(prompt: string): string | undefined {
+  return prompt.match(/(?:about |on |for |re )?([A-Z][A-Za-z0-9]+(?:\s[A-Z][A-Za-z0-9]+)*)/)?.[1];
+}
+
+function fallbackContextCandidates(prompt: string): PlannerArtifact[] {
+  const entity = inferEntity(prompt);
+  return [
+    {
+      id: "user_prompt",
+      label: "User prompt",
+      status: "selected",
+      confidence: 1,
+      detail: prompt || "Prompt loaded from the run row.",
+    },
+    {
+      id: "entity_mention",
+      label: entity ?? "Entity unresolved",
+      status: entity ? "candidate" : "deferred",
+      confidence: entity ? 0.72 : 0,
+      detail: entity ? "Detected from the prompt text." : "No stable entity mention found in the prompt.",
+    },
+    {
+      id: "active_report",
+      label: "Active report",
+      status: "deferred",
+      confidence: 0,
+      detail: "No report reference was available in the legacy run row.",
+    },
+  ];
+}
+
+function fallbackToolDecisions(trace: TraceRow[]): PlannerArtifact[] {
+  const hasFallback = trace.some((row) => /fallback/i.test(`${row.step} ${row.detail}`));
+  const hasGrounding = trace.some((row) => /gemini|ground/i.test(`${row.step} ${row.detail}`));
+  return [
+    {
+      id: "search_memory",
+      label: "search_memory",
+      status: "deferred",
+      riskTier: "low",
+      costUsd: 0,
+      detail: "Legacy run stream did not emit a memory-search decision.",
+    },
+    {
+      id: hasFallback ? "fallback_source_search" : "google_search_grounding",
+      label: hasFallback ? "fallback_source_search" : "google_search grounding",
+      status: hasFallback || hasGrounding ? "selected" : "pending",
+      riskTier: "medium",
+      detail: hasFallback
+        ? "Gemini returned no grounding chunks, so Linkup fallback sources were used."
+        : "Fresh evidence grounding was selected for this run.",
+    },
+    {
+      id: "verify_sources",
+      label: "verify_sources",
+      status: "pending",
+      riskTier: "low",
+      costUsd: 0,
+      detail: "Source URL substring validation runs after packet assembly.",
+    },
+    {
+      id: "patch_notebook",
+      label: "patch_notebook",
+      status: "deferred",
+      riskTier: "medium",
+      costUsd: 0,
+      detail: "Notebook writes require an explicit user action.",
+    },
+  ];
+}
+
 export interface RealChatRun {
   runId: string;
   hash?: string;
@@ -43,6 +161,8 @@ export interface RealChatRun {
   toolCalls: TraceRow[];
   /** Grounded source URLs as they arrive. */
   groundingChunks: EvidenceRow[];
+  /** Board-state, routing, tool-decision, claim-check, and metric artifacts. */
+  runtime: RuntimeTrace;
   status: "pending" | "running" | "complete" | "error";
   errorMessage?: string;
 }
@@ -51,12 +171,12 @@ export interface ChatRunState {
   status: "idle" | "thinking" | "ok" | "error";
   run: RealChatRun | null;
   error: string | null;
-  /** Whether the current user can run real chat (authenticated). */
+  /** Whether the real chat pipeline can be started from the current auth state. */
   available: boolean;
 }
 
 export function useRedesignChatRun() {
-  const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
+  const { isLoading: authLoading } = useConvexAuth();
   const startChat = useMutation(api.domains.redesign.chatRuns.startChat);
 
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
@@ -77,6 +197,11 @@ export function useRedesignChatRun() {
     let scratchpad = "";
     const toolCalls: TraceRow[] = [];
     const groundingChunks: EvidenceRow[] = [];
+    const contextCandidates: PlannerArtifact[] = [];
+    const toolDecisions: PlannerArtifact[] = [];
+    const claimChecks: ClaimCheck[] = [];
+    let boardState: RuntimeTrace["boardState"];
+    let metrics: RuntimeMetrics | undefined;
     const sections: Record<string, any> = {};
     let terminalError: string | undefined;
     for (const ev of list) {
@@ -101,6 +226,40 @@ export function useRedesignChatRun() {
         case "section":
           if (ev.payload?.name) sections[ev.payload.name] = ev.payload;
           break;
+        case "board_state":
+          boardState = ev.payload as RuntimeTrace["boardState"];
+          break;
+        case "context_candidate":
+          if (ev.payload?.id && ev.payload?.label) contextCandidates.push(ev.payload as PlannerArtifact);
+          break;
+        case "tool_decision":
+          if (ev.payload?.id && ev.payload?.label) toolDecisions.push(ev.payload as PlannerArtifact);
+          break;
+        case "claim_check":
+          if (typeof ev.payload?.idx === "number") claimChecks.push(ev.payload as ClaimCheck);
+          break;
+        case "sources_validated":
+          for (const item of ev.payload?.unverified ?? []) {
+            if (typeof item?.idx === "number") {
+              claimChecks.push({
+                idx: item.idx,
+                status: "source_validation_failed",
+                verified: false,
+                validationError: item.reason,
+              });
+            }
+          }
+          if (typeof ev.payload?.verified === "number" && typeof ev.payload?.total === "number") {
+            metrics = {
+              ...metrics,
+              sourceCount: ev.payload.total,
+              verifiedSourceCount: ev.payload.verified,
+            };
+          }
+          break;
+        case "run_metrics":
+          metrics = ev.payload as RuntimeMetrics;
+          break;
         case "error":
           terminalError = ev.payload?.errorMessage ?? "unknown error";
           break;
@@ -123,17 +282,35 @@ export function useRedesignChatRun() {
     const finalPacket = (runRow?.status === "complete" && runRow.packet)
       ? (runRow.packet as ChatAnswer)
       : partial;
+    const resolvedContextCandidates = contextCandidates.length > 0
+      ? contextCandidates
+      : fallbackContextCandidates(runRow?.prompt ?? "");
+    const resolvedToolDecisions = toolDecisions.length > 0
+      ? toolDecisions
+      : fallbackToolDecisions(toolCalls);
+    const runtime: RuntimeTrace = {
+      boardState,
+      contextCandidates: resolvedContextCandidates,
+      toolDecisions: resolvedToolDecisions,
+      claimChecks,
+      metrics,
+    };
+    const packet = {
+      ...finalPacket,
+      runtime,
+    };
 
     return {
       runId: activeRunId,
       hash: runRow?.hash ?? undefined,
-      packet: finalPacket,
+      packet,
       totalLatencyMs: runRow?.totalLatencyMs,
       totalTokens: runRow?.totalTokens,
       estimatedCostUsd: runRow?.estimatedCostUsd,
       scratchpad,
       toolCalls,
       groundingChunks,
+      runtime,
       status,
       errorMessage: terminalError ?? runRow?.errorMessage ?? undefined,
     };
@@ -152,8 +329,8 @@ export function useRedesignChatRun() {
       contextRef?: string,
       pinnedClaims?: Array<{ text: string; source?: string }>,
     ): Promise<string | null> => {
-      if (!isAuthenticated) {
-        setError("Sign in to run a real chat with grounded sources.");
+      if (authLoading) {
+        setError("Auth state is still loading. Try again in a moment.");
         return null;
       }
       setError(null);
@@ -167,7 +344,7 @@ export function useRedesignChatRun() {
         return null;
       }
     },
-    [isAuthenticated, startChat],
+    [authLoading, startChat],
   );
 
   const reset = useCallback(() => {
@@ -198,7 +375,7 @@ export function useRedesignChatRun() {
       status: externalStatus,
       run: projected,
       error,
-      available: !authLoading && isAuthenticated,
+      available: !authLoading,
     } as ChatRunState,
     submit,
     reset,

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -452,14 +452,15 @@
 /* The kernel layout: open-design's .split pattern, generalised for 3 zones */
 [data-redesign] .rd-shell {
   display: grid;
-  grid-template-columns: 248px minmax(0, 1fr);
-  height: 100vh;
+  grid-template-columns: 184px minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
 }
 
 [data-redesign] .rd-shell__main {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 360px;
+  grid-template-columns: minmax(0, 1fr) 400px;
   overflow: hidden;
 }
 
@@ -467,12 +468,18 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1100px) {
   [data-redesign] .rd-shell {
-    grid-template-columns: 188px minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
+  }
+  [data-redesign] .rd-shell > .rd-pane:first-child {
+    display: none;
   }
   [data-redesign] .rd-shell__main {
     grid-template-columns: minmax(0, 1fr);
+  }
+  [data-redesign] .rd-pane--right {
+    display: none;
   }
 }
 
@@ -489,6 +496,2475 @@
   border-right: none;
   border-left: 1px solid var(--rd-line-soft);
   background: var(--rd-paper-warm);
+}
+
+/* Home v2 prototype parity */
+[data-redesign] .rd-shell--home-v2 {
+  grid-template-columns: 184px minmax(0, 1fr);
+}
+
+[data-redesign] .rd-shell--home-v2 .rd-shell__main {
+  grid-template-columns: minmax(0, 1fr) 400px;
+}
+
+[data-redesign] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child {
+  align-items: center;
+  padding: 28px 48px 60px;
+  border-right: none;
+}
+
+[data-redesign] .rd-v2-left {
+  min-height: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--rd-line-soft);
+  background: var(--rd-paper);
+  padding: 0 8px 16px;
+}
+
+[data-redesign] .rd-v2-edition-month {
+  margin-top: 4px;
+  padding: 8px 10px 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--rd-ink-faint);
+}
+
+[data-redesign] .rd-v2-edition-block {
+  padding: 0 0 6px;
+}
+
+[data-redesign] .rd-v2-edition-block p {
+  margin: 3px 10px 2px 46px;
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v2-edition-date {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: var(--rd-r-sm);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+[data-redesign] .rd-v2-edition-date:hover {
+  background: var(--rd-muted);
+}
+
+[data-redesign] .rd-v2-edition-date.is-today {
+  background: var(--rd-accent-tint);
+}
+
+[data-redesign] .rd-v2-edition-day {
+  min-width: 28px;
+  text-align: center;
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--rd-ink-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+[data-redesign] .rd-v2-edition-date.is-today .rd-v2-edition-day {
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-edition-info {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+[data-redesign] .rd-v2-edition-label {
+  font-size: 11px;
+  font-weight: 590;
+  line-height: 1.2;
+  color: var(--rd-ink);
+}
+
+[data-redesign] .rd-v2-edition-sub {
+  font-size: 10px;
+  color: var(--rd-ink-faint);
+}
+
+[data-redesign] .rd-v2-rail-rule {
+  height: 1px;
+  margin: 8px;
+  background: var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-edition-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 5px 10px;
+  border: 0;
+  border-radius: var(--rd-r-sm);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+[data-redesign] .rd-v2-edition-group:hover {
+  background: var(--rd-muted);
+}
+
+[data-redesign] .rd-v2-edition-group span:first-child {
+  width: 10px;
+  flex-shrink: 0;
+  font-size: 8px;
+  color: var(--rd-ink-faint);
+}
+
+[data-redesign] .rd-v2-edition-group span:nth-child(2) {
+  flex: 1;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 590;
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] .rd-v2-edition-group b {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--rd-ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+[data-redesign] .rd-v2-home {
+  width: 100%;
+  max-width: 820px;
+}
+
+[data-redesign] .rd-v2-edition-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+[data-redesign] .rd-v2-edition-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-edition-subline {
+  font-size: 12px;
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v2-share-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 24px;
+}
+
+[data-redesign] .rd-v2-share-bar span {
+  margin-right: 6px;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-share-bar button,
+[data-redesign] .rd-v2-ed-selector button,
+[data-redesign] .rd-v2-card-actions button,
+[data-redesign] .rd-v2-queue-head button,
+[data-redesign] .rd-v2-action-row button,
+[data-redesign] .rd-v2-show-more button {
+  font: inherit;
+  border: 1px solid var(--rd-line);
+  background: var(--rd-panel);
+  color: var(--rd-ink-mute);
+  cursor: pointer;
+}
+
+[data-redesign] .rd-v2-share-bar button {
+  padding: 3px 10px;
+  border-radius: var(--rd-r-pill);
+  font-size: 10px;
+  font-weight: 590;
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v2-share-bar .rd-v2-share-primary,
+[data-redesign] .rd-v2-btn-primary {
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+  border-color: var(--rd-ink-strong);
+}
+
+[data-redesign] .rd-v2-card-actions .rd-v2-btn-primary,
+[data-redesign] .rd-v2-action-row .rd-v2-btn-primary {
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+  border-color: var(--rd-ink-strong);
+}
+
+[data-redesign] .rd-v2-hero-tagline {
+  margin: 0 0 4px;
+  color: var(--rd-ink-soft);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-hero {
+  max-width: 640px;
+  margin: 0 0 10px;
+  color: var(--rd-ink-strong);
+  font-size: 52px;
+  font-weight: 800;
+  letter-spacing: -2px;
+  line-height: 1.02;
+}
+
+[data-redesign] .rd-v2-hero-sub {
+  max-width: 520px;
+  margin: 0 0 32px;
+  color: var(--rd-ink-mute);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+[data-redesign] .rd-v2-ed-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 32px;
+}
+
+[data-redesign] .rd-v2-ed-selector button,
+[data-redesign] .rd-v2-queue-head button {
+  padding: 4px 12px;
+  border-radius: var(--rd-r-pill);
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-ed-selector button.is-active {
+  background: var(--rd-accent-tint);
+  border-color: var(--rd-accent);
+  color: var(--rd-accent-strong);
+  font-weight: 600;
+}
+
+[data-redesign] .rd-v2-twin-cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+[data-redesign] .rd-v2-card {
+  margin: 0;
+  padding: 24px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-lg);
+  background: var(--rd-panel-elevated);
+  box-shadow: var(--rd-shadow-sm);
+}
+
+[data-redesign] .rd-v2-card-kicker {
+  margin-bottom: 10px;
+  color: var(--rd-accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-card h2,
+[data-redesign] .rd-v2-card h3 {
+  margin: 0 0 10px;
+  color: var(--rd-ink-strong);
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  line-height: 1.15;
+}
+
+[data-redesign] .rd-v2-card h3 {
+  font-size: 16px;
+}
+
+[data-redesign] .rd-v2-card p {
+  margin: 0 0 16px;
+  color: var(--rd-ink-mute);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+[data-redesign] .rd-v2-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+[data-redesign] .rd-v2-card-actions button,
+[data-redesign] .rd-v2-action-row button {
+  padding: 7px 16px;
+  border-radius: var(--rd-r-pill);
+  color: var(--rd-ink);
+  font-size: 12px;
+  font-weight: 590;
+}
+
+[data-redesign] .rd-v2-sweep-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+[data-redesign] .rd-v2-sweep-list li {
+  display: flex;
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--rd-line-faint);
+  color: var(--rd-ink);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+[data-redesign] .rd-v2-sweep-list li::before {
+  content: "\2022";
+  flex-shrink: 0;
+  color: var(--rd-accent);
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-sweep-list li:last-child {
+  border-bottom: none;
+}
+
+[data-redesign] .rd-v2-stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2px;
+  margin-bottom: 28px;
+  overflow: hidden;
+  border-radius: var(--rd-r-sm);
+}
+
+[data-redesign] .rd-v2-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 12px 8px 10px;
+  border: 1px solid var(--rd-line-faint);
+  background: var(--rd-panel);
+  text-align: center;
+}
+
+[data-redesign] .rd-v2-stat span {
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-stat strong {
+  color: var(--rd-ink-strong);
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  line-height: 1;
+}
+
+[data-redesign] .rd-v2-stat[data-tone="accent"] strong {
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-stat[data-tone="blue"] strong {
+  color: var(--rd-blue);
+}
+
+[data-redesign] .rd-v2-queue-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+[data-redesign] .rd-v2-queue-head h3 {
+  margin: 0;
+  color: var(--rd-ink-strong);
+  font-size: 18px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-queue-head div {
+  display: flex;
+  gap: 3px;
+}
+
+[data-redesign] .rd-v2-queue-head button {
+  font-weight: 590;
+}
+
+[data-redesign] .rd-v2-queue-head button.is-active {
+  background: var(--rd-accent);
+  border-color: var(--rd-accent);
+  color: #fff;
+}
+
+[data-redesign] .rd-v2-selected {
+  margin-bottom: 12px;
+  padding: 18px 22px;
+  border: 1px solid var(--rd-accent-soft);
+  border-radius: var(--rd-r-md);
+  background: var(--rd-accent-tint);
+}
+
+[data-redesign] .rd-v2-selected-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+[data-redesign] .rd-v2-selected-top span {
+  color: var(--rd-accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-selected-top strong {
+  margin-left: auto;
+  color: var(--rd-accent-strong);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+[data-redesign] .rd-v2-selected h3 {
+  margin: 0 0 6px;
+  color: var(--rd-ink-strong);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+[data-redesign] .rd-v2-selected p {
+  margin: 0 0 8px;
+  color: var(--rd-ink-mute);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+[data-redesign] .rd-v2-selected .rd-v2-muted {
+  margin-bottom: 0;
+  color: var(--rd-ink-soft);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+[data-redesign] .rd-v2-proof-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+[data-redesign] .rd-v2-proof-card {
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-proof-card h4 {
+  margin: 0 0 4px;
+  color: var(--rd-ink-strong);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-proof-card p {
+  margin: 0;
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+[data-redesign] .rd-v2-proof-card span {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 2px 7px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  color: var(--rd-ink-soft);
+  font-size: 9px;
+  font-weight: 600;
+}
+
+[data-redesign] .rd-v2-proof-card span.is-highlight {
+  padding: 3px 8px;
+  border-color: transparent;
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v2-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+[data-redesign] .rd-v2-q-list {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: var(--rd-r-sm);
+  list-style: none;
+}
+
+[data-redesign] .rd-v2-q-list li {
+  display: grid;
+  grid-template-columns: 28px 52px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-q-list li:nth-child(odd) {
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-q-list li:nth-child(even) {
+  background: var(--rd-paper-warm);
+}
+
+[data-redesign] .rd-v2-q-list li:last-child {
+  border-bottom: none;
+}
+
+[data-redesign] .rd-v2-q-rank {
+  text-align: center;
+  color: var(--rd-ink-faint);
+  font-size: 12px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+[data-redesign] .rd-v2-q-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 8px;
+  border-radius: var(--rd-r-pill);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-q-badge[data-lane="Now"] {
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-q-badge[data-lane="Prep"] {
+  background: var(--rd-blue-bg);
+  color: var(--rd-blue);
+}
+
+[data-redesign] .rd-v2-q-badge[data-lane="Check"] {
+  background: var(--rd-amber-bg);
+  color: var(--rd-amber);
+}
+
+[data-redesign] .rd-v2-q-badge[data-lane="Report"] {
+  background: var(--rd-green-bg);
+  color: var(--rd-green);
+}
+
+[data-redesign] .rd-v2-q-title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--rd-ink);
+  font-size: 13px;
+  font-weight: 590;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-q-next {
+  color: var(--rd-accent);
+  font-size: 11px;
+  font-weight: 590;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-show-more {
+  padding: 8px;
+  border-top: 1px solid var(--rd-line-faint);
+  text-align: center;
+}
+
+[data-redesign] .rd-v2-show-more button {
+  padding: 4px 12px;
+  border: 0;
+  border-radius: var(--rd-r-pill);
+  background: transparent;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+[data-redesign] .rd-v2-editorial-divider {
+  height: 1px;
+  margin: 32px 0 0;
+  background: var(--rd-line);
+}
+
+[data-redesign] .rd-v2-ed-section {
+  padding: 28px 0;
+  border-top: 1px solid var(--rd-line);
+}
+
+[data-redesign] .rd-v2-ed-section span {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--rd-accent);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-ed-section h3 {
+  margin: 0 0 10px;
+  color: var(--rd-ink-strong);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  line-height: 1.3;
+}
+
+[data-redesign] .rd-v2-ed-section p {
+  margin: 0;
+  color: var(--rd-ink);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+[data-redesign] .rd-v2-briefing {
+  padding: 0;
+  background: rgba(250, 249, 247, 0.96);
+  backdrop-filter: blur(18px);
+}
+
+[data-redesign-theme="dark"] .rd-v2-briefing {
+  background: rgba(15, 16, 17, 0.96);
+}
+
+[data-redesign] .rd-v2-agent-head {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  gap: 3px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-agent-head-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-redesign] .rd-v2-agent-head-row strong {
+  color: var(--rd-ink-strong);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-agent-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--rd-green);
+  box-shadow: 0 0 0 3px var(--rd-green-bg);
+}
+
+[data-redesign] .rd-v2-agent-head button {
+  margin-left: auto;
+  padding: 2px 7px;
+  border: 0;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-muted);
+  color: var(--rd-ink-soft);
+  cursor: pointer;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-agent-head p {
+  margin: 0 0 0 16px;
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-agent-pills,
+[data-redesign] .rd-v2-agent-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+[data-redesign] .rd-v2-agent-pills {
+  padding: 10px 14px 0;
+}
+
+[data-redesign] .rd-v2-agent-pills span,
+[data-redesign] .rd-v2-agent-tools span,
+[data-redesign] .rd-v2-trace span {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: var(--rd-ink-mute);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-agent-pills span {
+  padding: 5px 9px;
+  border: 1px solid var(--rd-line);
+}
+
+[data-redesign] .rd-v2-agent-pills .is-entity {
+  border-color: var(--rd-blue-border);
+  background: var(--rd-blue-bg);
+  color: var(--rd-blue);
+}
+
+[data-redesign] .rd-v2-agent-pills .is-source {
+  border-color: var(--rd-green-border);
+  background: var(--rd-green-bg);
+  color: var(--rd-green);
+}
+
+[data-redesign] .rd-v2-agent-pills span:first-child {
+  border-color: var(--rd-accent-soft);
+  background: var(--rd-accent-tint);
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-agent-thread {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  padding: 10px 14px 8px;
+}
+
+[data-redesign] .rd-v2-msg {
+  border: 1px solid var(--rd-line-faint);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+  padding: 10px 14px;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+[data-redesign] .rd-v2-msg-user {
+  width: fit-content;
+  max-width: 78%;
+  margin: 2px 0 0 auto;
+  padding: 8px 12px;
+  border: 0;
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  line-height: 1.25;
+}
+
+[data-redesign] .rd-v2-msg-agent {
+  margin-right: 18px;
+  border: 0;
+  background: var(--rd-muted);
+}
+
+[data-redesign] .rd-v2-msg-agent strong {
+  color: var(--rd-ink-strong);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-msg-agent p {
+  margin: 6px 0 0;
+  color: var(--rd-ink-mute);
+  font-size: 11.5px;
+  line-height: 1.42;
+}
+
+[data-redesign] .rd-v2-trace {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+  padding-top: 5px;
+  border-top: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-trace small {
+  flex-basis: 100%;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  font-weight: 590;
+}
+
+[data-redesign] .rd-v2-trace span {
+  padding: 2px 7px;
+  background: var(--rd-panel);
+  color: var(--rd-accent);
+  font-size: 9px;
+}
+
+[data-redesign] .rd-v2-drawer-toggle {
+  width: 100%;
+  padding: 6px 0 5px;
+  border: 0;
+  border-top: 1px solid var(--rd-line-faint);
+  border-bottom: 1px solid var(--rd-line-faint);
+  background: transparent;
+  color: var(--rd-ink-soft);
+  cursor: pointer;
+  text-align: left;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-agent-context {
+  padding-top: 6px;
+}
+
+[data-redesign] .rd-v2-context-head {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 2px 5px;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-entity {
+  display: grid;
+  grid-template-columns: 26px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-entity > span {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-entity strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--rd-ink-strong);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-agent-threads {
+  padding-top: 8px;
+  border-top: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-thread-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding-bottom: 2px;
+}
+
+[data-redesign] .rd-v2-thread-pills span {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 7px;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-muted);
+  color: var(--rd-ink-soft);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-entity em {
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-green-bg);
+  color: var(--rd-green);
+  font-size: 9px;
+  font-style: normal;
+  font-weight: 700;
+  padding: 2px 6px;
+}
+
+[data-redesign] .rd-v2-entity b {
+  color: var(--rd-accent-strong);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+[data-redesign] .rd-v2-agent-composer {
+  flex-shrink: 0;
+  padding: 10px 14px;
+  border-top: 1px solid var(--rd-line-faint);
+  background: var(--rd-paper);
+}
+
+[data-redesign] .rd-v2-agent-composer input {
+  width: 100%;
+  min-height: 40px;
+  padding: 10px 42px 10px 12px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+  font: inherit;
+  font-size: 13px;
+}
+
+[data-redesign] .rd-v2-agent-composer button {
+  float: right;
+  width: 28px;
+  height: 28px;
+  margin-top: -34px;
+  margin-right: 6px;
+  border: 0;
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-agent-tools {
+  clear: both;
+  margin-top: 8px;
+}
+
+[data-redesign] .rd-v2-agent-tools span {
+  padding: 2px 7px;
+  background: var(--rd-muted);
+  color: var(--rd-ink-soft);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+@media (max-width: 1100px) {
+  [data-redesign] .rd-shell--home-v2 {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  [data-redesign] .rd-shell--home-v2 > .rd-v2-left {
+    display: none;
+  }
+
+  [data-redesign] .rd-shell--home-v2 .rd-shell__main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  [data-redesign] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child {
+    padding: 28px 48px 60px;
+  }
+
+  [data-redesign] .rd-v2-briefing {
+    display: none;
+  }
+
+  [data-redesign] .rd-v2-hero {
+    font-size: 32px;
+    letter-spacing: -0.8px;
+  }
+
+  [data-redesign] .rd-v2-twin-cards {
+    grid-template-columns: 1fr;
+  }
+
+  [data-redesign] .rd-v2-proof-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  [data-redesign] [data-rd-topnav] {
+    gap: 8px !important;
+    padding: 8px 10px !important;
+    overflow-x: auto;
+  }
+
+  [data-redesign] [data-rd-topnav-search] {
+    display: none !important;
+  }
+
+  [data-redesign] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child {
+    padding: 20px 16px 100px;
+  }
+
+  [data-redesign] .rd-v2-hero {
+    font-size: 28px;
+  }
+
+  [data-redesign] .rd-v2-proof-row,
+  [data-redesign] .rd-v2-stats-row {
+    grid-template-columns: 1fr;
+  }
+
+  [data-redesign] .rd-v2-report-grid,
+  [data-redesign] .rd-v2-integrations-grid {
+    grid-template-columns: 1fr;
+  }
+
+  [data-redesign] .rd-v2-filter-row,
+  [data-redesign] .rd-v2-action-row {
+    overflow-x: auto;
+    justify-content: flex-start;
+  }
+
+  [data-redesign] .rd-v2-q-list li {
+    grid-template-columns: 24px 44px minmax(0, 1fr);
+  }
+
+  [data-redesign] .rd-v2-q-next {
+    display: none;
+  }
+}
+
+[data-redesign] .rd-v2-left--nav {
+  position: relative;
+  padding: 14px 8px 16px;
+}
+
+[data-redesign] .rd-v2-rail-search {
+  width: calc(100% - 20px);
+  margin: 8px 10px 28px;
+  padding: 8px 12px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+  font: inherit;
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-rail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 14px;
+}
+
+[data-redesign] .rd-v2-rail-section-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 10px 5px;
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-rail-section-head b {
+  margin-left: auto;
+  color: var(--rd-ink-faint);
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-nav-row,
+[data-redesign] .rd-v2-thread-row {
+  display: grid;
+  width: 100%;
+  align-items: center;
+  border: 0;
+  border-radius: var(--rd-r-sm);
+  background: transparent;
+  color: var(--rd-ink-mute);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+[data-redesign] .rd-v2-nav-row {
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+  gap: 8px;
+  padding: 7px 10px;
+}
+
+[data-redesign] .rd-v2-nav-row.is-active,
+[data-redesign] .rd-v2-thread-row.is-active {
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-nav-row span {
+  color: var(--rd-accent);
+  text-align: center;
+}
+
+[data-redesign] .rd-v2-nav-row[data-tone="blue"] span { color: var(--rd-blue); }
+[data-redesign] .rd-v2-nav-row[data-tone="amber"] span { color: var(--rd-amber); }
+[data-redesign] .rd-v2-nav-row[data-tone="muted"] span { color: var(--rd-ink-soft); }
+[data-redesign] .rd-v2-nav-row[data-tone="red"] span { color: var(--rd-red); }
+
+[data-redesign] .rd-v2-nav-row strong {
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  font-size: 13px;
+  font-weight: 520;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-nav-row b {
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-new-thread {
+  width: calc(100% - 36px);
+  margin: 8px 18px 24px;
+  padding: 8px 14px;
+  border: 0;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-new-entity {
+  width: calc(100% - 20px);
+  margin: 4px 10px 16px;
+  padding: 7px 10px;
+  border: 1px dashed var(--rd-line);
+  border-radius: var(--rd-r-sm);
+  background: transparent;
+  color: var(--rd-accent-strong);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+[data-redesign] .rd-v2-thread-row {
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 9px 10px;
+}
+
+[data-redesign] .rd-v2-thread-row > span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--rd-line);
+}
+
+[data-redesign] .rd-v2-thread-row > span.is-live {
+  background: var(--rd-accent);
+}
+
+[data-redesign] .rd-v2-thread-row strong {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--rd-ink-strong);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-thread-row p {
+  margin: 1px 0 0;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--rd-ink-faint);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-thread-row b {
+  align-self: start;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  font-weight: 500;
+}
+
+[data-redesign] .rd-v2-keyboard-help {
+  position: absolute;
+  bottom: 34px;
+  left: 18px;
+  right: 18px;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+[data-redesign] .rd-v2-keyboard-help kbd {
+  padding: 1px 4px;
+  border: 1px solid var(--rd-line);
+  border-radius: 3px;
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-profile-mini {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 12px 24px;
+}
+
+[data-redesign] .rd-v2-profile-mini > span {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-profile-mini strong {
+  color: var(--rd-ink-strong);
+  font-size: 14px;
+}
+
+[data-redesign] .rd-v2-profile-mini p {
+  margin: 2px 0 0;
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-memory-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 12px;
+}
+
+[data-redesign] .rd-v2-memory-stats div {
+  display: flex;
+  justify-content: space-between;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-memory-stats strong {
+  color: var(--rd-ink-strong);
+}
+
+[data-redesign] .rd-v2-sign-out {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 30px;
+  padding: 8px;
+  border: 1px solid #fde8e8;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: #b91c1c;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-proto-center {
+  width: 100%;
+  max-width: 820px;
+}
+
+[data-redesign] .rd-v2-filter-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 7px;
+  margin: 14px 0 8px;
+}
+
+[data-redesign] .rd-v2-action-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin: 0 0 22px;
+}
+
+[data-redesign] .rd-v2-filter-row button,
+[data-redesign] .rd-v2-action-row button {
+  flex: 0 0 auto;
+  padding: 5px 11px;
+  border: 1px solid transparent;
+  border-radius: var(--rd-r-pill);
+  background: transparent;
+  color: var(--rd-ink-mute);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-filter-row button.is-active {
+  border-color: var(--rd-accent);
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-action-row .rd-v2-btn-primary {
+  background: var(--rd-ink-strong);
+  border-color: var(--rd-ink-strong);
+  color: var(--rd-paper);
+}
+
+[data-redesign] .rd-v2-filter-spacer {
+  flex: 1 1 20px;
+  min-width: 8px;
+}
+
+[data-redesign] .rd-v2-report-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+[data-redesign] .rd-v2-report-card {
+  min-height: 214px;
+  padding: 16px;
+  border: 1px solid var(--rd-line-faint);
+  border-left: 3px solid var(--rd-green);
+  border-radius: var(--rd-r-md);
+  background: var(--rd-panel);
+  box-shadow: var(--rd-shadow-xs);
+}
+
+[data-redesign] .rd-v2-report-card.is-active {
+  border-color: var(--rd-accent);
+  border-left-color: var(--rd-green);
+  box-shadow: 0 0 0 1px var(--rd-accent);
+}
+
+[data-redesign] .rd-v2-report-card--add {
+  display: flex;
+  min-height: 170px;
+  align-items: flex-start;
+  justify-content: center;
+  border-style: dashed;
+  border-left-color: var(--rd-line);
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v2-report-card--add h2 {
+  margin: 0;
+  color: var(--rd-ink-strong);
+  font-size: 14px;
+}
+
+[data-redesign] .rd-v2-report-card--add button,
+[data-redesign] .rd-v2-show-more {
+  align-self: flex-start;
+  margin-top: 8px;
+  padding: 6px 12px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: var(--rd-accent-strong);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+[data-redesign] .rd-v2-show-more {
+  margin: 14px auto 0;
+  display: block;
+}
+
+[data-redesign] .rd-v2-report-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-redesign] .rd-v2-report-title > span {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-report-title h2 {
+  margin: 0;
+  color: var(--rd-ink-strong);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-report-title b {
+  margin-left: auto;
+  padding: 2px 7px;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-green-bg);
+  color: var(--rd-green);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-report-title b[data-state="Needs review"] {
+  background: var(--rd-amber-bg);
+  color: var(--rd-amber);
+}
+
+[data-redesign] .rd-v2-report-title b[data-state="Stale"] {
+  background: var(--rd-amber-bg);
+  color: var(--rd-amber);
+}
+
+[data-redesign] .rd-v2-utility .rd-v2-report-title b,
+[data-redesign] .rd-v2-briefing .rd-v2-util-card .rd-v2-report-title b {
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-report-card p {
+  margin: 8px 0 0;
+  color: var(--rd-ink);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+[data-redesign] .rd-v2-report-card .rd-v2-report-kind,
+[data-redesign] .rd-v2-report-card .rd-v2-report-ref,
+[data-redesign] .rd-v2-report-card .rd-v2-report-meta {
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-report-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 10px;
+}
+
+[data-redesign] .rd-v2-report-tags span {
+  padding: 3px 8px;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v2-saved-banner {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  column-gap: 10px;
+  row-gap: 10px;
+  margin-bottom: 14px;
+  padding: 10px 14px;
+  border: 1px solid var(--rd-green-border);
+  border-radius: var(--rd-r);
+  background: var(--rd-green-bg);
+}
+
+[data-redesign] .rd-v2-saved-banner strong {
+  grid-column: 1 / 2;
+  color: var(--rd-ink-strong);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-saved-banner span {
+  grid-column: 2 / 6;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-saved-banner button {
+  grid-row: 2;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-saved-banner button:nth-of-type(1) { grid-column: 3; }
+[data-redesign] .rd-v2-saved-banner button:nth-of-type(2) { grid-column: 4; }
+[data-redesign] .rd-v2-saved-banner button:nth-of-type(3) { grid-column: 5; }
+
+[data-redesign] .rd-v2-saved-banner button,
+[data-redesign] .rd-v2-inbox-head button,
+[data-redesign] .rd-v2-bottom-composer button {
+  flex: 0 0 auto;
+  padding: 5px 12px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: var(--rd-ink-mute);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-chat-center h1 {
+  margin: 0;
+  color: var(--rd-ink-strong);
+  font-size: 16px;
+}
+
+[data-redesign] .rd-v2-muted-line {
+  margin: 4px 0 24px;
+  color: var(--rd-ink-soft);
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-checkpoints {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-bottom: 24px;
+}
+
+[data-redesign] .rd-v2-checkpoints div {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--rd-ink-soft);
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-checkpoints span {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--rd-green-bg);
+  color: var(--rd-green);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v2-checkpoints div[data-active="true"] span {
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent);
+}
+
+[data-redesign] .rd-v2-answer {
+  padding: 20px 16px;
+  border-top: 1px solid var(--rd-line-faint);
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-answer > span {
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-answer h3 {
+  margin: 22px 0 8px;
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-answer p {
+  margin: 0;
+  color: var(--rd-ink);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+[data-redesign] .rd-v2-answer mark {
+  padding: 2px 7px;
+  border: 1px solid var(--rd-accent-soft);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-accent-tint);
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-evidence-table {
+  width: 100%;
+  margin-top: 8px;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-evidence-table th,
+[data-redesign] .rd-v2-evidence-table td {
+  padding: 7px 8px;
+  border-bottom: 1px solid var(--rd-line-faint);
+  text-align: left;
+}
+
+[data-redesign] .rd-v2-evidence-table th {
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-context-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin: 12px 0 8px;
+}
+
+[data-redesign] .rd-v2-context-chips span {
+  padding: 3px 8px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-muted);
+  color: var(--rd-ink-mute);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-tool-strip,
+[data-redesign] .rd-v2-next-actions,
+[data-redesign] .rd-v2-composer-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+[data-redesign] .rd-v2-tool-strip {
+  margin: 8px 0 10px;
+}
+
+[data-redesign] .rd-v2-tool-strip span,
+[data-redesign] .rd-v2-composer-tools span {
+  padding: 3px 8px;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-muted);
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v2-next-actions {
+  margin-bottom: 12px;
+}
+
+[data-redesign] .rd-v2-next-actions button {
+  padding: 6px 10px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: var(--rd-ink-mute);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-user-followup,
+[data-redesign] .rd-v2-streaming-draft {
+  margin: 10px 0;
+  padding: 12px 14px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-streaming-draft {
+  border-color: var(--rd-accent-soft);
+  background: var(--rd-accent-tint);
+}
+
+[data-redesign] .rd-v2-user-followup strong,
+[data-redesign] .rd-v2-streaming-draft span {
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-user-followup p,
+[data-redesign] .rd-v2-streaming-draft p {
+  margin: 5px 0 0;
+  color: var(--rd-ink);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+[data-redesign] .rd-v2-bottom-composer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r);
+  background: var(--rd-panel);
+  padding: 8px;
+}
+
+[data-redesign] .rd-v2-composer-tools {
+  grid-column: 1 / -1;
+  padding-top: 7px;
+}
+
+[data-redesign] .rd-v2-bottom-composer input {
+  border: 0;
+  background: transparent;
+  color: var(--rd-ink);
+  font: inherit;
+  font-size: 13px;
+}
+
+[data-redesign] .rd-v2-bottom-composer button {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  background: var(--rd-accent);
+  color: #fff;
+}
+
+[data-redesign] .rd-v2-inbox-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-inbox-head h1 {
+  margin: 0;
+  color: var(--rd-ink-strong);
+  font-size: 16px;
+}
+
+[data-redesign] .rd-v2-inbox-head span {
+  color: var(--rd-ink-soft);
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-inbox-head .rd-v2-btn-primary {
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+}
+
+[data-redesign] .rd-v2-inbox-group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 16px;
+  background: var(--rd-paper-warm);
+  color: var(--rd-accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-inbox-group-head b {
+  padding: 1px 7px;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-muted);
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v2-inbox-group article {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) auto auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 56px;
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--rd-line-faint);
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-inbox-group article.is-active {
+  background: var(--rd-accent-tint);
+}
+
+[data-redesign] .rd-v2-source-icon {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: var(--rd-r-xs);
+  background: var(--rd-blue-bg);
+  color: var(--rd-blue);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-source-icon[data-source="slack"] {
+  background: #f0e4ff;
+  color: #7c3aed;
+}
+
+[data-redesign] .rd-v2-source-icon[data-source="doc"] {
+  background: var(--rd-green-bg);
+  color: var(--rd-green);
+}
+
+[data-redesign] .rd-v2-source-icon[data-source="alert"] {
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-inbox-title-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+[data-redesign] .rd-v2-inbox-title-row i {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--rd-accent);
+}
+
+[data-redesign] .rd-v2-inbox-group strong {
+  color: var(--rd-ink-strong);
+  font-size: 13.5px;
+}
+
+[data-redesign] .rd-v2-inbox-group p {
+  margin: 2px 0 0;
+  color: var(--rd-ink-faint);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-inbox-group time {
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v2-inbox-group article > b {
+  padding: 2px 6px;
+  border-radius: var(--rd-r-xs);
+  background: var(--rd-amber-bg);
+  color: var(--rd-amber);
+  font-size: 9px;
+}
+
+[data-redesign] .rd-v2-user-md {
+  padding: 24px 30px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-md);
+  background: var(--rd-panel);
+  box-shadow: var(--rd-shadow-xs);
+  font-family: var(--rd-font-mono);
+}
+
+[data-redesign] .rd-v2-user-md h2 {
+  margin: 0 0 20px;
+  color: var(--rd-ink-strong);
+  font-size: 16px;
+}
+
+[data-redesign] .rd-v2-user-md h2 + h2,
+[data-redesign] .rd-v2-user-md p + h2 {
+  margin-top: 26px;
+}
+
+[data-redesign] .rd-v2-user-md p {
+  margin: 4px 0;
+  color: var(--rd-ink);
+  font-size: 13px;
+}
+
+[data-redesign] .rd-v2-user-md p span {
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-integrations-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+[data-redesign] .rd-v2-integrations-grid article {
+  padding: 12px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-integrations-grid strong {
+  display: block;
+  color: var(--rd-ink-strong);
+  font-size: 13px;
+}
+
+[data-redesign] .rd-v2-integrations-grid span {
+  display: inline-flex;
+  margin-top: 6px;
+  color: var(--rd-green);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-integrations-grid p {
+  margin: 4px 0 0;
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-utility {
+  padding: 0;
+  background: var(--rd-paper);
+}
+
+[data-redesign] .rd-v2-util-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] .rd-v2-util-head button {
+  border: 0;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-muted);
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v2-util-search {
+  width: calc(100% - 28px);
+  margin: 0 14px 12px;
+  padding: 9px 12px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+  font: inherit;
+}
+
+[data-redesign] .rd-v2-util-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-util-tabs button {
+  padding: 9px 8px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--rd-ink-soft);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-util-tabs button.is-active {
+  border-bottom-color: var(--rd-accent);
+  color: var(--rd-accent-strong);
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-util-card {
+  margin: 14px;
+  padding: 14px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-util-card p {
+  margin: 8px 0 0;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+[data-redesign] .rd-v2-util-list {
+  padding: 8px 14px;
+}
+
+[data-redesign] .rd-v2-util-list h3,
+[data-redesign] .rd-v2-settings-list h3 {
+  margin: 12px 0 8px;
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-util-list p,
+[data-redesign] .rd-v2-settings-list p {
+  display: flex;
+  gap: 4px;
+  margin: 8px 0;
+  color: var(--rd-ink);
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-util-list p span,
+[data-redesign] .rd-v2-settings-list p strong {
+  margin-left: auto;
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v2-score-big {
+  color: var(--rd-ink-strong);
+  font-size: 34px;
+  font-weight: 800;
+}
+
+[data-redesign] .rd-v2-score-big small {
+  color: var(--rd-green);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+[data-redesign] .rd-v2-score-row {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) 26px;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-score-row b {
+  display: block;
+  height: 5px;
+  border-radius: var(--rd-r-pill);
+  overflow: hidden;
+  background: var(--rd-muted);
+}
+
+[data-redesign] .rd-v2-score-row i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--rd-green);
+}
+
+[data-redesign] .rd-v2-score-row i[data-tone="accent"] {
+  background: var(--rd-accent);
+}
+
+[data-redesign] .rd-v2-score-row i[data-tone="amber"] {
+  background: var(--rd-amber);
+}
+
+[data-redesign] .rd-v2-score-row strong {
+  color: var(--rd-ink-strong);
+  font-size: 11px;
+  text-align: right;
+}
+
+[data-redesign] .rd-v2-signal-line {
+  margin: 6px 0;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+[data-redesign] .rd-v2-related-entity {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 0;
+  border: 0;
+  border-bottom: 1px solid var(--rd-line-faint);
+  background: transparent;
+  color: var(--rd-ink);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+[data-redesign] .rd-v2-related-entity span {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-related-entity strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--rd-ink-strong);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-related-entity b {
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-agent-insight {
+  padding: 14px;
+  border: 1px solid var(--rd-accent-soft);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-accent-tint);
+}
+
+[data-redesign] .rd-v2-agent-insight strong {
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-agent-insight p {
+  margin: 8px 0 0;
+  color: var(--rd-ink);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+[data-redesign] .rd-v2-action-card-list {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+[data-redesign] .rd-v2-action-card-list button {
+  padding: 8px 10px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+  color: var(--rd-ink-mute);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+[data-redesign] .rd-v2-action-card-list button.is-primary {
+  border-color: var(--rd-ink-strong);
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+}
+
+[data-redesign] .rd-v2-settings-list {
+  padding: 4px 0;
+}
+
+[data-redesign] .rd-v2-settings-list b {
+  color: var(--rd-green);
+}
+
+[data-redesign] .rd-v2-settings-list em {
+  color: var(--rd-amber);
+  font-style: normal;
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  [data-redesign] .rd-v2-report-grid,
+  [data-redesign] .rd-v2-integrations-grid {
+    grid-template-columns: 1fr;
+  }
+
+  [data-redesign] .rd-v2-report-card {
+    min-height: auto;
+  }
+}
+
+[data-redesign] .rd-agent-rail {
+  padding: 20px 18px;
+  gap: 14px;
+}
+
+[data-redesign] .rd-agent-rail__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+[data-redesign] .rd-agent-rail__title {
+  margin: 5px 0 0;
+  font-size: 18px;
+  line-height: 1.12;
+  font-weight: 680;
+  color: var(--rd-ink-strong);
+}
+
+[data-redesign] .rd-agent-rail__pills,
+[data-redesign] .rd-agent-composer__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+[data-redesign] .rd-agent-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-panel);
+  box-shadow: var(--rd-shadow-xs);
+}
+
+[data-redesign] .rd-agent-score {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  align-items: center;
+}
+
+[data-redesign] .rd-agent-score__number {
+  width: 64px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 22px;
+  font-weight: 720;
+  font-family: var(--rd-font-mono);
+}
+
+[data-redesign] .rd-agent-score__label {
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--rd-ink-strong);
+}
+
+[data-redesign] .rd-agent-rail__copy,
+[data-redesign] .rd-agent-rail__next {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] .rd-agent-rail__next {
+  color: var(--rd-ink);
+  font-weight: 560;
+}
+
+[data-redesign] .rd-agent-rail__muted {
+  color: var(--rd-ink-soft);
+  font-size: 10.5px;
+}
+
+[data-redesign] .rd-agent-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+[data-redesign] .rd-agent-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] .rd-agent-bar__track {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--rd-muted);
+  overflow: hidden;
+}
+
+[data-redesign] .rd-agent-bar__track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--rd-blue);
+}
+
+[data-redesign] .rd-agent-bar__track span[data-tone="green"] { background: var(--rd-green); }
+[data-redesign] .rd-agent-bar__track span[data-tone="amber"] { background: var(--rd-amber); }
+
+[data-redesign] .rd-agent-related,
+[data-redesign] .rd-agent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+[data-redesign] .rd-agent-related__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: 7px;
+  background: var(--rd-paper);
+  color: var(--rd-ink);
+  font: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+[data-redesign] .rd-agent-related__item:hover {
+  border-color: var(--rd-accent-ring);
+  background: var(--rd-accent-soft);
+}
+
+[data-redesign] .rd-agent-trace summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--rd-ink);
+}
+
+[data-redesign] .rd-agent-trace ol {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+[data-redesign] .rd-agent-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+[data-redesign] .rd-agent-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--rd-ink);
+}
+
+[data-redesign] .rd-agent-list__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--rd-accent);
+  flex: 0 0 auto;
+}
+
+[data-redesign] .rd-agent-composer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-panel);
+  box-shadow: var(--rd-shadow-xs);
+}
+
+[data-redesign] .rd-agent-composer__chips span {
+  padding: 2px 7px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: 999px;
+  color: var(--rd-ink-soft);
+  font-family: var(--rd-font-mono);
+  font-size: 10.5px;
+}
+
+[data-redesign] .rd-agent-composer textarea {
+  width: 100%;
+  resize: none;
+  border: 1px solid var(--rd-line);
+  border-radius: 7px;
+  background: var(--rd-paper);
+  color: var(--rd-ink);
+  font: inherit;
+  font-size: 12.5px;
+  line-height: 1.45;
+  padding: 9px 10px;
+}
+
+[data-redesign] .rd-agent-composer textarea:focus {
+  outline: none;
+  border-color: var(--rd-accent);
+  box-shadow: 0 0 0 3px var(--rd-accent-soft);
 }
 
 /* Subtle paper texture for hero */
@@ -2904,6 +5380,141 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-working-notes__line {
   display: block;
   white-space: pre-wrap;
+}
+
+[data-redesign] .rd-runtime-board {
+  border: 1px dashed var(--rd-line-faint);
+  border-radius: var(--rd-r-sm);
+  background: color-mix(in srgb, var(--rd-paper-warm) 88%, transparent);
+}
+[data-redesign] .rd-runtime-board[open] {
+  border-style: solid;
+  border-color: var(--rd-line-strong);
+}
+[data-redesign] .rd-runtime-board__summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 12px;
+  cursor: pointer;
+  list-style: none;
+}
+[data-redesign] .rd-runtime-board__summary::-webkit-details-marker { display: none; }
+[data-redesign] .rd-runtime-board__title {
+  display: block;
+  margin-top: 2px;
+  color: var(--rd-ink-strong);
+  font-size: 12px;
+  font-weight: 590;
+}
+[data-redesign] .rd-runtime-board__meta {
+  font-family: var(--rd-font-mono);
+  font-size: 10.5px;
+  color: var(--rd-ink-soft);
+  white-space: nowrap;
+}
+[data-redesign] .rd-runtime-board__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 12px 12px;
+}
+[data-redesign] .rd-runtime-board__strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+}
+[data-redesign] .rd-runtime-metric {
+  min-width: 0;
+  padding: 7px 8px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: 6px;
+  background: var(--rd-paper);
+}
+[data-redesign] .rd-runtime-metric__label {
+  display: block;
+  font-family: var(--rd-font-mono);
+  font-size: 9.5px;
+  color: var(--rd-ink-soft);
+  text-transform: uppercase;
+}
+[data-redesign] .rd-runtime-metric__value {
+  display: block;
+  margin-top: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--rd-ink);
+  font-size: 11.5px;
+  font-weight: 590;
+}
+[data-redesign] .rd-runtime-table {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+[data-redesign] .rd-runtime-table__title {
+  font-family: var(--rd-font-mono);
+  font-size: 10px;
+  color: var(--rd-ink-soft);
+  text-transform: uppercase;
+}
+[data-redesign] .rd-runtime-table__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+[data-redesign] .rd-runtime-row {
+  display: grid;
+  grid-template-columns: 86px 150px minmax(0, 1fr);
+  gap: 8px;
+  align-items: baseline;
+  padding: 5px 7px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--rd-paper) 80%, transparent);
+  font-size: 11.5px;
+}
+[data-redesign] .rd-runtime-row__status {
+  font-family: var(--rd-font-mono);
+  font-size: 9.5px;
+  color: var(--rd-ink-soft);
+  text-transform: uppercase;
+}
+[data-redesign] .rd-runtime-row__status[data-status="selected"],
+[data-redesign] .rd-runtime-row__status[data-status="complete"] {
+  color: var(--rd-green);
+}
+[data-redesign] .rd-runtime-row__status[data-status="blocked"],
+[data-redesign] .rd-runtime-row__status[data-status="source_validation_failed"] {
+  color: var(--rd-amber);
+}
+[data-redesign] .rd-runtime-row__main {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--rd-ink-strong);
+  font-weight: 590;
+}
+[data-redesign] .rd-runtime-row__detail {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--rd-ink-mute);
+}
+@media (max-width: 720px) {
+  [data-redesign] .rd-runtime-board__summary {
+    grid-template-columns: 1fr;
+  }
+  [data-redesign] .rd-runtime-board__strip,
+  [data-redesign] .rd-runtime-row {
+    grid-template-columns: 1fr;
+  }
+  [data-redesign] .rd-runtime-row__detail {
+    white-space: normal;
+  }
 }
 
 [data-redesign] .rd-evidence-row {

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
 import { UniversalComposer, DEFAULT_TIERS, type RouterTier, type BatchTarget } from "../components/UniversalComposer";
 import { Pill } from "../components/Pill";
 import { StreamingMarkdown } from "../components/StreamingMarkdown";
@@ -197,6 +198,8 @@ ${topSources || "- No source rows returned yet"}`;
 interface ChatSurfaceProps {
   contextLabel?: string;
   workspaceDetail?: LiveArtifactDetail;
+  initialPrompt?: string;
+  onActiveContextChange?: (detail: LiveArtifactDetail | null) => void;
 }
 
 interface Turn {
@@ -307,64 +310,6 @@ function traceToToolCalls(trace: ChatAnswer["trace"]): ToolCall[] {
   }));
 }
 
-const STARTER_ANSWER: ChatAnswer = {
-  shortAnswer:
-    "NodeBench turns one question into a reusable report with claims [1], source rows [2], notebook blocks, and a next action [3].",
-  whyItMatters:
-    "The important shift is not a one-off answer. The useful artifact is the reusable entity memory [1] that can be reviewed, exported, and multiplied across a list [2].",
-  evidence: [
-    { idx: 1, quote: "Live artifacts hydrate from Convex when available.", source: "NodeBench runtime" },
-    { idx: 2, quote: "Reports preserve notebook, claim, source, and follow-up state.", source: "Redesign route contract" },
-    { idx: 3, quote: "The composer can run a question once or multiply it across a universe.", source: "Batch run workflow" },
-  ],
-  risks: [
-    "If no live artifact is selected, the user needs a clear starter path instead of a fake company sample.",
-    "Claim verification still needs visible source actions before export.",
-  ],
-  nextAction: "Ask about a real company, paste a list, or open the latest live brief from Reports.",
-  sourceCount: 3,
-  paidCalls: 0,
-  fromMemory: true,
-  trace: [
-    { step: "Start thread", status: "ok", detail: "Ready for entity, market, person, or list input", durationMs: 20 },
-    { step: "Router prepared", status: "ok", detail: "Single answer or batch run can start from the same composer", durationMs: 34 },
-    { step: "Report handoff", status: "info", detail: "A saved answer becomes notebook, claims, sources, and follow-ups", durationMs: 0 },
-  ],
-};
-
-const STREAMING_FOLLOWUP_MARKDOWN = `## Quick follow-up on reusable intelligence
-
-Based on the current workspace, three things are worth keeping visible:
-
-- The answer should preserve a notebook block, not disappear into chat history.
-- Claims need source rows attached before export.
-- The same rubric should be reusable across a list.
-
-\`\`\`text
-risk: weak sources should stay in review
-risk: batch outputs need visible approval rails
-\`\`\`
-
-> **Bottom line:** Create the report, preserve the evidence, then multiply the same judgment across the universe.
-
-[Open Reports →](/redesign/reports)`;
-
-const SAMPLE_TOOL_CALLS: ToolCall[] = [
-  { step: "Classify query", detail: "company_search · single entity", status: "ok", durationMs: 28, tool: "classify_query" },
-  { step: "Build context bundle", detail: "memory + prior reports", status: "ok", durationMs: 142, tool: "build_context_bundle", resultPreview: "{ mode: 'entity-intelligence', priorReports: 'available' }" },
-  { step: "Check live artifacts", detail: "daily briefs + archive rows", status: "ok", durationMs: 1840, tool: "load_live_artifacts", resultPreview: "reports · sources · claims · notebook blocks" },
-  { step: "Extract structured signals", detail: "Gemini 3 Flash", status: "ok", durationMs: 612, tool: "llm_extract" },
-  { step: "Assemble answer", detail: "claim · evidence · risks · next action", status: "ok", durationMs: 88, tool: "assemble_response" },
-];
-
-const NOW = Date.now();
-const SEED_TURNS: Turn[] = [
-  { id: "u1", role: "user", text: "Turn this research question into reusable entity intelligence.", createdAt: NOW - 4 * 60_000 },
-  { id: "a1", role: "assistant", packet: STARTER_ANSWER, tier: "auto", toolCalls: SAMPLE_TOOL_CALLS, createdAt: NOW - 4 * 60_000 + 3000 },
-  { id: "u2", role: "user", text: "What should happen after the answer?", createdAt: NOW - 30_000 },
-  { id: "a2", role: "assistant", markdown: STREAMING_FOLLOWUP_MARKDOWN, streaming: false, tier: "auto", createdAt: NOW - 25_000 },
-];
-
 function liveAnswer(detail: LiveArtifactDetail): ChatAnswer {
   const firstSection = detail.sections[0];
   const evidence = detail.sourceRows.slice(0, 4).map((source, index) => ({
@@ -417,8 +362,32 @@ ${bullets || `- ${detail.summary}`}
 [Open live workspace →](/redesign/workspace?report=${detail.id}&tab=brief)`;
 }
 
+function liveChatUnavailableMarkdown(reason: string, detail?: LiveArtifactDetail | null): string {
+  const context = detail
+    ? `Current live context is **${detail.title}** with ${detail.sourceCount} sources and ${detail.claimCount} claims.`
+    : "No live artifact context has loaded yet.";
+  return `## Live chat is not running
+
+${reason}
+
+${context}
+
+The UI is not inserting a showcase answer for this turn. Use the composer to start a Convex-backed chat run and stream tool events, scratchpad notes, evidence rows, and the final answer packet.`;
+}
+
 function buildSeedTurns(detail?: LiveArtifactDetail): Turn[] {
-  if (!detail) return SEED_TURNS;
+  if (!detail) {
+    return [
+      {
+        id: "a1",
+        role: "assistant",
+        markdown: liveChatUnavailableMarkdown("Waiting for Convex-backed live artifacts before seeding the thread."),
+        streaming: false,
+        tier: "auto",
+        createdAt: Date.now(),
+      },
+    ];
+  }
   const now = Date.now();
   return [
     { id: "u1", role: "user", text: `What is the latest read on ${detail.title}?`, createdAt: now - 4 * 60_000 },
@@ -502,20 +471,30 @@ function buildResearchStages(trace: ResearchTraceLike[] = [], complete = false):
   });
 }
 
-export function ChatSurface({ contextLabel = "Asking about: current context", workspaceDetail }: ChatSurfaceProps) {
+export function ChatSurface({
+  contextLabel = "Asking about: current context",
+  workspaceDetail,
+  initialPrompt,
+  onActiveContextChange,
+}: ChatSurfaceProps) {
+  const navigate = useNavigate();
   const liveArtifacts = useLiveArtifacts(24);
   const _rawLiveDetail = liveArtifacts.details[0];
   // Phase 1 — real LLM chat behind the composer for authenticated users.
   const chatRun = useRedesignChatRun();
+  const { isAuthenticated } = useConvexAuth();
   // Phase 4 — real reactions for inline correction + 👍/👎 toolbar.
   const recordReaction = useMutation(api.domains.redesign.agentRunFeedback.recordReaction);
   // Phase 5 — counterfactual probe re-run with masked source.
   const probeRun = useMutation(api.domains.redesign.chatRuns.probeRun);
-  // ?fresh=1 escape hatch: treat as if no live artifact is loaded (uses
-  // STARTER_ANSWER with inline [N] cites for the chat-sprints demo recorder).
+  // ?fresh=1 escape hatch: treat as if no live artifact is loaded and show the
+  // explicit live-chat unavailable state instead of seeded showcase content.
   const _skipLiveSeed = typeof window !== "undefined"
     && new URLSearchParams(window.location.search).has("fresh");
   const liveDetail = workspaceDetail ?? (_skipLiveSeed ? null : _rawLiveDetail);
+  useEffect(() => {
+    onActiveContextChange?.(liveDetail ?? null);
+  }, [liveDetail, onActiveContextChange]);
   const batchTargets = useMemo<BatchTarget[]>(() => {
     if (liveArtifacts.reports.length === 0) return [];
     return [
@@ -552,6 +531,12 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
   const [seedKey, setSeedKey] = useState<string | null>(null);
   const [turns, setTurns] = useState<Turn[]>([]);
   const [hasUserInteracted, setHasUserInteracted] = useState(false);
+  const consumedInitialPromptRef = useRef<string | null>(null);
+  const turnIdCounterRef = useRef(0);
+  const nextTurnId = (prefix: "u" | "a") => {
+    turnIdCounterRef.current += 1;
+    return `${prefix}-${Date.now().toString(36)}-${turnIdCounterRef.current}`;
+  };
   const [ctx, setCtx] = useState(contextLabel);
   const [tier, setTier] = useState<RouterTier>("auto");
   // Sprint S2: optional live batch monitor. Supporting telemetry is isolated
@@ -563,6 +548,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
 
   // Sprint 4 P1.6 — pinned items carried into the next turn's context.
   const [pinned, setPinned] = useState<Array<{ id: string; label: string; tier: RouterTier; sourceCount: number }>>([]);
+  const [followUps, setFollowUps] = useState<Array<{ id: string; label: string; reportTitle?: string; createdAt: number }>>([]);
   const pinClaim = (turnId: string, packet: ChatAnswer, packetTier: RouterTier) => {
     const id = `${turnId}-${Date.now()}`;
     const label = packet.shortAnswer.length > 80
@@ -577,13 +563,44 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
   const unpinClaim = (id: string) => {
     setPinned((cur) => cur.filter((p) => p.id !== id));
   };
+  const addFollowUp = (turnId: string, packet: ChatAnswer) => {
+    const label = packet.nextAction || packet.shortAnswer;
+    const id = `${turnId}-followup-${Date.now()}`;
+    setFollowUps((cur) => [
+      ...cur,
+      {
+        id,
+        label: label.length > 120 ? `${label.slice(0, 117)}...` : label,
+        reportTitle: liveDetail?.title,
+        createdAt: Date.now(),
+      },
+    ]);
+    showToast({
+      tone: "success",
+      message: "Follow-up queued in this chat. Open Inbox to promote it to shared workflow state.",
+      action: {
+        label: "Open Inbox",
+        onClick: () => navigate("/redesign/inbox"),
+      },
+    });
+  };
+  const removeFollowUp = (id: string) => {
+    setFollowUps((cur) => cur.filter((item) => item.id !== id));
+  };
+  const openCurrentReport = () => {
+    if (liveDetail?.id) {
+      navigate(`/redesign/workspace?report=${encodeURIComponent(liveDetail.id)}&tab=brief`);
+      return;
+    }
+    navigate("/redesign/reports");
+  };
 
   // Phase 5 — real counterfactual probe via the probeRun mutation.
   // Looks up the original run, kicks off a new run with the masked
   // source flagged unreliable in the system prompt, inserts a new
   // assistant turn that subscribes to the probed run's stream.
   const probeWithoutSourceReal = (originalTurnId: string, originalRunId: string, maskedIdx: number) => {
-    const probeId = `a${turns.length + 1}`;
+    const probeId = nextTurnId("a");
     setHasUserInteracted(true);
     setTurns((prev) => [
       ...prev,
@@ -669,21 +686,29 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
         out[idx] = next;
         return out;
       }
-      // Error → fall back to a fixture so the user isn't left staring.
+      if (real.packet?.runtime) {
+        live.packet = real.packet;
+      }
+      // Error: keep the turn honest and avoid inserting a synthetic answer.
       if (real.status === "error") {
         const next = {
           ...live,
           thinking: false,
-          packet: liveDetail ? liveAnswer(liveDetail) : STARTER_ANSWER,
-          toolCalls: liveDetail ? liveToolCalls(liveDetail) : SAMPLE_TOOL_CALLS,
+          packet: undefined,
+          markdown: liveChatUnavailableMarkdown(
+            real.errorMessage
+              ? `The Convex-backed chat run failed: ${real.errorMessage.slice(0, 180)}`
+              : "The Convex-backed chat run failed before producing a final packet.",
+            liveDetail,
+          ),
         };
         const out = [...prev];
         out[idx] = next;
         showToast({
           tone: "warning",
           message: real.errorMessage
-            ? `Real chat failed: ${real.errorMessage.slice(0, 100)}. Showing showcase fallback.`
-            : "Real chat failed — showing showcase fallback.",
+            ? `Real chat failed: ${real.errorMessage.slice(0, 100)}. No fixture answer inserted.`
+            : "Real chat failed. No fixture answer inserted.",
         });
         return out;
       }
@@ -696,20 +721,33 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
 
   const sendMessage = (text: string, submittedTier: RouterTier) => {
     const now = Date.now();
-    const userId = `u${turns.length + 1}`;
-    const assistantId = `a${turns.length + 1}`;
+    const userId = nextTurnId("u");
+    const assistantId = nextTurnId("a");
+    const canRunLiveChat = chatRun.state.available && !_skipLiveSeed;
+    const unavailableReason = _skipLiveSeed
+      ? "The `fresh=1` diagnostic flag disables live chat for this route."
+      : "NodeBench is still preparing the Convex-backed chat runtime.";
     setHasUserInteracted(true);
     setTurns((prev) => [
       ...prev,
       { id: userId, role: "user", text, createdAt: now },
-      { id: assistantId, role: "assistant", thinking: true, tier: submittedTier, createdAt: now + 50 },
+      canRunLiveChat
+        ? { id: assistantId, role: "assistant", thinking: true, tier: submittedTier, createdAt: now + 50 }
+        : {
+            id: assistantId,
+            role: "assistant",
+            markdown: liveChatUnavailableMarkdown(unavailableReason, liveDetail),
+            streaming: false,
+            tier: submittedTier,
+            createdAt: now + 50,
+          },
     ]);
     // Phase 2: if real chat is available, kick off a streaming run via
     // Convex scheduler. submit() returns a runId in <100ms; the projected
     // run state (packet + scratchpad + tool calls + grounding) arrives
     // reactively via Convex queries. The effect below watches for
     // status === "complete" to commit the final packet onto this turn.
-    if (chatRun.state.available && !_skipLiveSeed) {
+    if (canRunLiveChat) {
       // Phase 5 — carry pinned claims forward as hard context in the
       // system prompt. Each pin has a short label (the answer's tier +
       // shortAnswer) plus the source URL if grounded.
@@ -724,36 +762,97 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
               : t,
           ));
         } else {
-          // Submit failed (e.g. auth lost) — fall back to fixture
+          // Submit failed: keep the assistant turn explicit instead of
+          // fabricating a fallback answer packet.
           setTurns((prev) => prev.map((t) =>
             t.id === assistantId
-              ? { ...t, thinking: false, toolCalls: liveDetail ? liveToolCalls(liveDetail) : SAMPLE_TOOL_CALLS, packet: liveDetail ? liveAnswer(liveDetail) : STARTER_ANSWER }
+              ? {
+                  ...t,
+                  thinking: false,
+                  toolCalls: undefined,
+                  packet: undefined,
+                  markdown: liveChatUnavailableMarkdown(
+                    chatRun.state.error ?? "The Convex-backed chat run could not be started.",
+                    liveDetail,
+                  ),
+                }
               : t,
           ));
         }
       });
       return;
     }
-    // Showcase / fixture path
-    window.setTimeout(() => {
-      setTurns((prev) => prev.map((t) =>
-        t.id === assistantId
-          ? { ...t, thinking: false, toolCalls: liveDetail ? liveToolCalls(liveDetail) : SAMPLE_TOOL_CALLS, packet: liveDetail ? liveAnswer(liveDetail) : STARTER_ANSWER }
-          : t,
-      ));
-    }, 2200);
+    showToast({
+      tone: "info",
+      message: _skipLiveSeed
+        ? "Live chat was not started because fresh=1 disables the run path."
+        : "Live chat was not started. The Convex-backed runtime is still preparing.",
+    });
   };
 
+  useEffect(() => {
+    const prompt = initialPrompt?.trim();
+    if (!prompt || consumedInitialPromptRef.current === prompt) return;
+    if (!chatRun.state.available && !_skipLiveSeed) return;
+    consumedInitialPromptRef.current = prompt;
+    sendMessage(prompt, tier);
+  // sendMessage intentionally stays outside the dependency list because it is
+  // scoped to the current render state and this effect is keyed by URL prompt
+  // plus live-run availability to avoid consuming q= while Convex auth loads.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatRun.state.available, initialPrompt, _skipLiveSeed, tier]);
+
   const regenerate = (turnId: string, _tierOverride?: "free" | "fast" | "deep") => {
+    const targetIndex = turns.findIndex((t) => t.id === turnId);
+    const prompt = (() => {
+      for (let i = targetIndex - 1; i >= 0; i--) {
+        if (turns[i].role === "user" && turns[i].text?.trim()) return turns[i].text.trim();
+      }
+      return "";
+    })();
+    const requestedTier = (_tierOverride ?? turns[targetIndex]?.tier ?? tier) as RouterTier;
     setTurns((prev) => prev.map((t) =>
       t.id === turnId
         ? { ...t, thinking: true, packet: undefined, markdown: undefined, toolCalls: undefined, createdAt: Date.now() }
         : t,
     ));
+    if (prompt && chatRun.state.available && !_skipLiveSeed) {
+      const pinnedClaims = pinned.length > 0
+        ? pinned.map((p) => ({ text: p.label || "pinned claim", source: undefined as string | undefined }))
+        : undefined;
+      void chatRun.submit(prompt, requestedTier, liveDetail?.id, pinnedClaims).then((runId) => {
+        setTurns((prev) => prev.map((t) =>
+          t.id === turnId
+            ? runId
+              ? { ...t, chatRunId: runId, tier: requestedTier }
+              : {
+                  ...t,
+                  thinking: false,
+                  markdown: liveChatUnavailableMarkdown(
+                    chatRun.state.error ?? "Regenerate could not start a Convex-backed chat run.",
+                    liveDetail,
+                  ),
+                }
+            : t,
+        ));
+      });
+      return;
+    }
     window.setTimeout(() => {
       setTurns((prev) => prev.map((t) =>
         t.id === turnId
-          ? { ...t, thinking: false, toolCalls: liveDetail ? liveToolCalls(liveDetail) : SAMPLE_TOOL_CALLS, packet: liveDetail ? liveAnswer(liveDetail) : STARTER_ANSWER }
+          ? {
+              ...t,
+              thinking: false,
+              toolCalls: undefined,
+              packet: undefined,
+              markdown: liveChatUnavailableMarkdown(
+                prompt
+                  ? "Regenerate needs the Convex-backed chat runtime to be ready."
+                  : "Regenerate needs an original user prompt for this turn.",
+                liveDetail,
+              ),
+            }
           : t,
       ));
     }, 1800);
@@ -875,7 +974,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
             recentThread={liveDetail
               ? { id: liveDetail.id, entity: liveDetail.title, lastMessage: liveDetail.primaryAction, minutesAgo: 1 }
               : undefined}
-            onResume={() => { /* no-op in showcase */ }}
+            onResume={(threadId) => navigate(`/redesign/workspace?report=${encodeURIComponent(threadId)}&tab=chat`)}
           />
         ) : (
           turns.map((t) => {
@@ -890,6 +989,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
                     title="Live research run"
                     stages={buildResearchStages(t.toolCalls ?? [], false)}
                   />
+                  <RuntimeBoard runtime={t.packet?.runtime} />
                 </div>
               );
               if (t.markdown) return (
@@ -913,10 +1013,21 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
                   onRegenerate={(tierOverride) => regenerate(t.id, tierOverride)}
                   onBranch={() => branchFromTurn(t.id)}
                   onPin={() => pinClaim(t.id, t.packet!, t.tier ?? "auto")}
-                  onCompare={() => setCompareTurnId(t.id)}
+                  onAddFollowUp={() => addFollowUp(t.id, t.packet!)}
+                  onOpenReport={openCurrentReport}
+                  onCompare={t.chatRunId ? () => setCompareTurnId(t.id) : undefined}
                   onShare={() => shareAnswer(t.id, t.packet!, t.tier ?? "auto", t.runHash)}
                   onProbeRunWithoutSource={t.chatRunId ? (idx) => probeWithoutSourceReal(t.id, t.chatRunId!, idx) : undefined}
                   onReact={t.chatRunId ? (kind) => {
+                    if (!isAuthenticated) {
+                      showToast({
+                        tone: "info",
+                        message: kind === "up"
+                          ? "Marked helpful locally. Sign in to persist this to the eval flywheel."
+                          : "Marked not helpful locally. Sign in to persist this to the eval flywheel.",
+                      });
+                      return;
+                    }
                     void recordReaction({
                       runId: t.chatRunId!,
                       runSource: "redesign-chat",
@@ -931,7 +1042,15 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
                 />
               );
             })();
-            return <div key={t.id} data-turn-id={t.id}>{inner}</div>;
+            return (
+              <div
+                key={t.id}
+                data-turn-id={t.id}
+                data-chat-run-id={t.chatRunId || undefined}
+              >
+                {inner}
+              </div>
+            );
           })
         )}
       </div>
@@ -971,6 +1090,26 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
           </ul>
         </div>
       )}
+      {followUps.length > 0 && (
+        <div className="rd-pinned-bar" role="region" aria-label="Queued follow-ups from this chat">
+          <span className="rd-eyebrow rd-pinned-bar__eyebrow">Follow-ups queued · {followUps.length}</span>
+          <ul className="rd-pinned-bar__list">
+            {followUps.map((item) => (
+              <li key={item.id} className="rd-pinned-chip">
+                <span className="rd-pinned-chip__tier">next</span>
+                <span className="rd-pinned-chip__label" title={item.label}>{item.label}</span>
+                {item.reportTitle && <span className="rd-pinned-chip__count">{item.reportTitle}</span>}
+                <button
+                  type="button"
+                  className="rd-pinned-chip__close"
+                  aria-label="Remove queued follow-up"
+                  onClick={() => removeFollowUp(item.id)}
+                >×</button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <div className="rd-composer-dock" style={{ borderTop: "1px solid var(--rd-line-faint)" }}>
         <div style={{ maxWidth: 920, margin: "0 auto" }}>
           <UniversalComposer
@@ -988,7 +1127,15 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
             onStop={() => {
               setTurns((prev) => prev.map((t) =>
                 t.thinking || t.streaming
-                  ? { ...t, thinking: false, streaming: false, markdown: t.markdown ? t.markdown + "\n\n_(stopped by user)_" : t.markdown, packet: t.packet ?? (liveDetail ? liveAnswer(liveDetail) : STARTER_ANSWER) }
+                  ? {
+                      ...t,
+                      thinking: false,
+                      streaming: false,
+                      markdown: t.markdown
+                        ? `${t.markdown}\n\n_(stopped by user)_`
+                        : liveChatUnavailableMarkdown("Stopped before a live answer packet was available.", liveDetail),
+                      packet: t.packet,
+                    }
                   : t,
               ));
             }}
@@ -1000,7 +1147,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
           When authenticated, save persists the correction as a 👎 reaction
           with note via recordReaction (eval-flywheel signal). */}
       <InlineCorrection
-        onSave={chatRun.state.available && chatRun.state.run?.runId ? (
+        onSave={isAuthenticated && chatRun.state.run?.runId ? (
           async (original, correction) => {
             try {
               await recordReaction({
@@ -1034,6 +1181,13 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
           onClose={() => setCompareTurnId(null)}
           onPick={(variant, variantBRunId) => {
             setCompareTurnId(null);
+            if (!isAuthenticated) {
+              showToast({
+                tone: "info",
+                message: `Variant ${variant} selected locally. Sign in to persist A/B feedback to the eval flywheel.`,
+              });
+              return;
+            }
             const writes: Array<Promise<unknown>> = [];
             if (compareTurn.chatRunId) {
               writes.push(recordReaction({
@@ -1041,7 +1195,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
                 runSource: "redesign-chat",
                 turnId: compareTurn.id,
                 reaction: variant === "A" ? "up" : "down",
-                note: `[ab_compare] picked ${variant}; original=A; variantB=${variantBRunId ?? "fixture"}`,
+                note: `[ab_compare] picked ${variant}; original=A; variantB=${variantBRunId ?? "not-started"}`,
               }));
             }
             if (variantBRunId) {
@@ -1050,7 +1204,7 @@ export function ChatSurface({ contextLabel = "Asking about: current context", wo
                 runSource: "redesign-chat",
                 turnId: undefined,
                 reaction: variant === "B" ? "up" : "down",
-                note: `[ab_compare] picked ${variant}; variantB=B; original=${compareTurn.chatRunId ?? "fixture"}`,
+                note: `[ab_compare] picked ${variant}; variantB=B; original=${compareTurn.chatRunId ?? "not-recorded"}`,
               }));
             }
             if (writes.length === 0) {
@@ -1154,10 +1308,9 @@ function OpenQuestionsTray({ questions }: { questions: OpenQuestion[] }) {
  * Listens for text selections inside `.rd-chat-msg__body` (assistant
  * messages only). When the user highlights 5–300 chars, a floating
  * "Correct →" bubble appears at the selection's bounding rect. Clicking
- * opens an inline edit dialog pre-filled with the selection. Saving
- * fires a toast and (today) is no-op; once chat is live-wired this calls
- * `proposeMemoryPatch` from convex/domains/operatorProfile/manifest.ts
- * (PR #239) so the correction lands in /redesign/me's Memory Update Inbox.
+ * opens an inline edit dialog pre-filled with the selection. Saving persists
+ * against the current run when the user is authenticated; otherwise it gives
+ * an explicit sign-in prompt instead of pretending the correction was stored.
  */
 interface InlineCorrectionProps {
   /** Phase 4 — when set, save calls a real mutation against this run. */
@@ -1255,7 +1408,8 @@ function InlineCorrection({ onSave }: InlineCorrectionProps = {}) {
       }
       return;
     }
-    // Showcase fallback — anonymous user / fixture mode
+    // Unsigned persistence fallback: the correction still stays visible locally,
+    // but it is not written to the long-term feedback ledger.
     showToast({
       tone: "info",
       message: "Sign in to persist corrections to memory.",
@@ -1355,12 +1509,10 @@ function ABCompareModal({
   }, [onClose]);
 
   // Phase 7 — real Variant B parallel run.
-  // When the modal opens AND the user is authenticated AND a prompt was
-  // captured for the original answer, kick off a second startChat call
-  // and subscribe to its run row + events so the modal renders the
-  // streaming Variant B in real time. Anonymous / fixture users see the
-  // existing string-mutation fallback (Variant A's shortAnswer + " — high confidence.").
-  const { isAuthenticated } = useConvexAuth();
+  // When the modal opens and the original prompt was captured, kick off a
+  // second startChat call and subscribe to its run row + events so the modal
+  // renders the streaming Variant B in real time.
+  const { isLoading: authLoading } = useConvexAuth();
   const startChat = useMutation(api.domains.redesign.chatRuns.startChat);
   const [variantBRunId, setVariantBRunId] = useState<string | null>(null);
   const [variantBError, setVariantBError] = useState<string | null>(null);
@@ -1378,7 +1530,7 @@ function ABCompareModal({
   // a genuinely different draft.
   useEffect(() => {
     if (variantBRunId) return;
-    if (!isAuthenticated || !prompt || prompt.trim().length < 3) return;
+    if (authLoading || !prompt || prompt.trim().length < 3) return;
     let cancelled = false;
     void startChat({ prompt, tier: normalizeRouterTierForChatRun(tier), contextRef: undefined })
       .then((runId) => {
@@ -1388,7 +1540,7 @@ function ABCompareModal({
         if (!cancelled) setVariantBError((err?.message || String(err)).slice(0, 200));
       });
     return () => { cancelled = true; };
-  }, [isAuthenticated, prompt, tier, startChat, variantBRunId]);
+  }, [authLoading, prompt, tier, startChat, variantBRunId]);
 
   // Project Variant B from streamed sections so it renders progressively.
   const variantBPacket: { shortAnswer: string; whyItMatters: string } | null = (() => {
@@ -1412,8 +1564,8 @@ function ABCompareModal({
     };
   })();
 
-  const variantBStatus: "fixture" | "starting" | "streaming" | "complete" | "error" =
-    !isAuthenticated || !prompt ? "fixture"
+  const variantBStatus: "blocked" | "starting" | "streaming" | "complete" | "error" =
+    !prompt || prompt.trim().length < 3 ? "blocked"
     : variantBError ? "error"
     : !variantBRunId ? "starting"
     : variantBRow?.status === "complete" ? "complete"
@@ -1422,15 +1574,11 @@ function ABCompareModal({
 
   const tierMeta = DEFAULT_TIERS.find((t) => t.id === tier) ?? DEFAULT_TIERS[0];
 
-  // Fixture-mode fallback (anonymous users)
-  const fixtureBAnswer = packet.shortAnswer.replace(/\.$/, "") + " — high confidence.";
-  const fixtureBWhy = packet.whyItMatters;
-
-  const showShort = variantBStatus === "fixture"
-    ? fixtureBAnswer
+  const showShort = variantBStatus === "blocked"
+    ? "Variant B needs the original prompt to start a real parallel run."
     : variantBPacket?.shortAnswer || (variantBStatus === "streaming" ? "Streaming Variant B…" : variantBStatus === "starting" ? "Starting parallel run…" : variantBStatus === "error" ? `Error: ${variantBError ?? variantBRow?.errorMessage ?? "unknown"}` : "");
-  const showWhy = variantBStatus === "fixture"
-    ? fixtureBWhy
+  const showWhy = variantBStatus === "blocked"
+    ? "No fixture comparison is generated. Re-run from a turn with a captured user prompt."
     : variantBPacket?.whyItMatters || "";
 
   return (
@@ -1439,8 +1587,8 @@ function ABCompareModal({
         <header className="rd-ab-dialog__head">
           <span className="rd-eyebrow">A/B compare · {tierMeta.label} tier</span>
           <span className="rd-ab-dialog__hint">
-            {variantBStatus === "fixture"
-              ? "Same prompt, two parallel runs. Pick a winner."
+            {variantBStatus === "blocked"
+              ? "Original prompt unavailable — no fixture Variant B generated."
               : variantBStatus === "complete"
               ? "Both runs complete — pick the winner. Loser becomes a teach-me example."
               : variantBStatus === "streaming"
@@ -1480,7 +1628,7 @@ function ABCompareModal({
                   : variantBStatus === "streaming" ? "parallel run · streaming…"
                   : variantBStatus === "starting" ? "parallel run · starting…"
                   : variantBStatus === "error" ? "parallel run · error"
-                  : "fixture mode"}
+                  : "blocked"}
               </span>
             </header>
             <div className="rd-eyebrow">Short answer</div>
@@ -1491,7 +1639,7 @@ function ABCompareModal({
               type="button"
               className="rd-btn rd-btn--primary rd-btn--sm rd-ab-variant__pick"
               onClick={() => onPick("B", variantBRunId ?? undefined)}
-              disabled={variantBStatus === "starting" || variantBStatus === "error" || (variantBStatus === "streaming" && !variantBPacket?.shortAnswer)}
+              disabled={variantBStatus === "blocked" || variantBStatus === "starting" || variantBStatus === "error" || (variantBStatus === "streaming" && !variantBPacket?.shortAnswer)}
             >Pick B</button>
           </article>
         </div>
@@ -1614,10 +1762,7 @@ function StreamingAnswer({
         <MessageActions
           copyText={text}
           onRegenerate={onRegenerate}
-          onPin={() => { /* no-op showcase */ }}
           onBranch={onBranch}
-          onWhy={() => { /* no-op showcase */ }}
-          onReact={() => { /* no-op showcase */ }}
         />
       </article>
     </div>
@@ -1634,6 +1779,8 @@ function AnswerPacket({
   onRegenerate,
   onBranch,
   onPin,
+  onAddFollowUp,
+  onOpenReport,
   onCompare,
   onShare,
   onReact,
@@ -1648,6 +1795,8 @@ function AnswerPacket({
   onRegenerate?: (tierOverride?: "free" | "fast" | "deep") => void;
   onBranch?: () => void;
   onPin?: () => void;
+  onAddFollowUp?: () => void;
+  onOpenReport?: () => void;
   onCompare?: () => void;
   onShare?: () => void;
   /** Phase 5 — when set, the 👍/👎 buttons persist via recordReaction. */
@@ -1662,6 +1811,8 @@ function AnswerPacket({
   // Sprint 2 P0.3 — counterfactual probe state
   const [maskedIdx, setMaskedIdx] = useState<number | null>(null);
   const [probeMenu, setProbeMenu] = useState<{ idx: number; x: number; y: number } | null>(null);
+  const [traceOpen, setTraceOpen] = useState(false);
+  const traceRef = useRef<HTMLDetailsElement | null>(null);
 
   // Wire citation interactivity: hover [N] in body → highlight matching source row in evidence list
   const handleCiteEnter = (idx: number) => setHoverCite(idx);
@@ -1699,6 +1850,12 @@ function AnswerPacket({
   const restoreProbe = () => {
     setMaskedIdx(null);
     showToast({ tone: "success", message: "Source restored. Original answer in view." });
+  };
+  const showTrace = () => {
+    setTraceOpen(true);
+    window.setTimeout(() => {
+      traceRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }, 0);
   };
   // Dismiss probe menu on outside click / Escape
   useEffect(() => {
@@ -1739,6 +1896,7 @@ function AnswerPacket({
           title="Research run"
           stages={buildResearchStages(toolCalls ?? packet.trace, true)}
         />
+        <RuntimeBoard runtime={packet.runtime} />
 
         {/* Inline tool-call cards (parity-studio pattern) — render the agent's actual reasoning.
             Phase 7 — each card wrapped in an error boundary so one failed
@@ -1868,13 +2026,13 @@ function AnswerPacket({
         <div className="rd-eyebrow" style={{ color: "var(--rd-accent-strong)", marginBottom: 4 }}>Next action</div>
         <p className="rd-body" style={{ margin: 0, color: "var(--rd-ink)" }}>{packet.nextAction}</p>
         <div className="rd-row" style={{ gap: 6, marginTop: 10 }}>
-          <button className="rd-btn rd-btn--primary rd-btn--sm">Add to follow-ups</button>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm">Open {reportTitle ?? "report"}</button>
+          <button type="button" className="rd-btn rd-btn--primary rd-btn--sm" onClick={onAddFollowUp}>Add to follow-ups</button>
+          <button type="button" className="rd-btn rd-btn--quiet rd-btn--sm" onClick={onOpenReport}>Open {reportTitle ?? "report"}</button>
         </div>
       </section>
 
       {/* Trace */}
-      <details>
+      <details ref={traceRef} open={traceOpen} onToggle={(e) => setTraceOpen((e.currentTarget as HTMLDetailsElement).open)}>
         <summary className="rd-eyebrow" style={{ cursor: "pointer", listStyle: "none", display: "flex", alignItems: "center", gap: 6 }}>
           <span>How we got this answer</span>
           <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)" }}>{packet.trace.length} steps</span>
@@ -1902,7 +2060,7 @@ function AnswerPacket({
         onRegenerate={onRegenerate}
         onPin={onPin}
         onBranch={onBranch}
-        onWhy={() => { /* future: opens trace modal */ }}
+        onWhy={showTrace}
         onReact={onReact}
         onCompare={onCompare}
         onShare={onShare}
@@ -1988,6 +2146,89 @@ function WorkingNotes({ markdown }: { markdown: string }) {
  * The full feature would re-run the model with that source filtered out and
  * diff the answers; today we surface the affordance + a degradation note.
  */
+function RuntimeBoard({ runtime }: { runtime?: ChatAnswer["runtime"] }) {
+  const contextCandidates = runtime?.contextCandidates ?? [];
+  const toolDecisions = runtime?.toolDecisions ?? [];
+  const claimChecks = runtime?.claimChecks ?? [];
+  const metrics = runtime?.metrics;
+  const boardState = runtime?.boardState ?? {};
+  if (contextCandidates.length === 0 && toolDecisions.length === 0 && claimChecks.length === 0 && !metrics) {
+    return null;
+  }
+  const goal = typeof boardState.goal === "string" ? boardState.goal.replace(/_/g, " ") : "answer with cited research";
+  const entity = typeof boardState.entity === "string" ? boardState.entity : "no entity locked";
+  const targetReport = typeof boardState.targetReport === "string" ? boardState.targetReport : "no report selected";
+  return (
+    <details className="rd-runtime-board" data-testid="chat-runtime-board" open>
+      <summary className="rd-runtime-board__summary">
+        <span>
+          <span className="rd-eyebrow">Runtime board</span>
+          <span className="rd-runtime-board__title">{goal}</span>
+        </span>
+        <span className="rd-runtime-board__meta">
+          {contextCandidates.length} context · {toolDecisions.length} decisions · {claimChecks.length} checks
+        </span>
+      </summary>
+      <div className="rd-runtime-board__body">
+        <div className="rd-runtime-board__strip">
+          <RuntimeMetric label="Entity" value={entity} />
+          <RuntimeMetric label="Target" value={targetReport} />
+          <RuntimeMetric label="Cost" value={formatUsd(metrics?.estimatedCostUsd)} />
+          <RuntimeMetric label="Latency" value={formatMs(metrics?.totalLatencyMs ?? metrics?.timeToFinalMs)} />
+          <RuntimeMetric label="Memory hit" value={formatPct(metrics?.memoryHitRate)} />
+        </div>
+        <RuntimeArtifactTable title="Context candidates" rows={contextCandidates} />
+        <RuntimeArtifactTable title="Tool decisions" rows={toolDecisions} />
+        {claimChecks.length > 0 && (
+          <section className="rd-runtime-table">
+            <div className="rd-runtime-table__title">Claim checks</div>
+            <div className="rd-runtime-table__rows">
+              {claimChecks.slice(0, 6).map((row, index) => (
+                <div key={`${row.idx}-${row.status}-${index}`} className="rd-runtime-row">
+                  <span className="rd-runtime-row__status" data-status={row.verified === false ? "blocked" : row.status}>{row.status}</span>
+                  <span className="rd-runtime-row__main">Source [{row.idx}]</span>
+                  <span className="rd-runtime-row__detail">{row.validationError ?? row.detail ?? row.method ?? "verification queued"}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function RuntimeArtifactTable({ title, rows }: { title: string; rows: NonNullable<ChatAnswer["runtime"]>["contextCandidates"] }) {
+  if (!rows || rows.length === 0) return null;
+  return (
+    <section className="rd-runtime-table">
+      <div className="rd-runtime-table__title">{title}</div>
+      <div className="rd-runtime-table__rows">
+        {rows.map((row) => (
+          <div key={row.id} className="rd-runtime-row">
+            <span className="rd-runtime-row__status" data-status={row.status}>{row.status}</span>
+            <span className="rd-runtime-row__main">{row.label}</span>
+            <span className="rd-runtime-row__detail">
+              {row.confidence !== undefined ? `${Math.round(row.confidence * 100)}% · ` : ""}
+              {row.riskTier ? `${row.riskTier} risk · ` : ""}
+              {row.detail}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RuntimeMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="rd-runtime-metric">
+      <span className="rd-runtime-metric__label">{label}</span>
+      <span className="rd-runtime-metric__value">{value}</span>
+    </span>
+  );
+}
+
 function ProbeBanner({ idx, onRestore }: { idx: number; onRestore: () => void }) {
   return (
     <div className="rd-probe-banner" role="status" aria-live="polite">
@@ -2012,11 +2253,30 @@ function ProbeBanner({ idx, onRestore }: { idx: number; onRestore: () => void })
  * Showcase rate: $0.005/sec (replace with real provider billing once chat is live-wired).
  */
 function formatTraceCost(packet: ChatAnswer): string {
+  if (packet.runtime?.metrics) {
+    const metrics = packet.runtime.metrics;
+    return `${formatMs(metrics.totalLatencyMs ?? metrics.timeToFinalMs)} · ${formatUsd(metrics.estimatedCostUsd)}`;
+  }
   const totalMs = packet.trace.reduce((sum, step) => sum + (step.durationMs ?? 0), 0);
   const timeStr = totalMs < 1000 ? `${totalMs}ms` : `${(totalMs / 1000).toFixed(1)}s`;
   const usd = (totalMs / 1000) * 0.005;
   const costStr = usd >= 0.01 ? `$${usd.toFixed(3)}` : `<$0.01`;
   return `${timeStr} · ${costStr}`;
+}
+
+function formatUsd(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "pending";
+  return value >= 0.01 ? `$${value.toFixed(3)}` : "<$0.01";
+}
+
+function formatMs(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "pending";
+  return value < 1000 ? `${Math.round(value)}ms` : `${(value / 1000).toFixed(1)}s`;
+}
+
+function formatPct(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "pending";
+  return `${Math.round(value * 100)}%`;
 }
 
 /**

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -1,0 +1,1238 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+import type { LiveArtifactsResult } from "../hooks/useLiveArtifacts";
+
+interface HomeV2SurfaceProps {
+  onAsk?: (prompt: string) => void;
+  liveArtifacts?: LiveArtifactsResult;
+}
+
+interface PrototypeSelectionProps extends HomeV2SurfaceProps {
+  selectedEntity?: string;
+  onSelectEntity?: (entity: string) => void;
+}
+
+export type PrototypeSurface = "home" | "reports" | "chat" | "inbox" | "me";
+
+const editionItems = [
+  {
+    day: "11",
+    title: "Today",
+    meta: "4 signals \u00b7 12 sources",
+    body: "Anthropic repriced enterprise tier +40%. Sequoia added ratchet clause. SMB churn 3.2%.",
+    today: true,
+  },
+  {
+    day: "10",
+    title: "Sequoia counter-bid",
+    meta: "2 signals \u00b7 6 sources",
+    body: "Sequoia moved to $80M pre. New terms include board seat and pro-rata rights.",
+  },
+  {
+    day: "9",
+    title: "Bug0 pricing drop",
+    meta: "3 signals \u00b7 8 sources",
+    body: "Bug0 dropped enterprise to $199/seat. Three customers asked about our response.",
+  },
+  {
+    day: "8",
+    title: "SMB churn spike",
+    meta: "1 signal \u00b7 4 sources",
+    body: "First above-baseline churn week. Two exits cited pricing.",
+  },
+  {
+    day: "7",
+    title: "Patent filing update",
+    meta: "1 signal \u00b7 2 sources",
+    body: "USPTO acknowledged receipt of 17/892,341. Estimated 14-month review.",
+  },
+];
+
+const queueItems = [
+  ["1", "Now", "Anthropic partnership terms - board call Thu", "Open memo \u2192"],
+  ["2", "Now", "Series B term sheet from Sequoia - deadline Wed", "Draft reply \u2192"],
+  ["3", "Now", "Customer churn spike in SMB - 3 flagged", "Research \u2192"],
+  ["4", "Prep", "Competitor Bug0 dropped enterprise to $199/seat", "Read brief \u2192"],
+  ["5", "Prep", "Board deck Q2 financials - CFO updated projections", "Review \u2192"],
+  ["6", "Check", "Patent filing status for agent orchestration - USPTO pending", "Check \u2192"],
+  ["7", "Report", "Weekly hiring pipeline review - 4 senior eng in final round", "Open report \u2192"],
+  ["8", "Report", "Customer feedback digest from NPS survey - 340 responses", "Open report \u2192"],
+];
+
+const reportEntities = [
+  {
+    initial: "A",
+    name: "Anthropic",
+    status: "Verified",
+    score: 91,
+    sources: 12,
+    delta: "▲ 3 from last run",
+    kind: "Partnership intelligence - Company",
+    body: "Enterprise tier repriced +40%; Claude 4 Opus structure held. Managed Agent tier launched at $0.168/1K tokens.",
+    tags: ["Partnership", "AI", "Enterprise"],
+    ref: "Board prep - Q2 strategy - Vendor review",
+    meta: "Confidence 91 · 12 sources · 2 open claims · refreshed 2h ago",
+    dims: { Sources: 95, Freshness: 92, Verification: 80, Coverage: 88 },
+    signals: ["Enterprise pricing +40% effective June 1", "Managed Agent tier $0.168/1K tokens", "Partnership compressed $1.2M"],
+    related: ["Sequoia Capital", "OpenAI", "Google DeepMind"],
+    active: true,
+  },
+  {
+    initial: "S",
+    name: "Sequoia Capital",
+    status: "Needs review",
+    score: 74,
+    sources: 8,
+    delta: "▼ declining",
+    kind: "Term sheet analysis - Investor",
+    body: "Full-ratchet anti-dilution at 1x in term sheet v3; 33% below market norm. Board observer seat added at $83M.",
+    tags: ["Fundraising", "Term sheet", "Action needed"],
+    ref: "Cap table model - Dilution analysis - Deal memo",
+    meta: "Confidence 74 · 8 sources · 3 open claims · review needed",
+    dims: { Sources: 72, Freshness: 65, Verification: 58, Coverage: 80 },
+    signals: ["Full-ratchet anti-dilution clause added", "Board observer seat at $8.3M", "Counter-bid moved to $80M pre"],
+    related: ["Anthropic", "Bug0", "OpenAI"],
+  },
+  {
+    initial: "B",
+    name: "Bug0",
+    status: "Verified",
+    score: 88,
+    sources: 5,
+    delta: "▲ 2 from last run",
+    kind: "Competitive intelligence - Competitor",
+    body: "Pricing dropped to $199/mo from $349; SOC 2 Type II obtained. Feature gap narrowing on automated QA.",
+    tags: ["Competitive", "QA", "Enterprise"],
+    ref: "Competitive matrix - Pricing comparison",
+    meta: "Confidence 88 · 5 sources · 1 open claim · refreshed 1d ago",
+    dims: { Sources: 78, Freshness: 85, Verification: 90, Coverage: 82 },
+    signals: ["Pricing dropped to $199/mo from $349", "SOC 2 Type II obtained", "Feature gap narrowing on automated QA"],
+    related: ["Anthropic", "OpenAI", "Google DeepMind"],
+  },
+  {
+    initial: "O",
+    name: "OpenAI",
+    status: "Stale",
+    score: 62,
+    sources: 4,
+    delta: "▼ stale",
+    kind: "Market intelligence - Company",
+    body: "GPT-5 announcement rumored but unverified; 2 of 5 claims stale after 3 days. Refresh needed.",
+    tags: ["AI", "Unverified"],
+    ref: "Competitive matrix - API cost model",
+    meta: "Confidence 62 · 4 sources · 3 stale claims · refresh needed",
+    dims: { Sources: 55, Freshness: 42, Verification: 50, Coverage: 68 },
+    signals: ["GPT-5 announcement rumored, unverified", "2 of 5 claims now stale", "API pricing restructure signal"],
+    related: ["Anthropic", "Google DeepMind", "Bug0"],
+  },
+  {
+    initial: "G",
+    name: "Google DeepMind",
+    status: "Stale",
+    score: 55,
+    sources: 3,
+    delta: "▼ stale",
+    kind: "Coverage gap - Company",
+    body: "No new signals in 5 days; only 1 of 3 sources still verifiable. Refresh the research and update model capability notes.",
+    tags: ["AI", "Research", "Refresh"],
+    ref: "Model capability watch - Source ledger",
+    meta: "Confidence 55 · 3 sources · 2 stale claims · refresh needed",
+    dims: { Sources: 48, Freshness: 35, Verification: 45, Coverage: 55 },
+    signals: ["No new signals in 5 days", "Only 1 of 3 sources still verifiable", "Research tracker needs owner review"],
+    related: ["Anthropic", "OpenAI", "Sequoia Capital"],
+  },
+];
+
+type PrototypeReportEntity = (typeof reportEntities)[number];
+
+function getPrototypeEntity(name = "Anthropic"): PrototypeReportEntity {
+  return reportEntities.find((entity) => entity.name === name) ?? reportEntities[0];
+}
+
+type HomeV2QueueItem = [string, string, string, string];
+
+interface HomeV2Model {
+  editionItems: typeof editionItems;
+  editionLine: string;
+  heroSub: string;
+  primaryTitle: string;
+  primaryBody: string;
+  sweepTitle: string;
+  sweepBody: string;
+  sweepBullets: string[];
+  stats: Array<{ label: string; value: string; tone?: string }>;
+  selectedTitle: string;
+  selectedBody: string;
+  selectedNext: string;
+  selectedWhy: string;
+  selectedScore: string;
+  proofCards: Array<{ title: string; body: string; tag?: string; highlight?: boolean }>;
+  queueItems: HomeV2QueueItem[];
+  moreLabel: string;
+  whatChangedTitle: string;
+  whatChangedBody: string;
+  agentMeta: string;
+  agentLead: string;
+  agentBody: string;
+  agentTrace: string[];
+  agentEntities: Array<[string, string, string, string]>;
+}
+
+function compact(value: string | undefined, fallback: string): string {
+  const text = (value ?? "").replace(/\s+/g, " ").trim();
+  return text || fallback;
+}
+
+function monogram(value: string): string {
+  const words = value.replace(/[^a-zA-Z0-9 ]+/g, " ").trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "N";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return `${words[0][0]}${words[1][0]}`.toUpperCase();
+}
+
+function buildHomeV2Model(liveArtifacts?: LiveArtifactsResult): HomeV2Model {
+  const hasLive = Boolean(liveArtifacts?.isLive);
+  if (!liveArtifacts) {
+    return {
+      editionItems,
+      editionLine: "Sun, May 11 · 4 signals · 7 reports · 12 sources",
+      heroSub: "No dashboard theater. Today is only the signals that can change your pipeline. Everything below is supporting evidence.",
+      primaryTitle: "Book warm intro / YC AI Ops Co.",
+      primaryBody: "Use Wednesday, May 13 at 11:30 AM PT if available. Backup Thursday afternoon or Friday morning. Then move on.",
+      sweepTitle: "Public inbox tracker demo",
+      sweepBody: "Current sweep reduced the loaded 60-message demo inbox into five operating queues.",
+      sweepBullets: [
+        "Book the warm intro with YC AI Ops Co first.",
+        "Open the remote AI SWE lead and qualify company, role, comp, location.",
+        "Ask the operator friend whether the PE/AI lead has budget and role clarity.",
+        "Leave the submitted applied-AI role as waiting after submission.",
+      ],
+      stats: [
+        { label: "Must clear", value: "4", tone: "accent" },
+        { label: "Prep", value: "7", tone: "blue" },
+        { label: "Batch / Defer", value: "42" },
+      ],
+      selectedTitle: "Warm Intro Lead",
+      selectedBody: "Active founder-recruiter lead after Earlier Startup Lead / Insurance AI Co context.",
+      selectedNext: "Book Wed Wednesday 11:30 AM.",
+      selectedWhy: "This is specific, current, and high enough signal to clear before recruiter batch work.",
+      selectedScore: "91 strong",
+      proofCards: [
+        { title: "Pinned match", body: "active thread, calendar-ready, vertical AI", tag: "active thread" },
+        { title: "NodeBench proof", body: "Ready for action. 3 public-source signals attached.", tag: "ready" },
+        { title: "Calendar preview", body: "Scheduling/deadline logic from dashboard.", tag: "Wed May 13, 11:30 AM PT", highlight: true },
+        { title: "Privacy boundary", body: "Public demo only shows synthetic summaries. Raw email body, resume text, and private fit scoring stay local." },
+      ],
+      queueItems,
+      moreLabel: "Show 23 more items",
+      whatChangedTitle: "Anthropic raised valuation ceiling; Sequoia counter-bid changes cap table math",
+      whatChangedBody: "Two material signals converged overnight that shift the fundraise calculus. Anthropic's updated enterprise pricing model prices the partnership tier above Q1 rates, while Sequoia's revised term sheet introduces a ratchet clause that changes dilution math before the board call.",
+      agentMeta: "Daily Edition · 4 signals · 7 reports · 12 sources",
+      agentLead: "Three items matter most this morning.",
+      agentBody: "Anthropic repriced enterprise tier +40% effective June 1, Sequoia added a full-ratchet clause to the Series C term sheet, and SMB churn crossed the 3% threshold for the first time since Q3.",
+      agentTrace: ["entity_scan", "signal_rank", "source_verify"],
+      agentEntities: [
+        ["A", "Anthropic", "Verified", "91"],
+        ["S", "Sequoia Capital", "Review", "74"],
+        ["B", "Bug0", "", "68"],
+        ["O", "OpenAI", "", "62"],
+        ["D", "DeepMind", "", "55"],
+      ],
+    };
+  }
+
+  const reports = liveArtifacts.reports;
+  const pulse = liveArtifacts.pulse;
+  const metrics = liveArtifacts.metrics;
+  const publicResearch = liveArtifacts.publicResearch;
+  const topReport = reports[0];
+  const topPulse = pulse[0];
+  const topPublic = publicResearch[0];
+  const sourceCount = reports.reduce((total, report) => total + report.sources, 0);
+  const liveSummary = liveArtifacts.sourceLabel;
+  const statusPrefix = liveArtifacts.isLoading && !hasLive ? "Loading live edition" : hasLive ? "Live edition" : "No live artifacts yet";
+  const editionLine = `${statusPrefix} · ${reports.length} reports · ${liveArtifacts.briefFeatureCount} brief signals · ${sourceCount} sources`;
+  const actionTitle = compact(
+    topPulse?.title ?? topReport?.entity ?? topPublic?.entity,
+    liveArtifacts.isLoading ? "Loading live artifact queue..." : "No live reports returned yet",
+  );
+  const actionBody = compact(
+    topPulse?.body ?? topReport?.description ?? topPublic?.signal,
+    liveArtifacts.isLoading
+      ? "NodeBench is waiting for Convex-backed archive and daily-brief data before ranking the first action."
+      : "Run or refresh a report to populate the first ranked action from live artifacts.",
+  );
+  const queueSource = [
+    ...pulse.map((card) => ({ title: card.title, next: card.cta ?? "Open brief", meta: card.meta })),
+    ...reports.map((report) => ({ title: report.entity, next: "Open report", meta: `${report.sources} sources` })),
+  ];
+  const liveQueueItems: HomeV2QueueItem[] = queueSource.slice(0, 8).map((item, index) => [
+    String(index + 1),
+    index < 2 ? "Now" : index < 5 ? "Prep" : "Report",
+    compact(item.title, "Untitled live artifact"),
+    `${compact(item.next, "Review")} ->`,
+  ]);
+  const liveStats = metrics.slice(0, 3).map((metric, index) => ({
+    label: metric.label,
+    value: metric.value,
+    tone: index === 0 ? "accent" : index === 1 ? "blue" : undefined,
+  }));
+  const liveEditionItems = [
+    ...pulse.map((card, index) => ({
+      day: String(Math.max(1, 11 - index)),
+      title: index === 0 ? "Today" : compact(card.title, "Live signal").slice(0, 28),
+      meta: compact(card.meta, liveSummary),
+      body: compact(card.body, card.title).slice(0, 150),
+      today: index === 0,
+    })),
+    ...reports.map((report, index) => ({
+      day: String(Math.max(1, 11 - pulse.length - index)),
+      title: report.entity.slice(0, 28),
+      meta: `${report.sources} sources · ${report.claims} claims`,
+      body: compact(report.description, "Live report artifact").slice(0, 150),
+      today: pulse.length === 0 && index === 0,
+    })),
+  ].slice(0, 5);
+  const entityRows = reports.slice(0, 5).map((report) => [
+    monogram(report.entity),
+    report.entity,
+    report.status === "verified" ? "Verified" : report.status === "review" ? "Review" : "",
+    String(Math.round(Math.min(99, Math.max(40, report.sources * 7 + report.claims * 3)))),
+  ] as [string, string, string, string]);
+  const sweepBullets = queueSource.slice(0, 4).map((item) => `${compact(item.next, "Review")} ${compact(item.title, "live artifact")}.`);
+  const fallbackStats = liveArtifacts.isLoading
+    ? [
+        { label: "Live status", value: "Loading", tone: "accent" },
+        { label: "Reports", value: String(reports.length), tone: "blue" },
+        { label: "Sources", value: String(sourceCount) },
+      ]
+    : [
+        { label: "Live status", value: "Empty", tone: "accent" },
+        { label: "Reports", value: "0", tone: "blue" },
+        { label: "Sources", value: "0" },
+      ];
+
+  return {
+    editionItems: liveEditionItems.length > 0 ? liveEditionItems : editionItems.map((item) => ({
+      ...item,
+      title: item.today ? "Live status" : item.title,
+      body: item.today ? actionBody : item.body,
+    })),
+    editionLine,
+    heroSub: hasLive
+      ? "Live Convex-backed artifacts are ranked into the few decisions worth reading first. The static UI kit stays behind qa=home-v2-implementation."
+      : "NodeBench is connected to the live artifact path. This view stays explicit while Convex returns data instead of masking the state with fixture content.",
+    primaryTitle: actionTitle,
+    primaryBody: actionBody,
+    sweepTitle: hasLive ? "Live artifact sweep" : liveArtifacts.isLoading ? "Loading live artifact sweep" : "No live artifact sweep yet",
+    sweepBody: hasLive
+      ? liveSummary
+      : liveArtifacts.isLoading
+        ? "Waiting for Convex-backed archive stats and latest daily brief memory."
+        : "No Convex-backed public artifacts were returned for this session.",
+    sweepBullets: sweepBullets.length > 0 ? sweepBullets : [
+      liveArtifacts.isLoading ? "Load archive posts from Convex." : "Run a research or daily brief workflow to create the first artifact.",
+      "Keep private captures out of the public pulse.",
+      "Return an explicit empty state rather than a fixture dashboard.",
+    ],
+    stats: liveStats.length > 0 ? liveStats : fallbackStats,
+    selectedTitle: topReport?.entity ?? actionTitle,
+    selectedBody: topReport?.description ?? actionBody,
+    selectedNext: topPulse?.cta ?? (topReport ? "Open the live report." : "Wait for live artifacts or run a new report."),
+    selectedWhy: topReport
+      ? `${topReport.sources} sources, ${topReport.claims} claims, ${topReport.followUps} follow-ups.`
+      : "This card is driven by the live artifact hook state, not static starter data.",
+    selectedScore: hasLive ? "live" : liveArtifacts.isLoading ? "loading" : "empty",
+    proofCards: [
+      { title: "Live source", body: liveSummary, tag: hasLive ? "Convex-backed" : liveArtifacts.isLoading ? "loading" : "empty", highlight: hasLive },
+      { title: "Reports touched", body: `${reports.length} live report artifacts available.`, tag: `${reports.length} reports` },
+      { title: "Sources reused", body: `${sourceCount} source references available from current artifacts.`, tag: `${sourceCount} sources`, highlight: sourceCount > 0 },
+      { title: "Privacy boundary", body: "Home reads public archive and daily brief memory; private captures remain outside the public pulse." },
+    ],
+    queueItems: liveQueueItems.length > 0 ? liveQueueItems : [["1", "Now", actionTitle, "Refresh ->"]],
+    moreLabel: hasLive ? `Show ${Math.max(0, reports.length + pulse.length - 8)} more items` : "Show live artifact status",
+    whatChangedTitle: topPulse?.title ?? topReport?.entity ?? "Live artifact state",
+    whatChangedBody: topPulse?.body ?? topReport?.description ?? actionBody,
+    agentMeta: editionLine,
+    agentLead: hasLive ? "Live memory returned reusable context." : liveArtifacts.isLoading ? "Loading live memory now." : "No live artifacts returned yet.",
+    agentBody: hasLive
+      ? actionBody
+      : liveArtifacts.isLoading
+        ? "The briefing rail is waiting for Convex-backed archive and daily brief queries."
+        : "Run a report, daily brief, or archive-backed workflow to populate this rail.",
+    agentTrace: hasLive ? ["convex_archive", "daily_brief", "artifact_rank"] : ["convex_query", "empty_state", "no_fixture_fallback"],
+    agentEntities: entityRows.length > 0 ? entityRows : [["N", "No live report", liveArtifacts.isLoading ? "Loading" : "Empty", "0"]],
+  };
+}
+
+const chatCheckpoints = [
+  ["✓", "Searching memory"],
+  ["✓", "Found existing report"],
+  ["✓", "Checking source cache"],
+  ["✓", "Analyzing cap table model"],
+  ["•", "Updating notebook"],
+  ["○", "2 claims need review"],
+];
+
+const inboxRows = [
+  ["Requires action", "Sequoia - Revised term sheet v3", "Alfred Lin · New ratchet clause requires legal review", "2h", "Due Wed", true],
+  ["Requires action", "Anthropic - Enterprise pricing update", "Partnership team · Managed Agent tier +40%, effective June 1", "5h", "Today"],
+  ["Requires action", "Board meeting - Agenda review", "CFO · Q2 financials deck needs sign-off", "6h", "Due Thu"],
+  ["Requires action", "Customer escalation - Acme Corp", "CS team · Enterprise renewal at risk, competitor pricing cited", "8h", "Overdue"],
+  ["To read", "Weekly engineering standup notes", "Platform team · Infrastructure migration 80% complete", "1d", ""],
+  ["To read", "Competitor - Bug0 pricing drop", "Market intel · Enterprise tier now $199/seat, down from $349", "1d", ""],
+  ["To read", "Monthly investor update - Draft review", "CFO · ARR narrative needs your input before send", "2d", ""],
+  ["Waiting on others", "USPTO - Patent acknowledgement", "Filing 17/892,341 · Est. 14-month review period", "3d", "14 mo"],
+  ["Waiting on others", "Counsel - Redline turnaround", "Legal team · Waiting for anti-dilution comments", "4d", ""],
+  ["Waiting on others", "Partner intro - YC AI Ops Co.", "Warm intro sent · no reply yet", "5d", ""],
+  ["Filed", "Stripe renewal note", "Sales ops · Filed after ARR sync", "6d", ""],
+];
+
+const inboxSourceByTitle = {
+  "Customer escalation - Acme Corp": ["slack", "☁"],
+  "Weekly engineering standup notes": ["doc", "▤"],
+  "Competitor - Bug0 pricing drop": ["alert", "△"],
+} as const;
+
+const meLines = [
+  ["# USER.md", ""],
+  ["## Identity", ""],
+  ["name:", "Homen Shum"],
+  ["role:", "Founder · Builder-analyst hybrid"],
+  ["background:", "Banking/finance + data engineering + agentic AI + product/UI"],
+  ["edge:", "Context ingestion -> structure -> execution"],
+  ["## Decision style", ""],
+  ["bias:", "Action over analysis. Ship -> measure -> iterate."],
+  ["anti-pattern:", "Perfectionism disguised as rigor"],
+  ["reset-trigger:", "Spiraling, stuck choosing, doomscrolling"],
+  ["reset-action:", "Smallest bet, 7-day timebox, kill criteria, output"],
+  ["## Communication", ""],
+  ["style:", "Direct, tactical, specific. Push back when rationalizing."],
+  ["format:", "Decision -> Why -> Plan -> Risks -> Deliverable"],
+  ["no:", "Fluff. Motivational speech. Restating questions."],
+  ["## Agent corrections", ""],
+  ["# 23 corrections logged. Most recent:", ""],
+  ["2026-05-10:", "\"Don't summarize what you just did - I can read the diff\""],
+  ["2026-05-08:", "\"Interweave before execute on non-trivial tasks\""],
+];
+
+export function PrototypeV2LeftRail({ surface, selectedEntity = "Anthropic", onSelectEntity }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
+  if (surface === "home") return <HomeV2EditionRail />;
+  if (surface === "reports") {
+    return (
+      <aside className="rd-v2-left rd-v2-left--nav" aria-label="Reports navigation">
+        <input className="rd-v2-rail-search" placeholder="Filter entities..." aria-label="Filter entities" />
+        <div className="rd-v2-rail-rule" />
+        <RailGroup label="Companies" count="12" selectedName={selectedEntity} onSelectItem={onSelectEntity} items={[
+          ["A", "Anthropic", "3", true],
+          ["S", "Sequoia Capital", "2"],
+          ["B", "Bug0", "1"],
+          ["O", "OpenAI", ""],
+          ["G", "Google DeepMind", ""],
+          ["M", "Mistral", ""],
+        ]} />
+        <RailGroup label="People" count="8" items={[
+          ["•", "Dario Amodei", ""],
+          ["•", "Alfred Lin", ""],
+          ["•", "Sam Altman", ""],
+        ]} />
+        <RailGroup label="Topics" count="5" items={[["#", "Fundraise", ""], ["#", "Pricing", ""], ["#", "Hiring", ""]]} />
+        <button className="rd-v2-new-entity">+ New entity</button>
+      </aside>
+    );
+  }
+  if (surface === "chat") {
+    return (
+      <aside className="rd-v2-left rd-v2-left--nav" aria-label="Chat threads">
+        <button className="rd-v2-new-thread">+ New thread</button>
+        <div className="rd-v2-rail-rule" />
+        <ChatThreadGroup label="Today" items={[
+          ["Sequoia ratch...", "Under a 40% do...", "2m", true],
+          ["Anthropic pric...", "Enterprise tier mo...", "1h"],
+          ["SMB churn in...", "Monthly churn hit...", "3h"],
+        ]} />
+        <ChatThreadGroup label="Yesterday" items={[
+          ["Board deck prep", "Q2 financials proj...", "1d"],
+          ["Patent filing fo...", "USPTO acknowle...", "1d"],
+        ]} />
+        <ChatThreadGroup label="This week" items={[
+          ["Hiring pipelin...", "4 senior engine...", "3d"],
+          ["NPS survey a...", "340 responses, o...", "4d"],
+        ]} />
+      </aside>
+    );
+  }
+  if (surface === "inbox") {
+    return (
+      <aside className="rd-v2-left rd-v2-left--nav" aria-label="Inbox navigation">
+        <input className="rd-v2-rail-search" placeholder="Search inbox..." aria-label="Search inbox" />
+        <div className="rd-v2-rail-rule" />
+        <NavItem label="All items" count="53" active marker="★" />
+        <NavItem label="Act" count="4" marker="●" />
+        <NavItem label="Read" count="12" marker="●" tone="blue" />
+        <NavItem label="Waiting" count="8" marker="●" tone="amber" />
+        <NavItem label="Filed" count="24" marker="●" tone="muted" />
+        <NavItem label="Delete" count="5" marker="●" tone="red" />
+        <div className="rd-v2-rail-rule" />
+        <RailGroup label="Sources" count="" items={[
+          ["✉", "Email", "31"],
+          ["☁", "Slack", "14"],
+          ["▣", "Docs", "5"],
+          ["⚠", "Alerts", "3"],
+        ]} />
+        <div className="rd-v2-keyboard-help">Keyboard: <kbd>j</kbd> <kbd>k</kbd> navigate · <kbd>a</kbd> act · <kbd>d</kbd> delete</div>
+      </aside>
+    );
+  }
+  return (
+    <aside className="rd-v2-left rd-v2-left--nav" aria-label="Me navigation">
+      <div className="rd-v2-profile-mini">
+        <span>HS</span>
+        <div><strong>Homen Shum</strong><p>Founder · Builder</p></div>
+      </div>
+      <div className="rd-v2-rail-rule" />
+      <NavItem label="Identity" active marker="🧠" />
+      <NavItem label="Preferences" marker="⚙" />
+      <NavItem label="Integrations" marker="🔗" />
+      <NavItem label="Permissions" marker="🔒" />
+      <NavItem label="Style profile" marker="🎨" />
+      <div className="rd-v2-rail-rule" />
+      <div className="rd-v2-memory-stats">
+        <div><span>Observations</span><strong>847</strong></div>
+        <div><span>Corrections</span><strong>23</strong></div>
+        <div><span>Last updated</span><strong>2m ago</strong></div>
+      </div>
+      <button className="rd-v2-sign-out">Sign out</button>
+    </aside>
+  );
+}
+
+export function PrototypeV2Center({ surface, onAsk, selectedEntity = "Anthropic", onSelectEntity }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
+  if (surface === "home") return <HomeV2Surface onAsk={onAsk} />;
+  if (surface === "reports") return <ReportsPrototypeCenter selectedEntity={selectedEntity} onSelectEntity={onSelectEntity} />;
+  if (surface === "chat") return <ChatPrototypeCenter />;
+  if (surface === "inbox") return <InboxPrototypeCenter />;
+  return <MePrototypeCenter />;
+}
+
+export function PrototypeV2RightRail({ surface, onAsk, selectedEntity = "Anthropic", onSelectEntity }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
+  if (surface === "home") return <HomeV2BriefingRail onAsk={onAsk} />;
+  if (surface === "reports") return <ReportsPrototypeRail onAsk={onAsk} selectedEntity={selectedEntity} onSelectEntity={onSelectEntity} />;
+  if (surface === "chat") return <ChatPrototypeRail />;
+  if (surface === "inbox") return <InboxPrototypeRail onAsk={onAsk} />;
+  return <MePrototypeRail onAsk={onAsk} />;
+}
+
+function RailGroup({
+  label,
+  count,
+  items,
+  selectedName,
+  onSelectItem,
+}: {
+  label: string;
+  count: string;
+  items: Array<[string, string, string?, boolean?]>;
+  selectedName?: string;
+  onSelectItem?: (name: string) => void;
+}) {
+  return (
+    <section className="rd-v2-rail-section">
+      <div className="rd-v2-rail-section-head"><span>{label}</span><b>{count}</b></div>
+      {items.map(([icon, name, itemCount, active]) => (
+        <button
+          key={name}
+          className={`rd-v2-nav-row ${active || selectedName === name ? "is-active" : ""}`}
+          type="button"
+          onClick={() => onSelectItem?.(name)}
+        >
+          <span>{icon}</span>
+          <strong>{name}</strong>
+          {itemCount && <b>{itemCount}</b>}
+        </button>
+      ))}
+    </section>
+  );
+}
+
+function NavItem({ label, count, marker, active, tone }: { label: string; count?: string; marker: string; active?: boolean; tone?: string }) {
+  return (
+    <button type="button" className={`rd-v2-nav-row ${active ? "is-active" : ""}`} data-tone={tone}>
+      <span>{marker}</span>
+      <strong>{label}</strong>
+      {count && <b>{count}</b>}
+    </button>
+  );
+}
+
+function ChatThreadGroup({ label, items }: { label: string; items: Array<[string, string, string, boolean?]> }) {
+  return (
+    <section className="rd-v2-rail-section">
+      <div className="rd-v2-rail-section-head"><span>{label}</span></div>
+      {items.map(([title, preview, time, active]) => (
+        <button key={`${label}-${title}`} type="button" className={`rd-v2-thread-row ${active ? "is-active" : ""}`}>
+          <span className={active ? "is-live" : ""} />
+          <div><strong>{title}</strong><p>{preview}</p></div>
+          <b>{time}</b>
+        </button>
+      ))}
+    </section>
+  );
+}
+
+function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }: PrototypeSelectionProps) {
+  return (
+    <div className="rd-v2-proto-center">
+      <div className="rd-v2-edition-row">
+        <span className="rd-v2-edition-pill">Entity intelligence</span>
+        <span className="rd-v2-edition-subline">12 entities · 83% verified · avg score 87 · 48 sources</span>
+      </div>
+      <div className="rd-v2-filter-row">
+        {["All", "Watching", "Needs review", "Stale", "Updated"].map((item, index) => (
+          <button key={item} className={index === 0 ? "is-active" : ""}>{item}</button>
+        ))}
+        <button>Tags ▾</button>
+      </div>
+      <div className="rd-v2-action-row">
+        <button>Updated ▾</button>
+        <button>● Privacy</button>
+        <button className="rd-v2-btn-primary">+ New report</button>
+      </div>
+      <div className="rd-v2-report-grid">
+        {reportEntities.map((entity) => (
+          <article
+            key={entity.name}
+            className={`rd-v2-report-card ${selectedEntity === entity.name ? "is-active" : ""}`}
+            onClick={() => onSelectEntity?.(entity.name)}
+            aria-selected={selectedEntity === entity.name}
+          >
+            <div className="rd-v2-report-title">
+              <span>{entity.initial}</span>
+              <h2>{entity.name}</h2>
+              <b data-state={entity.status}>{entity.status}</b>
+            </div>
+            <p className="rd-v2-report-kind">{entity.kind}</p>
+            <p>{entity.body}</p>
+            <div className="rd-v2-report-tags">
+              {entity.tags.map((tag) => <span key={tag}>{tag}</span>)}
+            </div>
+            <p className="rd-v2-report-ref">Referenced in: {entity.ref}</p>
+            <p className="rd-v2-report-meta">{entity.meta}</p>
+          </article>
+        ))}
+        <article className="rd-v2-report-card rd-v2-report-card--add">
+          <h2>Add entity</h2>
+          <p>Capture a company, person, topic, or source cluster and let the coverage agent hydrate the first report.</p>
+          <button>+ New entity</button>
+        </article>
+      </div>
+      <button className="rd-v2-show-more">Show 7 more entities</button>
+    </div>
+  );
+}
+
+function ChatPrototypeCenter() {
+  return (
+    <div className="rd-v2-proto-center rd-v2-chat-center">
+      <div className="rd-v2-saved-banner">
+        <strong>✓ Saved to Sequoia Capital — term sheet analysis</strong>
+        <span>3 sections · 7 claims · 2 sources · notebook synced</span>
+        <button>Open notebook</button><button>Export</button><button>Track updates</button>
+      </div>
+      <h1>Sequoia ratchet analysis</h1>
+      <p className="rd-v2-muted-line">Started 2 minutes ago · 3 messages · opus-4</p>
+      <div className="rd-v2-checkpoints">
+        {chatCheckpoints.map(([mark, label]) => (
+          <div key={label} data-active={label === "Updating notebook"}>
+            <span>{mark}</span><strong>{label}</strong>
+          </div>
+        ))}
+      </div>
+      <article className="rd-v2-answer">
+        <span>Agent · Analysis</span>
+        <h3>Short answer</h3>
+        <p>Under a 40% down-round scenario ($48M), the <mark>full-ratchet</mark> clause would result in 19.1% additional dilution compared to 4.8% under the <mark>weighted-average</mark> mechanism. That is a 14.3 percentage point gap.</p>
+        <h3>Why this matters</h3>
+        <p>At $48M valuation, founders go from 62% to approximately 48% ownership under full-ratchet. The weighted-average clause would preserve roughly 57%.</p>
+        <h3>Evidence</h3>
+        <table className="rd-v2-evidence-table">
+          <thead><tr><th>Scenario</th><th>Founder dilution</th><th>Source</th></tr></thead>
+          <tbody>
+            <tr><td>Full-ratchet</td><td>19.1%</td><td>cap_table_model</td></tr>
+            <tr><td>Weighted-average</td><td>4.8%</td><td>dilution_calc</td></tr>
+            <tr><td>Negotiation gap</td><td>14.3pp</td><td>term_sheet_v3</td></tr>
+          </tbody>
+        </table>
+        <h3>Risks and open questions</h3>
+        <p>Board observer rights and pro-rata language are still pending verification. Treat the model result as decision support until counsel validates the clause language.</p>
+        <h3>Next action</h3>
+        <p>Draft a counterproposal that uses narrow-based weighted-average as the fallback floor and flags the board call deadline.</p>
+      </article>
+      <div className="rd-v2-context-chips">
+        <span>Sequoia Capital ×</span><span>Report: Term Sheet Analysis ×</span><span>Sources: 2 ×</span><span>Balanced</span>
+      </div>
+      <div className="rd-v2-tool-strip">
+        <span>opus-4</span><span>cap_table_model</span><span>dilution_calc</span><span>2 sources</span><span>1.2s</span><span>$0.05</span>
+      </div>
+      <div className="rd-v2-next-actions">
+        {["Open notebook", "Draft counterproposal", "Verify open claims", "Attach term sheet", "Share summary"].map((action) => (
+          <button key={action}>{action}</button>
+        ))}
+      </div>
+      <article className="rd-v2-user-followup">
+        <strong>You</strong>
+        <p>Draft the counterproposal and mark counsel review as approval-required.</p>
+      </article>
+      <article className="rd-v2-streaming-draft">
+        <span>Drafting</span>
+        <p>Counterproposal packet: narrow-based weighted-average floor, board observer carve-out, counsel review task, and report notebook patch.</p>
+      </article>
+      <div className="rd-v2-bottom-composer">
+        <input placeholder="Ask, capture, paste, upload, or record..." aria-label="Chat input" />
+        <button>↑</button>
+        <div className="rd-v2-composer-tools"><span>+ Context</span><span>@ Reference</span><span>/ Command</span><span>Attach</span><span>Record</span></div>
+      </div>
+    </div>
+  );
+}
+
+function InboxPrototypeCenter() {
+  return (
+    <div className="rd-v2-proto-center rd-v2-inbox-center">
+      <div className="rd-v2-inbox-head">
+        <h1>Inbox</h1>
+        <span>53 items · 4 need action</span>
+        <button>Mark all read</button>
+        <button className="rd-v2-btn-primary">Auto-triage</button>
+      </div>
+      {["Requires action", "To read", "Waiting on others", "Filed"].map((group) => (
+        <section key={group} className="rd-v2-inbox-group">
+          <div className="rd-v2-inbox-group-head"><span>{group}</span><b>{group === "Requires action" ? "4" : group === "To read" ? "12" : group === "Waiting on others" ? "8" : "24"}</b></div>
+          {inboxRows.filter((row) => row[0] === group).map(([, title, sub, time, badge, active]) => (
+            <article key={title} className={active ? "is-active" : ""}>
+              <span className="rd-v2-source-icon" data-source={inboxSourceByTitle[title as keyof typeof inboxSourceByTitle]?.[0] ?? "email"}>
+                {inboxSourceByTitle[title as keyof typeof inboxSourceByTitle]?.[1] ?? "✉"}
+              </span>
+              <div>
+                <span className="rd-v2-inbox-title-row">
+                  {active && <i />}
+                  <strong>{title}</strong>
+                </span>
+                <p>{sub}</p>
+              </div>
+              <time>{time}</time>
+              {badge && <b>{badge}</b>}
+            </article>
+          ))}
+        </section>
+      ))}
+      <button className="rd-v2-show-more">Show 38 more items</button>
+    </div>
+  );
+}
+
+function MePrototypeCenter() {
+  return (
+    <div className="rd-v2-proto-center rd-v2-me-center">
+      <div className="rd-v2-edition-row">
+        <span className="rd-v2-edition-pill">USER.md</span>
+        <span className="rd-v2-edition-subline">Your identity file · last edited 12m ago</span>
+      </div>
+      <div className="rd-v2-share-bar"><span>Actions</span><button className="rd-v2-share-primary">Edit</button><button>Export</button><button>Reset</button></div>
+      <article className="rd-v2-user-md">
+        {meLines.map(([key, value], index) => (
+          key.startsWith("#") ? <h2 key={`${key}-${index}`}>{key}</h2> : (
+            <p key={`${key}-${index}`}>
+              <span>{key}</span>{value}
+            </p>
+          )
+        ))}
+      </article>
+      <section className="rd-v2-integrations-grid">
+        {[
+          ["GitHub", "Connected", "12 repos indexed"],
+          ["Convex", "Connected", "agile-caribou prod"],
+          ["LinkedIn", "Approval required", "Posting gated"],
+          ["Slack", "Connected", "Daily digest enabled"],
+        ].map(([name, status, detail]) => (
+          <article key={name}>
+            <strong>{name}</strong>
+            <span>{status}</span>
+            <p>{detail}</p>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function AgentShell({
+  title,
+  context,
+  pills,
+  question,
+  children,
+  placeholder,
+  onAsk,
+}: {
+  title: string;
+  context: string;
+  pills: string[];
+  question: string;
+  children: ReactNode;
+  placeholder: string;
+  onAsk?: (prompt: string) => void;
+}) {
+  const pillClassName = (_pill: string, index: number) => {
+    const classes = ["rd-v2-agent-pill"];
+    if (index === 0) classes.push("is-active");
+    if (title === "Coverage agent") {
+      if (index === 1) classes.push("is-entity");
+      if (index === 2) classes.push("is-source");
+    }
+    if (title === "Triage agent" && index === 1) classes.push("is-entity");
+    return classes.join(" ");
+  };
+
+  return (
+    <aside className="rd-pane rd-pane--right rd-v2-briefing" aria-label={title}>
+      <header className="rd-v2-agent-head">
+        <div className="rd-v2-agent-head-row">
+          <span className="rd-v2-agent-dot" />
+          <strong>{title}</strong>
+          <button type="button" aria-label="Expand rail">{"\u2197"}</button>
+        </div>
+        <p>{context}</p>
+      </header>
+      <div className="rd-v2-agent-pills">
+        {pills.map((pill, index) => <span key={pill} className={pillClassName(pill, index)}>{pill}</span>)}
+      </div>
+      <div className="rd-v2-agent-thread">
+        <div className="rd-v2-msg rd-v2-msg-user">{question}</div>
+        {children}
+      </div>
+      <footer className="rd-v2-agent-composer">
+        <input placeholder={placeholder} onKeyDown={(event) => {
+          if (event.key === "Enter") onAsk?.((event.currentTarget as HTMLInputElement).value);
+        }} />
+        <button type="button" onClick={() => onAsk?.(question)}>{"\u2191"}</button>
+        <div className="rd-v2-agent-tools">
+          <span>+ Context</span><span>@ Reference</span><span>/ Command</span><span>Attach</span><span>to send</span>
+        </div>
+      </footer>
+    </aside>
+  );
+}
+
+function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", onSelectEntity }: PrototypeSelectionProps) {
+  const entity = getPrototypeEntity(selectedEntity);
+  const reviewText = entity.score < 75 ? `${entity.name} needs review.` : `${entity.name} is in good shape.`;
+  const summaryText = entity.score < 75
+    ? `${entity.name} is below coverage threshold. Refresh sources, verify open claims, and decide whether the report needs a notebook patch.`
+    : `${entity.name} has current sources and enough verified claims for the present coverage task. Keep it on watch.`;
+
+  return (
+    <AgentShell
+      title="Coverage agent"
+      context={`Reports · 5 entities · 48 sources · ${entity.sources} active`}
+      pills={["Reports", entity.name, `${entity.sources} sources`, `Score ${entity.score}`]}
+      question="Which reports need work?"
+      placeholder="Ask about these reports..."
+      onAsk={onAsk}
+    >
+      <div className="rd-v2-msg rd-v2-msg-agent">
+        <strong>{reviewText}</strong>
+        <p>{summaryText}</p>
+        <div className="rd-v2-trace"><small>3 steps completed</small><span>entity_health</span><span>freshness_scan</span><span>claim_verify</span></div>
+      </div>
+      <button className="rd-v2-drawer-toggle">{`Context · ${entity.name} ${entity.score} · ${entity.signals.length} signals · ${entity.related.length} entities`}</button>
+      <section className="rd-v2-agent-context">
+        <div className="rd-v2-context-head"><span>Active entity</span><span>{entity.score}</span></div>
+        <div className="rd-v2-score-big">{entity.score} <small>{entity.delta}</small></div>
+        {Object.entries(entity.dims).map(([label, value]) => (
+          <div className="rd-v2-score-row" key={label}>
+            <span>{label}</span>
+            <b><i data-tone={value >= 80 ? "green" : value >= 58 ? "accent" : "amber"} style={{ width: `${value}%` }} /></b>
+            <strong>{value}</strong>
+          </div>
+        ))}
+      </section>
+      <section className="rd-v2-agent-context">
+        <div className="rd-v2-context-head"><span>Recent signals</span><span>{entity.signals.length}</span></div>
+        {entity.signals.map((signal) => <p className="rd-v2-signal-line" key={signal}>{signal}</p>)}
+      </section>
+      <section className="rd-v2-agent-context">
+        <div className="rd-v2-context-head"><span>Related entities</span><span>{entity.related.length}</span></div>
+        {entity.related.map((name) => {
+          const related = getPrototypeEntity(name);
+          return (
+            <button className="rd-v2-related-entity" key={name} onClick={() => onSelectEntity?.(name)}>
+              <span>{related.initial}</span><strong>{name}</strong><b>{related.score}</b>
+            </button>
+          );
+        })}
+      </section>
+    </AgentShell>
+  );
+}
+
+function ChatPrototypeRail() {
+  const [activeTab, setActiveTab] = useState("Entity");
+  const panels: Record<string, ReactNode> = {
+    Entity: (
+      <>
+        <article className="rd-v2-util-card">
+          <div className="rd-v2-report-title"><span>S</span><h2>Sequoia Capital</h2><b>74</b></div>
+          <p>• Full-ratchet anti-dilution clause<br />• Series C term sheet Rev. 3<br />• Last verified: 2h ago</p>
+        </article>
+        <section className="rd-v2-util-list">
+          <h3>Key claims</h3>
+          <p>✓ <strong>Ratchet</strong> Full-ratchet vs weighted-average <span>verified</span></p>
+          <p>✓ <strong>Dilution</strong> 23% founder dilution at $180M <span>verified</span></p>
+          <p>○ <strong>Board seat</strong> Observer vs voting rights <span>pending</span></p>
+          <p>○ <strong>Pro-rata</strong> Follow-on participation rights <span>pending</span></p>
+        </section>
+      </>
+    ),
+    Graph: <section className="rd-v2-util-list"><h3>Graph neighborhood</h3><p><strong>Sequoia</strong> connects to YC AI Ops, Alfred Lin, cap table model, and board prep.</p><p><strong>Closest report</strong><span>Term Sheet Analysis</span></p></section>,
+    Sources: <section className="rd-v2-util-list"><h3>Sources</h3><p><strong>Term sheet v3</strong><span>PDF</span></p><p><strong>Cap table model</strong><span>Sheet</span></p><p><strong>Cooley primer</strong><span>Reference</span></p></section>,
+    Threads: <section className="rd-v2-util-list"><h3>Threads</h3><p><strong>Ratchet clause analysis</strong><span>3 messages</span></p><p><strong>Board deck prep</strong><span>2 messages</span></p></section>,
+    Notebook: <section className="rd-v2-util-list"><h3>Notebook patch</h3><p><strong>Proposed edit</strong><span>pending</span></p><p>Add dilution table, counsel review, and counterproposal summary.</p></section>,
+    Report: <section className="rd-v2-util-list"><h3>Report</h3><p><strong>Status</strong><span>Saved</span></p><p><strong>Claims</strong><span>7 total</span></p><p><strong>Open</strong><span>2 pending</span></p></section>,
+  };
+
+  return (
+    <aside className="rd-pane rd-pane--right rd-v2-utility" aria-label="Context">
+      <header className="rd-v2-util-head"><strong>Context</strong><button>{"\u2197"}</button></header>
+      <input className="rd-v2-util-search" placeholder="Search sources, entities..." />
+      <div className="rd-v2-util-tabs" role="tablist" aria-label="Chat utilities">
+        {Object.keys(panels).map((tab) => (
+          <button
+            key={tab}
+            role="tab"
+            aria-selected={activeTab === tab}
+            className={activeTab === tab ? "is-active" : ""}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+      {panels[activeTab]}
+    </aside>
+  );
+}
+
+function InboxPrototypeRail({ onAsk }: HomeV2SurfaceProps) {
+  return (
+    <AgentShell
+      title="Triage agent"
+      context="Inbox item · Sequoia term sheet v3 · 1 of 53"
+      pills={["Inbox", "Sequoia Capital", "Term sheet v3", "P0"]}
+      question="Why is this urgent?"
+      placeholder="Ask about this item..."
+      onAsk={onAsk}
+    >
+      <div className="rd-v2-msg rd-v2-msg-agent">
+        <strong>The ratchet clause needs legal review before Thursday's board call.</strong>
+        <p>Full-ratchet creates a 14.3pp dilution gap at $48M. This is the single largest negotiation risk in the term sheet.</p>
+        <div className="rd-v2-trace"><small>3 steps completed</small><span>term_sheet_parse</span><span>dilution_calc</span><span>calendar_check</span></div>
+      </div>
+      <button className="rd-v2-drawer-toggle">Context · Sequoia 74 · 2 threads</button>
+      <article className="rd-v2-util-card">
+        <div className="rd-v2-report-title"><span>S</span><h2>Sequoia Capital</h2><b>74</b></div>
+        <p>• Active term sheet negotiation<br />• $1.2M partnership · 3 prior rounds<br />• Last report: 6h ago</p>
+      </article>
+      <div className="rd-v2-agent-insight"><strong>Agent insight</strong><p>Full-ratchet clause creates 14.3pp dilution gap at $48M. Counter with narrow-based weighted-average as floor.</p></div>
+      <section className="rd-v2-action-card-list">
+        {["Draft reply", "Flag for legal", "Forward to counsel", "Defer"].map((action, index) => (
+          <button key={action} className={index === 0 ? "is-primary" : ""}>{action}</button>
+        ))}
+      </section>
+    </AgentShell>
+  );
+}
+
+function MePrototypeRail({ onAsk }: HomeV2SurfaceProps) {
+  return (
+    <AgentShell
+      title="Settings agent"
+      context="USER.md · 5 permissions · 7 sessions today"
+      pills={["Me", "Voice profile", "Permissions", "Usage"]}
+      question="Why did you suggest this memory update?"
+      placeholder="Ask about your settings..."
+      onAsk={onAsk}
+    >
+      <div className="rd-v2-msg rd-v2-msg-agent">
+        <strong>You prefer concise banker-style memos over long-form analysis.</strong>
+        <p>In the last 7 sessions, you shortened 4 of my outputs and asked for just the decision. I updated your voice profile to default to {"Decision -> Why -> Plan"} format.</p>
+        <div className="rd-v2-trace"><small>3 steps completed</small><span>memory_scan</span><span>preference_log</span><span>profile_update</span></div>
+      </div>
+      <button className="rd-v2-drawer-toggle">Context · Voice · Permissions · Usage</button>
+      <section className="rd-v2-settings-list">
+        <h3>Voice profile</h3>
+        <p><span>Tone</span><strong>Direct, tactical</strong></p>
+        <p><span>Format</span><strong>{"Decision -> Why -> Plan"}</strong></p>
+        <p><span>Jargon level</span><strong>High (match user)</strong></p>
+        <h3>Permissions</h3>
+        <p>• Web search: <b>Enabled</b></p>
+        <p>• File access: <b>Enabled</b></p>
+        <p>• Post to LinkedIn: <em>Approval required</em></p>
+        <p>• Send email: <em>Approval required</em></p>
+        <p>• Execute trades: <em>Disabled</em></p>
+        <h3>Session stats</h3>
+        <p><span>Memory hits</span><strong>71%</strong></p>
+        <p><span>Corrections</span><strong>23</strong></p>
+        <p><span>Current mode</span><strong>Builder</strong></p>
+      </section>
+      <section className="rd-v2-action-card-list">
+        <button className="is-primary">Review memory update</button>
+        <button>Export USER.md</button>
+        <button>Open permissions</button>
+      </section>
+    </AgentShell>
+  );
+}
+
+export function HomeV2EditionRail({ liveArtifacts }: { liveArtifacts?: LiveArtifactsResult } = {}) {
+  const model = buildHomeV2Model(liveArtifacts);
+  return (
+    <aside className="rd-v2-left" aria-label="Edition browser">
+      <div className="rd-v2-edition-month">May 2026</div>
+      {model.editionItems.map((item) => (
+        <div key={item.day} className="rd-v2-edition-block">
+          <button type="button" className={`rd-v2-edition-date ${item.today ? "is-today" : ""}`}>
+            <span className="rd-v2-edition-day">{item.day}</span>
+            <span className="rd-v2-edition-info">
+              <span className="rd-v2-edition-label">{item.title}</span>
+              <span className="rd-v2-edition-sub">{item.meta}</span>
+            </span>
+          </button>
+          <p>{item.body}</p>
+        </div>
+      ))}
+      <div className="rd-v2-rail-rule" />
+      <EditionGroup label="Week of May 4" count="5" />
+      <EditionGroup label="Week of Apr 27" count="7" />
+      <div className="rd-v2-rail-rule" />
+      <EditionGroup label="April 2026" count="28" />
+      <EditionGroup label="March 2026" count="31" />
+      <EditionGroup label="February 2026" count="28" />
+      <div className="rd-v2-rail-rule" />
+      <EditionGroup label="Q4 2025" count="62" />
+    </aside>
+  );
+}
+
+export function HomeV2Surface({ onAsk, liveArtifacts }: HomeV2SurfaceProps) {
+  const model = buildHomeV2Model(liveArtifacts);
+  return (
+    <div className="rd-v2-home">
+      <div className="rd-v2-edition-row">
+        <span className="rd-v2-edition-pill">Daily edition</span>
+        <span className="rd-v2-edition-subline">{model.editionLine}</span>
+      </div>
+
+      <div className="rd-v2-share-bar" aria-label="Share edition">
+        <span>Share</span>
+        <button className="rd-v2-share-primary">Email digest</button>
+        <button>LinkedIn</button>
+        <button>Slack</button>
+        <button>Copy link</button>
+        <button>PDF</button>
+      </div>
+
+      <p className="rd-v2-hero-tagline">Career ops</p>
+      <h1 className="rd-v2-hero">One queue. One decision at a time.</h1>
+      <p className="rd-v2-hero-sub">
+        {model.heroSub}
+      </p>
+
+      <div className="rd-v2-ed-selector" role="group" aria-label="Edition timeframe">
+        {["Today", "Yesterday", "This week", "This month", "Quarter", "Archive \u2192"].map((label, index) => (
+          <button key={label} className={index === 0 ? "is-active" : ""} aria-pressed={index === 0}>
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="rd-v2-twin-cards">
+        <article className="rd-v2-card">
+          <div className="rd-v2-card-kicker">Next best action</div>
+          <h2>{model.primaryTitle}</h2>
+          <p>{model.primaryBody}</p>
+          <div className="rd-v2-card-actions">
+            <button className="rd-v2-btn-primary" onClick={() => onAsk?.("Open today's booking queue.")}>Show booking queue</button>
+            <button onClick={() => onAsk?.("Open today's prep queue.")}>Show prep queue</button>
+          </div>
+        </article>
+        <article className="rd-v2-card">
+          <div className="rd-v2-card-kicker">Daily sweep / May 11</div>
+          <h3>{model.sweepTitle}</h3>
+          <p>{model.sweepBody}</p>
+          <ul className="rd-v2-sweep-list">
+            {model.sweepBullets.map((item) => <li key={item}>{item}</li>)}
+          </ul>
+        </article>
+      </div>
+
+      <div className="rd-v2-stats-row">
+        {model.stats.map((stat) => (
+          <StatCell key={stat.label} label={stat.label} value={stat.value} tone={stat.tone} />
+        ))}
+      </div>
+
+      <div className="rd-v2-queue-head">
+        <h3>Queue</h3>
+        <div>
+          {["All", "Now", "Prep", "Batch", "Later"].map((label, index) => (
+            <button key={label} className={index === 0 ? "is-active" : ""}>{label}</button>
+          ))}
+        </div>
+      </div>
+
+      <section className="rd-v2-selected">
+        <div className="rd-v2-selected-top">
+          <span>Now / Selected</span>
+          <strong>{model.selectedScore}</strong>
+        </div>
+        <h3>{model.selectedTitle}</h3>
+        <p>{model.selectedBody}</p>
+        <p><strong>Next:</strong> {model.selectedNext}</p>
+        <p className="rd-v2-muted"><strong>Why?</strong> {model.selectedWhy}</p>
+      </section>
+
+      <div className="rd-v2-proof-row">
+        {model.proofCards.map((card) => (
+          <ProofCard key={card.title} title={card.title} body={card.body} tag={card.tag} highlight={card.highlight} />
+        ))}
+      </div>
+
+      <div className="rd-v2-action-row">
+        {["Read", "Draft reply", "Book", "Research", "Defer"].map((label, index) => (
+          <button
+            key={label}
+            className={index === 0 ? "rd-v2-btn-primary" : ""}
+            onClick={() => onAsk?.(`${label} the selected queue item.`)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <ol className="rd-v2-q-list" aria-label="Ranked decision queue">
+        {model.queueItems.map(([rank, lane, title, next]) => (
+          <li key={rank}>
+            <span className="rd-v2-q-rank">{rank}</span>
+            <span className="rd-v2-q-badge" data-lane={lane}>{lane}</span>
+            <span className="rd-v2-q-title">{title}</span>
+            <span className="rd-v2-q-next">{next}</span>
+          </li>
+        ))}
+      </ol>
+      <div className="rd-v2-show-more"><button>{model.moreLabel}</button></div>
+
+      <div className="rd-v2-editorial-divider" />
+      <section className="rd-v2-ed-section">
+        <span>01 - What changed</span>
+        <h3>{model.whatChangedTitle}</h3>
+        <p>{model.whatChangedBody}</p>
+      </section>
+    </div>
+  );
+}
+
+export function HomeV2BriefingRail({ onAsk, liveArtifacts }: HomeV2SurfaceProps) {
+  const model = buildHomeV2Model(liveArtifacts);
+  return (
+    <aside className="rd-pane rd-pane--right rd-v2-briefing" aria-label="Briefing agent">
+      <header className="rd-v2-agent-head">
+        <div className="rd-v2-agent-head-row">
+          <span className="rd-v2-agent-dot" />
+          <strong>Briefing agent</strong>
+          <button type="button" aria-label="Expand rail">{"\u2197"}</button>
+        </div>
+        <p>{model.agentMeta}</p>
+      </header>
+      <div className="rd-v2-agent-pills">
+        <span>Home</span>
+        <span className="is-entity">Daily edition</span>
+        <span className="is-source">{liveArtifacts ? `${liveArtifacts.reports.reduce((total, report) => total + report.sources, 0)} sources` : "12 sources"}</span>
+        <span>Memory</span>
+      </div>
+      <div className="rd-v2-agent-thread">
+        <div className="rd-v2-msg rd-v2-msg-user">What changed today?</div>
+        <div className="rd-v2-msg rd-v2-msg-agent">
+          <strong>{model.agentLead}</strong>
+          <p>{model.agentBody}</p>
+          <div className="rd-v2-trace">
+            <small>{model.agentTrace.length} steps completed</small>
+            {model.agentTrace.map((step) => <span key={step}>{step}</span>)}
+          </div>
+        </div>
+        <button className="rd-v2-drawer-toggle">Context - 5 entities - 4 threads - 4 sources</button>
+        <section className="rd-v2-agent-context">
+          <div className="rd-v2-context-head"><span>Entities</span><span>{model.agentEntities.length}</span></div>
+          {model.agentEntities.map(([icon, name, badge, score]) => (
+            <div className="rd-v2-entity" key={name}>
+              <span>{icon}</span>
+              <strong>{name}</strong>
+              {badge && <em>{badge}</em>}
+              <b>{score}</b>
+            </div>
+          ))}
+        </section>
+        <section className="rd-v2-agent-threads">
+          <div className="rd-v2-context-head"><span>Threads</span><span>4</span></div>
+          <div className="rd-v2-thread-pills">
+            <span>Home</span>
+            <span>5 entities</span>
+            <span>opus-4</span>
+          </div>
+        </section>
+      </div>
+      <footer className="rd-v2-agent-composer">
+        <input placeholder="Ask about today's pulse..." onKeyDown={(event) => {
+          if (event.key === "Enter") onAsk?.((event.currentTarget as HTMLInputElement).value);
+        }} />
+        <button type="button" onClick={() => onAsk?.("What changed today?")}>{"\u2191"}</button>
+        <div className="rd-v2-agent-tools">
+          <span>+ Context</span>
+          <span>@ Reference</span>
+          <span>/ Command</span>
+          <span>Attach</span>
+          <span>to send</span>
+        </div>
+      </footer>
+    </aside>
+  );
+}
+
+function EditionGroup({ label, count }: { label: string; count: string }) {
+  return (
+    <button type="button" className="rd-v2-edition-group">
+      <span>&gt;</span>
+      <span>{label}</span>
+      <b>{count}</b>
+    </button>
+  );
+}
+
+function StatCell({ label, value, tone }: { label: string; value: string; tone?: string }) {
+  return (
+    <div className="rd-v2-stat" data-tone={tone}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function ProofCard({ title, body, tag, highlight }: { title: string; body: string; tag?: string; highlight?: boolean }) {
+  return (
+    <article className="rd-v2-proof-card">
+      <h4>{title}</h4>
+      <p>{body}</p>
+      {tag && <span className={highlight ? "is-highlight" : ""}>{tag}</span>}
+    </article>
+  );
+}

--- a/src/features/redesign/surfaces/InboxSurface.tsx
+++ b/src/features/redesign/surfaces/InboxSurface.tsx
@@ -161,6 +161,53 @@ export function InboxSurface() {
 
   const activeItem = useMemo(() => items.find((i) => i.id === activeId) ?? items[0] ?? null, [items, activeId]);
 
+  const completeOneNudge = async (itemId: string) => {
+    if (!itemId.startsWith("nudge_")) return false;
+    const anonymousSessionId = getAnonymousProductSessionId();
+    await completeNudge({ anonymousSessionId, nudgeId: itemId.slice("nudge_".length) });
+    return true;
+  };
+
+  const closePreviewItem = (item: InboxItem) => {
+    setSnoozed((prev) => new Set(prev).add(item.id));
+  };
+
+  const handlePreviewAction = (
+    item: InboxItem,
+    action: "accept" | "reject" | "edit" | "move" | "open",
+  ) => {
+    if (action === "accept" || action === "reject") {
+      closePreviewItem(item);
+      if (item.id.startsWith("nudge_")) {
+        void completeOneNudge(item.id)
+          .then(() => showToast({
+            tone: action === "accept" ? "success" : "warning",
+            message: `${action === "accept" ? "Accepted" : "Rejected"} and persisted this live nudge.`,
+          }))
+          .catch((error) => {
+            console.error(`[inbox] failed to ${action} nudge`, error);
+            showToast({ tone: "warning", message: "Local queue updated, but the persisted nudge write failed." });
+          });
+      } else {
+        showToast({
+          tone: action === "accept" ? "success" : "warning",
+          message: `${action === "accept" ? "Accepted" : "Rejected"} this starter item locally. Live artifacts persist through Convex nudges.`,
+        });
+      }
+      return;
+    }
+
+    if (action === "open") {
+      window.location.href = "/redesign/reports";
+      return;
+    }
+
+    showToast({
+      tone: "info",
+      message: `${action === "edit" ? "Edit" : "Move"} is a local preview until this item is attached to a live report or nudge.`,
+    });
+  };
+
   // Keyboard nav
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -169,12 +216,17 @@ export function InboxSurface() {
       if (e.key === "j") { e.preventDefault(); setActiveId(items[Math.min(items.length - 1, idx + 1)]?.id ?? null); }
       else if (e.key === "k") { e.preventDefault(); setActiveId(items[Math.max(0, idx - 1)]?.id ?? null); }
       else if (e.key === "a" || e.key === "r" || e.key === "e" || e.key === "m") {
-        // No-op handlers in showcase; production wires to mutations
+        if (!activeItem) return;
+        e.preventDefault();
+        if (e.key === "a") handlePreviewAction(activeItem, "accept");
+        if (e.key === "r") handlePreviewAction(activeItem, "reject");
+        if (e.key === "e") handlePreviewAction(activeItem, "edit");
+        if (e.key === "m") handlePreviewAction(activeItem, "move");
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [items, activeId]);
+  }, [items, activeId, activeItem]);
 
   return (
     <div className="rd-stack" style={{ padding: "32px 40px 40px", gap: 18, maxWidth: 1280, height: "100%" }}>
@@ -280,7 +332,14 @@ export function InboxSurface() {
 
         <div className="rd-inbox-preview">
           {activeItem ? (
-            <InboxPreview item={activeItem} />
+            <InboxPreview
+              item={activeItem}
+              onAccept={() => handlePreviewAction(activeItem, "accept")}
+              onReject={() => handlePreviewAction(activeItem, "reject")}
+              onEdit={() => handlePreviewAction(activeItem, "edit")}
+              onMove={() => handlePreviewAction(activeItem, "move")}
+              onOpenReport={() => handlePreviewAction(activeItem, "open")}
+            />
           ) : (
             <div className="rd-inbox-preview__empty">
               Pick an item to preview it here.<br />
@@ -342,7 +401,21 @@ function InboxRow({ item, isActive, isChecked, onActivate, onToggleCheck }: { it
   );
 }
 
-function InboxPreview({ item }: { item: InboxItem }) {
+function InboxPreview({
+  item,
+  onAccept,
+  onReject,
+  onEdit,
+  onMove,
+  onOpenReport,
+}: {
+  item: InboxItem;
+  onAccept: () => void;
+  onReject: () => void;
+  onEdit: () => void;
+  onMove: () => void;
+  onOpenReport: () => void;
+}) {
   // Per nexu-io/open-design pattern: actions live in the header next to the title,
   // not anchored to viewport-bottom. Decision velocity wins; no "empty card / floating accept" feel.
   const confidencePct = typeof item.confidence === "number" ? Math.round(item.confidence * 100) : null;
@@ -369,16 +442,16 @@ function InboxPreview({ item }: { item: InboxItem }) {
           <span className="rd-mono rd-inbox-preview__meta">{item.meta}</span>
         </div>
         <div className="rd-inbox-preview__actions">
-          <button className="rd-btn rd-btn--primary rd-btn--sm" aria-keyshortcuts="a">
+          <button className="rd-btn rd-btn--primary rd-btn--sm" aria-keyshortcuts="a" onClick={onAccept}>
             ✓ Accept <span className="rd-kbd">a</span>
           </button>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm" aria-keyshortcuts="r">
+          <button className="rd-btn rd-btn--quiet rd-btn--sm" aria-keyshortcuts="r" onClick={onReject}>
             Reject <span className="rd-kbd">r</span>
           </button>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm" aria-keyshortcuts="e">
+          <button className="rd-btn rd-btn--quiet rd-btn--sm" aria-keyshortcuts="e" onClick={onEdit}>
             Edit <span className="rd-kbd">e</span>
           </button>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm" aria-keyshortcuts="m">
+          <button className="rd-btn rd-btn--quiet rd-btn--sm" aria-keyshortcuts="m" onClick={onMove}>
             Move <span className="rd-kbd">m</span>
           </button>
         </div>
@@ -409,7 +482,7 @@ function InboxPreview({ item }: { item: InboxItem }) {
       )}
 
       <div className="rd-inbox-preview__deeplink">
-        <button className="rd-btn rd-btn--quiet rd-btn--sm">Open in report →</button>
+        <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={onOpenReport}>Open in report →</button>
       </div>
     </>
   );

--- a/src/features/redesign/surfaces/MeSurface.tsx
+++ b/src/features/redesign/surfaces/MeSurface.tsx
@@ -1,9 +1,9 @@
 /**
- * Me — Personal Context Notebook (USER.md as durable memory).
+ * Me - Personal Context Notebook (USER.md as editable memory draft).
  *
  * Aligns with the locked design board (proposed-design-views.html#me-view):
  *   - 3-card runtime row: "How NodeBench sees you" · product.me profile · USER.md document
- *   - TipTap-style toolbar with "Saved to Convex" pill
+ *   - TipTap-style toolbar with local draft save-state pill
  *   - Per-section editable memory rows + permission pill stack
  *   - Patch inbox aside (suggested patch with Accept / Edit diff / Reject)
  *   - Agent implementation hooks list (RichNotebookEditor, teachability, operatorProfile, OpenClaw)
@@ -99,13 +99,55 @@ const INITIAL_SECTIONS: Section[] = [
 export function MeSurface() {
   const [sections, setSections] = useState<Section[]>(INITIAL_SECTIONS);
   const [purpose, setPurpose] = useState("Control, editable memory, privacy, budget, files, integrations.");
-  const [savedAt, setSavedAt] = useState("Saved to Convex");
+  const [savedAt, setSavedAt] = useState("Local draft saved");
   const [patch, setPatch] = useState("You often rewrite reports into banker-style next actions.");
   const [policies, setPolicies] = useState({
     autoSaveExplicit: true,
     suggestLowRisk: true,
     diffPrivacy: true,
   });
+
+  const markLocalSaved = () => {
+    setSavedAt("Saving local draft...");
+    setTimeout(() => setSavedAt("Local draft saved"), 600);
+  };
+
+  const previewAction = (label: string) => {
+    showToast({
+      tone: "info",
+      message: `${label} is a local Me-page preview. Durable profile writes run through the operator profile tools.`,
+    });
+  };
+
+  const acceptPatch = () => {
+    if (!patch.trim()) return;
+    setSections((prev) =>
+      prev.map((section) =>
+        section.id === "communication"
+          ? {
+              ...section,
+              body: section.body.includes(patch.trim())
+                ? section.body
+                : `${section.body}\n\n${patch.trim()}`,
+            }
+          : section,
+      ),
+    );
+    setPatch("");
+    markLocalSaved();
+    showToast({ tone: "success", message: "Applied the suggested patch to the local USER.md draft." });
+  };
+
+  const rejectPatch = () => {
+    setPatch("");
+    markLocalSaved();
+    showToast({ tone: "warning", message: "Rejected the suggested patch locally." });
+  };
+
+  const updatePolicy = (key: keyof typeof policies, value: boolean) => {
+    setPolicies((p) => ({ ...p, [key]: value }));
+    markLocalSaved();
+  };
 
   const togglePerm = (sectionId: SectionId, permId: PermissionId) => {
     setSections((prev) =>
@@ -120,14 +162,12 @@ export function MeSurface() {
           : s
       )
     );
-    setSavedAt("Saving…");
-    setTimeout(() => setSavedAt("Saved to Convex"), 600);
+    markLocalSaved();
   };
 
   const updateBody = (sectionId: SectionId, body: string) => {
     setSections((prev) => prev.map((s) => (s.id === sectionId ? { ...s, body } : s)));
-    setSavedAt("Saving…");
-    setTimeout(() => setSavedAt("Saved to Convex"), 600);
+    markLocalSaved();
   };
 
   return (
@@ -154,7 +194,7 @@ export function MeSurface() {
               outline: "none",
               marginTop: 2,
             }}
-          >Editable, durable memory. Drives every report, chat, and agent action. Privacy and budget controls in the footer.</p>
+          >Editable memory draft. Live reports and chats can read persisted operator profile data once the profile tools save it.</p>
         </div>
         <div className="rd-row" style={{ gap: 6, flexWrap: "wrap" }}>
           <button
@@ -177,13 +217,14 @@ export function MeSurface() {
         <article className="rd-card" style={{ padding: 18, display: "flex", flexDirection: "column", gap: 12 }}>
           {/* Hero label + minimal toolbar — Save pill now lives in page header */}
           <div className="rd-row--between" style={{ paddingBottom: 8, borderBottom: "1px solid var(--rd-line-faint)" }}>
-            <div className="rd-eyebrow" style={{ fontSize: 11, color: "var(--rd-accent-strong)" }}>USER.md · editable durable memory</div>
+            <div className="rd-eyebrow" style={{ fontSize: 11, color: "var(--rd-accent-strong)" }}>USER.md · editable local draft</div>
             <div className="rd-row" style={{ gap: 4, flexWrap: "wrap", justifyContent: "flex-end" }}>
               {(["H2", "B", "I", "UL", "1.", "''", "Undo", "Redo"] as const).map((label) => (
                 <button
                   key={label}
                   type="button"
                   aria-label={`TipTap ${label}`}
+                  onClick={() => previewAction(`Toolbar ${label}`)}
                   className="rd-btn rd-btn--quiet"
                   style={{
                     width: label.length > 2 ? 44 : 32, height: 32, padding: 0,
@@ -306,9 +347,9 @@ export function MeSurface() {
               }}
             />
             <div className="rd-row" style={{ gap: 6, marginTop: 10, flexWrap: "wrap" }}>
-              <button className="rd-btn rd-btn--primary rd-btn--sm">Accept</button>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Edit diff</button>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Reject</button>
+              <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={acceptPatch}>Accept local</button>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => previewAction("Edit diff")}>Edit diff preview</button>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={rejectPatch}>Reject local</button>
             </div>
           </div>
 
@@ -323,7 +364,11 @@ export function MeSurface() {
                 { strong: "Open OpenClaw audit tools", body: "spawn session, execute skill, retrieve audit, end session" },
               ].map((hook) => (
                 <li key={hook.strong}>
-                  <button type="button" className="rd-btn rd-btn--quiet" style={{
+                  <button
+                    type="button"
+                    className="rd-btn rd-btn--quiet"
+                    onClick={() => previewAction(hook.strong)}
+                    style={{
                     width: "100%",
                     textAlign: "left",
                     padding: "7px 10px",
@@ -364,22 +409,22 @@ export function MeSurface() {
               <PolicySwitch
                 label="Auto-save explicit remember-this"
                 checked={policies.autoSaveExplicit}
-                onChange={(v) => setPolicies((p) => ({ ...p, autoSaveExplicit: v }))}
+                onChange={(v) => updatePolicy("autoSaveExplicit", v)}
               />
               <PolicySwitch
                 label="Suggest low-risk preferences"
                 checked={policies.suggestLowRisk}
-                onChange={(v) => setPolicies((p) => ({ ...p, suggestLowRisk: v }))}
+                onChange={(v) => updatePolicy("suggestLowRisk", v)}
               />
               <PolicySwitch
                 label="Require diff for privacy, budget, connectors"
                 checked={policies.diffPrivacy}
-                onChange={(v) => setPolicies((p) => ({ ...p, diffPrivacy: v }))}
+                onChange={(v) => updatePolicy("diffPrivacy", v)}
               />
             </div>
             <div className="rd-row" style={{ gap: 6, marginTop: 12 }}>
-              <button className="rd-btn rd-btn--primary rd-btn--sm">Review policy</button>
-              <button className="rd-btn rd-btn--quiet rd-btn--sm">Open audit log</button>
+              <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={() => previewAction("Review policy")}>Policy preview</button>
+              <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => previewAction("Open audit log")}>Audit log preview</button>
             </div>
           </div>
         </aside>
@@ -549,8 +594,8 @@ function StyleProfileSection() {
           <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => setShowGallery((v) => !v)}>
             {showGallery ? "Hide gallery" : "Browse public styles"}
           </button>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm">Recompute from history</button>
-          <button className="rd-btn rd-btn--primary rd-btn--sm">Save & apply</button>
+          <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Style recompute preview queued locally." })}>Recompute preview</button>
+          <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={() => showToast({ tone: "success", message: "Style profile saved locally for this session." })}>Save locally</button>
         </div>
       </header>
 
@@ -703,15 +748,15 @@ function RuntimeCard({
           background: "var(--rd-accent-soft)",
           color: "var(--rd-accent-strong)",
           border: "1px solid var(--rd-accent-ring)",
-        }}>{primaryAction}</button>
-        <button className="rd-btn rd-btn--quiet rd-btn--sm">{secondaryAction}</button>
+        }} onClick={() => showToast({ tone: "info", message: `${primaryAction} is a local runtime preview.` })}>{primaryAction}</button>
+        <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: `${secondaryAction} is a local runtime preview.` })}>{secondaryAction}</button>
       </div>
     </div>
   );
 }
 
 function SaveStatePill({ state }: { state: string }) {
-  const isSaving = state === "Saving…";
+  const isSaving = state.toLowerCase().includes("saving");
   return (
     <span
       role="status"

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -50,6 +50,8 @@ function displayReportDescription(description: string): string {
 
 interface ReportsSurfaceProps {
   onOpen: (id: string, tab: "brief" | "cards" | "chat") => void;
+  onSelectReport?: (report: ReportCardData) => void;
+  inspectedReportId?: string | null;
 }
 
 const STATUS_FILTERS = [
@@ -67,7 +69,7 @@ const KIND_FILTERS = [
   { id: "Coverage", label: "Coverage" },
 ] as const;
 
-export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
+export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: ReportsSurfaceProps) {
   const [filter, setFilter] = useState<typeof STATUS_FILTERS[number]["id"]>("all");
   const [kindFilter, setKindFilter] = useState<typeof KIND_FILTERS[number]["id"]>("all");
   const [density, setDensity] = useState<Density>("compact");
@@ -128,6 +130,12 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
     });
   }, [reports, filter, kindFilter, query, sortKey]);
 
+  useEffect(() => {
+    if (!onSelectReport || filtered.length === 0) return;
+    if (inspectedReportId && filtered.some((report) => report.id === inspectedReportId)) return;
+    onSelectReport(filtered[0]);
+  }, [filtered, inspectedReportId, onSelectReport]);
+
   const reportDecisionQueue = useMemo(
     () => buildReportsDecisionQueue(filtered.length > 0 ? filtered : reports),
     [filtered, reports],
@@ -142,8 +150,8 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
   const bulkExport = (format: "csv" | "markdown" | "notion" | "hubspot") => {
     showToast({
       tone: "success",
-      message: `Exporting ${selected.size} report${selected.size === 1 ? "" : "s"} as ${format.toUpperCase()}…`,
-      action: { label: "Open", onClick: () => { /* future: open downloads pane */ } },
+      message: `Prepared a local ${format.toUpperCase()} preview for ${selected.size} report${selected.size === 1 ? "" : "s"}. Connector writes still require approval.`,
+      action: { label: "Preview", onClick: () => { /* future: open downloads pane */ } },
     });
     setSelected(new Set());
   };
@@ -151,7 +159,7 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
   const bulkRefresh = () => {
     showToast({
       tone: "info",
-      message: `Triggered refresh for ${selected.size} entit${selected.size === 1 ? "y" : "ies"}. Briefs will appear here.`,
+      message: `Refresh preview queued locally for ${selected.size} entit${selected.size === 1 ? "y" : "ies"}. Live source refresh runs from Chat or scheduled agents.`,
     });
     setSelected(new Set());
   };
@@ -314,24 +322,24 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
         <div className="rd-bulk-bar">
           <span className="rd-bulk-bar__count">{selected.size} selected</span>
           <div className="rd-row" style={{ gap: 6, flexWrap: "wrap" }}>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={bulkRefresh}>Refresh sources</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={bulkRefresh}>Refresh preview</button>
             <button
               className="rd-btn rd-btn--quiet rd-btn--sm"
-              onClick={() => showToast({ tone: "info", message: `Queued rubric run for ${selected.size} selected report${selected.size === 1 ? "" : "s"}.` })}
+              onClick={() => showToast({ tone: "info", message: `Local rubric preview queued for ${selected.size} selected report${selected.size === 1 ? "" : "s"}. Run Chat to persist a scored artifact.` })}
             >
-              Run rubric
+              Rubric preview
             </button>
             <button
               className="rd-btn rd-btn--quiet rd-btn--sm"
-              onClick={() => showToast({ tone: "info", message: `Opening compare view for ${selected.size} selected report${selected.size === 1 ? "" : "s"}.` })}
+              onClick={() => showToast({ tone: "info", message: `Compare preview prepared for ${selected.size} selected report${selected.size === 1 ? "" : "s"}.` })}
             >
-              Compare
+              Compare preview
             </button>
             <span style={{ width: 1, height: 16, background: "var(--rd-line)" }} aria-hidden="true" />
-            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("csv")}>Export CSV</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("markdown")}>Export Markdown</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("notion")}>To Notion</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("hubspot")}>To HubSpot</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("csv")}>CSV preview</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("markdown")}>Markdown preview</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("notion")}>Notion preview</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => bulkExport("hubspot")}>HubSpot preview</button>
             <span style={{ width: 1, height: 16, background: "var(--rd-line)" }} aria-hidden="true" />
             <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={clearSelection}>Cancel</button>
           </div>
@@ -346,6 +354,8 @@ export function ReportsSurface({ onOpen }: ReportsSurfaceProps) {
         onToggleSelect={toggleSelect}
         hasActiveFilter={hasActiveFilter}
         onResetFilters={resetFilters}
+        inspectedReportId={inspectedReportId}
+        onSelectReport={onSelectReport}
       />
     </div>
   );
@@ -474,6 +484,8 @@ function ReportGrid({
   onToggleSelect,
   hasActiveFilter,
   onResetFilters,
+  inspectedReportId,
+  onSelectReport,
 }: {
   reports: ReportCardData[];
   density: Density;
@@ -482,6 +494,8 @@ function ReportGrid({
   onToggleSelect: (id: string) => void;
   hasActiveFilter?: boolean;
   onResetFilters?: () => void;
+  inspectedReportId?: string | null;
+  onSelectReport?: (report: ReportCardData) => void;
 }) {
   if (reports.length === 0) {
     return (
@@ -505,13 +519,31 @@ function ReportGrid({
     return (
       <div className="rd-card" style={{ padding: 0 }}>
         {reports.map((r, i) => (
-          <div key={r.id} style={{
+          <div
+            key={r.id}
+            role={onSelectReport ? "button" : undefined}
+            tabIndex={onSelectReport ? 0 : undefined}
+            aria-selected={inspectedReportId === r.id || undefined}
+            onClick={(event) => {
+              const target = event.target as HTMLElement;
+              if (target.closest("button, input")) return;
+              onSelectReport?.(r);
+            }}
+            onKeyDown={(event) => {
+              if (!onSelectReport) return;
+              if (event.key !== "Enter" && event.key !== " ") return;
+              event.preventDefault();
+              onSelectReport(r);
+            }}
+            style={{
             display: "grid",
             gridTemplateColumns: "minmax(0, 2fr) minmax(0, 1fr) auto",
             alignItems: "center",
             gap: 16,
             padding: "12px 16px",
             borderBottom: i === reports.length - 1 ? "none" : "1px solid var(--rd-line-faint)",
+            background: inspectedReportId === r.id ? "var(--rd-accent-soft)" : undefined,
+            cursor: onSelectReport ? "pointer" : undefined,
           }}>
             <div className="rd-stack" style={{ gap: 4 }}>
               <div className="rd-row" style={{ gap: 6 }}>
@@ -548,12 +580,13 @@ function ReportGrid({
           key={r.id}
           className="rd-report-card"
           data-status={r.status}
-          data-selected={selected.has(r.id) || undefined}
+          data-selected={selected.has(r.id) || inspectedReportId === r.id || undefined}
+          aria-selected={inspectedReportId === r.id || undefined}
           onClick={(e) => {
-            // Clicking the card body opens the brief; clicking a button or checkbox is excluded
+            // Clicking the card body inspects the report; footer buttons open the full workspace.
             const tgt = e.target as HTMLElement;
             if (tgt.closest("button, input")) return;
-            onOpen(r.id, "brief");
+            onSelectReport?.(r);
           }}
         >
           {/* Row 1: checkbox + entity + kind + status pill (Crunchbase row pattern) */}

--- a/src/features/redesign/surfaces/WorkspaceSurface.tsx
+++ b/src/features/redesign/surfaces/WorkspaceSurface.tsx
@@ -294,8 +294,8 @@ export function WorkspaceSurface({ reportId, initialTab = "brief" }: WorkspaceSu
               </button>
             )}
             <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "success", message: "Workspace link copied." })}>Share</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "success", message: "Export preview queued." })}>Export</button>
-            <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Refresh queued for this workspace." })}>Refresh</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "success", message: "Workspace export preview prepared locally." })}>Export preview</button>
+            <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Workspace refresh preview queued locally. Live refresh runs through Chat or scheduled agents." })}>Refresh preview</button>
           </div>
         </div>
 
@@ -648,9 +648,15 @@ function NotebookTab() {
   return (
     <div className="rd-stack" style={{ gap: 16, padding: "28px 32px", maxWidth: 760, overflow: "auto", height: "100%" }}>
       <div className="rd-row" style={{ gap: 8 }}>
-        <Pill tone="green"><span className="rd-dot rd-dot--live" />Saved · just now</Pill>
+        <Pill tone="green"><span className="rd-dot rd-dot--live" />Local draft · just now</Pill>
         <Pill>Public read-only mode</Pill>
-        <button className="rd-btn rd-btn--quiet rd-btn--sm" style={{ marginLeft: "auto" }}>Improve selection with AI</button>
+        <button
+          className="rd-btn rd-btn--quiet rd-btn--sm"
+          style={{ marginLeft: "auto" }}
+          onClick={() => showToast({ tone: "info", message: "Improve selection is a local notebook preview until a live artifact is selected." })}
+        >
+          Improve preview
+        </button>
       </div>
 
       <article className="rd-stack" style={{ gap: 14 }}>
@@ -988,8 +994,8 @@ function MapTab({
         <div className="rd-row--between rd-map-toolbar" style={{ position: "absolute", top: 16, left: 32, right: 32, zIndex: 2, gap: 10 }}>
           <Pill tone="blue">Top recommended flows</Pill>
           <div className="rd-row" style={{ gap: 6, flexWrap: "wrap" }}>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Map is filtered to the strongest live relationships." })}>Top flows</button>
-            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Showing confidence >= 0.7 relationships." })}>Confidence &gt;= 0.7</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Top-flow filter preview applied to the local map view." })}>Top flows preview</button>
+            <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Confidence filter preview applied to the local map view." })}>Confidence preview</button>
             <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={onOpenSources}>Sources</button>
             <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => onVerifySupport?.(selectedNode?.title ?? detail.title, selectedClaim)}>Verify support</button>
             <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={onOpenCards}>Open in Cards</button>
@@ -1058,7 +1064,7 @@ function MapTab({
         <Pill tone="blue">Map - wide-angle relationships</Pill>
         <div className="rd-row" style={{ gap: 6 }}>
           <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Open a live report to filter graph relationships." })}>Filter</button>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Confidence filtering needs a live artifact." })}>Confidence &gt;= 0.7</button>
+          <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => showToast({ tone: "info", message: "Confidence filtering needs a live artifact." })}>Confidence preview</button>
           <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={onOpenCards}>Open in Cards</button>
         </div>
       </div>

--- a/tests/e2e/home-v2-parity.spec.ts
+++ b/tests/e2e/home-v2-parity.spec.ts
@@ -1,0 +1,310 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+const DESKTOP = { width: 1440, height: 1000 };
+const NARROW_DESKTOP = { width: 1180, height: 900 };
+
+function rightRail(page: Page): Locator {
+  return page
+    .locator(
+      [
+        '[data-testid="home-v2-right-rail"]',
+        '[data-testid="redesign-right-rail"]',
+        '[data-testid="utility-inspector"]',
+        '[data-testid="right-inspector"]',
+        'aside[aria-label*="Right rail"]',
+        'aside[aria-label*="right rail"]',
+        'aside[aria-label*="Inspector"]',
+        'aside[aria-label*="inspector"]',
+        "aside.rd-pane--right",
+      ].join(", "),
+    )
+    .first();
+}
+
+function reportCards(page: Page): Locator {
+  return page.locator(
+    [
+      '[data-testid="report-card"]',
+      '[data-testid="redesign-report-card"]',
+      "[data-report-card]",
+      ".rd-report-card",
+    ].join(", "),
+  );
+}
+
+async function normalizedText(locator: Locator): Promise<string> {
+  return (await locator.innerText()).replace(/\s+/g, " ").trim();
+}
+
+async function reportTitle(card: Locator): Promise<string> {
+  const title = card
+    .locator('[data-report-title], .rd-report-card__entity, [role="heading"], h2, h3')
+    .first();
+  const titleText = (await title.textContent().catch(() => null))?.trim();
+  if (titleText) return titleText;
+  return (await normalizedText(card)).split(/\s{2,}|\n/)[0].trim();
+}
+
+async function selectReport(card: Locator): Promise<void> {
+  const bodyTarget = card.locator(".rd-report-card__entity, [data-report-title], h2, h3").first();
+  if ((await bodyTarget.count()) > 0) {
+    await bodyTarget.click();
+  } else {
+    await card.click();
+  }
+}
+
+async function expectRailInViewport(rail: Locator, minWidth = 280): Promise<void> {
+  await expect(rail).toBeVisible({ timeout: 10_000 });
+  const box = await rail.evaluate((node) => {
+    const rect = node.getBoundingClientRect();
+    return {
+      bottom: rect.bottom,
+      height: rect.height,
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      width: rect.width,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+    };
+  });
+
+  expect(box.width, "right rail keeps a usable desktop width").toBeGreaterThanOrEqual(minWidth);
+  expect(box.height, "right rail has visible vertical real estate").toBeGreaterThan(240);
+  expect(box.left, "right rail starts inside the viewport").toBeLessThan(box.viewportWidth);
+  expect(box.right, "right rail stays inside the viewport").toBeLessThanOrEqual(box.viewportWidth + 1);
+  expect(box.top, "right rail is not pushed below the fold").toBeLessThan(box.viewportHeight);
+  expect(box.bottom, "right rail intersects the visible viewport").toBeGreaterThan(0);
+}
+
+test.describe("Home v2 /redesign parity", () => {
+  test("desktop Home renders the live home-v2 layout", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/redesign", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("complementary", { name: "Edition browser" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "One queue. One decision at a time." })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Briefing agent" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Find a person, company, or action" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in" })).toHaveCount(0);
+    await expect(page.getByText("Public inbox tracker demo")).toHaveCount(0);
+    await expect(page.getByText(/Live edition · \d+ reports/).first()).toBeVisible({ timeout: 15_000 });
+
+    const primaryAction = page.getByRole("button", { name: "Show booking queue" });
+    await expect(primaryAction).toBeVisible();
+    await expect
+      .poll(async () => await primaryAction.evaluate((node) => getComputedStyle(node).backgroundColor))
+      .not.toBe("rgb(255, 255, 255)");
+  });
+
+  test("desktop Reports selection updates the right rail", async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await page.goto("/redesign/reports", { waitUntil: "domcontentloaded" });
+
+    const rail = rightRail(page);
+    await expectRailInViewport(rail);
+
+    const cards = reportCards(page);
+    await expect(cards.first()).toBeVisible({ timeout: 15_000 });
+    await expect.poll(async () => await cards.count()).toBeGreaterThanOrEqual(2);
+
+    const firstCard = cards.first();
+    const secondCard = cards.nth(1);
+    const firstTitle = await reportTitle(firstCard);
+    const secondTitle = await reportTitle(secondCard);
+
+    await selectReport(firstCard);
+    await expect.poll(async () => await normalizedText(rail)).toContain(firstTitle);
+    const firstRailText = await normalizedText(rail);
+
+    await selectReport(secondCard);
+    await expect.poll(async () => await normalizedText(rail)).toContain(secondTitle);
+    await expect.poll(async () => await normalizedText(rail)).not.toBe(firstRailText);
+  });
+
+  test("desktop Chat shows utility inspector tabs", async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await page.goto("/redesign/chat", { waitUntil: "domcontentloaded" });
+
+    const rail = rightRail(page);
+    await expectRailInViewport(rail);
+
+    const utilityTabs = rail.getByRole("tab");
+    await expect.poll(async () => await utilityTabs.count()).toBeGreaterThanOrEqual(4);
+    for (const label of ["Entity", "Graph", "Sources", "Threads"]) {
+      await expect(rail.getByRole("tab", { name: new RegExp(`^${label}$`, "i") })).toBeVisible();
+    }
+  });
+
+  test("desktop Chat starts the live run path without requiring sign-in", async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await page.goto("/redesign/chat?q=what%20changed%20today", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("what changed today").first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Sign in is required before NodeBench can start a real Convex-backed chat run.")).toHaveCount(0);
+    await expect(page.getByText("The UI is not inserting a showcase answer for this turn.")).toHaveCount(0);
+    await expect(page.getByText("Live chat was not started. The Convex-backed runtime is still preparing.")).toHaveCount(0);
+    await expect(page.locator("[data-chat-run-id]").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Live research run").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("chat-runtime-board").first()).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("Context candidates").first()).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("Tool decisions").first()).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole("button", { name: "Stop generation" })).toBeVisible();
+  });
+
+  test("desktop right rail remains visible at the narrow desktop breakpoint", async ({ page }) => {
+    await page.setViewportSize(NARROW_DESKTOP);
+    await page.goto("/redesign/chat", { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator("[data-redesign] .rd-shell")).toBeVisible({ timeout: 10_000 });
+    await expectRailInViewport(rightRail(page), 260);
+  });
+
+  test("desktop Me keeps its notebook width instead of adding the global agent rail", async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await page.goto("/redesign/me", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "This is what NodeBench remembers about you." })).toBeVisible();
+    await expect(page.locator("aside.rd-pane--right")).toHaveCount(0);
+  });
+
+  test("live and prototype routes avoid horizontal overflow at tablet and mobile widths", async ({ page }) => {
+    const paths = [
+      "/redesign",
+      "/redesign/reports",
+      "/redesign/chat",
+      "/redesign/inbox",
+      "/redesign/me",
+      "/redesign?qa=home-v2-implementation",
+      "/redesign/reports?qa=home-v2-implementation",
+      "/redesign/chat?qa=home-v2-implementation",
+      "/redesign/inbox?qa=home-v2-implementation",
+      "/redesign/me?qa=home-v2-implementation",
+    ];
+    for (const viewport of [{ width: 1280, height: 720 }, { width: 390, height: 844 }]) {
+      await page.setViewportSize(viewport);
+      for (const path of paths) {
+        await page.goto(path, { waitUntil: "domcontentloaded" });
+        await expect(page.locator("[data-redesign]").first()).toBeVisible({ timeout: 10_000 });
+        const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+        expect(overflow, `${path} overflow at ${viewport.width}x${viewport.height}`).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+});
+
+test.describe("Home v2 prototype kit mode", () => {
+  const qa = "qa=home-v2-implementation";
+
+  test("renders the UI kit chrome across every surface", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    const cases = [
+      {
+        path: `/redesign?${qa}`,
+        nav: "Home",
+        center: "One queue. One decision at a time.",
+        rail: "Briefing agent",
+      },
+      {
+        path: `/redesign/reports?${qa}`,
+        nav: "Reports",
+        center: "Entity intelligence",
+        rail: "Coverage agent",
+      },
+      {
+        path: `/redesign/chat?${qa}`,
+        nav: "Chat",
+        center: "Sequoia ratchet analysis",
+        rail: "Context",
+      },
+      {
+        path: `/redesign/inbox?${qa}`,
+        nav: "Inbox",
+        center: "Requires action",
+        rail: "Triage agent",
+      },
+      {
+        path: `/redesign/me?${qa}`,
+        nav: "Me",
+        center: "USER.md",
+        rail: "Settings agent",
+      },
+    ] as const;
+
+    for (const item of cases) {
+      await page.goto(item.path, { waitUntil: "domcontentloaded" });
+
+      await expect(page.getByRole("button", { name: "NodeBench home" })).toBeVisible();
+      await expect(page.getByRole("button", { name: item.nav, exact: true })).toHaveAttribute("aria-current", "page");
+      await expect(page.getByText(item.center).first()).toBeVisible();
+      await expect(page.getByRole("complementary", { name: item.rail })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Sign in" })).toHaveCount(0);
+    }
+  });
+
+  test("prototype mode preserves route navigation between surfaces", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto(`/redesign?${qa}`, { waitUntil: "domcontentloaded" });
+
+    await page.getByRole("button", { name: "Reports" }).click();
+    await expect(page).toHaveURL(/\/redesign\/reports\?qa=home-v2-implementation$/);
+    await expect(page.getByText("Entity intelligence").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Chat" }).click();
+    await expect(page).toHaveURL(/\/redesign\/chat\?qa=home-v2-implementation$/);
+    await expect(page.getByText("Saved to Sequoia Capital").first()).toBeVisible();
+  });
+
+  test("prototype Reports selection updates the coverage rail", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto(`/redesign/reports?${qa}`, { waitUntil: "domcontentloaded" });
+
+    await page.getByText("Sequoia Capital").first().click();
+    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Sequoia Capital");
+    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Score 74");
+    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Full-ratchet anti-dilution clause added");
+
+    await page.getByRole("button", { name: /OpenAI 62/i }).click();
+    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("OpenAI");
+    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Score 62");
+  });
+
+  test("prototype Chat includes answer packet details and interactive utility tabs", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto(`/redesign/chat?${qa}`, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("Evidence").first()).toBeVisible();
+    await expect(page.getByText("Draft counterproposal").first()).toBeVisible();
+    await expect(page.getByText("Attach").first()).toBeVisible();
+
+    await page.getByRole("tab", { name: "Graph" }).click();
+    await expect(page.getByRole("complementary", { name: "Context" })).toContainText("Graph neighborhood");
+    await page.getByRole("tab", { name: "Sources" }).click();
+    await expect(page.getByRole("complementary", { name: "Context" })).toContainText("Cooley primer");
+  });
+
+  test("prototype Inbox and Me include the deep parity affordances", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto(`/redesign/inbox?${qa}`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("Show 38 more items")).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Triage agent" })).toContainText("P0");
+    await expect(page.getByRole("complementary", { name: "Triage agent" })).toContainText("Draft reply");
+
+    await page.goto(`/redesign/me?${qa}`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("GitHub").first()).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Settings agent" })).toContainText("Execute trades");
+    await expect(page.getByRole("complementary", { name: "Settings agent" })).toContainText("Review memory update");
+  });
+
+  test("prototype QA mode bypasses the legacy mobile shell", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`/redesign/reports?${qa}`, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("Entity intelligence").first()).toBeVisible();
+    await expect(page.getByText("Enterprise tier repriced").first()).toBeVisible();
+    await expect(page.getByText("No reports yet")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ships the home-v2 parity shell, prototype QA mode, agent/right rail interactions, and chat runtime board
- wires/relabels preview-only actions across Reports, Inbox, Me, and Workspace so production UI does not overpromise durable writes
- adds the goal-mode release runbook and Playwright home-v2 parity coverage

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run src/features/redesign/surfaces/ProductDecisionQueue.test.ts src/features/redesign/components/TopNav.test.tsx src/features/redesign/hooks/useRedesignChatRun.test.ts
- npm run build
- npx playwright test tests/e2e/home-v2-parity.spec.ts (38/39 first pass; Firefox overflow retry passed)
- Convex prod deploy to agile-caribou-964.convex.cloud
- Vercel prod deploy dpl_2aKjBC7QjQM4WZ4CCmwuCNrnmoLc, aliased to www.nodebenchai.com
- Hosted smoke across /redesign, /redesign/chat, /redesign/reports, /redesign/me, /redesign/workspace: no failures, no relevant console errors

CSV updated: C:/Users/hshum/Downloads/nodebench_full_product_release_qa_matrix.csv