### PR TITLE
Refocus Home pulse on agent work

### DIFF
--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -876,6 +876,48 @@
   line-height: 1.45;
 }
 
+[data-redesign] .rd-v2-agent-steps {
+  display: grid;
+  gap: 10px;
+  margin: 20px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+[data-redesign] .rd-v2-agent-steps li {
+  display: grid;
+  grid-template-columns: 112px minmax(0, 1fr);
+  gap: 3px 12px;
+  min-width: 0;
+  padding: 11px 0;
+  border-top: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-agent-steps li > span {
+  align-self: start;
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.05em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-agent-steps strong {
+  color: var(--rd-ink);
+  font-size: 14px;
+  font-weight: 760;
+  line-height: 1.25;
+}
+
+[data-redesign] .rd-v2-agent-steps p {
+  grid-column: 2;
+  margin: 0;
+  color: var(--rd-ink-mute);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 [data-redesign] .rd-v2-pulse-side {
   display: grid;
   gap: 14px;
@@ -2041,6 +2083,14 @@
 
   [data-redesign] .rd-v2-pulse-lead h2 {
     font-size: 24px;
+  }
+
+  [data-redesign] .rd-v2-agent-steps li {
+    grid-template-columns: 1fr;
+  }
+
+  [data-redesign] .rd-v2-agent-steps p {
+    grid-column: 1;
   }
 
   [data-redesign] .rd-v2-pulse-statline {

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -1287,78 +1287,90 @@ function findBriefSection(model: HomeV2Model, label: string, fallbackIndex: numb
     model.dailyBriefSections[0];
 }
 
-function firstBriefItem(section: HomeV2BriefSection | undefined): HomeV2BriefItem | undefined {
-  return section?.items.find((item) => item.title || item.body);
+function countFromText(value: string | undefined, fallback: string): string {
+  const match = value?.match(/\d[\d,]*/);
+  return match?.[0] ?? fallback;
 }
 
 function LivePulseLanding({ model, onAsk }: { model: HomeV2Model; onAsk?: (text: string) => void }) {
   const whatChanged = findBriefSection(model, "changed", 0);
-  const whyMatters = findBriefSection(model, "matters", 1);
-  const nextMove = findBriefSection(model, "move", 2);
   const reportsTouched = findBriefSection(model, "reports", 3);
   const sourcesUsed = findBriefSection(model, "sources", 4);
   const actionsCreated = findBriefSection(model, "actions", 5);
-  const nextItem = firstBriefItem(nextMove);
-  const leadTitle = model.dailyBriefTitle.toLowerCase();
-  const seenLeadItems = new Set<string>();
-  const leadItems = whatChanged.items.filter((item) => {
-    const key = item.title.toLowerCase();
-    if (!key || key === leadTitle || seenLeadItems.has(key)) return false;
-    seenLeadItems.add(key);
-    return true;
-  }).slice(0, 2);
+  const changedCount = countFromText(whatChanged.metric, model.dailyBriefStats[0]?.value ?? "0");
+  const reportCount = countFromText(reportsTouched.metric, "0");
+  const sourceCount = countFromText(sourcesUsed.metric, model.dailyBriefStats[1]?.value ?? "0");
+  const actionCount = countFromText(actionsCreated.metric, model.dailyBriefStats[2]?.value ?? "0");
   const cardSections = [reportsTouched, sourcesUsed, actionsCreated];
+  const agentSteps = [
+    {
+      title: "Memory first",
+      body: `Searched the live brief and reusable report memory before asking the user to research again.`,
+      meta: `${changedCount} changed signals`,
+    },
+    {
+      title: "Report matching",
+      body: `Mapped the signal packet to existing coverage so the next click opens work in context.`,
+      meta: `${reportCount} reports touched`,
+    },
+    {
+      title: "Evidence and action",
+      body: `Kept sources and follow-ups visible so claims can be verified, patched, or routed to Chat.`,
+      meta: `${sourceCount} source rows · ${actionCount} follow-ups`,
+    },
+  ];
 
   return (
     <section className="rd-v2-pulse" data-testid="home-v2-pulse-landing" aria-labelledby="home-v2-pulse-title">
       <div className="rd-v2-pulse-topline" aria-label="Daily Brief status">
-        <span>Daily Brief</span>
+        <span>Agent brief</span>
         <span>{model.editionLine}</span>
       </div>
 
       <div className="rd-v2-pulse-head">
-        <p className="rd-v2-pulse-kicker">For your coverage book</p>
-        <h1 id="home-v2-pulse-title">Today for you</h1>
-        <p>{model.heroSub}</p>
+        <p className="rd-v2-pulse-kicker">For builders, investors, and operators</p>
+        <h1 id="home-v2-pulse-title">Your agent already did the first pass.</h1>
+        <p>NodeBench turns a noisy daily stream into a sourced work packet: what changed, which reports it touches, what evidence backs it, and what the agent should do next.</p>
       </div>
 
       <div className="rd-v2-pulse-grid">
         <article className="rd-v2-pulse-lead">
-          <div className="rd-v2-card-kicker">What changed</div>
-          <h2>{model.dailyBriefTitle}</h2>
-          <p>{whatChanged.body || model.dailyBriefDek}</p>
-          {leadItems.length > 0 && (
-            <ul className="rd-v2-pulse-list">
-              {leadItems.map((item, index) => (
-                <li key={`${item.title}-${index}`}>
-                  <strong>{item.title}</strong>
-                  <span>{item.body}</span>
-                </li>
-              ))}
-            </ul>
-          )}
+          <div className="rd-v2-card-kicker">What the agent did</div>
+          <h2>Compressed today&apos;s research into report work.</h2>
+          <p>
+            It scanned live memory, ranked changed signals, reused source rows, and turned the result into a follow-up queue. The point is not to read a feed headline. The point is to see what the agent already prepared.
+          </p>
+          <ul className="rd-v2-agent-steps" aria-label="Agent work completed">
+            {agentSteps.map((item) => (
+              <li key={item.title}>
+                <span>{item.meta}</span>
+                <strong>{item.title}</strong>
+                <p>{item.body}</p>
+              </li>
+            ))}
+          </ul>
           <div className="rd-v2-pulse-actions">
-            <button className="rd-v2-btn-primary" onClick={() => onAsk?.(`Open today's Daily Brief: ${model.dailyBriefTitle}`)}>
-              Ask in Chat
+            <button className="rd-v2-btn-primary" onClick={() => onAsk?.("Use the Daily Brief packet to brief me on the highest-leverage report updates and next actions.")}>
+              Ask the agent
             </button>
-            <button onClick={() => onAsk?.("Open the reports touched by today's Daily Brief.")}>
-              Open reports
+            <button onClick={() => onAsk?.("Open the reports touched by today's agent brief.")}>
+              Open touched reports
             </button>
           </div>
         </article>
 
         <div className="rd-v2-pulse-side">
           <article className="rd-v2-pulse-note">
-            <div className="rd-v2-card-kicker">Why it matters</div>
-            <h3>{whyMatters.title}</h3>
-            <p>{whyMatters.body}</p>
+            <div className="rd-v2-card-kicker">Who reads this</div>
+            <h3>People who need the next diligence move, not another feed.</h3>
+            <p>Founder, investor, banker, and operator workflows need reusable reports, source-backed claims, and clear follow-through. Raw news stays below as evidence, not the headline.</p>
           </article>
           <article className="rd-v2-pulse-note rd-v2-pulse-note--accent">
-            <div className="rd-v2-card-kicker">Next move</div>
-            <h3>{nextItem?.title ?? nextMove.title}</h3>
-            <p>{nextItem?.body ?? nextMove.body}</p>
-            <button onClick={() => onAsk?.(nextItem?.title ? `Help me with: ${nextItem.title}` : "Turn today's Daily Brief into next actions.")}>
-              Work this
+            <div className="rd-v2-card-kicker">Agent handoff</div>
+            <h3>Continue with the packet loaded.</h3>
+            <p>Open Chat with the report handles, source rows, and follow-up queue already attached. From there the agent can draft a memo, patch a notebook, or ask for approval before a write.</p>
+            <button onClick={() => onAsk?.("Continue from today's agent brief with report handles, source rows, and follow-up actions loaded.")}>
+              Continue in Chat
             </button>
           </article>
         </div>

--- a/tests/e2e/home-v2-parity.spec.ts
+++ b/tests/e2e/home-v2-parity.spec.ts
@@ -85,10 +85,12 @@ test.describe("Home v2 /redesign parity", () => {
 
     await expect(page.getByRole("complementary", { name: "Edition browser" })).toBeVisible();
     await expect(page.getByTestId("home-v2-pulse-landing")).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Today for you" })).toBeVisible();
-    await expect(page.getByText("What changed").first()).toBeVisible();
-    await expect(page.getByText("Why it matters").first()).toBeVisible();
-    await expect(page.getByText("Next move").first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Your agent already did the first pass." })).toBeVisible();
+    await expect(page.getByText("What the agent did").first()).toBeVisible();
+    await expect(page.getByText("Who reads this").first()).toBeVisible();
+    await expect(page.getByText("Agent handoff").first()).toBeVisible();
+    await expect(page.getByText("Memory first").first()).toBeVisible();
+    await expect(page.getByText("Report matching").first()).toBeVisible();
     await expect(page.getByRole("complementary", { name: "Briefing agent" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Find a person, company, or action" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Sign in" })).toHaveCount(0);
@@ -103,7 +105,10 @@ test.describe("Home v2 /redesign parity", () => {
     await expect(page.getByText("Sources used").first()).toBeVisible();
     await expect(page.getByText("Actions created").first()).toBeVisible();
 
-    const primaryAction = page.getByRole("button", { name: "Ask in Chat" });
+    const pulseText = await page.getByTestId("home-v2-pulse-landing").innerText();
+    expect(pulseText).not.toMatch(/r\/technology|random headline/i);
+
+    const primaryAction = page.getByRole("button", { name: "Ask the agent" });
     await expect(primaryAction).toBeVisible();
     await expect
       .poll(async () => await primaryAction.evaluate((node) => getComputedStyle(node).backgroundColor))


### PR DESCRIPTION
## Summary
- Replaces raw source-story prominence in live Home with an agent-work packet: who reads it, what the agent did, memory/report/source/follow-up steps, and Chat/Reports handoff.
- Keeps raw daily-brief signals as evidence below the first viewport instead of the first impression.
- Updates Home v2 parity coverage to assert the agent-work landing and prevent raw headline leakage in the Pulse viewport.

## Verification
- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
- npx vitest run src/features/redesign/surfaces/ProductDecisionQueue.test.ts src/features/redesign/components/TopNav.test.tsx src/features/redesign/hooks/useRedesignChatRun.test.ts
- npm run build
- BASE_URL=http://127.0.0.1:5185 npx playwright test tests/e2e/home-v2-parity.spec.ts
- Browser smoke: desktop/mobile Pulse has agent-work copy, no raw source headline leak, no old queue/static-kit copy, overflowX=0; Ask the agent routes to Chat with prompt preserved.