### PR TITLE
Align non-home center panes with v2 kit

### DIFF
--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -1333,6 +1333,25 @@ export function ChatSurface({
       <div ref={scrollRef} className="rd-stack" style={{ flex: 1, overflow: "auto", padding: "24px 40px 24px", gap: 18, maxWidth: 920, width: "100%", margin: "0 auto" }}>
         {batch && <BatchMonitorCell batch={batch} onCancel={() => setBatch(null)} />}
 
+        <ChatV2ReportBanner
+          liveDetail={liveDetail}
+          turns={turns}
+          isLive={liveArtifacts.isLive}
+          paidEligible={chatRun.state.paidEligible}
+          runStatus={chatRun.state.run?.status}
+          onOpenReport={openCurrentReport}
+          onExport={() => showToast({ tone: "info", message: "Export preview stays approval-gated until a final answer packet exists." })}
+          onTrack={() => showToast({ tone: "success", message: liveDetail ? `${liveDetail.title} is already attached as the active report context.` : "Track updates after selecting or creating a report context." })}
+        />
+        <ChatV2CheckpointStrip
+          liveDetail={liveDetail}
+          turns={turns}
+          toolCallCount={chatRun.state.run?.toolCalls.length ?? 0}
+          runStatus={chatRun.state.run?.status}
+          authReady={!authLoading}
+          isAuthenticated={isAuthenticated}
+        />
+
         {/* Compact thread header — no marketing copy. Just status + thread context. */}
         <header className="rd-chat-thread-head">
           <div className="rd-row" style={{ gap: 8, flexWrap: "wrap" }}>
@@ -1432,6 +1451,13 @@ export function ChatSurface({
             );
           })
         )}
