### PR TITLE
fix(redesign): close v2 prototype rail parity gaps

### DIFF
--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -8035,3 +8035,141 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
     max-width: none !important;
   }
 }
+
+/* ── v2 parity: collapsible trace (details/summary) ── */
+[data-redesign] details.rd-v2-trace {
+  display: block;
+  margin-top: 6px;
+  padding-top: 5px;
+  border-top: 1px solid var(--rd-line-faint);
+}
+[data-redesign] details.rd-v2-trace summary {
+  cursor: pointer;
+  list-style: none;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  font-weight: 590;
+}
+[data-redesign] details.rd-v2-trace summary::-webkit-details-marker { display: none; }
+[data-redesign] details.rd-v2-trace summary::before {
+  content: "\25B6";
+  display: inline-block;
+  margin-right: 4px;
+  font-size: 8px;
+  transition: transform 0.15s ease;
+}
+[data-redesign] details[open].rd-v2-trace summary::before {
+  transform: rotate(90deg);
+}
+[data-redesign] .rd-v2-trace-steps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+[data-redesign] .rd-v2-trace-steps span {
+  padding: 2px 7px;
+  background: var(--rd-panel);
+  color: var(--rd-accent);
+  font-size: 9px;
+  border-radius: 3px;
+}
+
+/* ── v2 parity: confidence label ── */
+[data-redesign] .rd-v2-confidence {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--rd-accent) 12%, transparent);
+  color: var(--rd-accent);
+  font-size: 10px;
+  font-weight: 590;
+}
+
+/* ── v2 parity: related threads ── */
+[data-redesign] .rd-v2-related-threads {
+  margin-top: 10px;
+}
+[data-redesign] .rd-v2-related-threads h3 {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--rd-ink-faint);
+  margin: 0 0 6px;
+}
+[data-redesign] .rd-v2-thread-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--rd-ink-soft);
+}
+[data-redesign] .rd-v2-thread-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--rd-accent);
+  flex-shrink: 0;
+}
+[data-redesign] .rd-v2-thread-time {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--rd-ink-faint);
+}
+
+/* ── v2 parity: signal timeline (Reports rail) ── */
+[data-redesign] .rd-v2-signal-tl {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+  font-size: 12px;
+  color: var(--rd-ink-soft);
+}
+[data-redesign] .rd-v2-signal-tl-time {
+  flex-shrink: 0;
+  width: 24px;
+  font-size: 10px;
+  color: var(--rd-ink-faint);
+  text-align: right;
+}
+[data-redesign] .rd-v2-signal-tl-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--rd-ink-faint);
+}
+[data-redesign] .rd-v2-signal-tl-dot[data-tone="accent"] { background: var(--rd-accent); }
+[data-redesign] .rd-v2-signal-tl-dot[data-tone="blue"] { background: #3b82f6; }
+[data-redesign] .rd-v2-signal-tl-dot[data-tone="green"] { background: #22c55e; }
+[data-redesign] .rd-v2-signal-tl-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── v2 parity: graph SVG (Chat rail) ── */
+[data-redesign] .rd-v2-graph-svg {
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+  background: var(--rd-panel);
+  border: 1px solid var(--rd-line-faint);
+  padding: 8px;
+}
+
+/* ── v2 parity: rail expand toggle ── */
+[data-redesign] .rd-v2-briefing[data-width="expanded"] {
+  width: 480px;
+  min-width: 480px;
+}
+[data-redesign] .rd-v2-utility[data-width="expanded"] {
+  width: 480px;
+  min-width: 480px;
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -8164,6 +8164,44 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   padding: 8px;
 }
 
+/* ── v2 parity: tool tag spans (below trace) ── */
+[data-redesign] .rd-v2-msg-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+[data-redesign] .rd-v2-msg-tools span {
+  padding: 2px 7px;
+  background: var(--rd-panel);
+  color: var(--rd-accent);
+  font-size: 9px;
+  border-radius: 3px;
+  font-family: var(--rd-font-mono, "JetBrains Mono", monospace);
+}
+
+/* ── v2 parity: action card icons ── */
+[data-redesign] .rd-v2-action-icon {
+  margin-right: 2px;
+}
+
+/* ── v2 parity: notebook new-note button ── */
+[data-redesign] .rd-v2-note-add {
+  display: block;
+  margin: 8px auto 0;
+  padding: 4px 14px;
+  border: 1px solid var(--rd-line);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+  cursor: pointer;
+}
+[data-redesign] .rd-v2-note-add:hover {
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+}
+
 /* ── v2 parity: rail expand toggle ── */
 [data-redesign] .rd-v2-briefing[data-width="expanded"] {
   width: 480px;

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -1259,6 +1259,7 @@ function AgentShell({
   placeholder: string;
   onAsk?: (prompt: string) => void;
 }) {
+  const [expanded, setExpanded] = useState(false);
   const pillClassName = (_pill: string, index: number) => {
     const classes = ["rd-v2-agent-pill"];
     if (index === 0) classes.push("is-active");
@@ -1271,12 +1272,12 @@ function AgentShell({
   };
 
   return (
-    <aside className="rd-pane rd-pane--right rd-v2-briefing" aria-label={title}>
+    <aside className="rd-pane rd-pane--right rd-v2-briefing" aria-label={title} data-width={expanded ? "expanded" : undefined}>
       <header className="rd-v2-agent-head">
         <div className="rd-v2-agent-head-row">
           <span className="rd-v2-agent-dot" />
           <strong>{title}</strong>
-          <button type="button" aria-label="Expand rail">{"\u2197"}</button>
+          <button type="button" aria-label={expanded ? "Collapse rail" : "Expand rail"} onClick={() => setExpanded(e => !e)}>{expanded ? "\u2921" : "\u2922"}</button>
         </div>
         <p>{context}</p>
       </header>
@@ -1319,8 +1320,16 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
       <div className="rd-v2-msg rd-v2-msg-agent">
         <strong>{reviewText}</strong>
         <p>{summaryText}</p>
-        <div className="rd-v2-trace"><small>3 steps completed</small><span>entity_health</span><span>freshness_scan</span><span>claim_verify</span></div>
+        <details className="rd-v2-trace">
+          <summary><small>3 steps completed</small></summary>
+          <div className="rd-v2-trace-steps"><span>entity_health</span><span>freshness_scan</span><span>claim_verify</span></div>
+        </details>
       </div>
+      <section className="rd-v2-action-card-list">
+        {[`Review ${entity.name}`, "Refresh stale sources", `Compare ${entity.related[0] ?? "entities"}`, "Export selected"].map((action, index) => (
+          <button key={action} className={index === 0 ? "is-primary" : ""} onClick={() => onAsk?.(`${action} for ${entity.name}`)}>{action}</button>
+        ))}
+      </section>
       <button className="rd-v2-drawer-toggle">{`Context · ${entity.name} ${entity.score} · ${entity.signals.length} signals · ${entity.related.length} entities`}</button>
       <section className="rd-v2-agent-context">
         <div className="rd-v2-context-head"><span>Active entity</span><span>{entity.score}</span></div>
@@ -1335,7 +1344,13 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
       </section>
       <section className="rd-v2-agent-context">
         <div className="rd-v2-context-head"><span>Recent signals</span><span>{entity.signals.length}</span></div>
-        {entity.signals.map((signal) => <p className="rd-v2-signal-line" key={signal}>{signal}</p>)}
+        {entity.signals.map((signal, index) => (
+          <div className="rd-v2-signal-tl" key={signal}>
+            <span className="rd-v2-signal-tl-time">{index === 0 ? "2h" : index === 1 ? "1d" : "3d"}</span>
+            <span className="rd-v2-signal-tl-dot" data-tone={index === 0 ? "accent" : index === 1 ? "blue" : "green"} />
+            <span className="rd-v2-signal-tl-text">{signal}</span>
+          </div>
+        ))}
       </section>
       <section className="rd-v2-agent-context">
         <div className="rd-v2-context-head"><span>Related entities</span><span>{entity.related.length}</span></div>
@@ -1372,11 +1387,45 @@ function ChatPrototypeRail() {
         </section>
       </>
     ),
-    Graph: <section className="rd-v2-util-list"><h3>Graph neighborhood</h3><p><strong>Sequoia</strong> connects to YC AI Ops, Alfred Lin, cap table model, and board prep.</p><p><strong>Closest report</strong><span>Term Sheet Analysis</span></p></section>,
+    Graph: (
+      <section className="rd-v2-util-list">
+        <h3>Graph neighborhood</h3>
+        <svg viewBox="0 0 300 160" xmlns="http://www.w3.org/2000/svg" className="rd-v2-graph-svg">
+          <line x1="150" y1="80" x2="50" y2="30" stroke="var(--rd-line)" strokeWidth="1" />
+          <line x1="150" y1="80" x2="250" y2="30" stroke="var(--rd-line)" strokeWidth="1" />
+          <line x1="150" y1="80" x2="60" y2="135" stroke="var(--rd-line)" strokeWidth="1" />
+          <line x1="150" y1="80" x2="240" y2="135" stroke="var(--rd-line)" strokeWidth="1" />
+          <line x1="50" y1="30" x2="250" y2="30" stroke="var(--rd-line-faint)" strokeWidth="1" strokeDasharray="4" />
+          <circle cx="150" cy="80" r="18" fill="var(--rd-accent-tint)" stroke="var(--rd-accent)" strokeWidth="1.5" />
+          <text x="150" y="84" textAnchor="middle" fontSize="8" fontWeight="700" fill="var(--rd-accent-strong)">You</text>
+          <circle cx="50" cy="30" r="14" fill="var(--rd-panel)" stroke="var(--rd-line)" strokeWidth="1" />
+          <text x="50" y="34" textAnchor="middle" fontSize="7" fill="var(--rd-ink-mute)">Anthropic</text>
+          <circle cx="250" cy="30" r="14" fill="var(--rd-panel)" stroke="var(--rd-line)" strokeWidth="1" />
+          <text x="250" y="34" textAnchor="middle" fontSize="7" fill="var(--rd-ink-mute)">Sequoia</text>
+          <circle cx="60" cy="135" r="14" fill="var(--rd-panel)" stroke="var(--rd-line)" strokeWidth="1" />
+          <text x="60" y="139" textAnchor="middle" fontSize="7" fill="var(--rd-ink-mute)">Bug0</text>
+          <circle cx="240" cy="135" r="14" fill="var(--rd-panel)" stroke="var(--rd-line)" strokeWidth="1" />
+          <text x="240" y="139" textAnchor="middle" fontSize="7" fill="var(--rd-ink-mute)">SMB</text>
+        </svg>
+        <p style={{ fontSize: "10px", color: "var(--rd-ink-faint)", textAlign: "center", marginTop: "8px" }}>4 entities · 6 relationships</p>
+      </section>
+    ),
     Sources: <section className="rd-v2-util-list"><h3>Sources</h3><p><strong>Term sheet v3</strong><span>PDF</span></p><p><strong>Cap table model</strong><span>Sheet</span></p><p><strong>Cooley primer</strong><span>Reference</span></p></section>,
     Threads: <section className="rd-v2-util-list"><h3>Threads</h3><p><strong>Ratchet clause analysis</strong><span>3 messages</span></p><p><strong>Board deck prep</strong><span>2 messages</span></p></section>,
     Notebook: <section className="rd-v2-util-list"><h3>Notebook patch</h3><p><strong>Proposed edit</strong><span>pending</span></p><p>Add dilution table, counsel review, and counterproposal summary.</p></section>,
-    Report: <section className="rd-v2-util-list"><h3>Report</h3><p><strong>Status</strong><span>Saved</span></p><p><strong>Claims</strong><span>7 total</span></p><p><strong>Open</strong><span>2 pending</span></p></section>,
+    Report: (
+      <section className="rd-v2-util-list">
+        <h3>Thread stats</h3>
+        <p><strong>Messages</strong><span>3</span></p>
+        <p><strong>Tools used</strong><span>5</span></p>
+        <p><strong>Cost</strong><span>$0.13</span></p>
+        <p><strong>Duration</strong><span>2m 14s</span></p>
+        <div className="rd-v2-action-card-list" style={{ marginTop: "12px" }}>
+          <button className="is-primary">Export report</button>
+          <button>Share</button>
+        </div>
+      </section>
+    ),
   };
 
   return (
@@ -1414,14 +1463,22 @@ function InboxPrototypeRail({ onAsk }: HomeV2SurfaceProps) {
       <div className="rd-v2-msg rd-v2-msg-agent">
         <strong>The ratchet clause needs legal review before Thursday's board call.</strong>
         <p>Full-ratchet creates a 14.3pp dilution gap at $48M. This is the single largest negotiation risk in the term sheet.</p>
-        <div className="rd-v2-trace"><small>3 steps completed</small><span>term_sheet_parse</span><span>dilution_calc</span><span>calendar_check</span></div>
+        <details className="rd-v2-trace">
+          <summary><small>3 steps completed</small></summary>
+          <div className="rd-v2-trace-steps"><span>term_sheet_parse</span><span>dilution_calc</span><span>calendar_check</span></div>
+        </details>
       </div>
       <button className="rd-v2-drawer-toggle">Context · Sequoia 74 · 2 threads</button>
       <article className="rd-v2-util-card">
         <div className="rd-v2-report-title"><span>S</span><h2>Sequoia Capital</h2><b>74</b></div>
         <p>• Active term sheet negotiation<br />• $1.2M partnership · 3 prior rounds<br />• Last report: 6h ago</p>
       </article>
-      <div className="rd-v2-agent-insight"><strong>Agent insight</strong><p>Full-ratchet clause creates 14.3pp dilution gap at $48M. Counter with narrow-based weighted-average as floor.</p></div>
+      <div className="rd-v2-agent-insight"><strong>Agent insight</strong><span className="rd-v2-confidence">92% confidence</span><p>Full-ratchet clause creates 14.3pp dilution gap at $48M. Counter with narrow-based weighted-average as floor.</p></div>
+      <section className="rd-v2-related-threads">
+        <h3>Related threads</h3>
+        <div className="rd-v2-thread-item"><span className="rd-v2-thread-dot" /><span>Term sheet v2 discussion</span><span className="rd-v2-thread-time">4d</span></div>
+        <div className="rd-v2-thread-item"><span className="rd-v2-thread-dot" /><span>Sequoia intro meeting notes</span><span className="rd-v2-thread-time">2w</span></div>
+      </section>
       <section className="rd-v2-action-card-list">
         {["Draft reply", "Flag for legal", "Forward to counsel", "Defer"].map((action, index) => (
           <button key={action} className={index === 0 ? "is-primary" : ""}>{action}</button>
@@ -1461,7 +1518,10 @@ function MePrototypeRail({ onAsk, guestSafe = false }: HomeV2SurfaceProps & { gu
         <div className="rd-v2-msg rd-v2-msg-agent">
           <strong>{lead}</strong>
           <p>{detail}</p>
-          <div className="rd-v2-trace"><small>3 steps completed</small>{trace.map((step) => <span key={step}>{step}</span>)}</div>
+          <details className="rd-v2-trace">
+            <summary><small>3 steps completed</small></summary>
+            <div className="rd-v2-trace-steps">{trace.map((step) => <span key={step}>{step}</span>)}</div>
+          </details>
         </div>
         <button className="rd-v2-drawer-toggle">Context - Private profile - Permissions - Usage</button>
         <section className="rd-v2-settings-list">
@@ -1501,7 +1561,10 @@ function MePrototypeRail({ onAsk, guestSafe = false }: HomeV2SurfaceProps & { gu
       <div className="rd-v2-msg rd-v2-msg-agent">
         <strong>You prefer concise banker-style memos over long-form analysis.</strong>
         <p>In the last 7 sessions, you shortened 4 of my outputs and asked for just the decision. I updated your voice profile to default to {"Decision -> Why -> Plan"} format.</p>
-        <div className="rd-v2-trace"><small>3 steps completed</small><span>memory_scan</span><span>preference_log</span><span>profile_update</span></div>
+        <details className="rd-v2-trace">
+          <summary><small>3 steps completed</small></summary>
+          <div className="rd-v2-trace-steps"><span>memory_scan</span><span>preference_log</span><span>profile_update</span></div>
+        </details>
       </div>
       <button className="rd-v2-drawer-toggle">Context · Voice · Permissions · Usage</button>
       <section className="rd-v2-settings-list">

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -1324,10 +1324,16 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
           <summary><small>3 steps completed</small></summary>
           <div className="rd-v2-trace-steps"><span>entity_health</span><span>freshness_scan</span><span>claim_verify</span></div>
         </details>
+        <div className="rd-v2-msg-tools"><span>entity_health</span><span>freshness_scan</span><span>claim_verify</span></div>
       </div>
       <section className="rd-v2-action-card-list">
-        {[`Review ${entity.name}`, "Refresh stale sources", `Compare ${entity.related[0] ?? "entities"}`, "Export selected"].map((action, index) => (
-          <button key={action} className={index === 0 ? "is-primary" : ""} onClick={() => onAsk?.(`${action} for ${entity.name}`)}>{action}</button>
+        {[
+          { icon: "🔍", label: `Review ${entity.name}` },
+          { icon: "↻", label: "Refresh stale sources" },
+          { icon: "⚖", label: `Compare ${entity.related[0] ?? "entities"}` },
+          { icon: "📤", label: "Export selected" },
+        ].map(({ icon, label }, index) => (
+          <button key={label} className={index === 0 ? "is-primary" : ""} onClick={() => onAsk?.(`${label} for ${entity.name}`)}><span className="rd-v2-action-icon">{icon}</span> {label}</button>
         ))}
       </section>
       <button className="rd-v2-drawer-toggle">{`Context · ${entity.name} ${entity.score} · ${entity.signals.length} signals · ${entity.related.length} entities`}</button>
@@ -1371,6 +1377,7 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
 
 function ChatPrototypeRail() {
   const [activeTab, setActiveTab] = useState("Entity");
+  const [expanded, setExpanded] = useState(false);
   const panels: Record<string, ReactNode> = {
     Entity: (
       <>
@@ -1410,9 +1417,9 @@ function ChatPrototypeRail() {
         <p style={{ fontSize: "10px", color: "var(--rd-ink-faint)", textAlign: "center", marginTop: "8px" }}>4 entities · 6 relationships</p>
       </section>
     ),
-    Sources: <section className="rd-v2-util-list"><h3>Sources</h3><p><strong>Term sheet v3</strong><span>PDF</span></p><p><strong>Cap table model</strong><span>Sheet</span></p><p><strong>Cooley primer</strong><span>Reference</span></p></section>,
-    Threads: <section className="rd-v2-util-list"><h3>Threads</h3><p><strong>Ratchet clause analysis</strong><span>3 messages</span></p><p><strong>Board deck prep</strong><span>2 messages</span></p></section>,
-    Notebook: <section className="rd-v2-util-list"><h3>Notebook patch</h3><p><strong>Proposed edit</strong><span>pending</span></p><p>Add dilution table, counsel review, and counterproposal summary.</p></section>,
+    Sources: <section className="rd-v2-util-list"><h3>Sources</h3><p><strong>Term sheet v3</strong><span>PDF</span></p><p><strong>Cap table model</strong><span>Sheet</span></p><p><strong>Cooley primer</strong><span>Reference</span></p><p><strong>Anti-dilution clause primer</strong><span>Web</span></p></section>,
+    Threads: <section className="rd-v2-util-list"><h3>Threads</h3><p><strong>Ratchet clause analysis</strong><span>3 messages</span></p><p><strong>Board deck prep</strong><span>2 messages</span></p><p><strong>Anti-dilution research</strong><span>1 message</span></p></section>,
+    Notebook: <section className="rd-v2-util-list"><h3>Notebook patch</h3><p><strong>Proposed edit</strong><span>pending</span></p><p>Add dilution table, counsel review, and counterproposal summary.</p><button className="rd-v2-note-add">+ New note</button></section>,
     Report: (
       <section className="rd-v2-util-list">
         <h3>Thread stats</h3>
@@ -1429,8 +1436,8 @@ function ChatPrototypeRail() {
   };
 
   return (
-    <aside className="rd-pane rd-pane--right rd-v2-utility" aria-label="Context">
-      <header className="rd-v2-util-head"><strong>Context</strong><button>{"\u2197"}</button></header>
+    <aside className="rd-pane rd-pane--right rd-v2-utility" aria-label="Context" data-width={expanded ? "expanded" : undefined}>
+      <header className="rd-v2-util-head"><strong>Context</strong><button type="button" aria-label={expanded ? "Collapse rail" : "Expand rail"} onClick={() => setExpanded(e => !e)}>{expanded ? "\u2921" : "\u2922"}</button></header>
       <input className="rd-v2-util-search" placeholder="Search sources, entities..." />
       <div className="rd-v2-util-tabs" role="tablist" aria-label="Chat utilities">
         {Object.keys(panels).map((tab) => (
@@ -1467,6 +1474,7 @@ function InboxPrototypeRail({ onAsk }: HomeV2SurfaceProps) {
           <summary><small>3 steps completed</small></summary>
           <div className="rd-v2-trace-steps"><span>term_sheet_parse</span><span>dilution_calc</span><span>calendar_check</span></div>
         </details>
+        <div className="rd-v2-msg-tools"><span>term_sheet_parse</span><span>dilution_calc</span><span>calendar_check</span></div>
       </div>
       <button className="rd-v2-drawer-toggle">Context · Sequoia 74 · 2 threads</button>
       <article className="rd-v2-util-card">
@@ -1480,8 +1488,13 @@ function InboxPrototypeRail({ onAsk }: HomeV2SurfaceProps) {
         <div className="rd-v2-thread-item"><span className="rd-v2-thread-dot" /><span>Sequoia intro meeting notes</span><span className="rd-v2-thread-time">2w</span></div>
       </section>
       <section className="rd-v2-action-card-list">
-        {["Draft reply", "Flag for legal", "Forward to counsel", "Defer"].map((action, index) => (
-          <button key={action} className={index === 0 ? "is-primary" : ""}>{action}</button>
+        {[
+          { icon: "✉", label: "Draft reply" },
+          { icon: "⚖", label: "Flag for legal" },
+          { icon: "↷", label: "Forward to counsel" },
+          { icon: "⏰", label: "Defer to Thursday" },
+        ].map(({ icon, label }, index) => (
+          <button key={label} className={index === 0 ? "is-primary" : ""}><span className="rd-v2-action-icon">{icon}</span> {label}</button>
         ))}
       </section>
     </AgentShell>
@@ -1522,6 +1535,7 @@ function MePrototypeRail({ onAsk, guestSafe = false }: HomeV2SurfaceProps & { gu
             <summary><small>3 steps completed</small></summary>
             <div className="rd-v2-trace-steps">{trace.map((step) => <span key={step}>{step}</span>)}</div>
           </details>
+          <div className="rd-v2-msg-tools">{trace.map((step) => <span key={step}>{step}</span>)}</div>
         </div>
         <button className="rd-v2-drawer-toggle">Context - Private profile - Permissions - Usage</button>
         <section className="rd-v2-settings-list">
@@ -1565,6 +1579,7 @@ function MePrototypeRail({ onAsk, guestSafe = false }: HomeV2SurfaceProps & { gu
           <summary><small>3 steps completed</small></summary>
           <div className="rd-v2-trace-steps"><span>memory_scan</span><span>preference_log</span><span>profile_update</span></div>
         </details>
+        <div className="rd-v2-msg-tools"><span>memory_scan</span><span>preference_log</span><span>profile_update</span></div>
       </div>
       <button className="rd-v2-drawer-toggle">Context · Voice · Permissions · Usage</button>
       <section className="rd-v2-settings-list">
@@ -1573,20 +1588,26 @@ function MePrototypeRail({ onAsk, guestSafe = false }: HomeV2SurfaceProps & { gu
         <p><span>Format</span><strong>{"Decision -> Why -> Plan"}</strong></p>
         <p><span>Jargon level</span><strong>High (match user)</strong></p>
         <h3>Permissions</h3>
-        <p>• Web search: <b>Enabled</b></p>
-        <p>• File access: <b>Enabled</b></p>
-        <p>• Post to LinkedIn: <em>Approval required</em></p>
-        <p>• Send email: <em>Approval required</em></p>
-        <p>• Execute trades: <em>Disabled</em></p>
+        <p>• Web search: <b style={{ color: "var(--rd-green, #22c55e)" }}>Enabled</b></p>
+        <p>• File access: <b style={{ color: "var(--rd-green, #22c55e)" }}>Enabled</b></p>
+        <p>• Post to LinkedIn: <em style={{ color: "var(--rd-amber, #f59e0b)" }}>Approval required</em></p>
+        <p>• Send email: <em style={{ color: "var(--rd-amber, #f59e0b)" }}>Approval required</em></p>
+        <p>• Execute trades: <em style={{ color: "#b91c1c" }}>Disabled</em></p>
         <h3>Session stats</h3>
-        <p><span>Memory hits</span><strong>71%</strong></p>
-        <p><span>Corrections</span><strong>23</strong></p>
-        <p><span>Current mode</span><strong>Builder</strong></p>
+        <p><span>Threads today</span><strong>7</strong></p>
+        <p><span>Tools called</span><strong>34</strong></p>
+        <p><span>Cost today</span><strong>$0.87</strong></p>
+        <p><span>Avg latency</span><strong>1.4s</strong></p>
       </section>
       <section className="rd-v2-action-card-list">
-        <button className="is-primary">Review memory update</button>
-        <button>Export USER.md</button>
-        <button>Open permissions</button>
+        {[
+          { icon: "⚙", label: "Calibrate voice" },
+          { icon: "🔒", label: "Review permissions" },
+          { icon: "📊", label: "View usage" },
+          { icon: "↺", label: "Reset suggestion" },
+        ].map(({ icon, label }, index) => (
+          <button key={label} className={index === 0 ? "is-primary" : ""}><span className="rd-v2-action-icon">{icon}</span> {label}</button>
+        ))}
       </section>
     </AgentShell>
   );


### PR DESCRIPTION
## Summary
- Closes all remaining parity gaps between `public/proto/home-v2.html` and the shipped prototype rail components for Reports, Chat, Inbox, and Me surfaces
- Adds collapsible `<details>` traces, tool tag spans, action card icons, expand/collapse toggles, confidence labels, related threads, permission status colors, and corrected session stats
- Complementary to #347 (center canvas spacing) — this PR covers the rail content layer, not the shell layout

## Changes
- **HomeV2PrototypeSurface.tsx**: tool tags on all 4 rails, action card icons (`{icon, label}` pattern), Chat expand toggle + missing content items (4th source, 3rd thread, new-note button), Inbox "Defer to Thursday" label, Me auth session stats/permission colors/action cards
- **primitives.css**: +176 lines — `.rd-v2-trace` collapsible, `.rd-v2-trace-steps`, `.rd-v2-confidence`, `.rd-v2-related-threads`, `.rd-v2-signal-tl`, `.rd-v2-msg-tools`, `.rd-v2-action-icon`, `.rd-v2-note-add`, `[data-width="expanded"]` rail expand

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vite build` — clean
- [x] Rebased on main (post-#347) — no conflicts, no regressions to center canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)