### PR TITLE
Bound report graph neighborhoods server-side

### DIFF
--- a/convex/domains/redesign/reportGraphNeighborhood.ts
+++ b/convex/domains/redesign/reportGraphNeighborhood.ts
@@ -1,0 +1,244 @@
+/**
+ * Server-bounded report graph neighborhood.
+ *
+ * The Reports graph should never need the whole report universe in the
+ * browser. This query returns a bounded root-plus-neighbors packet from the
+ * current Convex-backed artifacts, plus enough hidden-count metadata for the UI
+ * to explain clustering and search refinement.
+ */
+
+import { v } from "convex/values";
+import { query } from "../../_generated/server";
+import type { Id } from "../../_generated/dataModel";
+
+const POST_TYPE_LABELS: Record<string, string> = {
+  clinical: "Clinical signal",
+  daily_digest: "Daily brief",
+  did_you_know: "Did You Know",
+  fda: "FDA signal",
+  funding_brief: "Funding brief",
+  funding_tracker: "Funding tracker",
+  ma: "M&A signal",
+  research: "Research memo",
+};
+
+const GRAPH_REPORT_LIMIT_BY_MODE = {
+  focus: 32,
+  clustered: 64,
+  expanded: 96,
+} as const;
+
+type GraphNeighborhoodMode = keyof typeof GRAPH_REPORT_LIMIT_BY_MODE;
+
+type ArchivePostDoc = {
+  _id: Id<"linkedinPostArchive">;
+  dateString: string;
+  persona: string;
+  postType: string;
+  content: string;
+  postId?: string;
+  postUrl?: string;
+  factCheckCount?: number;
+  metadata?: any;
+  postedAt: number;
+};
+
+function getDedupeKey(post: {
+  dateString: string;
+  persona: string;
+  postType: string;
+  content: string;
+  postId?: string;
+  metadata?: any;
+}): string {
+  const postId = typeof post.postId === "string" ? post.postId.trim() : "";
+  if (postId) return `postId|${postId}`;
+  const part = typeof post.metadata?.part === "number" ? post.metadata.part : "";
+  return `${post.dateString}|${post.persona}|${post.postType}|${part}|${post.content}`;
+}
+
+function dedupeArchivePosts<T extends ArchivePostDoc>(posts: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const post of posts) {
+    const key = getDedupeKey(post);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(post);
+  }
+  return out;
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function postTypeLabel(postType: string): string {
+  return POST_TYPE_LABELS[postType] ?? postType.replace(/_/g, " ");
+}
+
+function archivePostStage(post: ArchivePostDoc): "verified" | "review" | "stale" | "drafting" {
+  const sources = Math.max(1, post.factCheckCount ?? 1);
+  if (post.postUrl || sources > 1) return "verified";
+  return "drafting";
+}
+
+function matchesArchivePost(
+  post: ArchivePostDoc,
+  args: {
+    query?: string;
+    stage?: string;
+    kind?: string;
+  },
+): boolean {
+  const q = normalizeText(args.query);
+  if (args.stage && args.stage !== "all" && archivePostStage(post) !== args.stage) return false;
+  if (args.kind && args.kind !== "all" && postTypeLabel(post.postType) !== args.kind) return false;
+  if (!q) return true;
+  return `${post.content} ${post.postType} ${post.dateString}`.toLowerCase().includes(q);
+}
+
+function matchesDailyBriefMemory(
+  memory: { dateString: string; goal: string; features?: Array<{ name?: string; notes?: string; type?: string }> },
+  args: {
+    query?: string;
+    stage?: string;
+    kind?: string;
+  },
+): boolean {
+  if (args.stage && args.stage !== "all" && args.stage !== "verified" && args.stage !== "review") return false;
+  if (args.kind && args.kind !== "all" && args.kind !== "Daily Brief") return false;
+  const q = normalizeText(args.query);
+  if (!q) return true;
+  const featureText = (memory.features ?? [])
+    .map((feature) => `${feature.name ?? ""} ${feature.notes ?? ""} ${feature.type ?? ""}`)
+    .join(" ");
+  return `${memory.dateString} ${memory.goal} ${featureText}`.toLowerCase().includes(q);
+}
+
+export const getReportGraphNeighborhood = query({
+  args: {
+    rootId: v.optional(v.string()),
+    query: v.optional(v.string()),
+    stage: v.optional(v.string()),
+    kind: v.optional(v.string()),
+    mode: v.optional(v.union(v.literal("focus"), v.literal("clustered"), v.literal("expanded"))),
+    limit: v.optional(v.number()),
+  },
+  returns: v.object({
+    mode: v.string(),
+    sourceLabel: v.string(),
+    rootId: v.optional(v.string()),
+    latestMemory: v.optional(v.any()),
+    posts: v.array(v.object({
+      _id: v.id("linkedinPostArchive"),
+      dateString: v.string(),
+      persona: v.string(),
+      postType: v.string(),
+      content: v.string(),
+      postId: v.optional(v.string()),
+      postUrl: v.optional(v.string()),
+      factCheckCount: v.optional(v.number()),
+      metadata: v.optional(v.any()),
+      postedAt: v.number(),
+    })),
+    reportLimit: v.number(),
+    scanLimit: v.number(),
+    scannedArchivePosts: v.number(),
+    totalCandidateReports: v.number(),
+    returnedReportCount: v.number(),
+    hiddenReportCount: v.number(),
+    hasMoreArchive: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const mode: GraphNeighborhoodMode = args.mode ?? "clustered";
+    const reportLimit = Math.max(1, Math.min(args.limit ?? GRAPH_REPORT_LIMIT_BY_MODE[mode], 120));
+    const scanLimit = Math.min(Math.max(reportLimit * 5, 120), 500);
+
+    const latestMemory = await ctx.db
+      .query("dailyBriefMemories")
+      .withIndex("by_generated_at")
+      .order("desc")
+      .first();
+
+    const archivePage = await ctx.db
+      .query("linkedinPostArchive")
+      .withIndex("by_postedAt")
+      .order("desc")
+      .paginate({ cursor: null, numItems: scanLimit });
+
+    const dedupedPosts = dedupeArchivePosts(archivePage.page as ArchivePostDoc[]);
+
+    const rootArchiveId = args.rootId?.startsWith("li_") ? args.rootId.slice(3) : null;
+    const normalizedRootArchiveId = rootArchiveId
+      ? (ctx.db as any).normalizeId("linkedinPostArchive", rootArchiveId)
+      : null;
+    const rootPost = normalizedRootArchiveId
+      ? await ctx.db.get(normalizedRootArchiveId)
+      : null;
+
+    const rootDailyMemory = args.rootId?.startsWith("daily_") && latestMemory
+      ? latestMemory
+      : null;
+
+    const archiveCandidates = dedupedPosts.filter((post) => matchesArchivePost(post, args));
+    const rootPostMatchesOutsideScan = rootPost
+      && matchesArchivePost(rootPost as ArchivePostDoc, args)
+      && !archiveCandidates.some((post) => String(post._id) === String(rootPost._id));
+    const includesDailyBrief = latestMemory ? matchesDailyBriefMemory(latestMemory, args) : false;
+    const totalCandidateReports = archiveCandidates.length
+      + (rootPostMatchesOutsideScan ? 1 : 0)
+      + (includesDailyBrief ? 1 : 0);
+
+    const selectedPosts: ArchivePostDoc[] = [];
+    const selectedPostIds = new Set<string>();
+    const addPost = (post: ArchivePostDoc | null) => {
+      if (!post || selectedPosts.length >= reportLimit) return;
+      const id = String(post._id);
+      if (selectedPostIds.has(id)) return;
+      if (!matchesArchivePost(post, args)) return;
+      selectedPostIds.add(id);
+      selectedPosts.push(post);
+    };
+
+    addPost(rootPost as ArchivePostDoc | null);
+    for (const post of archiveCandidates) addPost(post);
+
+    const dailyBriefBudgetCost = includesDailyBrief ? 1 : 0;
+    const postBudget = Math.max(0, reportLimit - dailyBriefBudgetCost);
+    const boundedPosts = selectedPosts.slice(0, postBudget);
+    const returnedReportCount = boundedPosts.length + (includesDailyBrief ? 1 : 0);
+    const hiddenReportCount = Math.max(0, totalCandidateReports - returnedReportCount);
+    const effectiveRootId = rootDailyMemory
+      ? `daily_${rootDailyMemory._id}`
+      : rootPost
+        ? `li_${rootPost._id}`
+        : args.rootId;
+
+    return {
+      mode,
+      sourceLabel: `Convex graph neighborhood - ${returnedReportCount}/${totalCandidateReports} reports`,
+      rootId: effectiveRootId,
+      latestMemory: includesDailyBrief ? latestMemory : undefined,
+      posts: boundedPosts.map((post) => ({
+        _id: post._id,
+        dateString: post.dateString,
+        persona: post.persona,
+        postType: post.postType,
+        content: post.content,
+        postId: post.postId,
+        postUrl: post.postUrl,
+        factCheckCount: post.factCheckCount,
+        metadata: post.metadata,
+        postedAt: post.postedAt,
+      })),
+      reportLimit,
+      scanLimit,
+      scannedArchivePosts: archivePage.page.length,
+      totalCandidateReports,
+      returnedReportCount,
+      hiddenReportCount,
+      hasMoreArchive: !archivePage.isDone,
+    };
+  },
+});

--- a/src/features/redesign/hooks/useLiveArtifacts.ts
+++ b/src/features/redesign/hooks/useLiveArtifacts.ts
@@ -159,8 +159,44 @@ const liveArtifactApi = api as unknown as {
         getLatestMemory: QueryRef;
       };
     };
