### PR TITLE
fix(reports): match home v3 drafting filter

### DIFF
--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -90,7 +90,7 @@ const STATUS_FILTERS: Array<{ id: "all" | ReportStage; label: string }> = [
   { id: "verified", label: "Verified" },
   { id: "review", label: "Review" },
   { id: "stale", label: "Stale" },
-  { id: "drafting", label: "Draft" },
+  { id: "drafting", label: "Drafting" },
 ];
 
 const KIND_FILTERS = [


### PR DESCRIPTION
## Summary
- Match the Reports center status filter copy to the latest home-v3.html UI kit: Drafting instead of Draft.
- Preserve the left rail short Draft label, which still matches the prototype rail.
- Rechecked board, table, graph, left rail, and right rail parity against the latest UI kit.

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run src/features/reports/views/ReportsHome.test.ts src/features/reports/lib/compactReportsReadModel.test.ts
- npm run build

## Notes
- The clean worktree initially exposed a local dependency-install gap for the d3 graph dependency. package.json already declared d3 and @types/d3, so refreshing local node_modules closed the build blocker without repo changes.