### PR TITLE
Align reports with home v3 workbench

### DIFF
--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -239,8 +239,8 @@ export default function RedesignShell() {
     isPrototypeKit;
   const suppressRightRail =
     !isPrototypeKit &&
-    ((surface === "chat" && Boolean(chatHash)) ||
-      (surface === "reports" && Boolean(reportId)));
+    surface === "chat" &&
+    Boolean(chatHash);
 
   return (
     <div
@@ -315,16 +315,12 @@ export default function RedesignShell() {
             {!isPrototypeKit && surface === "reports" && !reportId && (
               <ReportsSurface
                 onOpen={(id, tab) => {
-                  if (id.startsWith("li_") || id.startsWith("daily_") || id.startsWith("run_")) {
-                    const workspaceTab = tab === "chat" ? "chat" : tab === "cards" ? "cards" : "brief";
-                    navigate(`/redesign/workspace?report=${id}&tab=${workspaceTab}`);
-                    return;
-                  }
                   if (tab === "brief") navigate(`/redesign/reports/${id}`);
                   else navigate(`/redesign/workspace?report=${id}&tab=${tab}`);
                 }}
                 inspectedReportId={selectedReport?.id ?? null}
                 onSelectReport={selectLiveReport}
+                onRunBatch={sendPromptToChat}
               />
             )}
             {!isPrototypeKit && surface === "reports" && reportId && <ReportDetailRoute reportId={reportId} />}
@@ -378,7 +374,7 @@ export default function RedesignShell() {
 function ReportDetailRoute({ reportId }: { reportId: string }) {
   const liveArtifacts = useLiveArtifacts(60);
   const liveDetail = liveArtifacts.details.find((detail) => detail.id === reportId);
-  return <ReportNotebookView reportId={reportId} liveDetail={liveDetail} />;
+  return <ReportNotebookView reportId={reportId} liveDetail={liveDetail} showSidebar={false} />;
 }
 
 function useQaChromeFlag(search: string): boolean {

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -119,10 +119,14 @@ export default function RedesignShell() {
   const shellLiveArtifacts = useLiveArtifacts(24, { enabled: !isPrototypeKit });
   const [selectedReport, setSelectedReport] = useState<ReportCardData | null>(null);
   const [prototypeEntity, setPrototypeEntity] = useState("Anthropic");
+  const [reportsRailEntityMode, setReportsRailEntityMode] = useState(false);
   const [activeChatDetail, setActiveChatDetail] = useState<LiveArtifactDetail | null>(null);
   const [activeChatAgentRail, setActiveChatAgentRail] = useState<AgentRailSnapshot | null>(null);
   const goSurface = (id: SurfaceId) => {
-    if (id !== "reports") setSelectedReport(null);
+    if (id !== "reports") {
+      setSelectedReport(null);
+      setReportsRailEntityMode(false);
+    }
     const path = id === "home" ? "/redesign" : `/redesign/${id}`;
     navigate(isPrototypeKit ? `${path}?qa=home-v2-implementation` : path);
   };
@@ -138,19 +142,22 @@ export default function RedesignShell() {
   const selectPrototypeRailEntity = (entity: string) => {
     setPrototypeEntity(entity);
     if (!isPrototypeKit && surface === "reports") {
-      selectRelatedReport(entity);
+      setSelectedReport(null);
+      setReportsRailEntityMode(true);
     }
   };
-  const selectRelatedReport = (entity: string) => {
-    const key = normalizeEntityKey(entity);
-    const next = shellLiveArtifacts.reports.find((report) => normalizeEntityKey(report.entity) === key);
-    if (next) setSelectedReport(next);
-    else sendPromptToChat(`Find or create coverage context for ${entity}.`);
-  };
   const selectLiveReport = (report: ReportCardData | null) => {
+    setReportsRailEntityMode(false);
     setSelectedReport(report);
     if (report) setPrototypeEntity(report.entity);
   };
+  const selectedRailReport =
+    surface === "reports" &&
+    !reportsRailEntityMode &&
+    selectedReport &&
+    normalizeEntityKey(selectedReport.entity) === normalizeEntityKey(prototypeEntity)
+      ? selectedReport
+      : null;
 
   // Optionally lock body scroll while shell is mounted
   useEffect(() => {
@@ -318,7 +325,7 @@ export default function RedesignShell() {
                   if (tab === "brief") navigate(`/redesign/reports/${id}`);
                   else navigate(`/redesign/workspace?report=${id}&tab=${tab}`);
                 }}
-                inspectedReportId={selectedReport?.id ?? null}
+                inspectedReportId={reportsRailEntityMode ? "__rail_entity_override__" : selectedReport?.id ?? null}
                 onSelectReport={selectLiveReport}
                 onRunBatch={sendPromptToChat}
               />
@@ -350,7 +357,7 @@ export default function RedesignShell() {
                 surface={prototypeSurface}
                 onAsk={sendPromptToChat}
                 selectedEntity={surface === "reports" ? prototypeEntity : undefined}
-                selectedReport={surface === "reports" ? selectedReport : null}
+                selectedReport={selectedRailReport}
                 onSelectEntity={selectPrototypeRailEntity}
                 guestSafe={surface === "me"}
               />

--- a/src/features/redesign/components/ReportNotebookView.tsx
+++ b/src/features/redesign/components/ReportNotebookView.tsx
@@ -554,8 +554,8 @@ export function ReportNotebookView({ reportId, showSidebar = true, embedded = fa
               <div className="rd-page-chrome__prop rd-page-chrome__prop--wide" role="listitem">
                 <span className="rd-page-chrome__prop-key">Linked</span>
                 <span className="rd-page-chrome__prop-val">
-                  {linkedTags.map((tag) => (
-                    <a key={tag} className="rd-entity-link" href="#" data-entity={tag.toLowerCase().replace(/[^a-z0-9]+/g, "-")}>{tag}</a>
+                  {linkedTags.map((tag, index) => (
+                    <a key={`${tag}-${index}`} className="rd-entity-link" href="#" data-entity={tag.toLowerCase().replace(/[^a-z0-9]+/g, "-")}>{tag}</a>
                   ))}
                 </span>
               </div>

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -1898,7 +1898,7 @@
 
 [data-redesign] .rd-v2-drawer-toggle {
   width: 100%;
-  padding: 6px 0 5px;
+  padding: 6px 2px 5px;
   border: 0;
   border-top: 1px solid var(--rd-line-faint);
   border-bottom: 1px solid var(--rd-line-faint);
@@ -1912,8 +1912,84 @@
   text-transform: uppercase;
 }
 
+[data-redesign] .rd-v2-msg-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+[data-redesign] .rd-v2-msg-actions button {
+  padding: 3px 9px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: var(--rd-r-pill);
+  background: transparent;
+  color: var(--rd-ink-soft);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+[data-redesign] .rd-v2-msg-actions button:hover {
+  border-color: var(--rd-line-strong);
+  color: var(--rd-ink);
+}
+
+[data-redesign] .rd-v2-msg-actions button.is-primary {
+  border-color: var(--rd-line);
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] .rd-v2-pipeline {
+  padding: 8px 0 6px;
+  border-top: 1px solid var(--rd-line-faint);
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-pipeline-row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 7px;
+  padding: 4px 2px;
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-pipeline-row span {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--rd-muted);
+  color: var(--rd-ink-faint);
+  font-size: 9px;
+}
+
+[data-redesign] .rd-v2-pipeline-row[data-done="true"] span {
+  background: var(--rd-green-bg);
+  color: var(--rd-green);
+}
+
+[data-redesign] .rd-v2-pipeline-row strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--rd-ink-mute);
+  font-size: 11.5px;
+  font-weight: 560;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 [data-redesign] .rd-v2-agent-context {
   padding-top: 6px;
+}
+
+[data-redesign] .rd-v2-warning-line {
+  padding-left: 8px;
+  border-left: 2px solid var(--rd-amber);
 }
 
 [data-redesign] .rd-v2-context-head {
@@ -2172,19 +2248,102 @@
 
 [data-redesign] .rd-v2-left--nav {
   position: relative;
-  padding: 14px 8px 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0;
 }
 
 [data-redesign] .rd-v2-rail-search {
   width: calc(100% - 20px);
-  margin: 8px 10px 28px;
-  padding: 8px 12px;
+  flex-shrink: 0;
+  margin: 8px 10px;
+  padding: 6px 10px;
   border: 1px solid var(--rd-line);
-  border-radius: var(--rd-r-pill);
+  border-radius: var(--rd-r-sm);
   background: var(--rd-panel);
   color: var(--rd-ink);
   font: inherit;
-  font-size: 12px;
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-rail-search:focus {
+  border-color: var(--rd-accent);
+  outline: 0;
+}
+
+[data-redesign] .rd-v2-rail-filters {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 2px;
+  padding: 0 10px 7px;
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-rail-filters button {
+  padding: 3px 6px;
+  border: 0;
+  border-radius: var(--rd-r-sm);
+  background: transparent;
+  color: var(--rd-ink-faint);
+  cursor: pointer;
+  font: inherit;
+  font-size: 9px;
+  font-weight: 620;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-rail-filters button:hover {
+  background: var(--rd-muted);
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] .rd-v2-rail-filters button.is-active {
+  color: var(--rd-ink-strong);
+}
+
+[data-redesign] .rd-v2-rail-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+[data-redesign] .rd-v2-rail-empty {
+  margin: 8px 10px;
+  padding: 8px;
+  border: 1px dashed var(--rd-line);
+  border-radius: var(--rd-r-sm);
+  color: var(--rd-ink-faint);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v2-rail-footer {
+  display: flex;
+  flex-shrink: 0;
+  gap: 4px;
+  padding: 6px 10px;
+  border-top: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v2-rail-footer button {
+  flex: 1;
+  padding: 4px;
+  border: 0;
+  border-radius: var(--rd-r-sm);
+  background: transparent;
+  color: var(--rd-ink-faint);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+[data-redesign] .rd-v2-rail-footer button:hover {
+  color: var(--rd-ink-mute);
 }
 
 [data-redesign] .rd-v2-rail-section {
@@ -2198,12 +2357,26 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 10px 5px;
+  padding: 5px 10px;
   color: var(--rd-ink-soft);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+[data-redesign] .rd-v2-rail-section-toggle {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+[data-redesign] .rd-v2-rail-chevron {
+  color: var(--rd-ink-faint);
+  font-size: 8px;
 }
 
 [data-redesign] .rd-v2-rail-section-head b {
@@ -2232,6 +2405,15 @@
   padding: 7px 10px;
 }
 
+[data-redesign] .rd-v2-report-nav-row {
+  grid-template-columns: 18px minmax(0, 1fr) auto 6px;
+  gap: 6px;
+  padding: 4px 10px 4px 18px;
+  border-radius: 0;
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+}
+
 [data-redesign] .rd-v2-nav-row.is-active,
 [data-redesign] .rd-v2-thread-row.is-active {
   background: var(--rd-accent-soft);
@@ -2242,6 +2424,35 @@
   color: var(--rd-accent);
   text-align: center;
 }
+
+[data-redesign] .rd-v2-report-nav-icon {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  border-radius: 3px;
+  background: var(--rd-muted);
+  color: var(--rd-ink-faint) !important;
+  font-size: 8px;
+  font-weight: 760;
+}
+
+[data-redesign] .rd-v2-report-nav-row.is-active .rd-v2-report-nav-icon {
+  color: var(--rd-ink-mute) !important;
+}
+
+[data-redesign] .rd-v2-report-nav-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  opacity: 0.65;
+}
+
+[data-redesign] .rd-v2-report-nav-dot[data-status="verified"] { background: var(--rd-green); }
+[data-redesign] .rd-v2-report-nav-dot[data-status="review"] { background: var(--rd-amber); }
+[data-redesign] .rd-v2-report-nav-dot[data-status="stale"] { background: var(--rd-red); }
+[data-redesign] .rd-v2-report-nav-dot[data-status="drafting"] { background: var(--rd-ink-faint); }
+[data-redesign] .rd-v2-report-nav-dot[data-status="monitoring"] { background: var(--rd-blue); }
 
 [data-redesign] .rd-v2-nav-row[data-tone="blue"] span { color: var(--rd-blue); }
 [data-redesign] .rd-v2-nav-row[data-tone="amber"] span { color: var(--rd-amber); }

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -7138,6 +7138,425 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   margin-top: 4px;
 }
 
+/* ───────── Reports v3 command canvas ───────── */
+[data-redesign] .rd-v3-reports {
+  width: min(100%, 920px);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+[data-redesign] .rd-v3-universe-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+[data-redesign] .rd-v3-kicker {
+  font-family: var(--rd-font-mono);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--rd-accent-strong);
+}
+
+[data-redesign] .rd-v3-universe-header h1 {
+  margin: 4px 0 4px;
+  font-size: 38px;
+  line-height: 0.96;
+  font-weight: 760;
+  letter-spacing: 0;
+  color: var(--rd-ink-strong);
+}
+
+[data-redesign] .rd-v3-universe-header p {
+  margin: 0;
+  color: var(--rd-ink-mute);
+  font-size: 13px;
+}
+
+[data-redesign] .rd-v3-universe-actions,
+[data-redesign] .rd-v3-search-row,
+[data-redesign] .rd-v3-tabs,
+[data-redesign] .rd-v3-filter-pills,
+[data-redesign] .rd-v3-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+[data-redesign] .rd-v3-universe-actions button,
+[data-redesign] .rd-v3-search-row button,
+[data-redesign] .rd-v3-card__actions button,
+[data-redesign] .rd-v3-sort button,
+[data-redesign] .rd-v3-show-more {
+  border: 1px solid var(--rd-line);
+  border-radius: 999px;
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  padding: 7px 11px;
+  cursor: pointer;
+}
+
+[data-redesign] .rd-v3-universe-actions .rd-v3-primary {
+  background: var(--rd-ink-strong);
+  color: var(--rd-paper);
+  border-color: var(--rd-ink-strong);
+}
+
+[data-redesign] .rd-v3-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border: 1px solid var(--rd-line-faint);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v3-metrics span {
+  padding: 10px 12px;
+  border-right: 1px solid var(--rd-line-faint);
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+[data-redesign] .rd-v3-metrics span:last-child { border-right: 0; }
+[data-redesign] .rd-v3-metrics strong {
+  display: block;
+  font-size: 18px;
+  color: var(--rd-accent-strong);
+  font-weight: 760;
+}
+
+[data-redesign] .rd-v3-view-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+[data-redesign] .rd-v3-tabs,
+[data-redesign] .rd-v3-filter-pills {
+  padding: 2px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: 999px;
+  background: var(--rd-paper-warm);
+}
+
+[data-redesign] .rd-v3-tabs button,
+[data-redesign] .rd-v3-filter-pills button {
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--rd-ink-mute);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+[data-redesign] .rd-v3-tabs button.is-active,
+[data-redesign] .rd-v3-filter-pills button.is-active {
+  background: var(--rd-panel);
+  color: var(--rd-accent-strong);
+  box-shadow: 0 0 0 1px var(--rd-line);
+}
+
+[data-redesign] .rd-v3-sort {
+  position: relative;
+  margin-left: auto;
+}
+
+[data-redesign] .rd-v3-search-row {
+  flex-wrap: nowrap;
+}
+
+[data-redesign] .rd-v3-search-row input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid var(--rd-line);
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: var(--rd-panel);
+  color: var(--rd-ink);
+  font: inherit;
+}
+
+[data-redesign] .rd-v3-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(205px, 1fr));
+  gap: 10px;
+}
+
+[data-redesign] .rd-v3-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 214px;
+  padding: 12px;
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-panel);
+  box-shadow: var(--rd-shadow-xs);
+  cursor: pointer;
+  transition: border-color 100ms ease, box-shadow 100ms ease, transform 100ms ease;
+}
+
+[data-redesign] .rd-v3-card:hover,
+[data-redesign] .rd-v3-card[aria-selected="true"] {
+  border-color: var(--rd-accent-ring);
+  box-shadow: var(--rd-shadow-sm);
+  transform: translateY(-1px);
+}
+
+[data-redesign] .rd-v3-card__head {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 7px;
+}
+
+[data-redesign] .rd-v3-icon,
+[data-redesign] .rd-v3-mini > span,
+[data-redesign] .rd-v3-graph__root > span,
+[data-redesign] .rd-v3-graph__nodes span {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 11px;
+  font-weight: 760;
+}
+
+[data-redesign] .rd-v3-card__head strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+[data-redesign] .rd-v3-card__head > button {
+  border: 0;
+  background: transparent;
+  color: var(--rd-ink-soft);
+  cursor: pointer;
+}
+
+[data-redesign] .rd-v3-card__kind,
+[data-redesign] .rd-v3-card__foot,
+[data-redesign] .rd-v3-sources,
+[data-redesign] .rd-v3-backlinks {
+  margin: 0;
+  color: var(--rd-ink-soft);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v3-card__thesis {
+  margin: 0;
+  color: var(--rd-ink);
+  font-size: 12.5px;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+[data-redesign] .rd-v3-signals,
+[data-redesign] .rd-v3-sources,
+[data-redesign] .rd-v3-backlinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+[data-redesign] .rd-v3-signals span,
+[data-redesign] .rd-v3-sources span {
+  border-radius: 999px;
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  padding: 3px 7px;
+  font-size: 10.5px;
+  font-weight: 650;
+}
+
+[data-redesign] .rd-v3-backlinks span { color: var(--rd-ink-mute); }
+
+[data-redesign] .rd-v3-card__foot {
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--rd-line-faint);
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+[data-redesign] .rd-v3-card__actions {
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition: opacity 120ms ease, max-height 120ms ease;
+}
+
+[data-redesign] .rd-v3-card:hover .rd-v3-card__actions,
+[data-redesign] .rd-v3-card:focus-within .rd-v3-card__actions {
+  opacity: 1;
+  max-height: 80px;
+}
+
+[data-redesign] .rd-v3-card--add,
+[data-redesign] .rd-v3-card--empty {
+  border-style: dashed;
+  justify-content: center;
+}
+
+[data-redesign] .rd-v3-board {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  min-height: 400px;
+  max-height: calc(100vh - 360px);
+}
+
+[data-redesign] .rd-v3-board-column {
+  flex: 0 0 210px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--rd-line-faint);
+  border-radius: 8px;
+  background: var(--rd-paper-warm);
+  overflow-y: auto;
+}
+
+[data-redesign] .rd-v3-board-column header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2px 8px;
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v3-board-column header small {
+  grid-column: 1 / -1;
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v3-mini {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 4px 7px;
+  align-items: center;
+  text-align: left;
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-panel);
+  padding: 8px;
+  cursor: grab;
+}
+
+[data-redesign] .rd-v3-mini small {
+  grid-column: 2;
+  color: var(--rd-ink-soft);
+  font-size: 10.5px;
+}
+
+[data-redesign] .rd-v3-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v3-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+[data-redesign] .rd-v3-table th,
+[data-redesign] .rd-v3-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--rd-line-faint);
+  text-align: left;
+  vertical-align: top;
+}
+
+[data-redesign] .rd-v3-table td:first-child {
+  min-width: 240px;
+}
+
+[data-redesign] .rd-v3-table td:first-child span {
+  display: block;
+  margin-top: 3px;
+  color: var(--rd-ink-soft);
+}
+
+[data-redesign] .rd-v3-graph {
+  min-height: 430px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-panel);
+}
+
+[data-redesign] .rd-v3-graph__root {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border: 1px solid var(--rd-line);
+  border-radius: 999px;
+  background: var(--rd-panel);
+  box-shadow: var(--rd-shadow-sm);
+}
+
+[data-redesign] .rd-v3-graph__nodes {
+  margin-top: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  max-width: 620px;
+}
+
+[data-redesign] .rd-v3-graph__nodes button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--rd-line);
+  border-radius: 999px;
+  background: var(--rd-panel);
+  padding: 6px 10px 6px 6px;
+  cursor: pointer;
+}
+
+@media (max-width: 1320px) {
+  [data-redesign] .rd-v3-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 760px) {
+  [data-redesign] .rd-v3-reports { width: 100%; }
+  [data-redesign] .rd-v3-universe-header,
+  [data-redesign] .rd-v3-view-bar,
+  [data-redesign] .rd-v3-search-row { flex-direction: column; align-items: stretch; }
+  [data-redesign] .rd-v3-metrics,
+  [data-redesign] .rd-v3-grid { grid-template-columns: 1fr; }
+}
+
 /* ───────── Reports Crunchbase / Pitchbook filter bar ───────── */
 [data-redesign] .rd-reports-filterbar {
   display: flex;

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -897,23 +897,39 @@ export function PrototypeV2LeftRail({ surface, onAsk, selectedEntity = "Anthropi
   if (surface === "reports") {
     return (
       <aside className="rd-v2-left rd-v2-left--nav" aria-label="Reports navigation">
-        <input className="rd-v2-rail-search" placeholder="Filter entities..." aria-label="Filter entities" />
+        <input className="rd-v2-rail-search" placeholder="Find report, entity, source..." aria-label="Filter reports" />
         <div className="rd-v2-rail-rule" />
-        <RailGroup label="Companies" count="12" selectedName={selectedEntity} onSelectItem={onSelectEntity} items={[
-          ["A", "Anthropic", "3", true],
-          ["S", "Sequoia Capital", "2"],
-          ["B", "Bug0", "1"],
-          ["O", "OpenAI", ""],
-          ["G", "Google DeepMind", ""],
-          ["M", "Mistral", ""],
+        <RailGroup label="Universes" count="3" selectedName={selectedEntity} onSelectItem={onSelectEntity} items={[
+          ["AI", "AI Infrastructure", "87", true],
+          ["CX", "Customer Agents", "24"],
+          ["VC", "Startup Banking Targets", "31"],
+        ]} />
+        <RailGroup label="Report types" count="8" selectedName={selectedEntity} onSelectItem={onSelectEntity} items={[
+          ["D", "Daily Brief", "9"],
+          ["C", "Company Report", "38"],
+          ["P", "Person Report", "12"],
+          ["T", "Topic Report", "16"],
+          ["M", "Market Map", "4"],
+          ["F", "Funding Tracker", "8"],
+        ]} />
+        <RailGroup label="Review work" count="18" items={[
+          ["!", "Needs evidence", "6"],
+          ["?", "Needs review", "7"],
+          ["V", "Verified", "30"],
+          ["E", "Export ready", "5"],
+        ]} />
+        <RailGroup label="Agent runs" count="5" items={[
+          ["R", "Active batches", "3"],
+          ["S", "Source refreshes", "2"],
+          ["N", "Notebook patches", "4"],
         ]} />
         <RailGroup label="People" count="8" items={[
           ["•", "Dario Amodei", ""],
           ["•", "Alfred Lin", ""],
           ["•", "Sam Altman", ""],
         ]} />
-        <RailGroup label="Topics" count="5" items={[["#", "Fundraise", ""], ["#", "Pricing", ""], ["#", "Hiring", ""]]} />
-        <button className="rd-v2-new-entity">+ New entity</button>
+        <RailGroup label="Entity tags" count="5" items={[["#", "Fundraise", ""], ["#", "Pricing", ""], ["#", "Hiring", ""]]} />
+        <button className="rd-v2-new-entity">+ New batch</button>
       </aside>
     );
   }
@@ -1058,7 +1074,30 @@ function ChatThreadGroup({ label, items }: { label: string; items: Array<[string
 
 function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }: PrototypeSelectionProps) {
   return (
-    <div className="rd-v2-proto-center">
+    <div className="rd-v2-proto-center rd-v3-reports">
+      <div className="rd-v3-universe-header">
+        <div>
+          <div className="rd-v3-kicker">Reports</div>
+          <h1>AI Infrastructure Coverage</h1>
+          <p>87 reports, 48 sources, 7 need review, confidence 91/100.</p>
+        </div>
+        <div className="rd-v3-universe-actions">
+          <button type="button">Review queue</button>
+          <button type="button" className="rd-v3-primary">+ New batch</button>
+        </div>
+      </div>
+      <section className="rd-v3-metrics" aria-label="Coverage metrics">
+        <span><strong>87</strong> reports</span>
+        <span><strong>83%</strong> verified</span>
+        <span><strong>7</strong> need review</span>
+        <span><strong>3</strong> active runs</span>
+        <span><strong>12</strong> notebook patches</span>
+      </section>
+      <div className="rd-v3-tabs" role="tablist" aria-label="Report views">
+        {["Gallery", "Board", "Table", "Graph"].map((item, index) => (
+          <button key={item} type="button" role="tab" aria-selected={index === 0} className={index === 0 ? "is-active" : ""}>{item}</button>
+        ))}
+      </div>
       <div className="rd-v2-edition-row">
         <span className="rd-v2-edition-pill">Entity intelligence</span>
         <span className="rd-v2-edition-subline">12 entities · 83% verified · avg score 87 · 48 sources</span>
@@ -1262,7 +1301,7 @@ function AgentShell({
   const pillClassName = (_pill: string, index: number) => {
     const classes = ["rd-v2-agent-pill"];
     if (index === 0) classes.push("is-active");
-    if (title === "Coverage agent") {
+    if (title === "Coverage agent" || title === "Agent Inspector") {
       if (index === 1) classes.push("is-entity");
       if (index === 2) classes.push("is-source");
     }
@@ -1309,8 +1348,8 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
 
   return (
     <AgentShell
-      title="Coverage agent"
-      context={`Reports · 5 entities · 48 sources · ${entity.sources} active`}
+      title="Agent Inspector"
+      context={`Reports · ${entity.name} · ${entity.sources} sources · score ${entity.score}`}
       pills={["Reports", entity.name, `${entity.sources} sources`, `Score ${entity.score}`]}
       question="Which reports need work?"
       placeholder="Ask about these reports..."
@@ -1319,7 +1358,7 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
       <div className="rd-v2-msg rd-v2-msg-agent">
         <strong>{reviewText}</strong>
         <p>{summaryText}</p>
-        <div className="rd-v2-trace"><small>3 steps completed</small><span>entity_health</span><span>freshness_scan</span><span>claim_verify</span></div>
+        <div className="rd-v2-trace"><small>Agent run trace</small><span>source_scan</span><span>claim_verify</span><span>notebook_patch</span></div>
       </div>
       <button className="rd-v2-drawer-toggle">{`Context · ${entity.name} ${entity.score} · ${entity.signals.length} signals · ${entity.related.length} entities`}</button>
       <section className="rd-v2-agent-context">

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -148,6 +148,67 @@ const reportEntities = [
 ];
 
 type PrototypeReportEntity = (typeof reportEntities)[number];
+type ReportsRailStatus = "verified" | "review" | "stale" | "drafting" | "monitoring";
+type ReportsRailItem = {
+  icon: string;
+  name: string;
+  score: string;
+  status?: ReportsRailStatus;
+  active?: boolean;
+};
+
+const reportsRailGroups: Array<{ label: string; count: string; items: ReportsRailItem[] }> = [
+  {
+    label: "Universes",
+    count: "3",
+    items: [
+      { icon: "AI", name: "AI Infrastructure", score: "87", active: true },
+      { icon: "BT", name: "Banking Targets", score: "34" },
+      { icon: "FW", name: "Fundraise Watch", score: "12" },
+    ],
+  },
+  {
+    label: "Companies",
+    count: "5",
+    items: [
+      { icon: "A", name: "Anthropic", score: "91", status: "verified" },
+      { icon: "O", name: "OpenAI", score: "62", status: "stale" },
+      { icon: "M", name: "Mistral", score: "25", status: "drafting" },
+      { icon: "B", name: "Bug0", score: "88", status: "verified" },
+      { icon: "G", name: "Google DeepMind", score: "47", status: "stale" },
+    ],
+  },
+  {
+    label: "People",
+    count: "2",
+    items: [
+      { icon: "D", name: "Dario Amodei", score: "87", status: "verified" },
+      { icon: "S", name: "Sequoia Capital", score: "74", status: "review" },
+    ],
+  },
+  {
+    label: "Briefs",
+    count: "1",
+    items: [
+      { icon: "D", name: "Daily Brief - May 13", score: "80", status: "review" },
+    ],
+  },
+  {
+    label: "Monitoring",
+    count: "1",
+    items: [
+      { icon: "C", name: "Cohere", score: "82", status: "monitoring" },
+    ],
+  },
+];
+
+const reportRailFilters: Array<{ id: "all" | ReportsRailStatus; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "verified", label: "Verified" },
+  { id: "review", label: "Review" },
+  { id: "stale", label: "Stale" },
+  { id: "drafting", label: "Draft" },
+];
 
 function getPrototypeEntity(name = "Anthropic"): PrototypeReportEntity {
   return reportEntities.find((entity) => entity.name === name) ?? reportEntities[0];
@@ -893,43 +954,62 @@ const meLines = [
 ];
 
 export function PrototypeV2LeftRail({ surface, onAsk, selectedEntity = "Anthropic", onSelectEntity, guestSafe = false }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
+  const [reportsRailQuery, setReportsRailQuery] = useState("");
+  const [reportsRailFilter, setReportsRailFilter] = useState<(typeof reportRailFilters)[number]["id"]>("all");
   if (surface === "home") return <HomeV2EditionRail onAsk={onAsk} />;
   if (surface === "reports") {
+    const query = reportsRailQuery.trim().toLowerCase();
+    const filteredGroups = reportsRailGroups
+      .map((group) => ({
+        ...group,
+        items: group.items.filter((item) => {
+          const matchesQuery = !query || `${group.label} ${item.name}`.toLowerCase().includes(query);
+          const matchesStatus = reportsRailFilter === "all" || item.status === reportsRailFilter;
+          return matchesQuery && matchesStatus;
+        }),
+      }))
+      .filter((group) => group.items.length > 0);
     return (
       <aside className="rd-v2-left rd-v2-left--nav" aria-label="Reports navigation">
-        <input className="rd-v2-rail-search" placeholder="Find report, entity, source..." aria-label="Filter reports" />
+        <input
+          className="rd-v2-rail-search"
+          placeholder="Search reports..."
+          aria-label="Search reports"
+          value={reportsRailQuery}
+          onChange={(event) => setReportsRailQuery(event.currentTarget.value)}
+        />
+        <div className="rd-v2-rail-filters" role="tablist" aria-label="Filter reports by status">
+          {reportRailFilters.map((filter) => (
+            <button
+              key={filter.id}
+              type="button"
+              role="tab"
+              aria-selected={reportsRailFilter === filter.id}
+              className={reportsRailFilter === filter.id ? "is-active" : ""}
+              onClick={() => setReportsRailFilter(filter.id)}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
         <div className="rd-v2-rail-rule" />
-        <RailGroup label="Universes" count="3" selectedName={selectedEntity} onSelectItem={onSelectEntity} items={[
-          ["AI", "AI Infrastructure", "87", true],
-          ["CX", "Customer Agents", "24"],
-          ["VC", "Startup Banking Targets", "31"],
-        ]} />
-        <RailGroup label="Report types" count="8" selectedName={selectedEntity} onSelectItem={onSelectEntity} items={[
-          ["D", "Daily Brief", "9"],
-          ["C", "Company Report", "38"],
-          ["P", "Person Report", "12"],
-          ["T", "Topic Report", "16"],
-          ["M", "Market Map", "4"],
-          ["F", "Funding Tracker", "8"],
-        ]} />
-        <RailGroup label="Review work" count="18" items={[
-          ["!", "Needs evidence", "6"],
-          ["?", "Needs review", "7"],
-          ["V", "Verified", "30"],
-          ["E", "Export ready", "5"],
-        ]} />
-        <RailGroup label="Agent runs" count="5" items={[
-          ["R", "Active batches", "3"],
-          ["S", "Source refreshes", "2"],
-          ["N", "Notebook patches", "4"],
-        ]} />
-        <RailGroup label="People" count="8" items={[
-          ["•", "Dario Amodei", ""],
-          ["•", "Alfred Lin", ""],
-          ["•", "Sam Altman", ""],
-        ]} />
-        <RailGroup label="Entity tags" count="5" items={[["#", "Fundraise", ""], ["#", "Pricing", ""], ["#", "Hiring", ""]]} />
-        <button className="rd-v2-new-entity">+ New batch</button>
+        <div className="rd-v2-rail-scroll">
+          {filteredGroups.map((group) => (
+            <ReportsRailGroup
+              key={group.label}
+              label={group.label}
+              count={group.count}
+              items={group.items}
+              selectedName={selectedEntity}
+              onSelectItem={onSelectEntity}
+            />
+          ))}
+          {filteredGroups.length === 0 && <div className="rd-v2-rail-empty">No reports match this filter.</div>}
+        </div>
+        <div className="rd-v2-rail-footer">
+          <button type="button" onClick={() => onAsk?.("Create a new report entity and hydrate its first notebook.")}>+ Entity</button>
+          <button type="button" onClick={() => onAsk?.("Import a company list and run a sample coverage batch.")}>+ Import</button>
+        </div>
       </aside>
     );
   }
@@ -1043,6 +1123,53 @@ function RailGroup({
           {itemCount && <b>{itemCount}</b>}
         </button>
       ))}
+    </section>
+  );
+}
+
+function ReportsRailGroup({
+  label,
+  count,
+  items,
+  selectedName,
+  onSelectItem,
+}: {
+  label: string;
+  count: string;
+  items: ReportsRailItem[];
+  selectedName?: string;
+  onSelectItem?: (name: string) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+  return (
+    <section className={`rd-v2-rail-section rd-v2-rail-section--reports ${collapsed ? "is-collapsed" : ""}`}>
+      <button
+        type="button"
+        className="rd-v2-rail-section-head rd-v2-rail-section-toggle"
+        aria-expanded={!collapsed}
+        onClick={() => setCollapsed((value) => !value)}
+      >
+        <span className="rd-v2-rail-chevron">{collapsed ? "\u25b8" : "\u25be"}</span>
+        <span>{label}</span>
+        <b>{count}</b>
+      </button>
+      {!collapsed && items.map((item) => {
+        const selected = selectedName ? selectedName === item.name : item.active;
+        return (
+          <button
+            key={`${label}-${item.name}`}
+            className={`rd-v2-nav-row rd-v2-report-nav-row ${selected ? "is-active" : ""}`}
+            type="button"
+            data-status={item.status}
+            onClick={() => onSelectItem?.(item.name)}
+          >
+            <span className="rd-v2-report-nav-icon">{item.icon}</span>
+            <strong>{item.name}</strong>
+            <b>{item.score}</b>
+            {item.status && <i aria-label={item.status} className="rd-v2-report-nav-dot" data-status={item.status} />}
+          </button>
+        );
+      })}
     </section>
   );
 }
@@ -1339,8 +1466,42 @@ function AgentShell({
   );
 }
 
+function inspectorPipeline(entity: PrototypeReportEntity): Array<{ label: string; done: boolean }> {
+  const isDraft = /draft|generating|gathering/i.test(entity.status);
+  const needsReview = entity.score < 75 || /review|stale/i.test(entity.status);
+  return [
+    { label: isDraft ? "Gathering sources" : `Gathered ${Math.max(8, entity.sources * 4)} sources`, done: !isDraft || entity.sources > 2 },
+    { label: `Extracted ${Math.max(2, entity.signals.length)} entities`, done: !isDraft },
+    { label: `Generated ${Math.max(5, Math.round(entity.score / 4))} claims`, done: entity.score >= 45 },
+    { label: needsReview ? "Verifying evidence" : "Verified evidence", done: !needsReview },
+    { label: needsReview ? "Notebook patch pending" : "Notebook published", done: !needsReview },
+  ];
+}
+
+function inspectorWarnings(entity: PrototypeReportEntity): string[] {
+  if (/stale/i.test(entity.status)) {
+    return [
+      "Evidence freshness is below the release threshold.",
+      "Refresh public sources before exporting this notebook.",
+    ];
+  }
+  if (entity.score < 75 || /review/i.test(entity.status)) {
+    return [
+      "Open claims need human review before verification.",
+      "Notebook patch should preserve the prior source trail.",
+    ];
+  }
+  return [
+    "Source coverage is current enough for the present task.",
+    "Keep monitoring for fresh signals before the next daily brief.",
+  ];
+}
+
 function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedReport, onSelectEntity }: PrototypeSelectionProps) {
   const entity = selectedReport ? liveReportToPrototypeEntity(selectedReport) : getPrototypeEntity(selectedEntity);
+  const [drawerOpen, setDrawerOpen] = useState(true);
+  const pipeline = inspectorPipeline(entity);
+  const warnings = inspectorWarnings(entity);
   const reviewText = entity.score < 75 ? `${entity.name} needs review.` : `${entity.name} is in good shape.`;
   const summaryText = entity.score < 75
     ? `${entity.name} is below coverage threshold. Refresh sources, verify open claims, and decide whether the report needs a notebook patch.`
@@ -1358,37 +1519,64 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
       <div className="rd-v2-msg rd-v2-msg-agent">
         <strong>{reviewText}</strong>
         <p>{summaryText}</p>
-        <div className="rd-v2-trace"><small>Agent run trace</small><span>source_scan</span><span>claim_verify</span><span>notebook_patch</span></div>
+        <div className="rd-v2-trace"><small>Agent run trace</small><span>source_scan</span><span>claim_verify</span><span>score_compute</span><span>notebook_patch</span></div>
+        <div className="rd-v2-msg-actions">
+          <button type="button" className="is-primary" onClick={() => onAsk?.(`Open the ${entity.name} notebook and summarize the next review step.`)}>Open notebook</button>
+          <button type="button" onClick={() => onAsk?.(`Verify the weakest claims in ${entity.name}.`)}>Verify claims</button>
+          <button type="button" onClick={() => onAsk?.(`Export a memo preview for ${entity.name}.`)}>Export memo</button>
+        </div>
       </div>
-      <button className="rd-v2-drawer-toggle">{`Context · ${entity.name} ${entity.score} · ${entity.signals.length} signals · ${entity.related.length} entities`}</button>
-      <section className="rd-v2-agent-context">
-        <div className="rd-v2-context-head"><span>Active entity</span><span>{entity.score}</span></div>
-        <div className="rd-v2-score-big">{entity.score} <small>{entity.delta}</small></div>
-        {Object.entries(entity.dims).map(([label, value]) => (
-          <div className="rd-v2-score-row" key={label}>
-            <span>{label}</span>
-            <b><i data-tone={value >= 80 ? "green" : value >= 58 ? "accent" : "amber"} style={{ width: `${value}%` }} /></b>
-            <strong>{value}</strong>
+      <section className="rd-v2-pipeline" aria-label="Agent pipeline progress">
+        <div className="rd-v2-context-head"><span>Pipeline</span><span>{pipeline.filter((step) => step.done).length}/{pipeline.length}</span></div>
+        {pipeline.map((step) => (
+          <div key={step.label} className="rd-v2-pipeline-row" data-done={step.done}>
+            <span>{step.done ? "\u2713" : "\u25cb"}</span>
+            <strong>{step.label}</strong>
           </div>
         ))}
       </section>
-      <section className="rd-v2-agent-context">
-        <div className="rd-v2-context-head"><span>Recent signals</span><span>{entity.signals.length}</span></div>
-        {entity.signals.map((signal) => <p className="rd-v2-signal-line" key={signal}>{signal}</p>)}
-      </section>
-      <section className="rd-v2-agent-context">
-        <div className="rd-v2-context-head"><span>Related entities</span><span>{entity.related.length}</span></div>
-        {entity.related.map((name, index) => {
-          const related = reportEntities.find((item) => item.name === name);
-          const initial = related?.initial ?? name.slice(0, 1).toUpperCase();
-          const score = related?.score ?? Math.max(55, entity.score - (index + 1) * 4);
-          return (
-            <button className="rd-v2-related-entity" key={name} onClick={() => onSelectEntity?.(name)}>
-              <span>{initial}</span><strong>{name}</strong><b>{score}</b>
-            </button>
-          );
-        })}
-      </section>
+      <button
+        className="rd-v2-drawer-toggle"
+        type="button"
+        aria-expanded={drawerOpen}
+        onClick={() => setDrawerOpen((value) => !value)}
+      >{`Context - ${entity.name} ${entity.score} - ${warnings.length} warnings - ${entity.sources} sources`}</button>
+      {drawerOpen && (
+        <>
+          <section className="rd-v2-agent-context">
+            <div className="rd-v2-context-head"><span>Active entity</span><span>{entity.score}</span></div>
+            <div className="rd-v2-score-big">{entity.score} <small>{entity.delta}</small></div>
+            {Object.entries(entity.dims).map(([label, value]) => (
+              <div className="rd-v2-score-row" key={label}>
+                <span>{label}</span>
+                <b><i data-tone={value >= 80 ? "green" : value >= 58 ? "accent" : "amber"} style={{ width: `${value}%` }} /></b>
+                <strong>{value}</strong>
+              </div>
+            ))}
+          </section>
+          <section className="rd-v2-agent-context">
+            <div className="rd-v2-context-head"><span>Warnings</span><span>{warnings.length}</span></div>
+            {warnings.map((warning) => <p className="rd-v2-signal-line rd-v2-warning-line" key={warning}>{warning}</p>)}
+          </section>
+          <section className="rd-v2-agent-context">
+            <div className="rd-v2-context-head"><span>Recent signals</span><span>{entity.signals.length}</span></div>
+            {entity.signals.map((signal) => <p className="rd-v2-signal-line" key={signal}>{signal}</p>)}
+          </section>
+          <section className="rd-v2-agent-context">
+            <div className="rd-v2-context-head"><span>Related entities</span><span>{entity.related.length}</span></div>
+            {entity.related.map((name, index) => {
+              const related = reportEntities.find((item) => item.name === name);
+              const initial = related?.initial ?? name.slice(0, 1).toUpperCase();
+              const score = related?.score ?? Math.max(55, entity.score - (index + 1) * 4);
+              return (
+                <button className="rd-v2-related-entity" key={name} onClick={() => onSelectEntity?.(name)}>
+                  <span>{initial}</span><strong>{name}</strong><b>{score}</b>
+                </button>
+              );
+            })}
+          </section>
+        </>
+      )}
     </AgentShell>
   );
 }

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -5,7 +5,7 @@
  * Default density: compact. Sticky filter row.
  */
 
-import { useMemo, useState, useEffect, useRef } from "react";
+import { useMemo, useState, useEffect, useRef, type DragEvent } from "react";
 import { memoStyles, type ReportCardData, type Density, type Universe } from "../fixtures";
 import { Pill } from "../components/Pill";
 import { useReportsLive } from "../hooks/useReportsLive";
@@ -50,9 +50,28 @@ function displayReportDescription(description: string): string {
 
 interface ReportsSurfaceProps {
   onOpen: (id: string, tab: "brief" | "cards" | "chat") => void;
+  onRunBatch?: (prompt: string) => void;
   onSelectReport?: (report: ReportCardData) => void;
   inspectedReportId?: string | null;
 }
+
+type ReportViewMode = "gallery" | "board" | "table" | "graph";
+type ReportStage = "drafting" | "review" | "verified" | "stale" | "monitoring";
+
+const REPORT_VIEW_MODES: Array<{ id: ReportViewMode; label: string }> = [
+  { id: "gallery", label: "Gallery" },
+  { id: "board", label: "Board" },
+  { id: "table", label: "Table" },
+  { id: "graph", label: "Graph" },
+];
+
+const REPORT_STAGE_COLUMNS: Array<{ id: ReportStage; label: string; hint: string }> = [
+  { id: "drafting", label: "Drafting", hint: "Gathering sources" },
+  { id: "review", label: "Needs review", hint: "Claims need analyst review" },
+  { id: "verified", label: "Verified", hint: "Notebook ready" },
+  { id: "stale", label: "Stale", hint: "Refresh evidence" },
+  { id: "monitoring", label: "Monitoring", hint: "Watchlist active" },
+];
 
 const STATUS_FILTERS = [
   { id: "all", label: "All" },
@@ -69,14 +88,16 @@ const KIND_FILTERS = [
   { id: "Coverage", label: "Coverage" },
 ] as const;
 
-export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: ReportsSurfaceProps) {
+export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedReportId }: ReportsSurfaceProps) {
   const [filter, setFilter] = useState<typeof STATUS_FILTERS[number]["id"]>("all");
   const [kindFilter, setKindFilter] = useState<typeof KIND_FILTERS[number]["id"]>("all");
   const [density, setDensity] = useState<Density>("compact");
+  const [viewMode, setViewMode] = useState<ReportViewMode>("gallery");
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [sortKey, setSortKey] = useState<SortKey>("updated");
   const [sortOpen, setSortOpen] = useState(false);
+  const [stageOverrides, setStageOverrides] = useState<Record<string, ReportStage>>({});
   const sortRef = useRef<HTMLDivElement>(null);
 
   // Click-outside dismiss for sort dropdown
@@ -162,20 +183,71 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
     setSelected(new Set());
   };
 
-  const visibleReports = filtered.slice(0, 12);
+  const visibleReports = filtered.slice(0, 24);
   const verifiedShare = reports.length > 0 ? Math.round(((counts.verified ?? 0) / reports.length) * 100) : 0;
+  const totalSources = filtered.reduce((sum, report) => sum + report.sources, 0);
+  const reviewCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "review").length;
+  const staleCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "stale").length;
+  const draftingCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "drafting").length;
+  const confidenceScore = Math.max(0, Math.min(100, Math.round((verifiedShare * 0.62) + Math.min(totalSources, 120) * 0.18)));
+  const selectedReport = filtered.find((report) => report.id === inspectedReportId) ?? visibleReports[0] ?? null;
+  const runBatchPrompt = () => {
+    const prompt = "Run a coverage batch for my active report universe. Generate notebook-first reports, gather sources, extract claims, verify evidence, and create the review queue.";
+    if (onRunBatch) onRunBatch(prompt);
+    else onOpen("new", "chat");
+  };
+  const handleDragStart = (event: DragEvent<HTMLElement>, reportId: string) => {
+    event.dataTransfer.setData("text/plain", reportId);
+    event.dataTransfer.effectAllowed = "move";
+  };
+  const handleStageDrop = (event: DragEvent<HTMLElement>, stage: ReportStage) => {
+    event.preventDefault();
+    const reportId = event.dataTransfer.getData("text/plain");
+    if (!reportId) return;
+    setStageOverrides((prev) => ({ ...prev, [reportId]: stage }));
+    showToast({ tone: "success", message: `Moved report to ${stageLabel(stage)}. This is a local review-board preview until a write is approved.` });
+  };
 
   return (
-    <div className="rd-v2-proto-center">
-      <div className="rd-v2-edition-row">
-        <span className="rd-v2-edition-pill">Entity intelligence</span>
-        <span className="rd-v2-edition-subline">
-          {isLoading && reports.length === 0
-            ? "Checking Convex-backed artifacts"
-            : `${reports.length} live reports · ${verifiedShare}% verified · ${counts.review ?? 0} need review · ${reports.reduce((sum, report) => sum + report.sources, 0)} sources`}
-        </span>
-      </div>
-      <div className="rd-v2-filter-row" role="tablist" aria-label="Filter reports by status">
+    <div className="rd-v3-reports" data-view={viewMode}>
+      <header className="rd-v3-universe-header">
+        <div>
+          <div className="rd-v3-kicker">Reports</div>
+          <h1>AI Infrastructure Coverage</h1>
+          <p>
+            {isLoading && reports.length === 0
+              ? "Checking Convex-backed report artifacts."
+              : `${reports.length} reports, ${totalSources} sources, ${reviewCount} need review, confidence ${confidenceScore}/100.`}
+          </p>
+        </div>
+        <div className="rd-v3-universe-actions">
+          <button type="button" onClick={() => setViewMode("board")}>Review queue</button>
+          <button type="button" className="rd-v3-primary" onClick={runBatchPrompt}>+ New batch</button>
+        </div>
+      </header>
+      <section className="rd-v3-metrics" aria-label="Coverage metrics">
+        <span><strong>{reports.length}</strong> reports</span>
+        <span><strong>{verifiedShare}%</strong> verified</span>
+        <span><strong>{reviewCount}</strong> need review</span>
+        <span><strong>{staleCount}</strong> stale</span>
+        <span><strong>{draftingCount}</strong> drafting</span>
+      </section>
+      <div className="rd-v3-view-bar">
+        <div className="rd-v3-tabs" role="tablist" aria-label="Report views">
+          {REPORT_VIEW_MODES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={viewMode === item.id}
+              className={viewMode === item.id ? "is-active" : ""}
+              onClick={() => setViewMode(item.id)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      <div className="rd-v3-filter-pills" role="tablist" aria-label="Filter reports by status">
         {STATUS_FILTERS.map((item) => (
           <button
             key={item.id}
@@ -188,10 +260,10 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
           </button>
         ))}
         <button type="button" className={kindFilter !== "all" ? "is-active" : ""} onClick={() => setKindFilter(kindFilter === "all" ? "Diligence" : "all")}>
-          {kindFilter === "all" ? "Tags" : kindFilter} ▾
+          {kindFilter === "all" ? "Type" : kindFilter}
         </button>
       </div>
-      <div className="rd-v2-action-row" style={{ position: "relative" }}>
+      <div className="rd-v3-sort" style={{ position: "relative" }}>
         <button type="button" onClick={() => setSortOpen((v) => !v)}>
           {SORT_OPTIONS.find((s) => s.id === sortKey)?.label.split(" (")[0] ?? "Updated"} ▾
         </button>
@@ -211,40 +283,23 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
             ))}
           </div>
         )}
-        <button
-          type="button"
-          onClick={() => showToast({ tone: isLive ? "success" : "info", message: isLive ? `${sourceLabel}. Reports are Convex-backed.` : "No live reports yet. The page will not substitute fixtures." })}
-        >
-          ● {isLive ? "Convex-backed" : "No fixture fallback"}
-        </button>
-        {query && <button type="button" onClick={resetFilters}>Clear filters</button>}
-        <button
-          type="button"
-          className="rd-v2-btn-primary"
-          onClick={() => showToast({ tone: "info", message: "Start a new entity report from Chat so the first write has source trace and approval context." })}
-        >
-          + New report
-        </button>
       </div>
-      <div className="rd-v2-action-row" aria-label="Search reports">
-        <label className="rd-sr-only" htmlFor="reports-v2-search">Search reports</label>
+      </div>
+      <div className="rd-v3-search-row" aria-label="Search reports">
+        <label className="rd-sr-only" htmlFor="reports-v3-search">Search reports</label>
         <input
-          id="reports-v2-search"
+          id="reports-v3-search"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder={isLive ? `Search ${reports.length} live reports...` : "Search live reports..."}
-          style={{
-            width: "100%",
-            border: "1px solid var(--rd-line)",
-            borderRadius: 999,
-            padding: "10px 14px",
-            background: "var(--rd-panel)",
-            color: "var(--rd-ink)",
-          }}
+          placeholder={isLive ? `Search ${reports.length} reports, sources, claims...` : "Search reports, sources, claims..."}
         />
+        <button type="button" onClick={() => showToast({ tone: isLive ? "success" : "info", message: isLive ? `${sourceLabel}. Reports are live.` : "No live reports yet. This view does not silently substitute fixtures." })}>
+          {isLive ? "Live memory" : "No fixture fallback"}
+        </button>
+        {query && <button type="button" onClick={resetFilters}>Clear</button>}
       </div>
       {visibleReports.length === 0 ? (
-        <article className="rd-v2-report-card rd-v2-report-card--add">
+        <article className="rd-v3-card rd-v3-card--empty">
           <h2>{hasActiveFilter ? "No matching live reports" : "No live coverage returned"}</h2>
           <p>
             {hasActiveFilter
@@ -255,56 +310,42 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
             {hasActiveFilter ? "Clear filters" : "+ Start in Chat"}
           </button>
         </article>
+      ) : viewMode === "board" ? (
+        <ReportBoard
+          reports={visibleReports}
+          stageOverrides={stageOverrides}
+          onDragStart={handleDragStart}
+          onStageDrop={handleStageDrop}
+          onOpen={onOpen}
+          onSelect={onSelectReport}
+        />
+      ) : viewMode === "table" ? (
+        <ReportTable reports={visibleReports} stageOverrides={stageOverrides} onOpen={onOpen} onSelect={onSelectReport} />
+      ) : viewMode === "graph" ? (
+        <ReportGraphPreview reports={visibleReports} selectedReport={selectedReport} onOpen={onOpen} onSelect={onSelectReport} />
       ) : (
-        <div className="rd-v2-report-grid">
-          {visibleReports.map((report) => {
-            const active = inspectedReportId === report.id;
-            return (
-              <article
-                key={report.id}
-                className={`rd-v2-report-card ${active ? "is-active" : ""}`}
-                onClick={() => onSelectReport?.(report)}
-                aria-selected={active}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter" && event.key !== " ") return;
-                  event.preventDefault();
-                  onSelectReport?.(report);
-                }}
-              >
-                <div className="rd-v2-report-title">
-                  <span>{report.entity.slice(0, 1).toUpperCase()}</span>
-                  <h2>{report.entity}</h2>
-                  <b data-state={report.status}>{report.status === "review" ? "review" : report.status}</b>
-                </div>
-                <p className="rd-v2-report-kind">{report.kind}</p>
-                <p>{displayReportDescription(report.description)}</p>
-                <div className="rd-v2-report-tags">
-                  <span>{report.sources} sources</span>
-                  <span>{report.claims} claims</span>
-                  <span>{report.followUps} follow-ups</span>
-                </div>
-                <p className="rd-v2-report-ref">Referenced in: {sourceLabel}</p>
-                <p className="rd-v2-report-meta">Updated {report.updatedAt}</p>
-                <div className="rd-v2-next-actions" style={{ marginTop: 8 }}>
-                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "brief"); }}>Open</button>
-                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "cards"); }}>Cards</button>
-                  <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "chat"); }}>Chat</button>
-                </div>
-              </article>
-            );
-          })}
-          <article className="rd-v2-report-card rd-v2-report-card--add">
-            <h2>Add entity</h2>
-            <p>Capture a company, person, topic, or source cluster and let the coverage agent hydrate the first report.</p>
-            <button type="button" onClick={() => onOpen("new", "chat")}>+ New entity</button>
+        <div className="rd-v3-grid" data-density={density}>
+          {visibleReports.map((report) => (
+            <ReportCardV3
+              key={report.id}
+              report={report}
+              active={inspectedReportId === report.id}
+              stage={getReportStage(report, stageOverrides[report.id])}
+              sourceLabel={sourceLabel}
+              onOpen={onOpen}
+              onSelect={onSelectReport}
+            />
+          ))}
+          <article className="rd-v3-card rd-v3-card--add">
+            <h2>Run a batch</h2>
+            <p>Import companies, people, or topics and let the agent generate notebooks, claims, sources, and review tasks.</p>
+            <button type="button" onClick={runBatchPrompt}>+ New batch</button>
           </article>
         </div>
       )}
       {filtered.length > visibleReports.length && (
-        <button className="rd-v2-show-more" type="button" onClick={() => showToast({ tone: "info", message: `${filtered.length - visibleReports.length} more live reports are available through search and filters.` })}>
-          Show {filtered.length - visibleReports.length} more entities
+        <button className="rd-v3-show-more" type="button" onClick={() => showToast({ tone: "info", message: `${filtered.length - visibleReports.length} more live reports are available through search and filters.` })}>
+          Show {filtered.length - visibleReports.length} more reports
         </button>
       )}
     </div>
@@ -504,6 +545,229 @@ export function ReportsSurface({ onOpen, onSelectReport, inspectedReportId }: Re
         onSelectReport={onSelectReport}
       />
     </div>
+  );
+}
+
+function getReportStage(report: ReportCardData, override?: ReportStage): ReportStage {
+  if (override) return override;
+  if (report.status === "review") return "review";
+  if (report.status === "watching") return "monitoring";
+  const staleSignals = /stale|expired|refresh|old|3d|5d|week/i.test(`${report.description} ${report.updatedAt}`);
+  if (staleSignals) return "stale";
+  if (report.sources <= 2 || /draft|gathering|queued|generating/i.test(report.description)) return "drafting";
+  return "verified";
+}
+
+function stageLabel(stage: ReportStage): string {
+  return REPORT_STAGE_COLUMNS.find((item) => item.id === stage)?.label ?? stage;
+}
+
+function stageTone(stage: ReportStage): "green" | "amber" | "blue" | undefined {
+  if (stage === "verified") return "green";
+  if (stage === "review" || stage === "stale" || stage === "drafting") return "amber";
+  if (stage === "monitoring") return "blue";
+  return undefined;
+}
+
+function reportSignals(report: ReportCardData): string[] {
+  const kind = report.kind || "Coverage";
+  const signals = [kind, report.sources > 5 ? "source-rich" : "needs sources", report.followUps > 0 ? "actionable" : "monitor"];
+  return Array.from(new Set(signals)).slice(0, 3);
+}
+
+function reportBacklinks(report: ReportCardData): string[] {
+  const words = report.description
+    .split(/\s+/)
+    .map((word) => word.replace(/[^A-Za-z0-9]/g, ""))
+    .filter((word) => word.length > 4 && /^[A-Z]/.test(word));
+  return Array.from(new Set(words)).slice(0, 3);
+}
+
+function notebookState(stage: ReportStage): string {
+  if (stage === "verified" || stage === "monitoring") return "Notebook ready";
+  if (stage === "review") return "Review patch";
+  if (stage === "stale") return "Refresh needed";
+  return "Drafting";
+}
+
+function ReportCardV3({
+  report,
+  active,
+  stage,
+  sourceLabel,
+  onOpen,
+  onSelect,
+}: {
+  report: ReportCardData;
+  active: boolean;
+  stage: ReportStage;
+  sourceLabel: string;
+  onOpen: ReportsSurfaceProps["onOpen"];
+  onSelect?: (report: ReportCardData) => void;
+}) {
+  const signals = reportSignals(report);
+  const backlinks = reportBacklinks(report);
+  return (
+    <article
+      className="rd-v3-card"
+      data-status={stage}
+      aria-selected={active}
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect?.(report)}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onSelect?.(report);
+      }}
+    >
+      <div className="rd-v3-card__head">
+        <span className="rd-v3-icon">{report.entity.slice(0, 1).toUpperCase()}</span>
+        <strong>{report.entity}</strong>
+        <Pill tone={stageTone(stage)}>{stageLabel(stage)}</Pill>
+        <button type="button" aria-label={`More actions for ${report.entity}`} onClick={(event) => event.stopPropagation()}>⋯</button>
+      </div>
+      <p className="rd-v3-card__kind">{report.kind}</p>
+      <p className="rd-v3-card__thesis">{displayReportDescription(report.description)}</p>
+      <div className="rd-v3-signals">
+        {signals.map((signal) => <span key={signal}>{signal}</span>)}
+      </div>
+      <div className="rd-v3-sources">
+        <span>{report.sources} sources</span>
+        <span>{report.claims} claims</span>
+        <span>{report.followUps} follow-ups</span>
+      </div>
+      {backlinks.length > 0 && (
+        <div className="rd-v3-backlinks">
+          {backlinks.map((item) => <span key={item}>→ {item}</span>)}
+        </div>
+      )}
+      <div className="rd-v3-card__foot">
+        <span>{sourceLabel} · {report.updatedAt}</span>
+        <span>{notebookState(stage)}</span>
+      </div>
+      <div className="rd-v3-card__actions">
+        <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "brief"); }}>Open notebook</button>
+        <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "cards"); }}>Review evidence</button>
+        <button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "chat"); }}>Ask agent</button>
+      </div>
+    </article>
+  );
+}
+
+function ReportBoard({
+  reports,
+  stageOverrides,
+  onDragStart,
+  onStageDrop,
+  onOpen,
+  onSelect,
+}: {
+  reports: ReportCardData[];
+  stageOverrides: Record<string, ReportStage>;
+  onDragStart: (event: DragEvent<HTMLElement>, reportId: string) => void;
+  onStageDrop: (event: DragEvent<HTMLElement>, stage: ReportStage) => void;
+  onOpen: ReportsSurfaceProps["onOpen"];
+  onSelect?: (report: ReportCardData) => void;
+}) {
+  return (
+    <section className="rd-v3-board" aria-label="Draggable report review board">
+      {REPORT_STAGE_COLUMNS.map((column) => {
+        const columnReports = reports.filter((report) => getReportStage(report, stageOverrides[report.id]) === column.id);
+        return (
+          <div
+            key={column.id}
+            className="rd-v3-board-column"
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={(event) => onStageDrop(event, column.id)}
+          >
+            <header><strong>{column.label}</strong><span>{columnReports.length}</span><small>{column.hint}</small></header>
+            {columnReports.map((report) => (
+              <button
+                key={report.id}
+                type="button"
+                className="rd-v3-mini"
+                draggable
+                onDragStart={(event) => onDragStart(event, report.id)}
+                onClick={() => onSelect?.(report)}
+                onDoubleClick={() => onOpen(report.id, "brief")}
+              >
+                <span>{report.entity.slice(0, 1).toUpperCase()}</span>
+                <strong>{report.entity}</strong>
+                <small>{report.sources} sources · {report.claims} claims</small>
+              </button>
+            ))}
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+function ReportTable({
+  reports,
+  stageOverrides,
+  onOpen,
+  onSelect,
+}: {
+  reports: ReportCardData[];
+  stageOverrides: Record<string, ReportStage>;
+  onOpen: ReportsSurfaceProps["onOpen"];
+  onSelect?: (report: ReportCardData) => void;
+}) {
+  return (
+    <div className="rd-v3-table-wrap" role="region" aria-label="Analyst report table">
+      <table className="rd-v3-table">
+        <thead><tr><th>Report</th><th>Status</th><th>Type</th><th>Sources</th><th>Claims</th><th>Notebook</th><th>Action</th></tr></thead>
+        <tbody>
+          {reports.map((report) => {
+            const stage = getReportStage(report, stageOverrides[report.id]);
+            return (
+              <tr key={report.id} onClick={() => onSelect?.(report)}>
+                <td><strong>{report.entity}</strong><span>{displayReportDescription(report.description)}</span></td>
+                <td>{stageLabel(stage)}</td>
+                <td>{report.kind}</td>
+                <td>{report.sources}</td>
+                <td>{report.claims}</td>
+                <td>{notebookState(stage)}</td>
+                <td><button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "brief"); }}>Open notebook</button></td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ReportGraphPreview({
+  reports,
+  selectedReport,
+  onOpen,
+  onSelect,
+}: {
+  reports: ReportCardData[];
+  selectedReport: ReportCardData | null;
+  onOpen: ReportsSurfaceProps["onOpen"];
+  onSelect?: (report: ReportCardData) => void;
+}) {
+  const root = selectedReport ?? reports[0];
+  return (
+    <section className="rd-v3-graph" aria-label="Report relationship graph preview">
+      <div className="rd-v3-graph__root">
+        <span>{root?.entity.slice(0, 1).toUpperCase() ?? "R"}</span>
+        <strong>{root?.entity ?? "Select a report"}</strong>
+        <button type="button" onClick={() => root && onOpen(root.id, "brief")}>Open notebook</button>
+      </div>
+      <div className="rd-v3-graph__nodes">
+        {reports.slice(0, 10).map((report) => (
+          <button key={report.id} type="button" onClick={() => onSelect?.(report)} aria-pressed={root?.id === report.id}>
+            <span>{report.entity.slice(0, 1).toUpperCase()}</span>
+            {report.entity}
+          </button>
+        ))}
+      </div>
+    </section>
   );
 }
 

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -153,7 +153,7 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
 
   useEffect(() => {
     if (!onSelectReport || filtered.length === 0) return;
-    if (inspectedReportId && filtered.some((report) => report.id === inspectedReportId)) return;
+    if (inspectedReportId) return;
     onSelectReport(filtered[0]);
   }, [filtered, inspectedReportId, onSelectReport]);
 

--- a/tests/e2e/home-v2-parity.spec.ts
+++ b/tests/e2e/home-v2-parity.spec.ts
@@ -27,6 +27,7 @@ function reportCards(page: Page): Locator {
       '[data-testid="report-card"]',
       '[data-testid="redesign-report-card"]',
       "[data-report-card]",
+      ".rd-v3-card:not(.rd-v3-card--add):not(.rd-v3-card--empty)",
       ".rd-v2-report-card:not(.rd-v2-report-card--add)",
       ".rd-report-card",
     ].join(", "),
@@ -39,7 +40,7 @@ async function normalizedText(locator: Locator): Promise<string> {
 
 async function reportTitle(card: Locator): Promise<string> {
   const title = card
-    .locator('[data-report-title], .rd-report-card__entity, [role="heading"], h2, h3')
+    .locator('[data-report-title], .rd-v3-card__head strong, .rd-report-card__entity, [role="heading"], h2, h3')
     .first();
   const titleText = (await title.textContent().catch(() => null))?.trim();
   if (titleText) return titleText;
@@ -47,7 +48,7 @@ async function reportTitle(card: Locator): Promise<string> {
 }
 
 async function selectReport(card: Locator): Promise<void> {
-  const bodyTarget = card.locator(".rd-report-card__entity, [data-report-title], h2, h3").first();
+  const bodyTarget = card.locator(".rd-v3-card__head strong, .rd-report-card__entity, [data-report-title], h2, h3").first();
   if ((await bodyTarget.count()) > 0) {
     await bodyTarget.click();
   } else {
@@ -145,11 +146,11 @@ test.describe("Home v2 /redesign parity", () => {
     await page.goto("/redesign/reports", { waitUntil: "domcontentloaded" });
 
     await expect(page.getByRole("complementary", { name: "Reports navigation" })).toBeVisible();
-    await expect(page.getByLabel("Filter entities")).toBeVisible();
-    await expect(page.getByText("Entity intelligence").first()).toBeVisible();
-    await expect(page.locator(".rd-v2-report-grid")).toBeVisible({ timeout: 15_000 });
-    await expectV2CenterCanvas(page, ".rd-v2-proto-center");
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Filter reports" })).toBeVisible();
+    await expect(page.getByText("AI Infrastructure Coverage").first()).toBeVisible();
+    await expect(page.locator(".rd-v3-grid")).toBeVisible({ timeout: 15_000 });
+    await expectV2CenterCanvas(page, ".rd-v3-reports");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toBeVisible();
     const rail = rightRail(page);
     await expectRailInViewport(rail);
 
@@ -165,7 +166,7 @@ test.describe("Home v2 /redesign parity", () => {
     await selectReport(firstCard);
     await expect.poll(async () => await normalizedText(rail)).toContain(firstTitle);
     const firstRailText = await normalizedText(rail);
-    await expect(rail).toContainText("3 steps completed");
+    await expect(rail).toContainText("Agent run trace");
 
     await selectReport(secondCard);
     await expect.poll(async () => await normalizedText(rail)).toContain(secondTitle);
@@ -285,8 +286,8 @@ test.describe("Home v2 prototype kit mode", () => {
       {
         path: `/redesign/reports?${qa}`,
         nav: "Reports",
-        center: "Entity intelligence",
-        rail: "Coverage agent",
+        center: "AI Infrastructure Coverage",
+        rail: "Agent Inspector",
       },
       {
         path: `/redesign/chat?${qa}`,
@@ -337,13 +338,13 @@ test.describe("Home v2 prototype kit mode", () => {
     await page.goto(`/redesign/reports?${qa}`, { waitUntil: "domcontentloaded" });
 
     await page.getByText("Sequoia Capital").first().click();
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Sequoia Capital");
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Score 74");
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Full-ratchet anti-dilution clause added");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("Sequoia Capital");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("Score 74");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("Full-ratchet anti-dilution clause added");
 
     await page.getByRole("button", { name: /OpenAI 62/i }).click();
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("OpenAI");
-    await expect(page.getByRole("complementary", { name: "Coverage agent" })).toContainText("Score 62");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("OpenAI");
+    await expect(page.getByRole("complementary", { name: "Agent Inspector" })).toContainText("Score 62");
   });
 
   test("prototype Chat includes answer packet details and interactive utility tabs", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Reworks the redesign Reports surface around the home-v3 workbench model: universe header, metrics, Gallery/Board/Table/Graph modes, denser report cards, and review-board drag/drop preview.
- Updates Reports left rail and prototype kit to use universes, report types, review work, agent runs, and the Agent Inspector language.
- Keeps report notebook detail inside the redesign shell with the right Agent Inspector visible, and fixes duplicate linked-tag React keys on live notebooks.

## Verification
- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
- npm run build
- BASE_URL=http://127.0.0.1:5180 npx playwright test tests/e2e/home-v2-parity.spec.ts --project=chromium --grep "desktop Reports selection|live and prototype routes avoid horizontal overflow|prototype Reports selection|prototype QA mode"
- Browser probe: /redesign/reports renders 4 dense columns at 1600px, Board/Table/Graph render, /redesign/reports/:id opens live TipTap notebook with left rail + Agent Inspector and no console errors.