+    redesign: {
+      reportGraphNeighborhood: {
+        getReportGraphNeighborhood: QueryRef;
+      };
+    };
   };
 };
+
+export interface ReportGraphNeighborhoodScope {
+  isServerBounded: boolean;
+  mode: string;
+  reportLimit: number;
+  scanLimit: number;
+  scannedArchivePosts: number;
+  totalCandidateReports: number;
+  returnedReportCount: number;
+  hiddenReportCount: number;
+  hasMoreArchive: boolean;
+}
+
+interface ReportGraphNeighborhoodPacket {
+  mode: string;
+  sourceLabel: string;
+  rootId?: string;
+  latestMemory?: DailyBriefMemory | null;
+  posts: ArchivePost[];
+  reportLimit: number;
+  scanLimit: number;
+  scannedArchivePosts: number;
+  totalCandidateReports: number;
+  returnedReportCount: number;
+  hiddenReportCount: number;
+  hasMoreArchive: boolean;
+}
+
+export interface ReportGraphNeighborhoodResult extends LiveArtifactsResult {
+  scope: ReportGraphNeighborhoodScope | null;
+}
 
 const POST_TYPE_LABELS: Record<string, string> = {
   daily_digest: "Daily brief",
@@ -1032,4 +1068,91 @@ export function useLiveArtifacts(limit = 24, options: { enabled?: boolean } = {}
       briefFeatureCount,
     };
   }, [archive, archiveStats, enabled, latestMemory, limit]);