+        <ChatV2NextActions
+          liveDetail={liveDetail}
+          disabled={turns.some((t) => t.thinking || t.streaming)}
+          onOpenReport={openCurrentReport}
+          onPrompt={(prompt) => sendMessage(prompt, tier)}
+          onExport={() => showToast({ tone: "info", message: "Export will use the final sourced answer packet, not an unsourced draft." })}
+        />
       </div>
 
       {showScrollBtn && (
@@ -1611,6 +1637,117 @@ export function ChatSurface({
  * Today: fixture from OPEN_QUESTIONS. Once chat is live-wired, replace
  * with `useAgentRunFeedback` query filtered to flagged + unresolved items.
  */
+function ChatV2ReportBanner({
+  liveDetail,
+  turns,
+  isLive,
+  paidEligible,
+  runStatus,
+  onOpenReport,
+  onExport,
+  onTrack,
+}: {
+  liveDetail?: LiveArtifactDetail | null;
+  turns: Turn[];
+  isLive: boolean;
+  paidEligible: boolean;
+  runStatus?: string;
+  onOpenReport: () => void;
+  onExport: () => void;
+  onTrack: () => void;
+}) {
+  const savedLabel = liveDetail ? `Saved to ${liveDetail.title}` : "Ready for a live report packet";
+  const meta = liveDetail
+    ? `${liveDetail.sectionCount} sections · ${liveDetail.claimCount} claims · ${liveDetail.sourceCount} sources · notebook context loaded`
+    : `${turns.length} messages · ${isLive ? "memory hot" : "memory warming"} · ${paidEligible ? "paid eligible" : "free-first"} · ${runStatus ?? "idle"}`;
+
+  return (
+    <section className="rd-v2-saved-banner" aria-label="Current chat work packet">
+      <strong>{savedLabel}</strong>
+      <span>{meta}</span>
+      <button type="button" onClick={onOpenReport}>{liveDetail ? "Open notebook" : "Open reports"}</button>
+      <button type="button" onClick={onExport}>Export</button>
+      <button type="button" onClick={onTrack}>Track updates</button>
+    </section>
+  );
+}
+
+function ChatV2CheckpointStrip({
+  liveDetail,
+  turns,
+  toolCallCount,
+  runStatus,
+  authReady,
+  isAuthenticated,
+}: {
+  liveDetail?: LiveArtifactDetail | null;
+  turns: Turn[];
+  toolCallCount: number;
+  runStatus?: string;
+  authReady: boolean;
+  isAuthenticated: boolean;
+}) {
+  const hasUserTurn = turns.some((turn) => turn.role === "user");
+  const hasPacket = turns.some((turn) => turn.packet?.shortAnswer);
+  const hasFollowUp = turns.some((turn) => turn.markdown || turn.packet?.nextAction);
+  const running = runStatus === "running" || runStatus === "queued" || turns.some((turn) => turn.thinking || turn.streaming);
+  const checkpoints: Array<[string, string, boolean]> = [
+    ["✓", liveDetail ? "Report context loaded" : authReady ? "Memory checked" : "Resolving session", Boolean(liveDetail) || authReady],
+    [hasUserTurn ? "✓" : "○", "Prompt captured", hasUserTurn],
+    [toolCallCount > 0 ? "✓" : running ? "↻" : "○", `${toolCallCount} tool calls`, toolCallCount > 0 || running],
+    [hasPacket ? "✓" : running ? "↻" : "○", "Answer packet", hasPacket || running],
+    [hasFollowUp ? "✓" : "○", "Notebook / follow-up", hasFollowUp],
+    [isAuthenticated ? "✓" : "○", isAuthenticated ? "Telemetry persisted" : "Guest telemetry local", isAuthenticated],
+  ];
+
+  return (
+    <div className="rd-v2-chat-center">
+      <h1>{liveDetail ? `${liveDetail.title} workspace chat` : "Ask NodeBench to work the live packet"}</h1>
+      <p className="rd-v2-muted-line">
+        {runStatus ? `Run ${runStatus}` : "Idle"} · {turns.length} messages · context, tools, cost, and evidence stream through the rail.
+      </p>
+      <div className="rd-v2-checkpoints">
+        {checkpoints.map(([mark, label, active]) => (
+          <div key={label} data-active={active}>
+            <span>{mark}</span><strong>{label}</strong>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChatV2NextActions({
+  liveDetail,
+  disabled,
+  onOpenReport,
+  onPrompt,
+  onExport,
+}: {
+  liveDetail?: LiveArtifactDetail | null;
+  disabled: boolean;
+  onOpenReport: () => void;
+  onPrompt: (prompt: string) => void;
+  onExport: () => void;
+}) {
+  const title = liveDetail?.title ?? "current context";
+  const actions = [
+    ["Open notebook", onOpenReport],
+    ["Draft memo", () => onPrompt(`Draft a concise sourced memo for ${title}. Include answer, evidence, risks, and next action.`)],
+    ["Verify claims", () => onPrompt(`Verify the open claims for ${title}. Use memory first and list citation gaps explicitly.`)],
+    ["Compare", () => onPrompt(`Compare ${title} against the closest related reports already in memory.`)],
+    ["Export", onExport],
+  ] as const;
+
+  return (
+    <div className="rd-v2-next-actions" aria-label="Chat next actions">
+      {actions.map(([label, action]) => (
+        <button key={label} type="button" disabled={disabled} onClick={action}>{label}</button>
+      ))}
+    </div>
+  );
+}
+
 function OpenQuestionsTray({ questions }: { questions: OpenQuestion[] }) {
   const [open, setOpen] = useState(true);
   const [items, setItems] = useState(questions);

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -974,11 +974,11 @@ export function PrototypeV2LeftRail({ surface, onAsk, selectedEntity = "Anthropi
       <NavItem label="Style profile" marker="🎨" />
       <div className="rd-v2-rail-rule" />
       <div className="rd-v2-memory-stats">
-        <div><span>Observations</span><strong>847</strong></div>
-        <div><span>Corrections</span><strong>23</strong></div>
-        <div><span>Last updated</span><strong>2m ago</strong></div>
+        <div><span>Observations</span><strong>{guestSafe ? "Locked" : "847"}</strong></div>
+        <div><span>Corrections</span><strong>{guestSafe ? "Locked" : "23"}</strong></div>
+        <div><span>Last updated</span><strong>{guestSafe ? "After sign-in" : "2m ago"}</strong></div>
       </div>
-      <button className="rd-v2-sign-out">Sign out</button>
+      <button className="rd-v2-sign-out">{guestSafe ? "Sign in" : "Sign out"}</button>
     </aside>
   );
 }

--- a/src/features/redesign/surfaces/InboxSurface.tsx
+++ b/src/features/redesign/surfaces/InboxSurface.tsx
@@ -54,7 +54,7 @@ export function InboxSurface() {
   );
 
   // Sprint S3: live aggregator over pipeline runs.
-  const { items: allItems, isLive, liveCount } = useInboxLive();
+  const { items: allItems, isLive, isLoading, liveCount } = useInboxLive();
 
   const items = useMemo(() => {
     let base = allItems.filter((i) => !snoozed.has(i.id));
@@ -227,6 +227,82 @@ export function InboxSurface() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [items, activeId, activeItem]);
+
+  const inboxGroups = buildInboxV2Groups(items);
+
+  return (
+    <div className="rd-v2-proto-center rd-v2-inbox-center">
+      <div className="rd-v2-inbox-head">
+        <h1>Inbox</h1>
+        <span>
+          {isLive ? `${liveCount} live items` : isLoading ? "Checking live items" : "0 live items"} · {items.filter((item) => item.whyTone === "amber" || item.lane === "approvals").length} need action
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            if (items.length === 0) {
+              showToast({ tone: "info", message: "No live Inbox rows are available to mark read." });
+              return;
+            }
+            setSnoozed((prev) => new Set([...prev, ...items.map((item) => item.id)]));
+            showToast({ tone: "success", message: `Marked ${items.length} live Inbox item${items.length === 1 ? "" : "s"} read locally.` });
+          }}
+        >
+          Mark all read
+        </button>
+        <button
+          type="button"
+          className="rd-v2-btn-primary"
+          onClick={() => showToast({ tone: "info", message: "Auto-triage runs through the live nudge and pipeline queues. No starter rows were inserted." })}
+        >
+          Auto-triage
+        </button>
+      </div>
+      {inboxGroups.map((group) => (
+        <section key={group.label} className="rd-v2-inbox-group">
+          <div className="rd-v2-inbox-group-head"><span>{group.label}</span><b>{group.items.length}</b></div>
+          {group.items.length === 0 ? (
+            <article>
+              <span className="rd-v2-source-icon" data-source="system">·</span>
+              <div>
+                <span className="rd-v2-inbox-title-row"><strong>{group.empty}</strong></span>
+                <p>Convex returned no rows in this bucket for the current session.</p>
+              </div>
+              <time>live</time>
+            </article>
+          ) : (
+            group.items.map((item) => (
+              <article
+                key={item.id}
+                className={activeId === item.id ? "is-active" : ""}
+                onClick={() => setActiveId(item.id)}
+              >
+                <span className="rd-v2-source-icon" data-source={inboxV2Source(item)}>
+                  {inboxV2Icon(item)}
+                </span>
+                <div>
+                  <span className="rd-v2-inbox-title-row">
+                    {activeId === item.id && <i />}
+                    <strong>{item.title}</strong>
+                  </span>
+                  <p>{item.body}</p>
+                </div>
+                <time>{item.meta}</time>
+                <b>{item.whyHere ?? item.category.replace(/_/g, " ")}</b>
+              </article>
+            ))
+          )}
+        </section>
+      ))}
+      <button
+        className="rd-v2-show-more"
+        type="button"
+        onClick={() => showToast({ tone: "info", message: isLive ? "All live Inbox rows for this session are visible." : "Inbox is empty because no live nudges or pipeline review rows were returned." })}
+      >
+        {items.length > 0 ? `Show ${Math.max(0, allItems.length - items.length)} more items` : "No hidden fixture items"}
+      </button>
+    </div>
+  );
 
   return (
     <div className="rd-stack" style={{ padding: "32px 40px 40px", gap: 18, maxWidth: 1280, height: "100%" }}>
@@ -486,6 +562,65 @@ function InboxPreview({
       </div>
     </>
   );
+}
+
+function buildInboxV2Groups(items: InboxItem[]) {
+  const groups = [
+    {
+      label: "Requires action",
+      empty: "No approval or agent-action rows",
+      items: items.filter((item) =>
+        (item.lane ?? legacyToLane(item.category)) === "approvals" ||
+        (item.lane ?? legacyToLane(item.category)) === "agent_suggestions" ||
+        item.whyTone === "amber",
+      ),
+    },
+    {
+      label: "To read",
+      empty: "No watchlist or capture rows",
+      items: items.filter((item) =>
+        (item.lane ?? legacyToLane(item.category)) === "watchlist" ||
+        (item.lane ?? legacyToLane(item.category)) === "captures",
+      ),
+    },
+    {
+      label: "Waiting on others",
+      empty: "No waiting rows",
+      items: items.filter((item) =>
+        item.meta.toLowerCase().includes("waiting") ||
+        item.body.toLowerCase().includes("approval") ||
+        item.body.toLowerCase().includes("requires"),
+      ),
+    },
+    {
+      label: "Filed",
+      empty: "No filed rows",
+      items: items.filter((item) => item.whyTone === "green"),
+    },
+  ];
+
+  return groups.map((group, index) => ({
+    ...group,
+    items: index === 0
+      ? group.items
+      : group.items.filter((item) => !groups.slice(0, index).some((prior) => prior.items.some((priorItem) => priorItem.id === item.id))),
+  }));
+}
+
+function inboxV2Source(item: InboxItem): string {
+  const lane = item.lane ?? legacyToLane(item.category);
+  if (lane === "approvals") return "github";
+  if (lane === "watchlist") return "source";
+  if (lane === "agent_suggestions") return "agent";
+  return "email";
+}
+
+function inboxV2Icon(item: InboxItem): string {
+  const source = inboxV2Source(item);
+  if (source === "github") return "⌁";
+  if (source === "source") return "◦";
+  if (source === "agent") return "✦";
+  return "✉";
 }
 
 function LaneGlyph({ lane }: { lane: InboxLane }) {

--- a/src/features/redesign/surfaces/MeSurface.tsx
+++ b/src/features/redesign/surfaces/MeSurface.tsx
@@ -116,6 +116,22 @@ export function MeSurface() {
     return params.get("qa") === "1" || params.get("debugUi") === "1";
   }, []);
 
+  if (isLoading || !isAuthenticated) {
+    return (
+      <MeV2DocumentCenter
+        mode={isLoading ? "loading" : "guest"}
+        sections={[]}
+        savedAt={isLoading ? "Resolving private session" : "Sign in to create USER.md"}
+        onPrimary={() => {
+          if (isLoading) return;
+          void signIn("google", {
+            redirectTo: typeof window !== "undefined" ? window.location.href : "/redesign/me",
+          });
+        }}
+      />
+    );
+  }
+
   if (!isLoading && !isAuthenticated) {
     return (
       <div className="rd-stack" style={{ padding: "28px 40px 40px", gap: 20, maxWidth: 1120 }}>
@@ -242,6 +258,21 @@ export function MeSurface() {
     setSections((prev) => prev.map((s) => (s.id === sectionId ? { ...s, body } : s)));
     markLocalSaved();
   };
+
+  return (
+    <MeV2DocumentCenter
+      mode="authenticated"
+      sections={sections}
+      savedAt={savedAt}
+      patch={patch}
+      onPrimary={() => {
+        markLocalSaved();
+        showToast({ tone: "success", message: "USER.md local draft saved. Durable profile sync remains approval-gated." });
+      }}
+      onPatch={acceptPatch}
+      onRejectPatch={rejectPatch}
+    />
+  );
 
   return (
     <div className="rd-stack" style={{ padding: "28px 40px 40px", gap: 20, maxWidth: 1280 }}>
@@ -602,6 +633,89 @@ export function MeSurface() {
           </div>
         </section>
       </div>
+    </div>
+  );
+}
+
+function MeV2DocumentCenter({
+  mode,
+  sections,
+  savedAt,
+  patch,
+  onPrimary,
+  onPatch,
+  onRejectPatch,
+}: {
+  mode: "loading" | "guest" | "authenticated";
+  sections: Section[];
+  savedAt: string;
+  patch?: string;
+  onPrimary: () => void;
+  onPatch?: () => void;
+  onRejectPatch?: () => void;
+}) {
+  const guest = mode !== "authenticated";
+  const lines = guest
+    ? [
+        ["# Private Context", ""],
+        ["Profile:", mode === "loading" ? "Resolving private session." : "No signed-in profile is loaded."],
+        ["Memory:", "Watched entities, writing style, connector permissions, and budget rules are hidden until sign-in."],
+        ["Agent rule:", "No private captures, account names, connector rows, or prior profile data are rendered to public visitors."],
+        ["Next action:", mode === "loading" ? "Wait for auth resolution." : "Sign in to create a private USER.md file."],
+      ]
+    : sections.flatMap((section) => [
+        [section.heading, ""],
+        ["Policy:", section.permissions.filter((permission) => permission.pressed).map((permission) => PERM_LABEL[permission.id]).join(", ") || "review required"],
+        ["Memory:", section.body],
+      ]);
+
+  return (
+    <div className="rd-v2-proto-center rd-v2-me-center">
+      <div className="rd-v2-edition-row">
+        <span className="rd-v2-edition-pill">USER.md</span>
+        <span className="rd-v2-edition-subline">{guest ? savedAt : `Your identity file · ${savedAt}`}</span>
+      </div>
+      <div className="rd-v2-share-bar">
+        <span>Actions</span>
+        <button type="button" className="rd-v2-share-primary" onClick={onPrimary}>
+          {guest ? mode === "loading" ? "Loading" : "Sign in" : "Save"}
+        </button>
+        <button type="button" onClick={() => showToast({ tone: "info", message: guest ? "Exports unlock after sign-in." : "Export preview is local until connector approval." })}>Export</button>
+        <button type="button" onClick={() => showToast({ tone: "info", message: guest ? "No profile is loaded to reset." : "Reset requires diff review before mutating USER.md." })}>Reset</button>
+      </div>
+      <article className="rd-v2-user-md">
+        {lines.map(([key, value], index) => (
+          key.startsWith("#") ? <h2 key={`${key}-${index}`}>{key}</h2> : (
+            <p key={`${key}-${index}`}>
+              <span>{key}</span>{value}
+            </p>
+          )
+        ))}
+      </article>
+      {patch && !guest && (
+        <section className="rd-card rd-card__pad" style={{ background: "var(--rd-paper-warm)" }}>
+          <div className="rd-eyebrow">Suggested patch</div>
+          <p className="rd-faint" style={{ marginTop: 8 }}>{patch}</p>
+          <div className="rd-row" style={{ gap: 8, marginTop: 12 }}>
+            <button type="button" className="rd-btn rd-btn--primary rd-btn--sm" onClick={onPatch}>Accept</button>
+            <button type="button" className="rd-btn rd-btn--quiet rd-btn--sm" onClick={onRejectPatch}>Reject</button>
+          </div>
+        </section>
+      )}
+      <section className="rd-v2-integrations-grid">
+        {[
+          ["GitHub", guest ? "Connect after sign-in" : "Available", guest ? "No repository memory shown" : "Repository context can be indexed"],
+          ["Convex", guest ? "Public read only" : "Connected runtime", guest ? "No private tables exposed" : "Live profile writes stay gated"],
+          ["LinkedIn", "Approval required", "Posting and CRM writes require review"],
+          ["Slack", guest ? "Off" : "Optional", "Team memory stays permission-scoped"],
+        ].map(([name, status, detail]) => (
+          <article key={name}>
+            <strong>{name}</strong>
+            <span>{status}</span>
+            <p>{detail}</p>
+          </article>
+        ))}
+      </section>
     </div>
   );
 }

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -136,6 +136,9 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
     onSelectReport(filtered[0]);
   }, [filtered, inspectedReportId, onSelectReport]);
 
+  const hasActiveFilter = filter !== "all" || kindFilter !== "all" || query.length > 0;
+  const resetFilters = () => { setFilter("all"); setKindFilter("all"); setQuery(""); };
+
   const reportDecisionQueue = useMemo(
     () => buildReportsDecisionQueue(filtered.length > 0 ? filtered : reports),
     [filtered, reports],
@@ -143,10 +146,6 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
   const openDecisionItem = (item: ProductDecisionItem) => {
     if (item.reportId) onOpen(item.reportId, "brief");
   };
-
-  const hasActiveFilter = filter !== "all" || kindFilter !== "all" || query.length > 0;
-  const resetFilters = () => { setFilter("all"); setKindFilter("all"); setQuery(""); };
-
   const bulkExport = (format: "csv" | "markdown" | "notion" | "hubspot") => {
     showToast({
       tone: "success",
@@ -155,7 +154,6 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
     });
     setSelected(new Set());
   };
-
   const bulkRefresh = () => {
     showToast({
       tone: "info",
@@ -163,6 +161,154 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
     });
     setSelected(new Set());
   };
+
+  const visibleReports = filtered.slice(0, 12);
+  const verifiedShare = reports.length > 0 ? Math.round(((counts.verified ?? 0) / reports.length) * 100) : 0;
+
+  return (
+    <div className="rd-v2-proto-center">
+      <div className="rd-v2-edition-row">
+        <span className="rd-v2-edition-pill">Entity intelligence</span>
+        <span className="rd-v2-edition-subline">
+          {isLoading && reports.length === 0
+            ? "Checking Convex-backed artifacts"
+            : `${reports.length} live reports · ${verifiedShare}% verified · ${counts.review ?? 0} need review · ${reports.reduce((sum, report) => sum + report.sources, 0)} sources`}
+        </span>
+      </div>
+      <div className="rd-v2-filter-row" role="tablist" aria-label="Filter reports by status">
+        {STATUS_FILTERS.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className={filter === item.id ? "is-active" : ""}
+            aria-selected={filter === item.id}
+            onClick={() => setFilter(item.id)}
+          >
+            {item.label} {counts[item.id] ?? 0}
+          </button>
+        ))}
+        <button type="button" className={kindFilter !== "all" ? "is-active" : ""} onClick={() => setKindFilter(kindFilter === "all" ? "Diligence" : "all")}>
+          {kindFilter === "all" ? "Tags" : kindFilter} ▾
+        </button>
+      </div>
+      <div className="rd-v2-action-row" style={{ position: "relative" }}>
+        <button type="button" onClick={() => setSortOpen((v) => !v)}>
+          {SORT_OPTIONS.find((s) => s.id === sortKey)?.label.split(" (")[0] ?? "Updated"} ▾
+        </button>
+        {sortOpen && (
+          <div className="rd-sort__menu" role="menu" style={{ left: 0, top: 36 }}>
+            {SORT_OPTIONS.map((s) => (
+              <button
+                key={s.id}
+                role="menuitemradio"
+                aria-selected={sortKey === s.id}
+                className="rd-sort__option"
+                onClick={() => { setSortKey(s.id); setSortOpen(false); }}
+              >
+                <span aria-hidden="true">{sortKey === s.id ? "✓" : ""}</span>
+                <span>{s.label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => showToast({ tone: isLive ? "success" : "info", message: isLive ? `${sourceLabel}. Reports are Convex-backed.` : "No live reports yet. The page will not substitute fixtures." })}
+        >
+          ● {isLive ? "Convex-backed" : "No fixture fallback"}
+        </button>
+        {query && <button type="button" onClick={resetFilters}>Clear filters</button>}
+        <button
+          type="button"
+          className="rd-v2-btn-primary"
+          onClick={() => showToast({ tone: "info", message: "Start a new entity report from Chat so the first write has source trace and approval context." })}
+        >
+          + New report
+        </button>
+      </div>
+      <div className="rd-v2-action-row" aria-label="Search reports">
+        <label className="rd-sr-only" htmlFor="reports-v2-search">Search reports</label>
+        <input
+          id="reports-v2-search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={isLive ? `Search ${reports.length} live reports...` : "Search live reports..."}
+          style={{
+            width: "100%",
+            border: "1px solid var(--rd-line)",
+            borderRadius: 999,
+            padding: "10px 14px",
+            background: "var(--rd-panel)",
+            color: "var(--rd-ink)",
+          }}
+        />
+      </div>
+      {visibleReports.length === 0 ? (
+        <article className="rd-v2-report-card rd-v2-report-card--add">
+          <h2>{hasActiveFilter ? "No matching live reports" : "No live coverage returned"}</h2>
+          <p>
+            {hasActiveFilter
+              ? "Clear the filters to return to the live report set."
+              : "Convex returned zero report artifacts for this session. Run research from Chat to create the first report."}
+          </p>
+          <button type="button" onClick={hasActiveFilter ? resetFilters : () => onOpen("new", "chat")}>
+            {hasActiveFilter ? "Clear filters" : "+ Start in Chat"}
+          </button>
+        </article>
+      ) : (
+        <div className="rd-v2-report-grid">
+          {visibleReports.map((report) => {
+            const active = inspectedReportId === report.id;
+            return (
+              <article
+                key={report.id}
+                className={`rd-v2-report-card ${active ? "is-active" : ""}`}
+                onClick={() => onSelectReport?.(report)}
+                aria-selected={active}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") return;
+                  event.preventDefault();
+                  onSelectReport?.(report);
+                }}
+              >
+                <div className="rd-v2-report-title">
+                  <span>{report.entity.slice(0, 1).toUpperCase()}</span>
+                  <h2>{report.entity}</h2>
+                  <b data-state={report.status}>{report.status === "review" ? "review" : report.status}</b>
+                </div>
+                <p className="rd-v2-report-kind">{report.kind}</p>
+                <p>{displayReportDescription(report.description)}</p>
+                <div className="rd-v2-report-tags">
+                  <span>{report.sources} sources</span>
+                  <span>{report.claims} claims</span>
+                  <span>{report.followUps} follow-ups</span>
+                </div>
+                <p className="rd-v2-report-ref">Referenced in: {sourceLabel}</p>
+                <p className="rd-v2-report-meta">Updated {report.updatedAt}</p>
+                <div className="rd-v2-next-actions" style={{ marginTop: 8 }}>
+                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "brief"); }}>Open</button>
+                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "cards"); }}>Cards</button>
+                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "chat"); }}>Chat</button>
+                </div>
+              </article>
+            );
+          })}
+          <article className="rd-v2-report-card rd-v2-report-card--add">
+            <h2>Add entity</h2>
+            <p>Capture a company, person, topic, or source cluster and let the coverage agent hydrate the first report.</p>
+            <button type="button" onClick={() => onOpen("new", "chat")}>+ New entity</button>
+          </article>
+        </div>
+      )}
+      {filtered.length > visibleReports.length && (
+        <button className="rd-v2-show-more" type="button" onClick={() => showToast({ tone: "info", message: `${filtered.length - visibleReports.length} more live reports are available through search and filters.` })}>
+          Show {filtered.length - visibleReports.length} more entities
+        </button>
+      )}
+    </div>
+  );
 
   return (
     <div className="rd-stack" style={{ padding: "32px 40px 40px", gap: 20, maxWidth: 1440 }}>

--- a/tests/e2e/home-v2-parity.spec.ts
+++ b/tests/e2e/home-v2-parity.spec.ts
@@ -27,6 +27,7 @@ function reportCards(page: Page): Locator {
       '[data-testid="report-card"]',
       '[data-testid="redesign-report-card"]',
       "[data-report-card]",
+      ".rd-v2-report-card:not(.rd-v2-report-card--add)",
       ".rd-report-card",
     ].join(", "),
   );
@@ -122,6 +123,8 @@ test.describe("Home v2 /redesign parity", () => {
 
     await expect(page.getByRole("complementary", { name: "Reports navigation" })).toBeVisible();
     await expect(page.getByLabel("Filter entities")).toBeVisible();
+    await expect(page.getByText("Entity intelligence").first()).toBeVisible();
+    await expect(page.locator(".rd-v2-report-grid")).toBeVisible({ timeout: 15_000 });
     await expect(page.getByRole("complementary", { name: "Coverage agent" })).toBeVisible();
     const rail = rightRail(page);
     await expectRailInViewport(rail);
@@ -151,6 +154,9 @@ test.describe("Home v2 /redesign parity", () => {
 
     await expect(page.getByRole("complementary", { name: "Chat threads" })).toBeVisible();
     await expect(page.getByRole("button", { name: "+ New thread" })).toBeVisible();
+    await expect(page.getByText(/Ready for a live report packet|Saved to/i).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Ask NodeBench to work the live packet").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Prompt captured").first()).toBeVisible();
     const rail = rightRail(page);
     await expectRailInViewport(rail);
 
@@ -189,6 +195,9 @@ test.describe("Home v2 /redesign parity", () => {
     await page.goto("/redesign/inbox", { waitUntil: "domcontentloaded" });
     await expect(page.getByRole("complementary", { name: "Inbox navigation" })).toBeVisible();
     await expect(page.getByLabel("Search inbox")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible();
+    await expect(page.getByText("Requires action").first()).toBeVisible();
+    await expect(page.getByText("To read").first()).toBeVisible();
     await expect(page.getByRole("complementary", { name: "Triage agent" })).toBeVisible();
     await expect(page.getByRole("complementary", { name: "Triage agent" })).toContainText("3 steps completed");
     await expect(page.getByRole("complementary", { name: "Triage agent" })).toContainText("Draft reply");
@@ -197,7 +206,8 @@ test.describe("Home v2 /redesign parity", () => {
     await page.goto("/redesign/me", { waitUntil: "domcontentloaded" });
 
     await expect(page.getByRole("complementary", { name: "Me navigation" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Your profile starts empty." })).toBeVisible();
+    await expect(page.getByText("USER.md").first()).toBeVisible();
+    await expect(page.getByText("Private Context").first()).toBeVisible();
     await expect(page.getByRole("complementary", { name: "Settings agent" })).toBeVisible();
     await expect(page.getByRole("complementary", { name: "Settings agent" })).toContainText("privacy_boundary");
     await expect(page.getByRole("complementary", { name: "Settings agent" })).toContainText("Connect account");


### PR DESCRIPTION
## Summary\n- Replaces Reports center with live-backed v2 entity intelligence card layout\n- Adds Chat work-packet banner, checkpoint strip, and v2 next actions while preserving Convex chat run wiring\n- Reworks Inbox center into compact v2 grouped list from live Inbox data\n- Reworks Me center into guest-safe USER.md layout and locks guest stats\n- Extends home-v2 parity coverage for non-home centers\n\n## Verification\n- npx tsc --noEmit --pretty false\n- npx tsc -p convex --noEmit --pretty false\n- npx vitest run src/features/redesign/surfaces/ProductDecisionQueue.test.ts src/features/redesign/components/TopNav.test.tsx\n- npm run build\n- BASE_URL=http://127.0.0.1:5191 npx playwright test tests/e2e/home-v2-parity.spec.ts --project=chromium\n- Browser + screenshot pass for /redesign/reports, /redesign/chat, /redesign/inbox, /redesign/me