### PR TITLE
Align Reports v3 transparency UI

### DIFF
--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -381,7 +381,7 @@ export default function RedesignShell() {
 function ReportDetailRoute({ reportId }: { reportId: string }) {
   const liveArtifacts = useLiveArtifacts(60);
   const liveDetail = liveArtifacts.details.find((detail) => detail.id === reportId);
-  return <ReportNotebookView reportId={reportId} liveDetail={liveDetail} showSidebar={false} />;
+  return <ReportNotebookView reportId={reportId} liveDetail={liveDetail} showSidebar />;
 }
 
 function useQaChromeFlag(search: string): boolean {

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -3429,6 +3429,27 @@
   text-align: right;
 }
 
+[data-redesign] .rd-v2-transparency-row {
+  display: grid;
+  grid-template-columns: 84px minmax(0, 1fr);
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--rd-line-faint);
+  color: var(--rd-ink-mute);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+[data-redesign] .rd-v2-transparency-row:last-child {
+  border-bottom: 0;
+}
+
+[data-redesign] .rd-v2-transparency-row strong {
+  min-width: 0;
+  color: var(--rd-ink-strong);
+  font-weight: 650;
+}
+
 [data-redesign] .rd-v2-signal-line {
   margin: 6px 0;
   color: var(--rd-ink-mute);
@@ -7727,12 +7748,20 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-v3-graph__root {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 10px;
   padding: 14px 16px;
   border: 1px solid var(--rd-line);
   border-radius: 999px;
   background: var(--rd-panel);
   box-shadow: var(--rd-shadow-sm);
+}
+
+[data-redesign] .rd-v3-delta-refresh {
+  border-color: var(--rd-accent-soft);
+  background: var(--rd-accent-tint);
+  color: var(--rd-accent-strong);
 }
 
 [data-redesign] .rd-v3-graph__nodes {

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -70,12 +70,12 @@ const reportEntities = [
     status: "Verified",
     score: 91,
     sources: 12,
-    delta: "▲ 3 from last run",
+    delta: "Updated 2h ago",
     kind: "Partnership intelligence - Company",
     body: "Enterprise tier repriced +40%; Claude 4 Opus structure held. Managed Agent tier launched at $0.168/1K tokens.",
     tags: ["Partnership", "AI", "Enterprise"],
     ref: "Board prep - Q2 strategy - Vendor review",
-    meta: "Confidence 91 · 12 sources · 2 open claims · refreshed 2h ago",
+    meta: "5 of 5 claims verified · 12 sources · refreshed 2h ago",
     dims: { Sources: 95, Freshness: 92, Verification: 80, Coverage: 88 },
     signals: ["Enterprise pricing +40% effective June 1", "Managed Agent tier $0.168/1K tokens", "Partnership compressed $1.2M"],
     related: ["Sequoia Capital", "OpenAI", "Google DeepMind"],
@@ -87,12 +87,12 @@ const reportEntities = [
     status: "Needs review",
     score: 74,
     sources: 8,
-    delta: "▼ declining",
+    delta: "Last checked 1d ago",
     kind: "Term sheet analysis - Investor",
     body: "Full-ratchet anti-dilution at 1x in term sheet v3; 33% below market norm. Board observer seat added at $83M.",
     tags: ["Fundraising", "Term sheet", "Action needed"],
     ref: "Cap table model - Dilution analysis - Deal memo",
-    meta: "Confidence 74 · 8 sources · 3 open claims · review needed",
+    meta: "4 of 7 claims current · 8 sources · review needed",
     dims: { Sources: 72, Freshness: 65, Verification: 58, Coverage: 80 },
     signals: ["Full-ratchet anti-dilution clause added", "Board observer seat at $8.3M", "Counter-bid moved to $80M pre"],
     related: ["Anthropic", "Bug0", "OpenAI"],
@@ -103,12 +103,12 @@ const reportEntities = [
     status: "Verified",
     score: 88,
     sources: 5,
-    delta: "▲ 2 from last run",
+    delta: "Updated 1d ago",
     kind: "Competitive intelligence - Competitor",
     body: "Pricing dropped to $199/mo from $349; SOC 2 Type II obtained. Feature gap narrowing on automated QA.",
     tags: ["Competitive", "QA", "Enterprise"],
     ref: "Competitive matrix - Pricing comparison",
-    meta: "Confidence 88 · 5 sources · 1 open claim · refreshed 1d ago",
+    meta: "4 of 4 claims verified · 5 sources · refreshed 1d ago",
     dims: { Sources: 78, Freshness: 85, Verification: 90, Coverage: 82 },
     signals: ["Pricing dropped to $199/mo from $349", "SOC 2 Type II obtained", "Feature gap narrowing on automated QA"],
     related: ["Anthropic", "OpenAI", "Google DeepMind"],
@@ -119,12 +119,12 @@ const reportEntities = [
     status: "Stale",
     score: 62,
     sources: 4,
-    delta: "▼ stale",
+    delta: "Last checked 3d ago",
     kind: "Market intelligence - Company",
     body: "GPT-5 announcement rumored but unverified; 2 of 5 claims stale after 3 days. Refresh needed.",
     tags: ["AI", "Unverified"],
     ref: "Competitive matrix - API cost model",
-    meta: "Confidence 62 · 4 sources · 3 stale claims · refresh needed",
+    meta: "3 of 5 claims current · 4 sources · refresh needed",
     dims: { Sources: 55, Freshness: 42, Verification: 50, Coverage: 68 },
     signals: ["GPT-5 announcement rumored, unverified", "2 of 5 claims now stale", "API pricing restructure signal"],
     related: ["Anthropic", "Google DeepMind", "Bug0"],
@@ -135,12 +135,12 @@ const reportEntities = [
     status: "Stale",
     score: 55,
     sources: 3,
-    delta: "▼ stale",
+    delta: "Last checked 5d ago",
     kind: "Coverage gap - Company",
     body: "No new signals in 5 days; only 1 of 3 sources still verifiable. Refresh the research and update model capability notes.",
     tags: ["AI", "Research", "Refresh"],
     ref: "Model capability watch - Source ledger",
-    meta: "Confidence 55 · 3 sources · 2 stale claims · refresh needed",
+    meta: "1 of 3 sources still verifiable · 3 sources · refresh needed",
     dims: { Sources: 48, Freshness: 35, Verification: 45, Coverage: 55 },
     signals: ["No new signals in 5 days", "Only 1 of 3 sources still verifiable", "Research tracker needs owner review"],
     related: ["Anthropic", "OpenAI", "Sequoia Capital"],
@@ -152,7 +152,6 @@ type ReportsRailStatus = "verified" | "review" | "stale" | "drafting" | "monitor
 type ReportsRailItem = {
   icon: string;
   name: string;
-  score: string;
   status?: ReportsRailStatus;
   active?: boolean;
 };
@@ -162,42 +161,42 @@ const reportsRailGroups: Array<{ label: string; count: string; items: ReportsRai
     label: "Universes",
     count: "3",
     items: [
-      { icon: "AI", name: "AI Infrastructure", score: "87", active: true },
-      { icon: "BT", name: "Banking Targets", score: "34" },
-      { icon: "FW", name: "Fundraise Watch", score: "12" },
+      { icon: "AI", name: "AI Infrastructure", active: true },
+      { icon: "BT", name: "Banking Targets" },
+      { icon: "FW", name: "Fundraise Watch" },
     ],
   },
   {
     label: "Companies",
     count: "5",
     items: [
-      { icon: "A", name: "Anthropic", score: "91", status: "verified" },
-      { icon: "O", name: "OpenAI", score: "62", status: "stale" },
-      { icon: "M", name: "Mistral", score: "25", status: "drafting" },
-      { icon: "B", name: "Bug0", score: "88", status: "verified" },
-      { icon: "G", name: "Google DeepMind", score: "47", status: "stale" },
+      { icon: "A", name: "Anthropic", status: "verified" },
+      { icon: "O", name: "OpenAI", status: "stale" },
+      { icon: "M", name: "Mistral", status: "drafting" },
+      { icon: "B", name: "Bug0", status: "verified" },
+      { icon: "G", name: "Google DeepMind", status: "stale" },
     ],
   },
   {
     label: "People",
     count: "2",
     items: [
-      { icon: "D", name: "Dario Amodei", score: "87", status: "verified" },
-      { icon: "S", name: "Sequoia Capital", score: "74", status: "review" },
+      { icon: "D", name: "Dario Amodei", status: "verified" },
+      { icon: "S", name: "Sequoia Capital", status: "review" },
     ],
   },
   {
     label: "Briefs",
     count: "1",
     items: [
-      { icon: "D", name: "Daily Brief - May 13", score: "80", status: "review" },
+      { icon: "D", name: "Daily Brief - May 13", status: "review" },
     ],
   },
   {
     label: "Monitoring",
     count: "1",
     items: [
-      { icon: "C", name: "Cohere", score: "82", status: "monitoring" },
+      { icon: "C", name: "Cohere", status: "monitoring" },
     ],
   },
 ];
@@ -236,12 +235,12 @@ function liveReportToPrototypeEntity(report: ReportCardData): PrototypeReportEnt
     status,
     score,
     sources: report.sources,
-    delta: report.updatedAt,
+    delta: `Updated ${report.updatedAt}`,
     kind: `${report.kind} - Live report`,
     body: report.description,
     tags: [report.kind, status, report.followUps > 0 ? "Action needed" : "Current"],
     ref: "Live Convex artifacts - notebook - sources",
-    meta: `Confidence ${score} · ${report.sources} sources · ${report.claims} claims · ${report.followUps} follow-ups`,
+    meta: `${report.claims} claims · ${report.sources} sources · ${report.followUps} follow-ups · ${report.updatedAt}`,
     dims: { Sources: evidence, Freshness: freshness, Verification: actionability, Coverage: graphFit },
     signals: [
       report.description,
@@ -371,7 +370,7 @@ function introspectionSourceTitle(source: LiveArtifactSourceRow | undefined, fal
 function introspectionSourceBody(source: LiveArtifactSourceRow | undefined, fallback: string): string {
   if (!source) return fallback;
   if (isNoisyFirstViewportSource(source)) {
-    return "The raw headline stays below the fold as evidence. The useful part is that provenance, reuse count, and confidence are ready for the agent to judge.";
+    return "The raw headline stays below the fold as evidence. The useful part is that provenance, reuse count, and review state are ready for the agent to judge.";
   }
   return trimSentence(source.excerpt, fallback, 180);
 }
@@ -620,7 +619,7 @@ function buildHomeV2Model(liveArtifacts?: LiveArtifactsResult): HomeV2Model {
       selectedBody: "Active founder-recruiter lead after Earlier Startup Lead / Insurance AI Co context.",
       selectedNext: "Book Wed Wednesday 11:30 AM.",
       selectedWhy: "This is specific, current, and high enough signal to clear before recruiter batch work.",
-      selectedScore: "91 strong",
+      selectedScore: "Verified",
       proofCards: [
         { title: "Pinned match", body: "active thread, calendar-ready, vertical AI", tag: "active thread" },
         { title: "NodeBench proof", body: "Ready for action. 3 public-source signals attached.", tag: "ready" },
@@ -642,11 +641,11 @@ function buildHomeV2Model(liveArtifacts?: LiveArtifactsResult): HomeV2Model {
       agentBody: "Anthropic repriced enterprise tier +40% effective June 1, Sequoia added a full-ratchet clause to the Series C term sheet, and SMB churn crossed the 3% threshold for the first time since Q3.",
       agentTrace: ["entity_scan", "signal_rank", "source_verify"],
       agentEntities: [
-        ["A", "Anthropic", "Verified", "91"],
-        ["S", "Sequoia Capital", "Review", "74"],
-        ["B", "Bug0", "", "68"],
-        ["O", "OpenAI", "", "62"],
-        ["D", "DeepMind", "", "55"],
+        ["A", "Anthropic", "Verified", "12 sources"],
+        ["S", "Sequoia Capital", "Review", "8 sources"],
+        ["B", "Bug0", "", "5 sources"],
+        ["O", "OpenAI", "Stale", "4 sources"],
+        ["D", "DeepMind", "Stale", "3 sources"],
       ],
     };
   }
@@ -740,7 +739,7 @@ function buildHomeV2Model(liveArtifacts?: LiveArtifactsResult): HomeV2Model {
     monogram(report.entity),
     report.entity,
     report.status === "verified" ? "Verified" : report.status === "review" ? "Review" : "",
-    String(Math.round(Math.min(99, Math.max(40, report.sources * 7 + report.claims * 3)))),
+    `${report.sources} sources`,
   ] as [string, string, string, string]);
   const sweepBullets = queueSource.slice(0, 4).map((item) => `${compact(item.next, "Review")} ${compact(item.title, "live signal")}.`);
   const fallbackStats = liveArtifacts.isLoading
@@ -759,9 +758,9 @@ function buildHomeV2Model(liveArtifacts?: LiveArtifactsResult): HomeV2Model {
     .find((source) => compact(source.title || source.excerpt, "").length > 0);
   const followUpTotal = reports.reduce((total, report) => total + report.followUps, 0);
   const changedSignalCount = Math.max(liveArtifacts.briefFeatureCount, pulse.length, reports.length);
-  const sourceConfidence = typeof topSource?.confidence === "number"
-    ? `${Math.round(topSource.confidence * 100)}% confidence`
-    : "confidence pending";
+  const sourceReviewState = typeof topSource?.confidence === "number"
+    ? topSource.confidence >= 0.82 ? "verified source row" : "needs review"
+    : "review pending";
   const liveIntrospection: HomeV2Introspection = {
     kicker: "Daily introspection",
     title: "One useful thing surfaced while you were not looking.",
@@ -784,7 +783,7 @@ function buildHomeV2Model(liveArtifacts?: LiveArtifactsResult): HomeV2Model {
       topReport?.description ?? "Source-backed evidence will appear here once a live report, daily brief, or public archive row returns.",
     ),
     sourceMeta: topSource
-      ? `${sourceLabel(topSource.type)} - ${topSource.reused} reuses - ${sourceConfidence}`
+      ? `${sourceLabel(topSource.type)} - ${topSource.reused} reuses - ${sourceReviewState}`
       : hasLive
         ? "No source row attached to the top packet"
         : "Waiting for live evidence",
@@ -1165,7 +1164,6 @@ function ReportsRailGroup({
           >
             <span className="rd-v2-report-nav-icon">{item.icon}</span>
             <strong>{item.name}</strong>
-            <b>{item.score}</b>
             {item.status && <i aria-label={item.status} className="rd-v2-report-nav-dot" data-status={item.status} />}
           </button>
         );
@@ -1206,7 +1204,7 @@ function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }
         <div>
           <div className="rd-v3-kicker">Reports</div>
           <h1>AI Infrastructure Coverage</h1>
-          <p>87 reports, 48 sources, 7 need review, confidence 91/100.</p>
+          <p>87 reports, 312 sources, 18 need review.</p>
         </div>
         <div className="rd-v3-universe-actions">
           <button type="button">Review queue</button>
@@ -1227,7 +1225,7 @@ function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }
       </div>
       <div className="rd-v2-edition-row">
         <span className="rd-v2-edition-pill">Entity intelligence</span>
-        <span className="rd-v2-edition-subline">12 entities · 83% verified · avg score 87 · 48 sources</span>
+        <span className="rd-v2-edition-subline">12 entities · 83% verified · 48 sources · 7 notebook patches</span>
       </div>
       <div className="rd-v2-filter-row">
         {["All", "Watching", "Needs review", "Stale", "Updated"].map((item, index) => (
@@ -1469,14 +1467,51 @@ function AgentShell({
 
 function inspectorPipeline(entity: PrototypeReportEntity): Array<{ label: string; done: boolean }> {
   const isDraft = /draft|generating|gathering/i.test(entity.status);
-  const needsReview = entity.score < 75 || /review|stale/i.test(entity.status);
+  const needsReview = entityNeedsReview(entity);
+  const claimCount = claimCountForEntity(entity);
   return [
     { label: isDraft ? "Gathering sources" : `Gathered ${Math.max(8, entity.sources * 4)} sources`, done: !isDraft || entity.sources > 2 },
     { label: `Extracted ${Math.max(2, entity.signals.length)} entities`, done: !isDraft },
-    { label: `Generated ${Math.max(5, Math.round(entity.score / 4))} claims`, done: entity.score >= 45 },
+    { label: `Generated ${claimCount} source-backed claims`, done: entity.sources > 0 },
     { label: needsReview ? "Verifying evidence" : "Verified evidence", done: !needsReview },
     { label: needsReview ? "Notebook patch pending" : "Notebook published", done: !needsReview },
   ];
+}
+
+function entityNeedsReview(entity: PrototypeReportEntity): boolean {
+  return /review|stale|draft|generating|gathering/i.test(entity.status) || entity.sources < 5;
+}
+
+function claimCountForEntity(entity: PrototypeReportEntity): number {
+  return Math.max(3, Math.min(9, entity.signals.length + Math.ceil(entity.sources / 2)));
+}
+
+function entityStatusLabel(entity: PrototypeReportEntity): string {
+  if (/stale/i.test(entity.status)) return "Stale";
+  if (/review/i.test(entity.status)) return "Review";
+  if (/draft|generating|gathering/i.test(entity.status)) return "Drafting";
+  if (/watch/i.test(entity.status)) return "Watching";
+  return "Verified";
+}
+
+function entityEvidenceText(entity: PrototypeReportEntity): string {
+  const claims = claimCountForEntity(entity);
+  if (/stale/i.test(entity.status)) return `${Math.max(1, claims - 2)} of ${claims} claims current`;
+  if (entityNeedsReview(entity)) return `${Math.max(1, claims - 1)} of ${claims} claims need review`;
+  return `${claims} of ${claims} claims verified`;
+}
+
+function entityFreshnessText(entity: PrototypeReportEntity): string {
+  return entity.delta;
+}
+
+function entityCoverageText(entity: PrototypeReportEntity): string {
+  return entity.tags.slice(0, 3).join(" - ");
+}
+
+function relatedStatusLabel(entityName: string): string {
+  const related = reportEntities.find((item) => item.name === entityName);
+  return related ? entityStatusLabel(related) : "Related";
 }
 
 function inspectorWarnings(entity: PrototypeReportEntity): string[] {
@@ -1486,7 +1521,7 @@ function inspectorWarnings(entity: PrototypeReportEntity): string[] {
       "Refresh public sources before exporting this notebook.",
     ];
   }
-  if (entity.score < 75 || /review/i.test(entity.status)) {
+  if (entityNeedsReview(entity)) {
     return [
       "Open claims need human review before verification.",
       "Notebook patch should preserve the prior source trail.",
@@ -1503,16 +1538,17 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
   const [drawerOpen, setDrawerOpen] = useState(true);
   const pipeline = inspectorPipeline(entity);
   const warnings = inspectorWarnings(entity);
-  const reviewText = entity.score < 75 ? `${entity.name} needs review.` : `${entity.name} is in good shape.`;
-  const summaryText = entity.score < 75
-    ? `${entity.name} is below coverage threshold. Refresh sources, verify open claims, and decide whether the report needs a notebook patch.`
-    : `${entity.name} has current sources and enough verified claims for the present coverage task. Keep it on watch.`;
+  const needsReview = entityNeedsReview(entity);
+  const reviewText = needsReview ? `${entity.name} needs source review.` : `${entity.name} is ready for the current coverage task.`;
+  const summaryText = needsReview
+    ? `${entity.name} has open evidence work. Refresh stale rows, verify open claims, and decide whether the report needs a notebook patch.`
+    : `${entity.name} has current sources, verified claims, and a notebook trail the agent can reuse. Keep it on watch.`;
 
   return (
     <AgentShell
-      title="Agent Inspector"
-      context={`Reports - ${entity.name} - ${entity.sources} sources - score ${entity.score}`}
-      pills={["Reports", entity.name, `${entity.sources} sources`, `Score ${entity.score}`]}
+      title="Coverage agent"
+      context={`Reports - ${entity.name} - ${entityStatusLabel(entity)} - ${entity.sources} sources`}
+      pills={["Reports", entity.name, `${entity.sources} sources`, entityStatusLabel(entity)]}
       question="Which reports need work?"
       placeholder="Ask about these reports..."
       onAsk={onAsk}
@@ -1522,7 +1558,7 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
         <p>{summaryText}</p>
         <details className="rd-v2-trace" open>
           <summary><small>Agent run trace</small></summary>
-          <div className="rd-v2-trace-steps"><span>source_scan</span><span>claim_verify</span><span>score_compute</span><span>notebook_patch</span></div>
+          <div className="rd-v2-trace-steps"><span>source_scan</span><span>claim_verify</span><span>freshness_check</span><span>notebook_patch</span></div>
         </details>
         <div className="rd-v2-msg-actions">
           <button type="button" className="is-primary" onClick={() => onAsk?.(`Open the ${entity.name} notebook and summarize the next review step.`)}>Open notebook</button>
@@ -1544,19 +1580,15 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
         type="button"
         aria-expanded={drawerOpen}
         onClick={() => setDrawerOpen((value) => !value)}
-      >{`Context - ${entity.name} ${entity.score} - ${warnings.length} warnings - ${entity.sources} sources`}</button>
+      >{`Context - ${entity.name} - ${warnings.length} warnings - ${entity.sources} sources`}</button>
       {drawerOpen && (
         <>
           <section className="rd-v2-agent-context">
-            <div className="rd-v2-context-head"><span>Active entity</span><span>{entity.score}</span></div>
-            <div className="rd-v2-score-big">{entity.score} <small>{entity.delta}</small></div>
-            {Object.entries(entity.dims).map(([label, value]) => (
-              <div className="rd-v2-score-row" key={label}>
-                <span>{label}</span>
-                <b><i data-tone={value >= 80 ? "green" : value >= 58 ? "accent" : "amber"} style={{ width: `${value}%` }} /></b>
-                <strong>{value}</strong>
-              </div>
-            ))}
+            <div className="rd-v2-context-head"><span>Active entity</span><span>{entityStatusLabel(entity)}</span></div>
+            <div className="rd-v2-transparency-row"><span>Evidence</span><strong>{entityEvidenceText(entity)}</strong></div>
+            <div className="rd-v2-transparency-row"><span>Sources</span><strong>{entity.sources} source rows</strong></div>
+            <div className="rd-v2-transparency-row"><span>Freshness</span><strong>{entityFreshnessText(entity)}</strong></div>
+            <div className="rd-v2-transparency-row"><span>Coverage</span><strong>{entityCoverageText(entity)}</strong></div>
           </section>
           <section className="rd-v2-agent-context">
             <div className="rd-v2-context-head"><span>Warnings</span><span>{warnings.length}</span></div>
@@ -1574,13 +1606,12 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
           </section>
           <section className="rd-v2-agent-context">
             <div className="rd-v2-context-head"><span>Related entities</span><span>{entity.related.length}</span></div>
-            {entity.related.map((name, index) => {
+            {entity.related.map((name) => {
               const related = reportEntities.find((item) => item.name === name);
               const initial = related?.initial ?? name.slice(0, 1).toUpperCase();
-              const score = related?.score ?? Math.max(55, entity.score - (index + 1) * 4);
               return (
                 <button className="rd-v2-related-entity" key={name} onClick={() => onSelectEntity?.(name)}>
-                  <span>{initial}</span><strong>{name}</strong><b>{score}</b>
+                  <span>{initial}</span><strong>{name}</strong><b>{relatedStatusLabel(name)}</b>
                 </button>
               );
             })}
@@ -1697,7 +1728,7 @@ function InboxPrototypeRail({ onAsk }: HomeV2SurfaceProps) {
         <div className="rd-v2-report-title"><span>S</span><h2>Sequoia Capital</h2><b>74</b></div>
         <p>• Active term sheet negotiation<br />• $1.2M partnership · 3 prior rounds<br />• Last report: 6h ago</p>
       </article>
-      <div className="rd-v2-agent-insight"><strong>Agent insight</strong><span className="rd-v2-confidence">92% confidence</span><p>Full-ratchet clause creates 14.3pp dilution gap at $48M. Counter with narrow-based weighted-average as floor.</p></div>
+      <div className="rd-v2-agent-insight"><strong>Agent insight</strong><span className="rd-v2-confidence">Verified evidence</span><p>Full-ratchet clause creates 14.3pp dilution gap at $48M. Counter with narrow-based weighted-average as floor.</p></div>
       <section className="rd-v2-related-threads">
         <h3>Related threads</h3>
         <div className="rd-v2-thread-item"><span className="rd-v2-thread-dot" /><span>Term sheet v2 discussion</span><span className="rd-v2-thread-time">4d</span></div>
@@ -2208,12 +2239,12 @@ export function HomeV2BriefingRail({ onAsk, onOpenReports, liveArtifacts }: Home
         </button>
         <section className="rd-v2-agent-context">
           <div className="rd-v2-context-head"><span>Entities</span><span>{model.agentEntities.length}</span></div>
-          {model.agentEntities.map(([icon, name, badge, score]) => (
+          {model.agentEntities.map(([icon, name, badge, detail]) => (
             <div className="rd-v2-entity" key={name}>
               <span>{icon}</span>
               <strong>{name}</strong>
               {badge && <em>{badge}</em>}
-              <b>{score}</b>
+              <b>{detail}</b>
             </div>
           ))}
         </section>

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -45,7 +45,10 @@ function StyleChip({ reportId }: { reportId: string }) {
 }
 
 function displayReportDescription(description: string): string {
-  return sanitizeDecisionText(description);
+  return sanitizeDecisionText(description)
+    .replace(/\s*\|\s*confidence\s+\d+%/gi, "")
+    .replace(/\bconfidence\s+\d+%/gi, "source review recorded")
+    .replace(/\bexecutive confidence\s+\d+%\.?/gi, "executive review recorded.");
 }
 
 interface ReportsSurfaceProps {
@@ -73,12 +76,13 @@ const REPORT_STAGE_COLUMNS: Array<{ id: ReportStage; label: string; hint: string
   { id: "monitoring", label: "Monitoring", hint: "Watchlist active" },
 ];
 
-const STATUS_FILTERS = [
+const STATUS_FILTERS: Array<{ id: "all" | ReportStage; label: string }> = [
   { id: "all", label: "All" },
   { id: "verified", label: "Verified" },
-  { id: "watching", label: "Watching" },
-  { id: "review", label: "Needs review" },
-] as const;
+  { id: "review", label: "Review" },
+  { id: "stale", label: "Stale" },
+  { id: "drafting", label: "Draft" },
+];
 
 const KIND_FILTERS = [
   { id: "all", label: "All types" },
@@ -89,7 +93,7 @@ const KIND_FILTERS = [
 ] as const;
 
 export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedReportId }: ReportsSurfaceProps) {
-  const [filter, setFilter] = useState<typeof STATUS_FILTERS[number]["id"]>("all");
+  const [filter, setFilter] = useState<(typeof STATUS_FILTERS)[number]["id"]>("all");
   const [kindFilter, setKindFilter] = useState<typeof KIND_FILTERS[number]["id"]>("all");
   const [density, setDensity] = useState<Density>("compact");
   const [viewMode, setViewMode] = useState<ReportViewMode>("gallery");
@@ -122,34 +126,36 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
   });
   const clearSelection = () => setSelected(new Set());
 
-  // Status facet counts (Crunchbase-style with N badge per chip)
+  // Status facet counts use workflow state, not arbitrary score bands.
   const counts = useMemo(() => {
-    const c: Record<string, number> = { all: reports.length, verified: 0, watching: 0, review: 0 };
-    for (const r of reports) c[r.status] = (c[r.status] ?? 0) + 1;
+    const c: Record<string, number> = { all: reports.length, verified: 0, review: 0, stale: 0, drafting: 0 };
+    for (const r of reports) {
+      const stage = getReportStage(r, stageOverrides[r.id]);
+      c[stage] = (c[stage] ?? 0) + 1;
+    }
     return c;
-  }, [reports]);
+  }, [reports, stageOverrides]);
 
   const filtered = useMemo(() => {
     const base = reports.filter((r) => {
-      if (filter === "verified" && r.status !== "verified") return false;
-      if (filter === "watching" && r.status !== "watching") return false;
-      if (filter === "review" && r.status !== "review") return false;
+      const stage = getReportStage(r, stageOverrides[r.id]);
+      if (filter !== "all" && stage !== filter) return false;
       if (kindFilter !== "all" && r.kind !== kindFilter) return false;
       if (query && !`${r.entity} ${r.description}`.toLowerCase().includes(query.toLowerCase())) return false;
       return true;
     });
-    const statusRank: Record<ReportCardData["status"], number> = { review: 0, watching: 1, verified: 2 };
+    const statusRank: Record<ReportStage, number> = { review: 0, stale: 1, drafting: 2, monitoring: 3, verified: 4 };
     return [...base].sort((a, b) => {
       switch (sortKey) {
         case "entity":  return a.entity.localeCompare(b.entity);
         case "sources": return b.sources - a.sources;
         case "claims":  return b.claims - a.claims;
-        case "status":  return statusRank[a.status] - statusRank[b.status];
+        case "status":  return statusRank[getReportStage(a, stageOverrides[a.id])] - statusRank[getReportStage(b, stageOverrides[b.id])];
         case "updated":
         default: return 0; // live query order is already recency-ranked
       }
     });
-  }, [reports, filter, kindFilter, query, sortKey]);
+  }, [reports, filter, kindFilter, query, sortKey, stageOverrides]);
 
   useEffect(() => {
     if (!onSelectReport || filtered.length === 0) return;
@@ -189,7 +195,6 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
   const reviewCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "review").length;
   const staleCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "stale").length;
   const draftingCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "drafting").length;
-  const confidenceScore = Math.max(0, Math.min(100, Math.round((verifiedShare * 0.62) + Math.min(totalSources, 120) * 0.18)));
   const selectedReport = filtered.find((report) => report.id === inspectedReportId) ?? visibleReports[0] ?? null;
   const runBatchPrompt = () => {
     const prompt = "Run a coverage batch for my active report universe. Generate notebook-first reports, gather sources, extract claims, verify evidence, and create the review queue.";
@@ -217,7 +222,7 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
           <p>
             {isLoading && reports.length === 0
               ? "Checking Convex-backed report artifacts."
-              : `${reports.length} reports, ${totalSources} sources, ${reviewCount} need review, confidence ${confidenceScore}/100.`}
+              : `${reports.length} reports, ${totalSources} sources, ${reviewCount} need review.`}
           </p>
         </div>
         <div className="rd-v3-universe-actions">
@@ -512,7 +517,7 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
             <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={bulkRefresh}>Refresh preview</button>
             <button
               className="rd-btn rd-btn--quiet rd-btn--sm"
-              onClick={() => showToast({ tone: "info", message: `Local rubric preview queued for ${selected.size} selected report${selected.size === 1 ? "" : "s"}. Run Chat to persist a scored artifact.` })}
+              onClick={() => showToast({ tone: "info", message: `Local review rubric queued for ${selected.size} selected report${selected.size === 1 ? "" : "s"}. Run Chat to persist a source-backed artifact.` })}
             >
               Rubric preview
             </button>
@@ -590,6 +595,19 @@ function notebookState(stage: ReportStage): string {
   return "Drafting";
 }
 
+function evidenceText(report: ReportCardData, stage: ReportStage): string {
+  if (stage === "drafting") return "Gathering sources...";
+  if (stage === "stale") return `${Math.max(1, Math.min(report.claims, Math.ceil(report.claims / 2)))} of ${Math.max(1, report.claims)} claims need refresh`;
+  if (stage === "review") return `${Math.max(1, report.followUps || 1)} claim${(report.followUps || 1) === 1 ? "" : "s"} need review`;
+  return `${Math.max(1, report.claims)} of ${Math.max(1, report.claims)} claims verified`;
+}
+
+function freshnessText(report: ReportCardData, stage: ReportStage): string {
+  if (stage === "stale") return `Last checked ${report.updatedAt}`;
+  if (stage === "drafting") return "Started recently";
+  return `Updated ${report.updatedAt}`;
+}
+
 function ReportCardV3({
   report,
   active,
@@ -614,11 +632,15 @@ function ReportCardV3({
       aria-selected={active}
       role="button"
       tabIndex={0}
-      onClick={() => onSelect?.(report)}
+      onClick={() => {
+        onSelect?.(report);
+        onOpen(report.id, "brief");
+      }}
       onKeyDown={(event) => {
         if (event.key !== "Enter" && event.key !== " ") return;
         event.preventDefault();
         onSelect?.(report);
+        onOpen(report.id, "brief");
       }}
     >
       <div className="rd-v3-card__head">
@@ -633,8 +655,8 @@ function ReportCardV3({
         {signals.map((signal) => <span key={signal}>{signal}</span>)}
       </div>
       <div className="rd-v3-sources">
-        <span>{report.sources} sources</span>
-        <span>{report.claims} claims</span>
+        <span>{evidenceText(report, stage)}</span>
+        <span>{report.sources} source rows</span>
         <span>{report.followUps} follow-ups</span>
       </div>
       {backlinks.length > 0 && (
@@ -643,7 +665,7 @@ function ReportCardV3({
         </div>
       )}
       <div className="rd-v3-card__foot">
-        <span>{sourceLabel} · {report.updatedAt}</span>
+        <span>{sourceLabel} · {freshnessText(report, stage)}</span>
         <span>{notebookState(stage)}</span>
       </div>
       <div className="rd-v3-card__actions">
@@ -689,12 +711,14 @@ function ReportBoard({
                 className="rd-v3-mini"
                 draggable
                 onDragStart={(event) => onDragStart(event, report.id)}
-                onClick={() => onSelect?.(report)}
-                onDoubleClick={() => onOpen(report.id, "brief")}
+                onClick={() => {
+                  onSelect?.(report);
+                  onOpen(report.id, "brief");
+                }}
               >
                 <span>{report.entity.slice(0, 1).toUpperCase()}</span>
                 <strong>{report.entity}</strong>
-                <small>{report.sources} sources · {report.claims} claims</small>
+                <small>{evidenceText(report, getReportStage(report, stageOverrides[report.id]))} · {report.sources} sources</small>
               </button>
             ))}
           </div>
@@ -718,18 +742,21 @@ function ReportTable({
   return (
     <div className="rd-v3-table-wrap" role="region" aria-label="Analyst report table">
       <table className="rd-v3-table">
-        <thead><tr><th>Report</th><th>Status</th><th>Type</th><th>Sources</th><th>Claims</th><th>Notebook</th><th>Action</th></tr></thead>
+        <thead><tr><th>Report</th><th>Type</th><th>Status</th><th>Evidence</th><th>Sources</th><th>Updated</th><th>Action</th></tr></thead>
         <tbody>
           {reports.map((report) => {
             const stage = getReportStage(report, stageOverrides[report.id]);
             return (
-              <tr key={report.id} onClick={() => onSelect?.(report)}>
+              <tr key={report.id} onClick={() => {
+                onSelect?.(report);
+                onOpen(report.id, "brief");
+              }}>
                 <td><strong>{report.entity}</strong><span>{displayReportDescription(report.description)}</span></td>
-                <td>{stageLabel(stage)}</td>
                 <td>{report.kind}</td>
-                <td>{report.sources}</td>
-                <td>{report.claims}</td>
-                <td>{notebookState(stage)}</td>
+                <td>{stageLabel(stage)}</td>
+                <td>{evidenceText(report, stage)}</td>
+                <td>{report.sources} source rows</td>
+                <td>{freshnessText(report, stage)}</td>
                 <td><button type="button" onClick={(event) => { event.stopPropagation(); onOpen(report.id, "brief"); }}>Open notebook</button></td>
               </tr>
             );
@@ -758,12 +785,23 @@ function ReportGraphPreview({
         <span>{root?.entity.slice(0, 1).toUpperCase() ?? "R"}</span>
         <strong>{root?.entity ?? "Select a report"}</strong>
         <button type="button" onClick={() => root && onOpen(root.id, "brief")}>Open notebook</button>
+        {root && getReportStage(root) === "stale" && (
+          <button
+            type="button"
+            className="rd-v3-delta-refresh"
+            title="Run a delta-only refresh from the last checked timestamp"
+            onClick={() => showToast({ tone: "info", message: `Delta refresh preview queued for ${root.entity}. New sources only; unchanged content skips extraction.` })}
+          >
+            ↻ Refresh delta
+          </button>
+        )}
       </div>
       <div className="rd-v3-graph__nodes">
         {reports.slice(0, 10).map((report) => (
           <button key={report.id} type="button" onClick={() => onSelect?.(report)} aria-pressed={root?.id === report.id}>
             <span>{report.entity.slice(0, 1).toUpperCase()}</span>
-            {report.entity}
+            <strong>{report.entity}</strong>
+            <small>{stageLabel(getReportStage(report))}</small>
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- aligns Reports v3 center, left rail, and Coverage agent rail with the home-v3 transparency model
- replaces arbitrary score/confidence presentation with status, evidence, source rows, freshness, warnings, and notebook state
- opens report cards/board/table rows into the notebook route and keeps the evidence/source sidebar visible on report detail
- sanitizes raw live artifact confidence strings from report card thesis text

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run src/features/redesign/components/TopNav.test.tsx src/features/redesign/surfaces/ProductDecisionQueue.test.ts src/features/redesign/components/CommandPalette.test.tsx
- npm run build
- Browser DOM verified http://127.0.0.1:5209/redesign/reports?qa=home-v3-transparency: no Convex fallback, no Score/score_compute/raw confidence strings, Gallery/Board/Table/Graph, left rail groups, Coverage agent transparency drawer, notebook route with source/claim context
- Playwright screenshots: .tmp/reports-v3-gallery.png, .tmp/reports-v3-notebook.png

## QA Matrix
- Updated C:\\Users\\hshum\\Downloads\\nodebench_full_product_release_qa_matrix.csv with HOMEV3-REPORTS-001..003 evidence rows