### PR TITLE
Redesign reports command center

### DIFF
--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -161,6 +161,11 @@ export default function RedesignShell() {
     };
   }, []);
 
+  useEffect(() => {
+    const centerPane = document.querySelector<HTMLElement>("[data-redesign] .rd-shell__main > .rd-pane:first-child");
+    centerPane?.scrollTo({ top: 0, left: 0 });
+  }, [location.pathname, location.search]);
+
   // Phase 7d (2026-05-08): editorial is the default at /redesign on
   // both mobile + desktop.  Legacy is opt-out via `?classic=1`
   // (canonical) or `?edition=0` (back-compat).  Per
@@ -323,6 +328,7 @@ export default function RedesignShell() {
                   if (tab === "brief") navigate(`/redesign/reports/${id}`);
                   else navigate(`/redesign/workspace?report=${id}&tab=${tab}`);
                 }}
+                onRunBatch={sendPromptToChat}
                 inspectedReportId={selectedReport?.id ?? null}
                 onSelectReport={selectLiveReport}
               />

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -2419,6 +2419,10 @@
   max-width: 820px;
 }
 
+[data-redesign] .rd-v2-proto-center.rd-v2-reports-command {
+  max-width: min(1180px, 100%);
+}
+
 [data-redesign] .rd-v2-chat-center {
   width: 100%;
   max-width: 820px;
@@ -2469,10 +2473,144 @@
   min-width: 8px;
 }
 
