### PR TITLE
Update workspace live smoke contract

### DIFF
--- a/tests/e2e/live-smoke.spec.ts
+++ b/tests/e2e/live-smoke.spec.ts
@@ -127,14 +127,15 @@ test.describe("live-smoke — Tier B hydrated-DOM verification", () => {
     const response = await page.goto(BASE_URL + "/workspace/w/acme-ai?tab=brief");
     expect(response?.status()).toBe(200);
     // Chromeless shell — no cockpit rails, no top nav, no bottom tabbar.
-    // We just assert the workspace mounted + brand mark is present.
-    await expect(page.getByText(/NodeBench/i).first()).toBeVisible({
+    // Assert the workspace mounted and kept the no-fixture-fallback contract.
+    await expect(page.getByRole("heading", { name: /Workspace draft/i })).toBeVisible({
       timeout: 15_000,
     });
     // Brand-aware: the product lock docs say "Workspace" should appear in the
     // chromeless header; this also proves the route didn't fall through to
     // the cockpit layout.
     await expect(page.getByText(/Workspace/i).first()).toBeVisible();
+    await expect(page.getByText(/No fixture fallback/i)).toBeVisible();
   });
 
   test("console has no uncaught errors during landing load", async ({ page }) => {


### PR DESCRIPTION
﻿## Summary
- updates the chromeless workspace live smoke to assert the current Workspace draft/no-fixture-fallback contract instead of a stale NodeBench brand-mark assertion

## Verification
- BASE_URL=https://www.nodebenchai.com npx playwright test tests/e2e/live-smoke.spec.ts --project=chromium --workers=1 --grep "/workspace/w/:id mounts"
- npm run post-deploy:verify
- npx tsc --noEmit --pretty false