+}
+
+export function useReportGraphNeighborhood(
+  args: {
+    rootId?: string | null;
+    query?: string;
+    stage?: string;
+    kind?: string;
+    mode?: "focus" | "clustered" | "expanded";
+    limit?: number;
+  },
+  options: { enabled?: boolean } = {},
+): ReportGraphNeighborhoodResult {
+  const enabled = options.enabled ?? true;
+  const packet = useQuery(
+    liveArtifactApi.domains.redesign.reportGraphNeighborhood.getReportGraphNeighborhood,
+    enabled
+      ? ({
+          rootId: args.rootId ?? undefined,
+          query: args.query || undefined,
+          stage: args.stage || undefined,
+          kind: args.kind || undefined,
+          mode: args.mode ?? "expanded",
+          limit: args.limit,
+        } as Parameters<typeof useQuery>[1])
+      : "skip",
+  ) as ReportGraphNeighborhoodPacket | undefined;
+
+  return useMemo(() => {
+    if (!enabled) {
+      return {
+        ...EMPTY_LIVE_ARTIFACTS,
+        scope: null,
+      };
+    }
+
+    if (packet === undefined) {
+      return {
+        ...EMPTY_LIVE_ARTIFACTS,
+        isLoading: true,
+        sourceLabel: "Loading graph neighborhood",
+        scope: null,
+      };
+    }
+
+    const memory = packet.latestMemory ?? null;
+    const posts = packet.posts ?? [];
+    const artifactReports = [
+      ...(memory ? [dailyBriefToReport(memory)] : []),
+      ...posts.map(archivePostToReport),
+    ];
+    const details = [
+      ...(memory ? [dailyBriefToDetail(memory)] : []),
+      ...posts.map(archivePostToDetail),
+    ];
+    const dailyBriefCards = memory ? dailyBriefPublicCards(memory) : [];
+    const publicResearch = [
+      ...dailyBriefCards,
+      ...posts.map(archivePostToPublicCard),
+    ];
+    const isLive = artifactReports.length > 0 || publicResearch.length > 0;
+    const briefFeatureCount = dailyBriefCards.length || (memory ? uniqueDailyBriefFeatures(memory.features ?? []).filter(isCustomerFacingFeature).length : 0);
+
+    return {
+      isLoading: false,
+      isLive,
+      sourceLabel: packet.sourceLabel,
+      metrics: [],
+      pulse: [],
+      publicResearch,
+      reports: artifactReports,
+      details,
+      archiveCount: posts.length,
+      briefFeatureCount,
+      scope: {
+        isServerBounded: true,
+        mode: packet.mode,
+        reportLimit: packet.reportLimit,
+        scanLimit: packet.scanLimit,
+        scannedArchivePosts: packet.scannedArchivePosts,
+        totalCandidateReports: packet.totalCandidateReports,
+        returnedReportCount: packet.returnedReportCount,
+        hiddenReportCount: packet.hiddenReportCount,
+        hasMoreArchive: packet.hasMoreArchive,
+      },
+    };
+  }, [enabled, packet]);
 }

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -11,7 +11,12 @@ import { memoStyles, reports as fixtureReports, type ReportCardData, type Densit
 import { Pill } from "../components/Pill";
 import { ReportNotebookView } from "../components/ReportNotebookView";
 import { useReportsLive } from "../hooks/useReportsLive";
-import type { LiveArtifactDetail, LiveArtifactMapNode } from "../hooks/useLiveArtifacts";
+import {
+  useReportGraphNeighborhood,
+  type LiveArtifactDetail,
+  type LiveArtifactMapNode,
+  type ReportGraphNeighborhoodScope,
+} from "../hooks/useLiveArtifacts";
 import { showToast } from "../components/Toast";
 import {
   buildReportsDecisionQueue,
@@ -196,6 +201,7 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
   const [sortOpen, setSortOpen] = useState(false);
   const [stageOverrides, setStageOverrides] = useState<Record<string, ReportStage>>({});
   const [graphSelectedReportId, setGraphSelectedReportId] = useState<string | null>(null);
+  const [graphScaleMode, setGraphScaleMode] = useState<ReportGraphScaleMode>("clustered");
   const [notebookReportId, setNotebookReportId] = useState<string | null>(null);
   const sortRef = useRef<HTMLDivElement>(null);
   const inlineFilterRef = useRef<HTMLInputElement>(null);
@@ -339,6 +345,19 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
   const staleCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "stale").length;
   const draftingCount = filtered.filter((report) => getReportStage(report, stageOverrides[report.id]) === "drafting").length;
   const selectedReport = filtered.find((report) => report.id === (graphSelectedReportId ?? inspectedReportId)) ?? visibleReports[0] ?? null;
+  const graphNeighborhood = useReportGraphNeighborhood(
+    {
+      rootId: selectedReport?.id ?? inspectedReportId ?? undefined,
+      query,
+      stage: filter === "all" ? undefined : filter,
+      kind: kindFilter === "all" ? undefined : kindFilter,
+      mode: graphScaleMode,
+    },
+    { enabled: viewMode === "graph" && !useGraphScaleQaData },
+  );
+  const graphReports = !useGraphScaleQaData && graphNeighborhood.isLive ? graphNeighborhood.reports : filtered;
+  const graphDetails = !useGraphScaleQaData && graphNeighborhood.isLive ? graphNeighborhood.details : details;
+  const graphSelectedReport = graphReports.find((report) => report.id === (graphSelectedReportId ?? inspectedReportId ?? selectedReport?.id)) ?? graphReports[0] ?? selectedReport;
   const handleSelectReport = (report: ReportCardData) => {
     setGraphSelectedReportId(report.id);
     onSelectReport?.(report);
@@ -528,9 +547,12 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
         <ReportTable reports={visibleReports} stageOverrides={stageOverrides} onOpen={openReportAction} onSelect={handleSelectReport} />
       ) : viewMode === "graph" ? (
         <ReportGraphPreviewD3
-          reports={filtered}
-          details={details}
-          selectedReport={selectedReport}
+          reports={graphReports}
+          details={graphDetails}
+          selectedReport={graphSelectedReport}
+          serverScope={!useGraphScaleQaData ? graphNeighborhood.scope : null}
+          scaleMode={graphScaleMode}
+          onScaleModeChange={setGraphScaleMode}
           stageOverrides={stageOverrides}
           onOpen={openReportAction}
           onSelect={handleSelectReport}
@@ -2289,6 +2311,9 @@ function ReportGraphPreviewD3({
   reports,
   details,
   selectedReport,
+  serverScope,
+  scaleMode,
+  onScaleModeChange,
   stageOverrides,
   onOpen,
   onSelect,
@@ -2297,6 +2322,9 @@ function ReportGraphPreviewD3({
   reports: ReportCardData[];
   details: LiveArtifactDetail[];
   selectedReport: ReportCardData | null;
+  serverScope?: ReportGraphNeighborhoodScope | null;
+  scaleMode: ReportGraphScaleMode;
+  onScaleModeChange: (mode: ReportGraphScaleMode) => void;
   stageOverrides: Record<string, ReportStage>;
   onOpen: ReportsSurfaceProps["onOpen"];
   onSelect?: (report: ReportCardData) => void;
@@ -2312,7 +2340,6 @@ function ReportGraphPreviewD3({
   const svgRef = useRef<SVGSVGElement>(null);
   const zoomBehaviorRef = useRef<d3.ZoomBehavior<SVGSVGElement, unknown> | null>(null);
   const pinnedNodeIdRef = useRef<string | null>(null);
-  const [scaleMode, setScaleMode] = useState<ReportGraphScaleMode>("clustered");
   const graph = useMemo(
     () => buildReportGraph(reports, details, selectedReport, stageOverrides, { scaleMode }),
     [reports, details, selectedReport, stageOverrides, scaleMode],
@@ -2753,6 +2780,13 @@ function ReportGraphPreviewD3({
       data-visible-edge-budget={graph.edgeBudget}
       data-raw-edge-count={graph.rawEdgeCount}
       data-scale-mode={graph.scaleMode}
+      data-server-bounded={serverScope?.isServerBounded ? "true" : "false"}
+      data-server-report-limit={serverScope?.reportLimit ?? ""}
+      data-server-scan-limit={serverScope?.scanLimit ?? ""}
+      data-server-scanned-archive-posts={serverScope?.scannedArchivePosts ?? ""}
+      data-server-total-candidate-reports={serverScope?.totalCandidateReports ?? ""}
+      data-server-returned-report-count={serverScope?.returnedReportCount ?? ""}
+      data-server-hidden-report-count={serverScope?.hiddenReportCount ?? ""}
     >
       <div className="rd-v3-graph__controls">
         <button type="button" className="rd-v3-graph__fit" onClick={resetGraph}>Fit</button>
@@ -2764,7 +2798,7 @@ function ReportGraphPreviewD3({
               aria-pressed={scaleMode === mode.id}
               title={mode.hint}
               onClick={() => {
-                setScaleMode(mode.id);
+                onScaleModeChange(mode.id);
                 pinnedNodeIdRef.current = null;
                 setPinnedNodeId(null);
                 setTooltip(null);
@@ -2955,6 +2989,9 @@ function ReportGraphPreviewD3({
       </div>
       <p className="rd-v3-graph__provenance">
         {graph.sourceLabel} - {graph.nodes.length}/{graph.nodeBudget} visible nodes - {graph.links.length}/{graph.rawEdgeCount} edges - {graph.sourceRows} source rows - {linkedReportCount} neighboring reports{graph.hiddenReportCount > 0 ? ` - ${graph.hiddenReportCount} reports hidden behind clusters` : ""}
+        {serverScope?.isServerBounded
+          ? ` - server query returned ${serverScope.returnedReportCount}/${serverScope.totalCandidateReports} candidate reports from ${serverScope.scannedArchivePosts}/${serverScope.scanLimit} scanned archive rows`
+          : ""}
       </p>
     </section>
   );


### PR DESCRIPTION
## Summary
- add a Convex report graph neighborhood query that returns bounded root-plus-neighbor packets with hidden-count metadata
- wire the Reports graph tab to prefer the server-bounded packet when active
- expose server query budgets as DOM QA attributes and provenance text

## Verification
- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
- npx vitest run src/layouts/ActiveSurfaceHost.test.tsx
- npm run build