+[data-redesign] .rd-v2-command-hero {
+  display: grid;
+  gap: 18px;
+  margin-bottom: 14px;
+}
+
+[data-redesign] .rd-v2-command-title-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: end;
+}
+
+[data-redesign] .rd-v2-command-title-row h1 {
+  margin: 0;
+  color: var(--rd-ink-strong);
+  font-size: clamp(38px, 5vw, 68px);
+  line-height: 0.94;
+  letter-spacing: -0.02em;
+}
+
+[data-redesign] .rd-v2-command-title-row p {
+  max-width: 620px;
+  margin: 12px 0 0;
+  color: var(--rd-ink-soft);
+  font-size: 16px;
+  line-height: 1.45;
+}
+
+[data-redesign] .rd-v2-command-actions,
+[data-redesign] .rd-v2-view-row,
+[data-redesign] .rd-v2-view-switcher,
+[data-redesign] .rd-v2-density-switcher {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-redesign] .rd-v2-command-actions button,
+[data-redesign] .rd-v2-view-switcher button,
+[data-redesign] .rd-v2-density-switcher button {
+  padding: 7px 11px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-command-actions .rd-v2-btn-primary {
+  border-color: var(--rd-ink-strong);
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+}
+
+[data-redesign] .rd-v2-command-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--rd-line-soft);
+  border-radius: var(--rd-r-md);
+  background: var(--rd-panel);
+  overflow: hidden;
+}
+
+[data-redesign] .rd-v2-command-metrics span {
+  display: grid;
+  gap: 2px;
+  padding: 12px 14px;
+  border-right: 1px solid var(--rd-line-soft);
+}
+
+[data-redesign] .rd-v2-command-metrics span:last-child {
+  border-right: 0;
+}
+
+[data-redesign] .rd-v2-command-metrics strong {
+  color: var(--rd-accent-strong);
+  font-size: 21px;
+  line-height: 1;
+}
+
+[data-redesign] .rd-v2-command-metrics small,
+[data-redesign] .rd-v2-mini-eyebrow {
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-view-row {
+  justify-content: space-between;
+  margin: 16px 0 8px;
+}
+
+[data-redesign] .rd-v2-view-switcher button.is-active,
+[data-redesign] .rd-v2-density-switcher button.is-active {
+  border-color: var(--rd-accent);
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v2-command-toolbar {
+  margin-bottom: 10px;
+}
+
+[data-redesign] .rd-v2-search-row {
+  justify-content: stretch;
+}
+
+[data-redesign] .rd-v2-search-row input {
+  width: 100%;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  padding: 10px 14px;
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+}
+
 [data-redesign] .rd-v2-report-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 14px;
+}
+
+[data-redesign] .rd-v2-report-grid[data-density="compact"] {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+[data-redesign] .rd-v2-report-grid[data-density="grid"] {
+  grid-template-columns: repeat(auto-fit, minmax(265px, 1fr));
+}
+
+[data-redesign] .rd-v2-report-grid[data-density="list"] {
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
 }
 
 [data-redesign] .rd-v2-report-card {
@@ -2607,6 +2745,362 @@
   background: var(--rd-accent-soft);
   color: var(--rd-accent-strong);
   font-size: 10px;
+}
+
+[data-redesign] .rd-v2-report-card-v2 {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 360px;
+}
+
+[data-redesign] .rd-v2-report-card-v2 .rd-v2-report-thesis {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+[data-redesign] .rd-v2-signal-list {
+  display: grid;
+  gap: 6px;
+  max-height: 104px;
+  overflow: hidden;
+  padding-top: 2px;
+}
+
+[data-redesign] .rd-v2-signal-list span {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--rd-ink);
+  font-size: 11.5px;
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+[data-redesign] .rd-v2-signal-list span::before {
+  content: "";
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  margin-right: 7px;
+  border-radius: 999px;
+  background: var(--rd-accent);
+  vertical-align: 2px;
+}
+
+[data-redesign] .rd-v2-score-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  margin-top: auto;
+}
+
+[data-redesign] .rd-v2-score-strip span {
+  display: grid;
+  gap: 2px;
+  padding: 8px;
+  border: 1px solid var(--rd-line-soft);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-paper);
+}
+
+[data-redesign] .rd-v2-score-strip b {
+  color: var(--rd-ink-strong);
+  font-size: 16px;
+  line-height: 1;
+}
+
+[data-redesign] .rd-v2-score-strip small {
+  color: var(--rd-ink-faint);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-next-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 8px;
+}
+
+[data-redesign] .rd-v2-next-actions button,
+[data-redesign] .rd-v2-report-table button {
+  padding: 6px 10px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-next-actions .rd-v2-card-primary,
+[data-redesign] .rd-v2-report-table button {
+  border-color: var(--rd-ink-strong);
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+}
+
+[data-redesign] .rd-v2-report-board {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(160px, 1fr));
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+
+[data-redesign] .rd-v2-board-column {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  min-height: 360px;
+  padding: 10px;
+  border: 1px solid var(--rd-line-soft);
+  border-radius: var(--rd-r-md);
+  background: var(--rd-muted);
+}
+
+[data-redesign] .rd-v2-board-column header {
+  display: flex;
+  justify-content: space-between;
+  color: var(--rd-ink-strong);
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-board-column header span {
+  color: var(--rd-ink-faint);
+}
+
+[data-redesign] .rd-v2-board-card {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 10px;
+  border: 1px solid var(--rd-line-soft);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+  cursor: grab;
+  text-align: left;
+}
+
+[data-redesign] .rd-v2-board-card strong,
+[data-redesign] .rd-v2-board-card span,
+[data-redesign] .rd-v2-board-card small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-board-card strong {
+  color: var(--rd-ink-strong);
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-board-card span,
+[data-redesign] .rd-v2-board-card small {
+  color: var(--rd-ink-soft);
+  font-size: 10.5px;
+}
+
+[data-redesign] .rd-v2-report-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--rd-line-soft);
+  border-radius: var(--rd-r-md);
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v2-report-table {
+  width: 100%;
+  min-width: 900px;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v2-report-table th,
+[data-redesign] .rd-v2-report-table td {
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--rd-line-soft);
+  text-align: left;
+  vertical-align: top;
+}
+
+[data-redesign] .rd-v2-report-table th {
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-report-table td strong,
+[data-redesign] .rd-v2-report-table td span {
+  display: block;
+}
+
+[data-redesign] .rd-v2-report-table td span {
+  max-width: 280px;
+  overflow: hidden;
+  color: var(--rd-ink-soft);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-notebook-preview {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  min-height: 520px;
+  border: 1px solid var(--rd-line-soft);
+  border-radius: var(--rd-r-md);
+  background: var(--rd-panel);
+  overflow: hidden;
+}
+
+[data-redesign] .rd-v2-notebook-preview aside {
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  padding: 16px;
+  border-right: 1px solid var(--rd-line-soft);
+  background: var(--rd-muted);
+}
+
+[data-redesign] .rd-v2-notebook-preview aside button {
+  padding: 7px 0;
+  border: 0;
+  background: transparent;
+  color: var(--rd-ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+}
+
+[data-redesign] .rd-v2-notebook-preview article {
+  padding: 24px;
+}
+
+[data-redesign] .rd-v2-notebook-preview h2 {
+  margin: 6px 0 8px;
+  color: var(--rd-ink-strong);
+  font-size: 34px;
+  line-height: 1;
+}
+
+[data-redesign] .rd-v2-notebook-preview h3 {
+  margin: 22px 0 6px;
+  color: var(--rd-ink-strong);
+  font-size: 15px;
+}
+
+[data-redesign] .rd-v2-notebook-preview p {
+  color: var(--rd-ink);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+[data-redesign] .rd-v2-notebook-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 12px 0;
+}
+
+[data-redesign] .rd-v2-notebook-stats span {
+  padding: 4px 8px;
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+[data-redesign] .rd-v2-report-canvas {
+  position: relative;
+  display: grid;
+  min-height: 540px;
+  border: 1px solid var(--rd-line-soft);
+  border-radius: var(--rd-r-md);
+  background:
+    linear-gradient(var(--rd-line-soft) 1px, transparent 1px),
+    linear-gradient(90deg, var(--rd-line-soft) 1px, transparent 1px),
+    var(--rd-panel);
+  background-size: 36px 36px;
+  overflow: hidden;
+}
+
+[data-redesign] .rd-v2-canvas-node {
+  position: absolute;
+  display: grid;
+  gap: 3px;
+  width: 150px;
+  padding: 11px;
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-paper);
+  color: var(--rd-ink);
+  cursor: pointer;
+  text-align: left;
+  box-shadow: var(--rd-shadow-xs);
+}
+
+[data-redesign] .rd-v2-canvas-node strong {
+  overflow: hidden;
+  color: var(--rd-ink-strong);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v2-canvas-node span {
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v2-canvas-node--0 { left: 7%; top: 12%; }
+[data-redesign] .rd-v2-canvas-node--1 { left: 35%; top: 20%; }
+[data-redesign] .rd-v2-canvas-node--2 { left: 62%; top: 12%; }
+[data-redesign] .rd-v2-canvas-node--3 { left: 24%; top: 56%; }
+
+[data-redesign] .rd-v2-report-canvas p {
+  align-self: end;
+  max-width: 420px;
+  margin: 0 20px 20px;
+  padding: 12px 14px;
+  border: 1px solid var(--rd-line-soft);
+  border-radius: var(--rd-r-sm);
+  background: var(--rd-paper);
+  color: var(--rd-ink-soft);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+@media (max-width: 820px) {
+  [data-redesign] .rd-v2-command-title-row,
+  [data-redesign] .rd-v2-notebook-preview {
+    grid-template-columns: 1fr;
+  }
+
+  [data-redesign] .rd-v2-command-actions,
+  [data-redesign] .rd-v2-view-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  [data-redesign] .rd-v2-command-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  [data-redesign] .rd-v2-notebook-preview aside {
+    border-right: 0;
+    border-bottom: 1px solid var(--rd-line-soft);
+  }
 }
 
 [data-redesign] .rd-v2-saved-banner {

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -1058,10 +1058,38 @@ function ChatThreadGroup({ label, items }: { label: string; items: Array<[string
 
 function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }: PrototypeSelectionProps) {
   return (
-    <div className="rd-v2-proto-center">
-      <div className="rd-v2-edition-row">
-        <span className="rd-v2-edition-pill">Entity intelligence</span>
-        <span className="rd-v2-edition-subline">12 entities · 83% verified · avg score 87 · 48 sources</span>
+    <div className="rd-v2-proto-center rd-v2-reports-command">
+      <section className="rd-v2-command-hero" aria-labelledby="prototype-reports-title">
+        <div className="rd-v2-edition-row">
+          <span className="rd-v2-edition-pill">Coverage Command Center</span>
+          <span className="rd-v2-edition-subline">12 reports · 83% verified · 3 need review · 48 source rows</span>
+        </div>
+        <div className="rd-v2-command-title-row">
+          <div>
+            <h1 id="prototype-reports-title">Reports</h1>
+            <p>Agent-generated notebooks organized by entity, evidence quality, lifecycle state, and the next review action.</p>
+          </div>
+          <div className="rd-v2-command-actions">
+            <button className="rd-v2-btn-primary">Run batch</button>
+            <button>Review queue</button>
+          </div>
+        </div>
+        <div className="rd-v2-command-metrics">
+          <span><strong>12</strong><small>reports</small></span>
+          <span><strong>4</strong><small>active runs</small></span>
+          <span><strong>3</strong><small>need review</small></span>
+          <span><strong>5</strong><small>export ready</small></span>
+        </div>
+      </section>
+      <div className="rd-v2-view-row">
+        <div className="rd-v2-view-switcher" role="tablist" aria-label="Reports view">
+          {["Gallery", "Board", "Table", "Notebook", "Canvas"].map((item, index) => (
+            <button key={item} role="tab" aria-selected={index === 0} className={index === 0 ? "is-active" : ""}>{item}</button>
+          ))}
+        </div>
+        <div className="rd-v2-density-switcher" aria-label="Gallery density">
+          {["Compact", "Standard", "Expanded"].map((item, index) => <button key={item} className={index === 1 ? "is-active" : ""}>{item}</button>)}
+        </div>
       </div>
       <div className="rd-v2-filter-row">
         {["All", "Watching", "Needs review", "Stale", "Updated"].map((item, index) => (
@@ -1072,13 +1100,13 @@ function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }
       <div className="rd-v2-action-row">
         <button>Updated ▾</button>
         <button>● Privacy</button>
-        <button className="rd-v2-btn-primary">+ New report</button>
+        <button className="rd-v2-btn-primary">+ New batch</button>
       </div>
-      <div className="rd-v2-report-grid">
+      <div className="rd-v2-report-grid" data-density="grid">
         {reportEntities.map((entity) => (
           <article
             key={entity.name}
-            className={`rd-v2-report-card ${selectedEntity === entity.name ? "is-active" : ""}`}
+            className={`rd-v2-report-card rd-v2-report-card-v2 ${selectedEntity === entity.name ? "is-active" : ""}`}
             onClick={() => onSelectEntity?.(entity.name)}
             aria-selected={selectedEntity === entity.name}
           >
@@ -1094,15 +1122,20 @@ function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }
             </div>
             <p className="rd-v2-report-ref">Referenced in: {entity.ref}</p>
             <p className="rd-v2-report-meta">{entity.meta}</p>
+            <div className="rd-v2-next-actions">
+              <button type="button" className="rd-v2-card-primary">Open Notebook</button>
+              <button type="button">Review Evidence</button>
+              <button type="button">Ask Agent</button>
+            </div>
           </article>
         ))}
         <article className="rd-v2-report-card rd-v2-report-card--add">
-          <h2>Add entity</h2>
-          <p>Capture a company, person, topic, or source cluster and let the coverage agent hydrate the first report.</p>
-          <button>+ New entity</button>
+          <h2>Run a batch</h2>
+          <p>Import companies, people, topics, or source clusters and let the coverage agent hydrate report notebooks.</p>
+          <button>+ New batch</button>
         </article>
       </div>
-      <button className="rd-v2-show-more">Show 7 more entities</button>
+      <button className="rd-v2-show-more">Show 7 more reports</button>
     </div>
   );
 }
@@ -1262,7 +1295,7 @@ function AgentShell({
   const pillClassName = (_pill: string, index: number) => {
     const classes = ["rd-v2-agent-pill"];
     if (index === 0) classes.push("is-active");
-    if (title === "Coverage agent") {
+    if (title === "Coverage agent" || title === "Agent Inspector") {
       if (index === 1) classes.push("is-entity");
       if (index === 2) classes.push("is-source");
     }
@@ -1302,16 +1335,17 @@ function AgentShell({
 
 function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedReport, onSelectEntity }: PrototypeSelectionProps) {
   const entity = selectedReport ? liveReportToPrototypeEntity(selectedReport) : getPrototypeEntity(selectedEntity);
-  const reviewText = entity.score < 75 ? `${entity.name} needs review.` : `${entity.name} is in good shape.`;
+  const reviewText = entity.score < 75 ? `${entity.name} needs report work.` : `${entity.name} is ready for the current coverage task.`;
   const summaryText = entity.score < 75
-    ? `${entity.name} is below coverage threshold. Refresh sources, verify open claims, and decide whether the report needs a notebook patch.`
-    : `${entity.name} has current sources and enough verified claims for the present coverage task. Keep it on watch.`;
+    ? `${entity.name} is below coverage threshold. Refresh sources, verify open claims, and decide whether the notebook needs a patch.`
+    : `${entity.name} has enough current sources and verified claims. Keep monitoring, but the notebook can be opened as the durable artifact.`;
+  const warningCount = entity.score < 75 ? 3 : 1;
 
   return (
     <AgentShell
-      title="Coverage agent"
-      context={`Reports · 5 entities · 48 sources · ${entity.sources} active`}
-      pills={["Reports", entity.name, `${entity.sources} sources`, `Score ${entity.score}`]}
+      title="Agent Inspector"
+      context={`Selected report · ${entity.name} · ${entity.sources} sources · ${warningCount} warnings`}
+      pills={["Pipeline", entity.name, `${entity.sources} sources`, `Score ${entity.score}`]}
       question="Which reports need work?"
       placeholder="Ask about these reports..."
       onAsk={onAsk}
@@ -1319,9 +1353,14 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
       <div className="rd-v2-msg rd-v2-msg-agent">
         <strong>{reviewText}</strong>
         <p>{summaryText}</p>
-        <div className="rd-v2-trace"><small>3 steps completed</small><span>entity_health</span><span>freshness_scan</span><span>claim_verify</span></div>
+        <div className="rd-v2-trace"><small>Agent run trace</small><span>sources_gathered</span><span>claims_extracted</span><span>notebook_checked</span></div>
       </div>
-      <button className="rd-v2-drawer-toggle">{`Context · ${entity.name} ${entity.score} · ${entity.signals.length} signals · ${entity.related.length} entities`}</button>
+      <button className="rd-v2-drawer-toggle">{`Inspector · ${entity.name} ${entity.score} · ${entity.signals.length} signals · ${entity.related.length} entities`}</button>
+      <section className="rd-v2-agent-context">
+        <div className="rd-v2-context-head"><span>Pipeline progress</span><span>{warningCount} warnings</span></div>
+        <p className="rd-v2-signal-line">Done: gathered sources, extracted claims, matched report target.</p>
+        <p className="rd-v2-signal-line">Next: verify weak claims, patch notebook, then approve export.</p>
+      </section>
       <section className="rd-v2-agent-context">
         <div className="rd-v2-context-head"><span>Active entity</span><span>{entity.score}</span></div>
         <div className="rd-v2-score-big">{entity.score} <small>{entity.delta}</small></div>

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -5,7 +5,7 @@
  * Default density: compact. Sticky filter row.
  */
 
-import { useMemo, useState, useEffect, useRef } from "react";
+import { useMemo, useState, useEffect, useRef, type DragEvent } from "react";
 import { memoStyles, type ReportCardData, type Density, type Universe } from "../fixtures";
 import { Pill } from "../components/Pill";
 import { useReportsLive } from "../hooks/useReportsLive";
@@ -50,9 +50,36 @@ function displayReportDescription(description: string): string {
 
 interface ReportsSurfaceProps {
   onOpen: (id: string, tab: "brief" | "cards" | "chat") => void;
+  onRunBatch?: (prompt: string) => void;
   onSelectReport?: (report: ReportCardData) => void;
   inspectedReportId?: string | null;
 }
+
+type ReportViewMode = "gallery" | "board" | "table" | "notebook" | "canvas";
+type ReportStage = "Generating" | "Needs evidence" | "Needs review" | "Verified" | "Export ready" | "Monitoring";
+
+const REPORT_VIEW_MODES: Array<{ id: ReportViewMode; label: string }> = [
+  { id: "gallery", label: "Gallery" },
+  { id: "board", label: "Board" },
+  { id: "table", label: "Table" },
+  { id: "notebook", label: "Notebook" },
+  { id: "canvas", label: "Canvas" },
+];
+
+const REPORT_DENSITY_OPTIONS: Array<{ id: Density; label: string; detail: string }> = [
+  { id: "compact", label: "Compact", detail: "4-5 cards" },
+  { id: "grid", label: "Standard", detail: "3 cards" },
+  { id: "list", label: "Expanded", detail: "2 cards" },
+];
+
+const REPORT_STAGE_COLUMNS: ReportStage[] = [
+  "Generating",
+  "Needs evidence",
+  "Needs review",
+  "Verified",
+  "Export ready",
+  "Monitoring",
+];
 
 const STATUS_FILTERS = [
   { id: "all", label: "All" },
@@ -69,14 +96,16 @@ const KIND_FILTERS = [
   { id: "Coverage", label: "Coverage" },
 ] as const;
 
-export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: ReportsSurfaceProps) {
+export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedReportId }: ReportsSurfaceProps) {
   const [filter, setFilter] = useState<typeof STATUS_FILTERS[number]["id"]>("all");
   const [kindFilter, setKindFilter] = useState<typeof KIND_FILTERS[number]["id"]>("all");
-  const [density, setDensity] = useState<Density>("compact");
+  const [density, setDensity] = useState<Density>("grid");
+  const [viewMode, setViewMode] = useState<ReportViewMode>("gallery");
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [sortKey, setSortKey] = useState<SortKey>("updated");
   const [sortOpen, setSortOpen] = useState(false);
+  const [stageOverrides, setStageOverrides] = useState<Record<string, ReportStage>>({});
   const sortRef = useRef<HTMLDivElement>(null);
 
   // Click-outside dismiss for sort dropdown
@@ -162,18 +191,114 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
     setSelected(new Set());
   };
 
-  const visibleReports = filtered.slice(0, 12);
+  const visibleReports = filtered.slice(0, 24);
   const verifiedShare = reports.length > 0 ? Math.round(((counts.verified ?? 0) / reports.length) * 100) : 0;
+  const totalSources = filtered.reduce((sum, report) => sum + report.sources, 0);
+  const reviewCount = filtered.filter((report) => report.status === "review" || getReportStage(report, stageOverrides[report.id]) === "Needs review").length;
+  const exportReadyCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "Export ready").length;
+  const activeRunCount = filtered.filter((report) => {
+    const stage = getReportStage(report, stageOverrides[report.id]);
+    return stage === "Generating" || stage === "Needs evidence" || stage === "Needs review";
+  }).length;
+  const selectedReport = filtered.find((report) => report.id === inspectedReportId) ?? visibleReports[0] ?? reports[0] ?? null;
+  const selectedStage = selectedReport ? getReportStage(selectedReport, stageOverrides[selectedReport.id]) : null;
+
+  const boardReportsByStage = useMemo(() => {
+    const grouped = new Map<ReportStage, ReportCardData[]>();
+    for (const stage of REPORT_STAGE_COLUMNS) grouped.set(stage, []);
+    for (const report of visibleReports) {
+      grouped.get(getReportStage(report, stageOverrides[report.id]))?.push(report);
+    }
+    return grouped;
+  }, [stageOverrides, visibleReports]);
+
+  const runBatchPrompt = () => {
+    const prompt = "Run a research batch for my active entity universe. Generate banking-style report notebooks, verify sources, create review queue items, and show the agent run trace.";
+    if (onRunBatch) {
+      onRunBatch(prompt);
+      return;
+    }
+    onOpen("new", "chat");
+  };
+
+  const handleDragStart = (event: DragEvent<HTMLElement>, reportId: string) => {
+    event.dataTransfer.setData("text/plain", reportId);
+    event.dataTransfer.effectAllowed = "move";
+  };
+
+  const handleStageDrop = (event: DragEvent<HTMLElement>, stage: ReportStage) => {
+    event.preventDefault();
+    const reportId = event.dataTransfer.getData("text/plain");
+    if (!reportId) return;
+    setStageOverrides((prev) => ({ ...prev, [reportId]: stage }));
+    showToast({ tone: "success", message: `Moved report to ${stage}. This is a local review-board preview until writes are approved.` });
+  };
+
+  const selectAndOpen = (report: ReportCardData, tab: "brief" | "cards" | "chat") => {
+    onSelectReport?.(report);
+    onOpen(report.id, tab);
+  };
 
   return (
-    <div className="rd-v2-proto-center">
-      <div className="rd-v2-edition-row">
-        <span className="rd-v2-edition-pill">Entity intelligence</span>
-        <span className="rd-v2-edition-subline">
-          {isLoading && reports.length === 0
-            ? "Checking Convex-backed artifacts"
-            : `${reports.length} live reports · ${verifiedShare}% verified · ${counts.review ?? 0} need review · ${reports.reduce((sum, report) => sum + report.sources, 0)} sources`}
-        </span>
+    <div className="rd-v2-proto-center rd-v2-reports-command">
+      <section className="rd-v2-command-hero" aria-labelledby="reports-command-title">
+        <div className="rd-v2-edition-row">
+          <span className="rd-v2-edition-pill">Coverage Command Center</span>
+          <span className="rd-v2-edition-subline">
+            {isLoading && reports.length === 0
+              ? "Checking Convex-backed artifacts"
+              : `${reports.length} live reports - ${verifiedShare}% verified - ${reviewCount} need review - ${totalSources} source rows`}
+          </span>
+        </div>
+        <div className="rd-v2-command-title-row">
+          <div>
+            <h1 id="reports-command-title">Reports</h1>
+            <p>
+              Agent-generated notebooks organized by entity, evidence quality, lifecycle state, and the next review action.
+            </p>
+          </div>
+          <div className="rd-v2-command-actions">
+            <button type="button" className="rd-v2-btn-primary" onClick={runBatchPrompt}>Run batch</button>
+            <button type="button" onClick={() => setViewMode("board")}>Review queue</button>
+          </div>
+        </div>
+        <div className="rd-v2-command-metrics" aria-label="Reports operational metrics">
+          <span><strong>{filtered.length}</strong><small>live reports</small></span>
+          <span><strong>{activeRunCount}</strong><small>active runs</small></span>
+          <span><strong>{reviewCount}</strong><small>need review</small></span>
+          <span><strong>{exportReadyCount}</strong><small>export ready</small></span>
+        </div>
+      </section>
+      <div className="rd-v2-view-row">
+        <div className="rd-v2-view-switcher" role="tablist" aria-label="Reports view">
+          {REPORT_VIEW_MODES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={viewMode === item.id}
+              className={viewMode === item.id ? "is-active" : ""}
+              onClick={() => setViewMode(item.id)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+        {viewMode === "gallery" && (
+          <div className="rd-v2-density-switcher" aria-label="Gallery density">
+            {REPORT_DENSITY_OPTIONS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={density === item.id ? "is-active" : ""}
+                title={item.detail}
+                onClick={() => setDensity(item.id)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
       <div className="rd-v2-filter-row" role="tablist" aria-label="Filter reports by status">
         {STATUS_FILTERS.map((item) => (
@@ -188,10 +313,10 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
           </button>
         ))}
         <button type="button" className={kindFilter !== "all" ? "is-active" : ""} onClick={() => setKindFilter(kindFilter === "all" ? "Diligence" : "all")}>
-          {kindFilter === "all" ? "Tags" : kindFilter} ▾
+          {kindFilter === "all" ? "Type" : kindFilter} ▾
         </button>
       </div>
-      <div className="rd-v2-action-row" style={{ position: "relative" }}>
+      <div className="rd-v2-action-row rd-v2-command-toolbar" style={{ position: "relative" }}>
         <button type="button" onClick={() => setSortOpen((v) => !v)}>
           {SORT_OPTIONS.find((s) => s.id === sortKey)?.label.split(" (")[0] ?? "Updated"} ▾
         </button>
@@ -221,26 +346,18 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
         <button
           type="button"
           className="rd-v2-btn-primary"
-          onClick={() => showToast({ tone: "info", message: "Start a new entity report from Chat so the first write has source trace and approval context." })}
+          onClick={runBatchPrompt}
         >
-          + New report
+          + New batch
         </button>
       </div>
-      <div className="rd-v2-action-row" aria-label="Search reports">
+      <div className="rd-v2-action-row rd-v2-search-row" aria-label="Search reports">
         <label className="rd-sr-only" htmlFor="reports-v2-search">Search reports</label>
         <input
           id="reports-v2-search"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder={isLive ? `Search ${reports.length} live reports...` : "Search live reports..."}
-          style={{
-            width: "100%",
-            border: "1px solid var(--rd-line)",
-            borderRadius: 999,
-            padding: "10px 14px",
-            background: "var(--rd-panel)",
-            color: "var(--rd-ink)",
-          }}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={isLive ? `Search ${reports.length} live reports by entity, claim, source, or action...` : "Search live reports by entity, claim, source, or action..."}
         />
       </div>
       {visibleReports.length === 0 ? (
@@ -251,60 +368,134 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
               ? "Clear the filters to return to the live report set."
               : "Convex returned zero report artifacts for this session. Run research from Chat to create the first report."}
           </p>
-          <button type="button" onClick={hasActiveFilter ? resetFilters : () => onOpen("new", "chat")}>
-            {hasActiveFilter ? "Clear filters" : "+ Start in Chat"}
+          <button type="button" onClick={hasActiveFilter ? resetFilters : runBatchPrompt}>
+            {hasActiveFilter ? "Clear filters" : "Run first batch"}
           </button>
         </article>
-      ) : (
-        <div className="rd-v2-report-grid">
-          {visibleReports.map((report) => {
-            const active = inspectedReportId === report.id;
+      ) : viewMode === "board" ? (
+        <section className="rd-v2-report-board" aria-label="Draggable report review board">
+          {REPORT_STAGE_COLUMNS.map((stage) => {
+            const stageReports = boardReportsByStage.get(stage) ?? [];
             return (
               <article
-                key={report.id}
-                className={`rd-v2-report-card ${active ? "is-active" : ""}`}
-                onClick={() => onSelectReport?.(report)}
-                aria-selected={active}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter" && event.key !== " ") return;
-                  event.preventDefault();
-                  onSelectReport?.(report);
-                }}
+                key={stage}
+                className="rd-v2-board-column"
+                onDrop={(event) => handleStageDrop(event, stage)}
+                onDragOver={(event) => event.preventDefault()}
               >
-                <div className="rd-v2-report-title">
-                  <span>{report.entity.slice(0, 1).toUpperCase()}</span>
-                  <h2>{report.entity}</h2>
-                  <b data-state={report.status}>{report.status === "review" ? "review" : report.status}</b>
-                </div>
-                <p className="rd-v2-report-kind">{report.kind}</p>
-                <p>{displayReportDescription(report.description)}</p>
-                <div className="rd-v2-report-tags">
-                  <span>{report.sources} sources</span>
-                  <span>{report.claims} claims</span>
-                  <span>{report.followUps} follow-ups</span>
-                </div>
-                <p className="rd-v2-report-ref">Referenced in: {sourceLabel}</p>
-                <p className="rd-v2-report-meta">Updated {report.updatedAt}</p>
-                <div className="rd-v2-next-actions" style={{ marginTop: 8 }}>
-                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "brief"); }}>Open</button>
-                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "cards"); }}>Cards</button>
-                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "chat"); }}>Chat</button>
-                </div>
+                <header><strong>{stage}</strong><span>{stageReports.length}</span></header>
+                {stageReports.map((report) => (
+                  <button
+                    key={report.id}
+                    className="rd-v2-board-card"
+                    draggable
+                    onDragStart={(event) => handleDragStart(event, report.id)}
+                    onClick={() => onSelectReport?.(report)}
+                  >
+                    <strong>{report.entity}</strong>
+                    <span>{getReportType(report)} - {report.sources} sources</span>
+                    <small>{getNotebookState(report)}</small>
+                  </button>
+                ))}
               </article>
             );
           })}
+        </section>
+      ) : viewMode === "table" ? (
+        <section className="rd-v2-report-table-wrap" aria-label="Analyst report table">
+          <table className="rd-v2-report-table">
+            <thead>
+              <tr>
+                <th>Report</th>
+                <th>Type</th>
+                <th>Status</th>
+                <th>Sources</th>
+                <th>Claims</th>
+                <th>Scores</th>
+                <th>Notebook</th>
+                <th>Next</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleReports.map((report) => {
+                const scores = getReportScores(report);
+                return (
+                  <tr key={report.id} onClick={() => onSelectReport?.(report)}>
+                    <td><strong>{report.entity}</strong><span>{displayReportDescription(report.description)}</span></td>
+                    <td>{getReportType(report)}</td>
+                    <td>{getReportStage(report, stageOverrides[report.id])}</td>
+                    <td>{report.sources}</td>
+                    <td>{report.claims}</td>
+                    <td>{scores.evidence}/{scores.freshness}/{scores.confidence}</td>
+                    <td>{getNotebookState(report)}</td>
+                    <td><button type="button" onClick={(event) => { event.stopPropagation(); selectAndOpen(report, "brief"); }}>{getNextAction(report)}</button></td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </section>
+      ) : viewMode === "notebook" && selectedReport ? (
+        <section className="rd-v2-notebook-preview" aria-label="Selected report notebook preview">
+          <aside>
+            <span className="rd-v2-mini-eyebrow">Outline</span>
+            {getNotebookSections(selectedReport).map((section) => <button key={section} type="button">{section}</button>)}
+          </aside>
+          <article>
+            <span className="rd-v2-mini-eyebrow">{getReportType(selectedReport)} - {selectedStage}</span>
+            <h2>{selectedReport.entity}</h2>
+            <p>{displayReportDescription(selectedReport.description)}</p>
+            <div className="rd-v2-notebook-stats">
+              <span>{selectedReport.sources} sources</span>
+              <span>{selectedReport.claims} claims</span>
+              <span>{getNotebookState(selectedReport)}</span>
+            </div>
+            <h3>Executive read</h3>
+            <p>{buildReportSignals(selectedReport)[0]}</p>
+            <h3>Evidence appendix</h3>
+            <p>Sources, claims, warnings, and prior chat handles stay attached to the notebook before any export or write.</p>
+            <button type="button" className="rd-v2-btn-primary" onClick={() => selectAndOpen(selectedReport, "brief")}>Open Notebook</button>
+          </article>
+        </section>
+      ) : viewMode === "canvas" ? (
+        <section className="rd-v2-report-canvas" aria-label="Entity and report relationship canvas preview">
+          {visibleReports.slice(0, 10).map((report, index) => (
+            <button
+              key={report.id}
+              type="button"
+              className={`rd-v2-canvas-node rd-v2-canvas-node--${index % 4}`}
+              onClick={() => onSelectReport?.(report)}
+            >
+              <strong>{report.entity}</strong>
+              <span>{getReportType(report)}</span>
+            </button>
+          ))}
+          <p>Canvas mode maps companies, people, sources, claims, and notebooks. Writes stay gated through the agent inspector.</p>
+        </section>
+      ) : (
+        <div className="rd-v2-report-grid" data-density={density}>
+          {visibleReports.map((report) => (
+            <ReportCardV2
+              key={report.id}
+              report={report}
+              active={inspectedReportId === report.id}
+              stage={getReportStage(report, stageOverrides[report.id])}
+              sourceLabel={sourceLabel}
+              onSelect={() => onSelectReport?.(report)}
+              onOpen={selectAndOpen}
+              onExport={() => showToast({ tone: "info", message: `Prepared export preview for ${report.entity}. Connector writes require approval.` })}
+            />
+          ))}
           <article className="rd-v2-report-card rd-v2-report-card--add">
-            <h2>Add entity</h2>
-            <p>Capture a company, person, topic, or source cluster and let the coverage agent hydrate the first report.</p>
-            <button type="button" onClick={() => onOpen("new", "chat")}>+ New entity</button>
+            <h2>Run a batch</h2>
+            <p>Import companies, people, topics, or source clusters and let the agent create report notebooks with review state.</p>
+            <button type="button" onClick={runBatchPrompt}>+ New batch</button>
           </article>
         </div>
       )}
       {filtered.length > visibleReports.length && (
         <button className="rd-v2-show-more" type="button" onClick={() => showToast({ tone: "info", message: `${filtered.length - visibleReports.length} more live reports are available through search and filters.` })}>
-          Show {filtered.length - visibleReports.length} more entities
+          Show {filtered.length - visibleReports.length} more reports
         </button>
       )}
     </div>
@@ -505,6 +696,140 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
       />
     </div>
   );
+}
+
+function ReportCardV2({
+  report,
+  active,
+  stage,
+  sourceLabel,
+  onSelect,
+  onOpen,
+  onExport,
+}: {
+  report: ReportCardData;
+  active: boolean;
+  stage: ReportStage;
+  sourceLabel: string;
+  onSelect: () => void;
+  onOpen: (report: ReportCardData, tab: "brief" | "cards" | "chat") => void;
+  onExport: () => void;
+}) {
+  const scores = getReportScores(report);
+  const signals = buildReportSignals(report);
+  const type = getReportType(report);
+
+  return (
+    <article
+      className={`rd-v2-report-card rd-v2-report-card-v2 ${active ? "is-active" : ""}`}
+      onClick={onSelect}
+      aria-selected={active}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onSelect();
+      }}
+    >
+      <div className="rd-v2-report-title">
+        <span>{type.slice(0, 1).toUpperCase()}</span>
+        <h2>{report.entity}</h2>
+        <b data-state={stage}>{stage}</b>
+      </div>
+      <p className="rd-v2-report-kind">{type} - {report.kind}</p>
+      <p className="rd-v2-report-thesis">{displayReportDescription(report.description)}</p>
+      <div className="rd-v2-signal-list" aria-label={`${report.entity} key signals`}>
+        {signals.map((signal) => <span key={signal}>{signal}</span>)}
+      </div>
+      <div className="rd-v2-score-strip" aria-label={`${report.entity} report scores`}>
+        <span><b>{scores.evidence}</b><small>Evidence</small></span>
+        <span><b>{scores.freshness}</b><small>Freshness</small></span>
+        <span><b>{scores.confidence}</b><small>Confidence</small></span>
+      </div>
+      <div className="rd-v2-report-tags">
+        <span>{report.sources} sources</span>
+        <span>{report.claims} claims</span>
+        <span>{report.followUps} follow-ups</span>
+      </div>
+      <p className="rd-v2-report-ref">Referenced in: {sourceLabel}</p>
+      <p className="rd-v2-report-meta">Notebook: {getNotebookState(report)} - Updated {report.updatedAt}</p>
+      <div className="rd-v2-next-actions">
+        <button type="button" className="rd-v2-card-primary" onClick={(event) => { event.stopPropagation(); onOpen(report, "brief"); }}>Open Notebook</button>
+        <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report, "cards"); }}>Review Evidence</button>
+        <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report, "chat"); }}>Ask Agent</button>
+        <button type="button" onClick={(event) => { event.stopPropagation(); onExport(); }}>Export</button>
+      </div>
+    </article>
+  );
+}
+
+function getReportType(report: ReportCardData): string {
+  const text = `${report.kind} ${report.entity} ${report.description}`.toLowerCase();
+  if (text.includes("daily brief") || text.includes("brief")) return "Daily Brief";
+  if (text.includes("funding") || text.includes("round") || text.includes("raise")) return "Funding Tracker";
+  if (text.includes("person") || text.includes("founder") || text.includes("operator")) return "Person Report";
+  if (text.includes("market map") || text.includes("landscape")) return "Market Map";
+  if (text.includes("batch") || report.id.startsWith("run_")) return "Batch Run";
+  if (text.includes("source") || text.includes("dossier")) return "Source Dossier";
+  if (text.includes("theme") || text.includes("topic")) return "Topic Report";
+  return "Company Report";
+}
+
+function getReportStage(report: ReportCardData, override?: ReportStage): ReportStage {
+  if (override) return override;
+  if (report.status === "review") return "Needs review";
+  if (report.sources === 0 || report.claims === 0) return "Needs evidence";
+  if (report.followUps > 3) return "Needs review";
+  if (report.status === "watching") return "Monitoring";
+  if (report.sources >= 8 && report.claims >= 3) return "Export ready";
+  return "Verified";
+}
+
+function getReportScores(report: ReportCardData): { evidence: number; freshness: number; confidence: number } {
+  const evidence = clampScore(48 + report.sources * 6 + Math.min(report.claims, 8) * 3);
+  const freshness = report.updatedAt.includes("h") || report.updatedAt.includes("m") ? 88 : report.updatedAt.includes("d") ? 76 : 64;
+  const confidence = clampScore(54 + report.claims * 5 + report.sources * 2 - report.followUps * 4);
+  return { evidence, freshness, confidence };
+}
+
+function clampScore(value: number): number {
+  return Math.max(42, Math.min(96, Math.round(value)));
+}
+
+function getNotebookState(report: ReportCardData): string {
+  if (report.status === "review" || report.followUps > 2) return "Patch suggested";
+  if (report.sources < 2 || report.claims < 1) return "Needs sources";
+  return "Ready";
+}
+
+function getNextAction(report: ReportCardData): string {
+  if (report.status === "review" || report.followUps > 2) return "Review evidence";
+  if (getNotebookState(report) === "Needs sources") return "Find sources";
+  return "Open notebook";
+}
+
+function buildReportSignals(report: ReportCardData): string[] {
+  const clean = displayReportDescription(report.description).replace(/\s+/g, " ").trim();
+  const split = clean
+    .split(/(?<=[.!?])\s+|\s+\|\s+|;\s+/)
+    .map((item) => item.replace(/^\d+\.\s*/, "").trim())
+    .filter(Boolean)
+    .slice(0, 3);
+  while (split.length < 3) {
+    if (split.length === 0) split.push(`${report.sources} sources attached for evidence review.`);
+    else if (split.length === 1) split.push(`${report.claims} claims available for verification.`);
+    else split.push(`${report.followUps} follow-ups route into the review queue.`);
+  }
+  return split;
+}
+
+function getNotebookSections(report: ReportCardData): string[] {
+  const type = getReportType(report);
+  if (type === "Person Report") return ["Executive read", "Current role", "Relationship map", "Outreach angle", "Evidence appendix"];
+  if (type === "Topic Report" || type === "Market Map") return ["Executive read", "Market context", "Key entities", "Contradictions", "Recommended research", "Evidence appendix"];
+  if (type === "Daily Brief") return ["What changed", "Why it matters", "Top entities", "Reports needing review", "Recommended follow-ups", "Evidence appendix"];
+  return ["Executive read", "Business overview", "Product and market", "Traction signals", "Risks and unknowns", "Recommended action", "Evidence appendix"];
 }
 
 function ReportsLiveEmptyState() {

--- a/tests/e2e/home-v2-parity.spec.ts
+++ b/tests/e2e/home-v2-parity.spec.ts
@@ -146,10 +146,10 @@ test.describe("Home v2 /redesign parity", () => {
 
     await expect(page.getByRole("complementary", { name: "Reports navigation" })).toBeVisible();
     await expect(page.getByLabel("Filter entities")).toBeVisible();
-    await expect(page.getByText("Entity intelligence").first()).toBeVisible();
+    await expect(page.getByText("Coverage Command Center").first()).toBeVisible();
     await expect(page.locator(".rd-v2-report-grid")).toBeVisible({ timeout: 15_000 });
     await expectV2CenterCanvas(page, ".rd-v2-proto-center");
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toBeVisible();
     const rail = rightRail(page);
     await expectRailInViewport(rail);
 
@@ -162,10 +162,18 @@ test.describe("Home v2 /redesign parity", () => {
     const firstTitle = await reportTitle(firstCard);
     const secondTitle = await reportTitle(secondCard);
 
+    await page.getByRole("tab", { name: "Board" }).click();
+    await expect(page.getByRole("region", { name: "Draggable report review board" })).toBeVisible();
+    await page.getByRole("tab", { name: "Table" }).click();
+    await expect(page.getByRole("region", { name: "Analyst report table" })).toBeVisible();
+    await page.getByRole("tab", { name: "Notebook" }).click();
+    await expect(page.getByRole("region", { name: "Selected report notebook preview" })).toBeVisible();
+    await page.getByRole("tab", { name: "Gallery" }).click();
+
     await selectReport(firstCard);
     await expect.poll(async () => await normalizedText(rail)).toContain(firstTitle);
     const firstRailText = await normalizedText(rail);
-    await expect(rail).toContainText("3 steps completed");
+    await expect(rail).toContainText("Agent run trace");
 
     await selectReport(secondCard);
     await expect.poll(async () => await normalizedText(rail)).toContain(secondTitle);
@@ -285,8 +293,8 @@ test.describe("Home v2 prototype kit mode", () => {
       {
         path: `/redesign/reports?${qa}`,
         nav: "Reports",
-        center: "Entity intelligence",
-        rail: "Coverage agent",
+        center: "Coverage Command Center",
+        rail: "Agent Inspector",
       },
       {
         path: `/redesign/chat?${qa}`,
@@ -325,7 +333,7 @@ test.describe("Home v2 prototype kit mode", () => {
 
     await page.getByRole("button", { name: "Reports" }).click();
     await expect(page).toHaveURL(/\/redesign\/reports\?qa=home-v2-implementation$/);
-    await expect(page.getByText("Entity intelligence").first()).toBeVisible();
+    await expect(page.getByText("Coverage Command Center").first()).toBeVisible();
 
     await page.getByRole("button", { name: "Chat" }).click();
     await expect(page).toHaveURL(/\/redesign\/chat\?qa=home-v2-implementation$/);
@@ -337,13 +345,13 @@ test.describe("Home v2 prototype kit mode", () => {
     await page.goto(`/redesign/reports?${qa}`, { waitUntil: "domcontentloaded" });
 
     await page.getByText("Sequoia Capital").first().click();
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Sequoia Capital");
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Score 74");
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Full-ratchet anti-dilution clause added");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("Sequoia Capital");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("Score 74");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("Full-ratchet anti-dilution clause added");
 
     await page.getByRole("button", { name: /OpenAI 62/i }).click();
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("OpenAI");
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Score 62");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("OpenAI");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("Score 62");
   });
 
   test("prototype Chat includes answer packet details and interactive utility tabs", async ({ page }) => {
@@ -378,7 +386,7 @@ test.describe("Home v2 prototype kit mode", () => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto(`/redesign/reports?${qa}`, { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByText("Entity intelligence").first()).toBeVisible();
+    await expect(page.getByText("Coverage Command Center").first()).toBeVisible();
     await expect(page.getByText("Enterprise tier repriced").first()).toBeVisible();
     await expect(page.getByText("No reports yet")).toHaveCount(0);
   });


### PR DESCRIPTION
﻿## Summary
- Reframes Reports as a research operations command center with Gallery, Board, Table, Notebook, and Canvas views.
- Adds denser notebook-first report cards, draggable review board stages, analyst table, notebook preview, and canvas preview.
- Updates the home-v2 prototype Reports center and Agent Inspector rail to match the new direction.

## Verification
- npx tsc --noEmit --pretty false
- npm run build
- BASE_URL=http://127.0.0.1:5180 npx playwright test tests/e2e/home-v2-parity.spec.ts --project=chromium --grep "desktop Reports selection|live and prototype routes avoid horizontal overflow|prototype Reports selection|prototype QA mode"
