### PR TITLE
Make report topology a persisted runtime primitive

### DIFF
--- a/convex/domains/mcp/mcpGatewayDispatcher.ts
+++ b/convex/domains/mcp/mcpGatewayDispatcher.ts
@@ -215,6 +215,10 @@ const ALLOWLIST: Record<string, AllowlistEntry> = {
     ref: api.domains.search.federatedSearch.federatedSearch,
     type: "action",
   },
+  inspectReportTopologyShape: {
+    ref: api.domains.redesign.reportTopology.inspectReportTopologyShape,
+    type: "query",
+  },
   getDimensionProfile: {
     ref: api.domains.deepTrace.dimensions.getDimensionProfile,
     type: "query",

--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -287,6 +287,15 @@ function buildBoardState(args: {
         : "No active report reference was supplied, so the run stays answer-first.",
     },
     {
+      id: "graph_context_packet",
+      label: hasReportContext ? `Graph context for ${args.contextRef}` : "Graph context packet",
+      status: hasReportContext ? "selected" : "deferred",
+      confidence: hasReportContext ? 0.82 : 0,
+      detail: hasReportContext
+        ? "Resolve a bounded report graph packet before live search: root, first-ring neighbors, source refs, claim refs, and safe action handles."
+        : "No report context was supplied, so graph context stays on demand.",
+    },
+    {
       id: "entity_mention",
       label: entityLabel,
       status: args.classification.entity ? "candidate" : "deferred",
@@ -307,6 +316,16 @@ function buildBoardState(args: {
       detail: hasReportContext
         ? "Use the selected live report as memory context before live grounding."
         : "No report context to search in this anonymous/public run.",
+    },
+    {
+      id: "resolve_report_graph_context",
+      label: "resolve_report_graph_context",
+      status: hasReportContext ? "selected" : "deferred",
+      riskTier: "low",
+      costUsd: 0,
+      detail: hasReportContext
+        ? "Pack the selected report graph into a token-bounded context packet with source and claim refs."
+        : "Requires a selected report/context reference.",
     },
     {
       id: "google_search_grounding",
@@ -347,6 +366,7 @@ function buildBoardState(args: {
       successCriteria: [
         "classify intent",
         "select available memory/context",
+        "resolve bounded report graph context",
         "ground answer in sources",
         "bind evidence rows",
         "schedule source validation",

--- a/convex/domains/redesign/reportTopology.ts
+++ b/convex/domains/redesign/reportTopology.ts
@@ -1,0 +1,332 @@
+import { v } from "convex/values";
+import { action, internalMutation, internalQuery, query } from "../../_generated/server";
+import { internal } from "../../_generated/api";
+import {
+  buildReportTopologySnapshot,
+  type ReportTopologyArchivePost,
+  type ReportTopologyDailyBriefMemory,
+  type ReportTopologyScaleMode,
+  type ReportTopologySnapshot,
+  type ReportTopologyViewMode,
+} from "./reportTopologyRuntime";
+
+const TOPOLOGY_TTL_MS = 5 * 60 * 1000;
+
+const topologyArgs = {
+  rootId: v.optional(v.string()),
+  query: v.optional(v.string()),
+  stage: v.optional(v.string()),
+  kind: v.optional(v.string()),
+  mode: v.optional(v.union(v.literal("focus"), v.literal("clustered"), v.literal("expanded"))),
+  view: v.optional(v.union(v.literal("density"), v.literal("pca"), v.literal("centroid"))),
+  limit: v.optional(v.number()),
+};
+
+function normalizeText(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function postTypeLabel(postType: string): string {
+  const labels: Record<string, string> = {
+    clinical: "Clinical signal",
+    daily_digest: "Daily brief",
+    did_you_know: "Did You Know",
+    fda: "FDA signal",
+    funding_brief: "Funding brief",
+    funding_tracker: "Funding tracker",
+    ma: "M&A signal",
+    research: "Research memo",
+  };
+  return labels[postType] ?? postType.replace(/_/g, " ");
+}
+
+function firstMeaningfulLine(markdown: string): string {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^#+\s*/, "").replace(/^[-*]\s*/, "").replace(/\s+/g, " ").trim())
+    .find((line) => line && !/^={3,}$/.test(line)) ?? "Published intelligence artifact";
+}
+
+function archivePostStage(post: ReportTopologyArchivePost): "verified" | "review" | "stale" | "drafting" | "monitoring" {
+  const sources = Math.max(1, post.factCheckCount ?? 1);
+  if (post.postUrl || sources > 1) return "verified";
+  return "monitoring";
+}
+
+function matchesArchivePost(
+  post: ReportTopologyArchivePost,
+  args: { query?: string; stage?: string; kind?: string },
+): boolean {
+  const q = normalizeText(args.query);
+  if (args.stage && args.stage !== "all" && archivePostStage(post) !== args.stage) return false;
+  if (args.kind && args.kind !== "all" && postTypeLabel(post.postType) !== args.kind) return false;
+  if (!q) return true;
+  return `${post.content} ${post.postType} ${post.dateString}`.toLowerCase().includes(q);
+}
+
+function matchesDailyBriefMemory(
+  memory: ReportTopologyDailyBriefMemory,
+  args: { query?: string; stage?: string; kind?: string },
+): boolean {
+  if (args.stage && args.stage !== "all" && args.stage !== "verified" && args.stage !== "review") return false;
+  if (args.kind && args.kind !== "all" && args.kind !== "Daily Brief") return false;
+  const q = normalizeText(args.query);
+  if (!q) return true;
+  const featureText = (memory.features ?? [])
+    .map((feature) => `${feature.name ?? ""} ${feature.notes ?? ""} ${feature.type ?? ""}`)
+    .join(" ");
+  return `${memory.dateString} ${memory.goal} ${featureText}`.toLowerCase().includes(q);
+}
+
+function getDedupeKey(post: ReportTopologyArchivePost): string {
+  const postId = typeof post.postId === "string" ? post.postId.trim() : "";
+  if (postId) return `postId|${postId}`;
+  const part = typeof post.metadata?.part === "number" ? post.metadata.part : "";
+  return `${post.dateString}|${post.persona}|${post.postType}|${part}|${post.content}`;
+}
+
+function dedupeArchivePosts(posts: ReportTopologyArchivePost[]): ReportTopologyArchivePost[] {
+  const seen = new Set<string>();
+  const out: ReportTopologyArchivePost[] = [];
+  for (const post of posts) {
+    const key = getDedupeKey(post);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(post);
+  }
+  return out;
+}
+
+function snapshotArgs(args: {
+  rootId?: string;
+  query?: string;
+  stage?: string;
+  kind?: string;
+  mode?: "focus" | "clustered" | "expanded";
+  view?: "density" | "pca" | "centroid";
+  limit?: number;
+}) {
+  return {
+    rootId: args.rootId,
+    query: args.query,
+    stage: args.stage,
+    kind: args.kind,
+    mode: (args.mode ?? "clustered") as ReportTopologyScaleMode,
+    view: (args.view ?? "density") as ReportTopologyViewMode,
+    limit: Math.max(1, Math.min(args.limit ?? 96, 120)),
+  };
+}
+
+async function buildSnapshotFromDb(ctx: any, rawArgs: {
+  rootId?: string;
+  query?: string;
+  stage?: string;
+  kind?: string;
+  mode?: "focus" | "clustered" | "expanded";
+  view?: "density" | "pca" | "centroid";
+  limit?: number;
+}): Promise<ReportTopologySnapshot> {
+  const args = snapshotArgs(rawArgs);
+  const reportLimit = args.limit;
+  const scanLimit = Math.min(Math.max(reportLimit * 5, 120), 500);
+  const latestMemory = await ctx.db
+    .query("dailyBriefMemories")
+    .withIndex("by_generated_at")
+    .order("desc")
+    .first();
+  const archivePage = await ctx.db
+    .query("linkedinPostArchive")
+    .withIndex("by_postedAt")
+    .order("desc")
+    .paginate({ cursor: null, numItems: scanLimit });
+  const dedupedPosts = dedupeArchivePosts(archivePage.page as ReportTopologyArchivePost[]);
+
+  let rootPost: ReportTopologyArchivePost | null = null;
+  const rootArchiveId = args.rootId?.startsWith("li_") ? args.rootId.slice(3) : null;
+  if (rootArchiveId) {
+    const normalizedRootArchiveId = (ctx.db as any).normalizeId("linkedinPostArchive", rootArchiveId);
+    rootPost = normalizedRootArchiveId ? await ctx.db.get(normalizedRootArchiveId) : null;
+  }
+
+  const selectedPosts: ReportTopologyArchivePost[] = [];
+  const selectedPostIds = new Set<string>();
+  const addPost = (post: ReportTopologyArchivePost | null) => {
+    if (!post || selectedPosts.length >= reportLimit) return;
+    const id = String(post._id);
+    if (selectedPostIds.has(id)) return;
+    if (!matchesArchivePost(post, args)) return;
+    selectedPostIds.add(id);
+    selectedPosts.push({ ...post, _id: id });
+  };
+  addPost(rootPost);
+  for (const post of dedupedPosts) addPost({ ...post, _id: String(post._id) });
+
+  const includeMemory = latestMemory ? matchesDailyBriefMemory({ ...latestMemory, _id: String(latestMemory._id) }, args) : false;
+  const latestMemoryForSnapshot = includeMemory && latestMemory
+    ? { ...latestMemory, _id: String(latestMemory._id) } as ReportTopologyDailyBriefMemory
+    : null;
+
+  const postBudget = Math.max(0, reportLimit - (latestMemoryForSnapshot ? 1 : 0));
+  return buildReportTopologySnapshot({
+    posts: selectedPosts.slice(0, postBudget),
+    latestMemory: latestMemoryForSnapshot,
+    rootId: args.rootId,
+    query: args.query,
+    stage: args.stage,
+    kind: args.kind,
+    mode: args.mode,
+    view: args.view,
+    limit: args.limit,
+    now: Date.now(),
+    ttlMs: TOPOLOGY_TTL_MS,
+  });
+}
+
+function withPersistence(snapshot: ReportTopologySnapshot, stored: any | null): ReportTopologySnapshot {
+  if (!stored || stored.graphHash !== snapshot.graphHash || stored.expiresAt <= Date.now()) {
+    return snapshot;
+  }
+  return {
+    ...(stored.snapshot as ReportTopologySnapshot),
+    persisted: true,
+    persistedAt: stored.generatedAt,
+    source: "convex-persisted",
+  };
+}
+
+export const computeReportTopologySnapshot = internalQuery({
+  args: topologyArgs,
+  returns: v.any(),
+  handler: async (ctx, args) => buildSnapshotFromDb(ctx, args),
+});
+
+export const upsertReportTopologySnapshot = internalMutation({
+  args: {
+    snapshot: v.any(),
+  },
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    const snapshot = args.snapshot as ReportTopologySnapshot;
+    const existing = await ctx.db
+      .query("reportTopologySnapshots")
+      .withIndex("by_snapshot_key", (q) => q.eq("snapshotKey", snapshot.snapshotKey))
+      .order("desc")
+      .first();
+    const doc = {
+      snapshotKey: snapshot.snapshotKey,
+      rootKey: snapshot.graph.nodes[0]?.id ?? "auto",
+      view: snapshot.view,
+      mode: snapshot.mode,
+      graphHash: snapshot.graphHash,
+      generatedAt: snapshot.generatedAt,
+      expiresAt: snapshot.expiresAt,
+      nodeCount: snapshot.summary.nodeCount,
+      edgeCount: snapshot.summary.edgeCount,
+      clusterCount: snapshot.summary.clusterCount,
+      snapshot: {
+        ...snapshot,
+        persisted: true,
+        persistedAt: snapshot.generatedAt,
+        source: "convex-persisted",
+      },
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, doc);
+      return { snapshotId: existing._id, inserted: false, snapshotKey: snapshot.snapshotKey };
+    }
+    const snapshotId = await ctx.db.insert("reportTopologySnapshots", doc);
+    return { snapshotId, inserted: true, snapshotKey: snapshot.snapshotKey };
+  },
+});
+
+export const getReportTopologySnapshot = query({
+  args: topologyArgs,
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    const computed = await buildSnapshotFromDb(ctx, args);
+    const stored = await ctx.db
+      .query("reportTopologySnapshots")
+      .withIndex("by_snapshot_key", (q) => q.eq("snapshotKey", computed.snapshotKey))
+      .order("desc")
+      .first();
+    return withPersistence(computed, stored);
+  },
+});
+
+export const refreshReportTopologySnapshot = action({
+  args: topologyArgs,
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    const snapshot = await ctx.runQuery(internal.domains.redesign.reportTopology.computeReportTopologySnapshot, args);
+    const write = await ctx.runMutation(internal.domains.redesign.reportTopology.upsertReportTopologySnapshot, { snapshot });
+    return {
+      ...(snapshot as ReportTopologySnapshot),
+      persisted: true,
+      persistedAt: (snapshot as ReportTopologySnapshot).generatedAt,
+      source: "convex-persisted",
+      write,
+    };
+  },
+});
+
+export const inspectReportTopologyShape = query({
+  args: {
+    ...topologyArgs,
+    nodeId: v.optional(v.string()),
+  },
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    const computed = await buildSnapshotFromDb(ctx, args);
+    const stored = await ctx.db
+      .query("reportTopologySnapshots")
+      .withIndex("by_snapshot_key", (q) => q.eq("snapshotKey", computed.snapshotKey))
+      .order("desc")
+      .first();
+    const snapshot = withPersistence(computed, stored);
+    const selectedId = args.nodeId ?? snapshot.summary.hotNodeId ?? snapshot.nodes[0]?.id ?? null;
+    const node = selectedId ? snapshot.nodesById[selectedId] : null;
+    const graphNode = selectedId ? snapshot.graph.nodes.find((item) => item.id === selectedId) ?? null : null;
+    const clusters = selectedId
+      ? snapshot.mapperClusters.filter((cluster) => cluster.memberIds.includes(selectedId)).slice(0, 6)
+      : [];
+    const neighborEdges = selectedId
+      ? snapshot.graph.links.filter((link) => link.source === selectedId || link.target === selectedId).slice(0, 12)
+      : [];
+    const neighborIds = new Set(neighborEdges.flatMap((edge) => [edge.source, edge.target]).filter((id) => id !== selectedId));
+    const neighbors = [...neighborIds]
+      .map((id) => snapshot.graph.nodes.find((item) => item.id === id))
+      .filter(Boolean)
+      .slice(0, 10);
+    return {
+      success: Boolean(node),
+      snapshotKey: snapshot.snapshotKey,
+      graphHash: snapshot.graphHash,
+      source: snapshot.source,
+      persisted: snapshot.persisted,
+      view: snapshot.view,
+      selectedId,
+      node,
+      graphNode,
+      clusters,
+      neighborEdges,
+      neighbors,
+      summary: snapshot.summary,
+      pcaAxes: snapshot.pcaAxes,
+      retrievalPlan: {
+        human: graphNode
+          ? `Open ${graphNode.label} as a ${graphNode.provenance} node, then scan ${clusters.length} Mapper clusters and ${neighbors.length} first-ring neighbors.`
+          : "Select a graph node before opening the topology shape.",
+        agent: node
+          ? `Use topology=${snapshot.view}, density=${node.densityScore}, outlier=${node.outlierScore}, clusters=${node.mapperClusterIds.length}; retrieve first-ring neighbors before live search.`
+          : "No node projection available.",
+      },
+      recommendedActions: node
+        ? [
+            node.densityScore >= 70 ? "prioritize_dense_context" : "keep_searchable",
+            node.outlierScore >= 70 ? "inspect_outlier_before_patch" : "reuse_neighborhood_context",
+            clusters.length > 0 ? "expand_mapper_cluster" : "search_memory",
+          ]
+        : ["search_memory"],
+    };
+  },
+});

--- a/convex/domains/redesign/reportTopologyRuntime.test.ts
+++ b/convex/domains/redesign/reportTopologyRuntime.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReportTopologyKey,
+  buildReportTopologySnapshot,
+  buildRuntimeReportGraph,
+  type ReportTopologyArchivePost,
+  type ReportTopologyDailyBriefMemory,
+} from "./reportTopologyRuntime";
+
+const now = Date.UTC(2026, 4, 15);
+
+const memory: ReportTopologyDailyBriefMemory = {
+  _id: "mem_1",
+  dateString: "2026-05-15",
+  generatedAt: now - 60_000,
+  goal: "Daily brief memory with source-backed signals.",
+  features: [
+    { id: "signal-a", type: "funding", name: "Funding signal", status: "passing", testCriteria: "Has source", sourceRefs: ["https://example.com/a"], updatedAt: now },
+    { id: "signal-b", type: "voice", name: "Voice AI signal", status: "pending", testCriteria: "Needs review", sourceRefs: ["https://example.com/b"], updatedAt: now },
+    { id: "signal-c", type: "infra", name: "Infrastructure signal", status: "passing", testCriteria: "Has evidence", sourceRefs: ["https://example.com/c"], updatedAt: now },
+  ],
+};
+
+const posts: ReportTopologyArchivePost[] = [
+  {
+    _id: "post_1",
+    dateString: "2026-05-15",
+    persona: "GENERAL",
+    postType: "funding_tracker",
+    content: "Anthropic raised a new round\n\nEvidence-backed funding tracker.",
+    postUrl: "https://linkedin.com/feed/update/1",
+    factCheckCount: 4,
+    metadata: { sourcesUsed: ["https://example.com/anthropic"] },
+    postedAt: now - 90_000,
+  },
+  {
+    _id: "post_2",
+    dateString: "2026-05-15",
+    persona: "GENERAL",
+    postType: "research",
+    content: "OpenAI voice workflow note\n\nRealtime workflow implications.",
+    factCheckCount: 1,
+    metadata: { sourcesUsed: ["https://example.com/openai"] },
+    postedAt: now - 120_000,
+  },
+];
+
+describe("report topology runtime", () => {
+  it("builds a bounded graph with ids that match the Reports UI contract", () => {
+    const graph = buildRuntimeReportGraph({ posts, latestMemory: memory, rootId: "daily_mem_1", mode: "clustered", now });
+    expect(graph.nodes.some((node) => node.id === "daily_mem_1")).toBe(true);
+    expect(graph.nodes.some((node) => node.id === "entity:dailybrief")).toBe(true);
+    expect(graph.nodes.some((node) => node.id === "artifact:daily_mem_1:signal-a")).toBe(true);
+    expect(graph.links.some((link) => link.type === "has_report")).toBe(true);
+    expect(graph.links.some((link) => link.type === "causes")).toBe(true);
+  });
+
+  it("computes persisted-ready density topology with mapper clusters", () => {
+    const snapshot = buildReportTopologySnapshot({
+      posts,
+      latestMemory: memory,
+      rootId: "daily_mem_1",
+      mode: "clustered",
+      view: "density",
+      now,
+    });
+    expect(snapshot.snapshotKey).toMatch(/^report-topology:/);
+    expect(snapshot.graphHash.length).toBeGreaterThan(0);
+    expect(snapshot.summary.nodeCount).toBeGreaterThan(4);
+    expect(snapshot.summary.hotNodeId).toBeTruthy();
+    expect(snapshot.mapperClusters.length).toBeGreaterThan(0);
+    expect(snapshot.nodesById["daily_mem_1"]?.densityScore).toBeGreaterThanOrEqual(0);
+  });
+
+  it("separates PCA and centroid views while keeping deterministic keys", () => {
+    const pca = buildReportTopologySnapshot({ posts, latestMemory: memory, rootId: "daily_mem_1", mode: "expanded", view: "pca", now });
+    const centroid = buildReportTopologySnapshot({ posts, latestMemory: memory, rootId: "daily_mem_1", mode: "expanded", view: "centroid", now });
+    expect(pca.view).toBe("pca");
+    expect(centroid.view).toBe("centroid");
+    expect(pca.pcaAxes.pc1.length).toBeGreaterThan(0);
+    expect(centroid.summary.outlierNodeId).toBeTruthy();
+    expect(buildReportTopologyKey({ rootId: "daily_mem_1", mode: "expanded", view: "pca" }))
+      .toBe(buildReportTopologyKey({ rootId: "daily_mem_1", mode: "expanded", view: "pca" }));
+  });
+});

--- a/convex/domains/redesign/reportTopologyRuntime.ts
+++ b/convex/domains/redesign/reportTopologyRuntime.ts
@@ -1,0 +1,913 @@
+export type ReportTopologyViewMode = "density" | "pca" | "centroid";
+export type ReportTopologyScaleMode = "focus" | "clustered" | "expanded";
+
+export type ReportTopologyArchivePost = {
+  _id: string;
+  dateString: string;
+  persona: string;
+  postType: string;
+  content: string;
+  postId?: string;
+  postUrl?: string;
+  factCheckCount?: number;
+  metadata?: any;
+  postedAt: number;
+};
+
+export type ReportTopologyDailyBriefMemory = {
+  _id: string;
+  dateString: string;
+  generatedAt: number;
+  goal: string;
+  features?: Array<{
+    id: string;
+    type: string;
+    name: string;
+    status: "pending" | "failing" | "passing";
+    priority?: number;
+    testCriteria: string;
+    sourceRefs?: any;
+    notes?: string;
+    updatedAt: number;
+  }>;
+  context?: any;
+};
+
+export type ReportTopologyGraphNode = {
+  id: string;
+  label: string;
+  type: string;
+  graphType: "company" | "person" | "investor" | "brief" | "monitoring" | "report" | "artifact" | "portfolio" | "cluster";
+  provenance: "universe" | "entity" | "report" | "artifact" | "source" | "portfolio" | "cluster";
+  stage: "drafting" | "review" | "verified" | "stale" | "monitoring" | "universe";
+  weight: number;
+  sources: string;
+  freshness: string;
+  staleHours: number;
+  verified: string;
+  coverage: string[];
+  signals: string[];
+  attentionScore: number;
+  reasonSelected: string;
+  attentionTier: "promoted" | "shelf" | "searchable" | "agent_only";
+};
+
+export type ReportTopologyGraphLink = {
+  source: string;
+  target: string;
+  type: string;
+  label: string;
+  basis?: string;
+  strength?: number;
+  confidence?: number;
+  sourceRefs?: number;
+  claimRefs?: number;
+};
+
+export type ReportTopologyNodeProjection = {
+  id: string;
+  densityScore: number;
+  attentionScore: number;
+  degree: number;
+  pc1: number;
+  pc2: number;
+  centroidDistance: number;
+  outlierScore: number;
+  mapperClusterIds: string[];
+  x: number;
+  y: number;
+};
+
+export type ReportTopologyMapperCluster = {
+  id: string;
+  label: string;
+  memberIds: string[];
+  x: number;
+  y: number;
+  densityScore: number;
+  attentionScore: number;
+};
+
+export type ReportTopologySnapshot = {
+  snapshotKey: string;
+  graphHash: string;
+  view: ReportTopologyViewMode;
+  mode: ReportTopologyScaleMode;
+  generatedAt: number;
+  expiresAt: number;
+  persisted: boolean;
+  persistedAt?: number;
+  source: "convex-computed" | "convex-persisted";
+  nodes: ReportTopologyNodeProjection[];
+  nodesById: Record<string, ReportTopologyNodeProjection>;
+  mapperClusters: ReportTopologyMapperCluster[];
+  mapperEdges: Array<{ source: string; target: string; sharedMembers: number }>;
+  summary: {
+    nodeCount: number;
+    edgeCount: number;
+    hotNodeId: string | null;
+    centroidNodeId: string | null;
+    outlierNodeId: string | null;
+    clusterCount: number;
+    viewRationale: string;
+  };
+  pcaAxes: {
+    pc1: Array<{ label: string; weight: number }>;
+    pc2: Array<{ label: string; weight: number }>;
+  };
+  graph: {
+    sourceLabel: string;
+    sourceRows: number;
+    totalReportCount: number;
+    visibleReportCount: number;
+    hiddenReportCount: number;
+    nodes: ReportTopologyGraphNode[];
+    links: ReportTopologyGraphLink[];
+  };
+};
+
+const POST_TYPE_LABELS: Record<string, string> = {
+  clinical: "Clinical signal",
+  daily_digest: "Daily brief",
+  did_you_know: "Did You Know",
+  fda: "FDA signal",
+  funding_brief: "Funding brief",
+  funding_tracker: "Funding tracker",
+  ma: "M&A signal",
+  research: "Research memo",
+};
+
+const SCALE_CONFIG: Record<ReportTopologyScaleMode, { neighborReports: number; rootArtifacts: number; relatedArtifacts: number; sourceRows: number; coveredEntities: number; relationEdges: number }> = {
+  focus: { neighborReports: 8, rootArtifacts: 4, relatedArtifacts: 1, sourceRows: 3, coveredEntities: 4, relationEdges: 3 },
+  clustered: { neighborReports: 12, rootArtifacts: 4, relatedArtifacts: 1, sourceRows: 3, coveredEntities: 5, relationEdges: 5 },
+  expanded: { neighborReports: 18, rootArtifacts: 5, relatedArtifacts: 2, sourceRows: 4, coveredEntities: 6, relationEdges: 8 },
+};
+
+const FEATURE_LABELS = ["attention", "degree", "weight", "sources", "verified", "freshness", "signals", "causal"] as const;
+
+type ReportRow = {
+  id: string;
+  entity: string;
+  kind: string;
+  status: "verified" | "review" | "watching";
+  description: string;
+  sources: number;
+  claims: number;
+  followUps: number;
+  updatedAt: string;
+  updatedAtMs: number;
+  tags: string[];
+  detailNodes: Array<{ id: string; title: string; subtitle: string; tone: string; artifactType?: string }>;
+  detailEdges: Array<{ from: string; to: string; type?: string; label?: string; basis?: string; strength?: number }>;
+  sourceRows: Array<{ id: string; type: string; title: string; confidence?: number; href?: string }>;
+};
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function clamp100(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function normalizeSpace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeGraphKey(value: string | undefined): string {
+  return (value ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function firstMeaningfulLine(markdown: string): string {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => normalizeSpace(line.replace(/^#+\s*/, "").replace(/^[-*]\s*/, "")))
+    .find((line) => line && !/^={3,}$/.test(line)) ?? "Published intelligence artifact";
+}
+
+function excerpt(markdown: string, max = 190): string {
+  const text = markdown
+    .split(/\r?\n/)
+    .map((line) => normalizeSpace(line.replace(/^#+\s*/, "").replace(/^[-*]\s*/, "")))
+    .filter(Boolean)
+    .join(" ");
+  return text.length > max ? `${text.slice(0, max - 1).trim()}...` : text;
+}
+
+function timeAgoFrom(now: number, at: number): string {
+  const delta = Math.max(0, now - at);
+  const m = Math.floor(delta / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return `${Math.floor(d / 7)}w ago`;
+}
+
+function freshnessHours(value: string): number {
+  const text = value.toLowerCase();
+  if (/now|today|recently/.test(text)) return 0;
+  const number = Number(text.match(/(\d+(?:\.\d+)?)/)?.[1] ?? 0);
+  if (!Number.isFinite(number) || number <= 0) return 0;
+  if (/\bmin|m ago/.test(text)) return number / 60;
+  if (/\bh|hour/.test(text)) return number;
+  if (/\bd|day/.test(text)) return number * 24;
+  if (/\bw|week/.test(text)) return number * 24 * 7;
+  return number;
+}
+
+function asRecord(value: unknown): Record<string, any> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, any> : {};
+}
+
+function sourceRefCount(value: unknown): number {
+  if (!value) return 0;
+  if (Array.isArray(value)) return value.reduce((sum, item) => sum + Math.max(1, sourceRefCount(item)), 0);
+  if (typeof value === "string") return value ? 1 : 0;
+  if (typeof value === "object") return Object.values(value as Record<string, unknown>).reduce<number>((sum, item) => sum + sourceRefCount(item), 0);
+  return 0;
+}
+
+function sourceRefLabels(value: unknown, limit = 8): string[] {
+  const out: string[] = [];
+  const visit = (item: unknown) => {
+    if (out.length >= limit || !item) return;
+    if (typeof item === "string") {
+      if (item.trim()) out.push(item.trim());
+      return;
+    }
+    if (Array.isArray(item)) {
+      item.forEach(visit);
+      return;
+    }
+    if (typeof item === "object") {
+      const record = item as Record<string, unknown>;
+      const label = record.url ?? record.title ?? record.source ?? record.name;
+      if (typeof label === "string" && label.trim()) out.push(label.trim());
+      else Object.values(record).forEach(visit);
+    }
+  };
+  visit(value);
+  return Array.from(new Set(out)).slice(0, limit);
+}
+
+function postTypeLabel(postType: string): string {
+  return POST_TYPE_LABELS[postType] ?? postType.replace(/_/g, " ");
+}
+
+function stageFromReport(report: ReportRow): ReportTopologyGraphNode["stage"] {
+  if (report.status === "review") return "review";
+  if (report.status === "watching") return "monitoring";
+  if (/stale|expired|refresh|old|3d|5d|week/i.test(`${report.description} ${report.updatedAt}`)) return "stale";
+  if (report.sources <= 2 || /draft|gathering|queued|generating/i.test(report.description)) return "drafting";
+  return "verified";
+}
+
+function entityLabelForReport(report: ReportRow): string {
+  const fundingMatch = report.entity.match(/^(.+?)\s+(?:just\s+)?raised\b/i);
+  if (fundingMatch?.[1]) return fundingMatch[1].trim();
+  if (/daily|brief|edition|digest/i.test(report.kind)) return "Daily Brief";
+  return report.entity.split(/\s+[|-]\s+/)[0]?.trim() || report.entity;
+}
+
+function entityNodeKey(report: ReportRow): string {
+  return `entity:${normalizeGraphKey(entityLabelForReport(report) || report.id) || report.id}`;
+}
+
+function liveNodeKey(report: ReportRow, nodeId: string): string {
+  return `artifact:${report.id}:${nodeId}`;
+}
+
+function liveSourceKey(report: ReportRow, sourceId: string): string {
+  return `source:${report.id}:${sourceId}`;
+}
+
+function reportGraphType(report: ReportRow, stage: ReportTopologyGraphNode["stage"]): ReportTopologyGraphNode["graphType"] {
+  const text = `${report.kind} ${report.entity} ${report.description}`.toLowerCase();
+  if (/daily|brief|edition|digest/.test(text)) return "brief";
+  if (/sequoia|capital|ventures|fund|investor|partner/.test(text)) return "investor";
+  if (/person|founder|ceo|partner|investor|amodei|altman|lin/.test(text)) return "person";
+  if (stage === "monitoring" || /watch|monitor/.test(text)) return "monitoring";
+  return "company";
+}
+
+function graphEdgeType(report: ReportRow, stage: ReportTopologyGraphNode["stage"]): string {
+  const text = `${report.kind} ${report.entity} ${report.description}`.toLowerCase();
+  if (text.includes("funding") || text.includes("raise") || text.includes("series ")) return "funding";
+  if (text.includes("pricing") || text.includes("compet")) return "competition";
+  if (text.includes("source") || text.includes("api") || text.includes("workflow")) return "integration";
+  if (stage === "review" || stage === "stale") return "review";
+  if (stage === "drafting") return "drafting";
+  return "coverage";
+}
+
+function defaultGraphAttention(node: Omit<ReportTopologyGraphNode, "attentionScore" | "reasonSelected" | "attentionTier">): Pick<ReportTopologyGraphNode, "attentionScore" | "reasonSelected" | "attentionTier"> {
+  const sourceCount = Number(node.sources.match(/\d+/)?.[0] ?? 0);
+  const evidenceScore = Math.min(38, sourceCount * 3);
+  const stageScore = node.stage === "verified" ? 24 : node.stage === "review" || node.stage === "stale" ? 18 : node.stage === "drafting" ? 12 : 14;
+  const provenanceScore = node.provenance === "artifact" ? 20 : node.provenance === "report" ? 18 : node.provenance === "portfolio" ? 16 : node.provenance === "entity" ? 14 : node.provenance === "cluster" ? 10 : 8;
+  const actionScore = node.signals.length > 0 ? 12 : 4;
+  const attentionScore = Math.max(0, Math.min(100, Math.round(18 + evidenceScore + stageScore + provenanceScore + actionScore - Math.min(16, node.staleHours / 12))));
+  const attentionTier = attentionScore >= 78 ? "promoted" : attentionScore >= 62 ? "shelf" : attentionScore >= 42 ? "searchable" : "agent_only";
+  const reasonSelected =
+    node.provenance === "artifact" ? "Generated artifact can become report work, evidence review, or chat context." :
+    node.provenance === "report" ? "Report notebook is the durable artifact for this graph node." :
+    node.provenance === "portfolio" ? "Portfolio node summarizes cross-entity movement and review order." :
+    node.stage === "review" || node.stage === "stale" ? "Needs review or freshness work before the agent can safely patch outputs." :
+    "Promoted from source, claim, freshness, and graph-context signals.";
+  return { attentionScore, reasonSelected, attentionTier };
+}
+
+function cleanTextHash(input: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function buildReportTopologyKey(args: {
+  rootId?: string | null;
+  query?: string | null;
+  stage?: string | null;
+  kind?: string | null;
+  mode?: ReportTopologyScaleMode | null;
+  view?: ReportTopologyViewMode | null;
+  limit?: number | null;
+}): string {
+  const parts = [
+    args.view ?? "density",
+    args.mode ?? "clustered",
+    args.rootId ?? "auto",
+    normalizeSpace(args.query ?? "").toLowerCase(),
+    args.stage ?? "all",
+    args.kind ?? "all",
+    String(args.limit ?? 0),
+  ];
+  return `report-topology:${cleanTextHash(parts.join("|"))}`;
+}
+
+function archiveToReport(post: ReportTopologyArchivePost, now: number): ReportRow {
+  const metadata = asRecord(post.metadata);
+  const sourceLabels = sourceRefLabels(metadata.sourcesUsed ?? metadata.sourceRefs ?? metadata.sources, 8);
+  const label = postTypeLabel(post.postType);
+  const sources = Math.max(1, post.factCheckCount ?? sourceLabels.length);
+  return {
+    id: `li_${post._id}`,
+    entity: firstMeaningfulLine(post.content).slice(0, 72),
+    kind: label,
+    status: post.postUrl || sources > 1 ? "verified" : "watching",
+    description: excerpt(post.content, 220),
+    sources,
+    claims: Math.max(1, post.factCheckCount ?? 1),
+    followUps: 0,
+    updatedAt: timeAgoFrom(now, post.postedAt),
+    updatedAtMs: post.postedAt,
+    tags: [label, post.persona, post.dateString].filter(Boolean),
+    detailNodes: [
+      { id: "archive", title: "Archive post", subtitle: `${sources} sources`, tone: "blue", artifactType: "EVIDENCE" },
+      { id: "persona", title: post.persona, subtitle: "persona", tone: "default", artifactType: "PACKET" },
+    ],
+    detailEdges: [
+      { from: "archive", to: "persona", type: "correlates_with", label: "correlates", basis: "Archive artifact and persona context are part of the same published packet.", strength: 0.58 },
+    ],
+    sourceRows: sourceLabels.length
+      ? sourceLabels.map((label, index) => ({ id: `source-${index}`, type: "source", title: label, confidence: post.postUrl ? 0.84 : 0.72, href: /^https?:\/\//.test(label) ? label : undefined }))
+      : [{ id: "archive-row", type: label, title: post.postUrl ? "LinkedIn archive post" : "NodeBench archive row", confidence: post.postUrl ? 0.84 : 0.72, href: post.postUrl }],
+  };
+}
+
+function dailyBriefToReport(memory: ReportTopologyDailyBriefMemory, now: number): ReportRow {
+  const features = memory.features ?? [];
+  const passing = features.filter((feature) => feature.status === "passing").length;
+  const failing = features.filter((feature) => feature.status === "failing").length;
+  const sources = Math.max(1, sourceRefCount(features.map((feature) => feature.sourceRefs)));
+  const claims = Math.max(1, passing || features.length);
+  return {
+    id: `daily_${memory._id}`,
+    entity: `Daily Brief - ${memory.dateString}`,
+    kind: "Daily Brief",
+    status: failing > 0 ? "review" : "verified",
+    description: normalizeSpace(memory.goal || "Daily brief memory generated by NodeBench.").slice(0, 220),
+    sources,
+    claims,
+    followUps: features.filter((feature) => feature.status !== "passing").length,
+    updatedAt: timeAgoFrom(now, memory.generatedAt),
+    updatedAtMs: memory.generatedAt,
+    tags: ["Daily Brief", memory.dateString, ...features.slice(0, 3).map((feature) => feature.type)],
+    detailNodes: features.slice(0, 8).map((feature) => ({
+      id: feature.id,
+      title: feature.name.slice(0, 28),
+      subtitle: `${feature.type} - ${feature.status}`,
+      tone: feature.status === "passing" ? "green" : feature.status === "pending" ? "blue" : "amber",
+      artifactType: feature.status === "passing" ? "EVIDENCE" : "DASHBOARD",
+    })),
+    detailEdges: features.length >= 2 ? [
+      { from: features[0].id, to: features[1].id, type: "causes", label: "causes", basis: "The first ranked signal changes the next artifact's review order.", strength: 0.74 },
+      ...(features.length >= 3 ? [{ from: features[1].id, to: features[2].id, type: "correlates_with", label: "correlates", basis: "Adjacent daily brief artifacts share source timing or topic overlap.", strength: 0.66 }] : []),
+    ] : [],
+    sourceRows: features.slice(0, 8).map((feature, index) => ({
+      id: feature.id || `feature-${index}`,
+      type: feature.type,
+      title: feature.name,
+      confidence: feature.status === "passing" ? 0.86 : feature.status === "pending" ? 0.62 : 0.44,
+    })),
+  };
+}
+
+function addAttention(node: Omit<ReportTopologyGraphNode, "attentionScore" | "reasonSelected" | "attentionTier">): ReportTopologyGraphNode {
+  return { ...node, ...defaultGraphAttention(node) };
+}
+
+export function buildRuntimeReportGraph(args: {
+  posts: ReportTopologyArchivePost[];
+  latestMemory?: ReportTopologyDailyBriefMemory | null;
+  rootId?: string | null;
+  mode: ReportTopologyScaleMode;
+  now: number;
+}): ReportTopologySnapshot["graph"] {
+  const config = SCALE_CONFIG[args.mode];
+  const reports = [
+    ...(args.latestMemory ? [dailyBriefToReport(args.latestMemory, args.now)] : []),
+    ...args.posts.map((post) => archiveToReport(post, args.now)),
+  ];
+  const rootReport = reports.find((report) => report.id === args.rootId) ?? reports[0] ?? null;
+  if (!rootReport) {
+    return { sourceLabel: "No live graph", sourceRows: 0, totalReportCount: 0, visibleReportCount: 0, hiddenReportCount: 0, nodes: [], links: [] };
+  }
+  const related = reports.filter((report) => report.id !== rootReport.id).slice(0, config.neighborReports);
+  const visible = [rootReport, ...related];
+  const hiddenReportCount = Math.max(0, reports.length - visible.length);
+  const nodes: ReportTopologyGraphNode[] = [];
+  const links: ReportTopologyGraphLink[] = [];
+  const seenNodes = new Set<string>();
+  const seenLinks = new Set<string>();
+  const totalSources = visible.reduce((sum, report) => sum + report.sourceRows.length, 0);
+
+  const addNode = (node: Omit<ReportTopologyGraphNode, "attentionScore" | "reasonSelected" | "attentionTier">) => {
+    if (seenNodes.has(node.id)) return;
+    seenNodes.add(node.id);
+    nodes.push(addAttention(node));
+  };
+  const addLink = (link: ReportTopologyGraphLink) => {
+    if (link.source === link.target) return;
+    const key = `${link.source}->${link.target}:${link.type}:${link.label}`;
+    if (seenLinks.has(key)) return;
+    seenLinks.add(key);
+    const sourceNode = nodes.find((node) => node.id === link.source);
+    const targetNode = nodes.find((node) => node.id === link.target);
+    const sourceRefs = link.sourceRefs ?? Number(sourceNode?.sources.match(/\d+/)?.[0] ?? targetNode?.sources.match(/\d+/)?.[0] ?? 0);
+    const claimRefs = link.claimRefs ?? Number(sourceNode?.verified.match(/\d+/)?.[0] ?? targetNode?.verified.match(/\d+/)?.[0] ?? 0);
+    const strength = link.strength ?? (link.type === "causes" ? 0.72 : link.type === "correlates_with" ? 0.64 : link.type === "has_report" || link.type === "has_artifact" ? 0.82 : 0.55);
+    links.push({
+      sourceRefs,
+      claimRefs,
+      strength,
+      confidence: link.confidence ?? Math.max(0.35, Math.min(0.96, strength + Math.min(0.14, sourceRefs * 0.015) + Math.min(0.08, claimRefs * 0.01))),
+      ...link,
+    });
+  };
+
+  visible.forEach((report) => {
+    const stage = stageFromReport(report);
+    const entityGraphType = reportGraphType(report, stage);
+    const entityId = entityNodeKey(report);
+    const freshness = `Updated ${report.updatedAt}`;
+    addNode({
+      id: entityId,
+      label: entityLabelForReport(report),
+      type: entityGraphType === "brief" ? "Brief" : entityGraphType === "investor" ? "Investor" : entityGraphType === "person" ? "Person" : "Entity",
+      graphType: entityGraphType,
+      provenance: "entity",
+      stage,
+      weight: Math.max(1, report.sourceRows.length || report.sources),
+      sources: `${Math.max(1, report.sourceRows.length || report.sources)} source rows`,
+      freshness,
+      staleHours: stage === "stale" ? Math.max(48, freshnessHours(freshness)) : freshnessHours(freshness),
+      verified: `${report.claims} claims - ${stage}`,
+      coverage: report.tags.slice(0, 4),
+      signals: [report.description, `${report.followUps} follow-ups queued`].filter(Boolean),
+    });
+    addNode({
+      id: report.id,
+      label: report.entity,
+      type: report.kind,
+      graphType: "report",
+      provenance: "report",
+      stage,
+      weight: Math.max(1, report.sourceRows.length || report.sources),
+      sources: `${Math.max(1, report.sourceRows.length || report.sources)} source rows`,
+      freshness,
+      staleHours: stage === "stale" ? Math.max(48, freshnessHours(freshness)) : freshnessHours(freshness),
+      verified: `${report.claims} claims - ${stage}`,
+      coverage: report.tags.slice(0, 4),
+      signals: [report.description, `${report.followUps} follow-ups queued`].filter(Boolean),
+    });
+    addLink({ source: entityId, target: report.id, type: "has_report", label: report.kind, basis: "Reports are durable child artifacts of the resolved entity." });
+  });
+
+  visible.forEach((report, reportIndex) => {
+    const stage = stageFromReport(report);
+    const artifactLimit = report.id === rootReport.id ? config.rootArtifacts : config.relatedArtifacts;
+    report.detailNodes.slice(0, artifactLimit).forEach((item) => {
+      const artifactId = liveNodeKey(report, item.id);
+      addNode({
+        id: artifactId,
+        label: item.title,
+        type: item.artifactType ?? "PACKET",
+        graphType: "artifact",
+        provenance: "artifact",
+        stage: item.tone === "green" ? "verified" : item.tone === "amber" ? "review" : stage,
+        weight: Math.max(1, report.sourceRows.length),
+        sources: item.subtitle,
+        freshness: `From ${report.entity}`,
+        staleHours: freshnessHours(report.updatedAt),
+        verified: `${report.claims} claims - ${report.sourceRows.length} sources`,
+        coverage: [report.kind, item.artifactType ?? "PACKET", ...report.tags].slice(0, 4),
+        signals: [item.title, item.subtitle, report.description].filter(Boolean).slice(0, 4),
+      });
+      addLink({ source: report.id, target: artifactId, type: "has_artifact", label: item.artifactType ?? "PACKET", basis: "Artifact is generated from this report packet." });
+    });
+    report.detailEdges.slice(0, 4).forEach((edge) => {
+      const source = edge.from === "root" ? report.id : liveNodeKey(report, edge.from);
+      const target = edge.to === "root" ? report.id : liveNodeKey(report, edge.to);
+      addLink({ source, target, type: edge.type ?? "coverage", label: edge.label ?? "artifact edge", basis: edge.basis, strength: edge.strength });
+    });
+    if (reportIndex === 0) {
+      report.sourceRows.slice(0, config.sourceRows).forEach((sourceRow) => {
+        const sourceId = liveSourceKey(report, sourceRow.id);
+        addNode({
+          id: sourceId,
+          label: sourceRow.title.slice(0, 38),
+          type: sourceRow.type || "Source",
+          graphType: "monitoring",
+          provenance: "source",
+          stage: (sourceRow.confidence ?? 0.72) >= 0.8 ? "verified" : "review",
+          weight: 2,
+          sources: sourceRow.href ? "Linked source row" : "Stored source row",
+          freshness: `Refreshed ${report.updatedAt}`,
+          staleHours: freshnessHours(report.updatedAt),
+          verified: sourceRow.confidence ? `${Math.round(sourceRow.confidence * 100)}% source confidence` : "Source available",
+          coverage: [sourceRow.type, "source", report.kind].filter(Boolean),
+          signals: [sourceRow.title, sourceRow.href ?? "Convex source row"].filter(Boolean).slice(0, 3),
+        });
+        addLink({ source: report.id, target: sourceId, type: "evidence", label: sourceRow.type.slice(0, 24) || "source row" });
+      });
+    }
+  });
+
+  if (visible.length > 1) {
+    addNode({
+      id: "__portfolio_ai_infrastructure__",
+      label: "AI Infrastructure",
+      type: "Portfolio",
+      graphType: "portfolio",
+      provenance: "portfolio",
+      stage: "monitoring",
+      weight: Math.max(2, Math.min(10, visible.length)),
+      sources: `${totalSources} source rows`,
+      freshness: `${visible.length} covered reports`,
+      staleHours: 0,
+      verified: "Coverage graph ready",
+      coverage: ["portfolio", "watchlist", "coverage"],
+      signals: ["Cross-entity universe built from the visible Convex-backed report set.", "Portfolio artifacts show which reports move together."],
+    });
+    visible.slice(0, config.coveredEntities).forEach((report, index) => {
+      addLink({ source: "__portfolio_ai_infrastructure__", target: entityNodeKey(report), type: "covers", label: index === 0 ? "strategic" : index === 1 ? "watch" : "coverage", strength: index === 0 ? 0.86 : 0.62 });
+    });
+  }
+
+  const artifactIds = nodes.filter((node) => node.provenance === "artifact").map((node) => node.id);
+  if (artifactIds.length >= 2 && config.relationEdges >= 1) addLink({ source: artifactIds[0], target: artifactIds[1], type: "causes", label: "causes", basis: "The lead artifact changes downstream review order.", strength: 0.74 });
+  if (artifactIds.length >= 3 && config.relationEdges >= 2) addLink({ source: artifactIds[1], target: artifactIds[2], type: "correlates_with", label: "correlates", basis: "Artifacts share report context, source timing, or entity overlap.", strength: 0.66 });
+  if (artifactIds.length >= 4 && config.relationEdges >= 3) addLink({ source: artifactIds[0], target: artifactIds[3], type: "causes", label: "causes", basis: "One artifact can influence multiple downstream artifacts.", strength: 0.61 });
+
+  addNode({
+    id: "__universe__",
+    label: "AI Infra universe",
+    type: "Universe",
+    graphType: "monitoring",
+    provenance: "universe",
+    stage: "universe",
+    weight: Math.max(1, Math.min(12, totalSources)),
+    sources: `${totalSources} source rows`,
+    freshness: `${reports.length} live reports`,
+    staleHours: 0,
+    verified: "All visible reports have a next step",
+    coverage: ["reports", "sources", "claims"],
+    signals: ["This graph is derived from live report artifacts.", "Open a node to jump into the durable notebook."],
+  });
+  addLink({ source: "__universe__", target: rootReport.id, type: "coverage", label: "active root" });
+  related.slice(0, 4).forEach((report) => addLink({ source: "__universe__", target: entityNodeKey(report), type: graphEdgeType(report, stageFromReport(report)), label: "coverage" }));
+
+  return {
+    sourceLabel: "Convex persisted topology graph",
+    sourceRows: totalSources,
+    totalReportCount: reports.length,
+    visibleReportCount: visible.length,
+    hiddenReportCount,
+    nodes,
+    links,
+  };
+}
+
+function edgeEndpoint(value: string | { id?: string } | undefined): string {
+  if (typeof value === "object" && value?.id) return value.id;
+  return String(value ?? "");
+}
+
+function sourceCount(value?: string): number {
+  return Number(value?.match(/\d+(?:\.\d+)?/)?.[0] ?? 0);
+}
+
+function verifiedScore(value?: string): number {
+  const text = (value ?? "").toLowerCase();
+  const pct = Number(text.match(/(\d+(?:\.\d+)?)%/)?.[1] ?? NaN);
+  if (Number.isFinite(pct)) return pct / 100;
+  if (/verified|passed|ready/.test(text)) return 0.86;
+  if (/review|pending|unknown/.test(text)) return 0.46;
+  if (/failing|blocked|stale/.test(text)) return 0.22;
+  return 0.58;
+}
+
+function normalizeColumns(rows: number[][]): number[][] {
+  if (rows.length === 0) return [];
+  const width = rows[0]?.length ?? 0;
+  const mins = Array.from({ length: width }, (_, column) => Math.min(...rows.map((row) => row[column] ?? 0)));
+  const maxs = Array.from({ length: width }, (_, column) => Math.max(...rows.map((row) => row[column] ?? 0)));
+  return rows.map((row) => row.map((value, column) => {
+    const range = maxs[column] - mins[column];
+    if (range <= 1e-9) return 0.5;
+    return (value - mins[column]) / range;
+  }));
+}
+
+function dot(a: number[], b: number[]): number {
+  return a.reduce((sum, value, index) => sum + value * (b[index] ?? 0), 0);
+}
+
+function normalizeVector(vector: number[]): number[] {
+  const magnitude = Math.sqrt(dot(vector, vector));
+  if (magnitude <= 1e-9) return vector.map(() => 0);
+  return vector.map((value) => value / magnitude);
+}
+
+function covarianceMatrix(rows: number[][]): number[][] {
+  const width = rows[0]?.length ?? 0;
+  const means = Array.from({ length: width }, (_, column) => rows.reduce((sum, row) => sum + (row[column] ?? 0), 0) / Math.max(1, rows.length));
+  return Array.from({ length: width }, (_, rowIndex) =>
+    Array.from({ length: width }, (_, columnIndex) => rows.reduce((sum, row) => sum + ((row[rowIndex] ?? 0) - means[rowIndex]) * ((row[columnIndex] ?? 0) - means[columnIndex]), 0) / Math.max(1, rows.length - 1)),
+  );
+}
+
+function matVec(matrix: number[][], vector: number[]): number[] {
+  return matrix.map((row) => dot(row, vector));
+}
+
+function powerIteration(matrix: number[][], seedShift = 0): { vector: number[]; value: number } {
+  const width = matrix.length;
+  let vector = normalizeVector(Array.from({ length: width }, (_, index) => 1 + ((index + seedShift) % 3) * 0.17));
+  for (let iteration = 0; iteration < 32; iteration += 1) {
+    const next = normalizeVector(matVec(matrix, vector));
+    if (next.every((value) => Math.abs(value) < 1e-9)) break;
+    vector = next;
+  }
+  return { vector, value: dot(vector, matVec(matrix, vector)) };
+}
+
+function deflate(matrix: number[][], eigen: { vector: number[]; value: number }): number[][] {
+  return matrix.map((row, rowIndex) => row.map((value, columnIndex) => value - eigen.value * eigen.vector[rowIndex] * eigen.vector[columnIndex]));
+}
+
+function scaled(values: number[]): number[] {
+  const min = Math.min(...values, 0);
+  const max = Math.max(...values, 0);
+  const range = max - min;
+  if (range <= 1e-9) return values.map(() => 0.5);
+  return values.map((value) => (value - min) / range);
+}
+
+function buildFeatureRows(nodes: ReportTopologyGraphNode[], links: ReportTopologyGraphLink[]) {
+  const degree = new Map<string, number>();
+  const causal = new Map<string, number>();
+  links.forEach((link) => {
+    const source = edgeEndpoint(link.source);
+    const target = edgeEndpoint(link.target);
+    degree.set(source, (degree.get(source) ?? 0) + 1);
+    degree.set(target, (degree.get(target) ?? 0) + 1);
+    if (link.type === "causes" || link.type === "correlates_with") {
+      const score = (link.strength ?? 0.5) + (link.confidence ?? 0.5);
+      causal.set(source, (causal.get(source) ?? 0) + score);
+      causal.set(target, (causal.get(target) ?? 0) + score);
+    }
+  });
+  const rawRows = nodes.map((node) => [
+    clamp01((node.attentionScore ?? 0) / 100),
+    degree.get(node.id) ?? 0,
+    Math.max(1, node.weight ?? 1),
+    sourceCount(node.sources),
+    verifiedScore(node.verified),
+    1 / (1 + Math.max(0, node.staleHours ?? 0) / 24),
+    (node.signals?.length ?? 0) + (node.coverage?.length ?? 0) * 0.5,
+    causal.get(node.id) ?? 0,
+  ]);
+  const normalized = normalizeColumns(rawRows);
+  return nodes.map((node, index) => ({ node, raw: rawRows[index] ?? [], vector: normalized[index] ?? [] }));
+}
+
+function topLoadings(loadings: number[]) {
+  return loadings
+    .map((weight, index) => ({ label: FEATURE_LABELS[index] ?? `feature-${index}`, weight }))
+    .sort((a, b) => Math.abs(b.weight) - Math.abs(a.weight))
+    .slice(0, 3);
+}
+
+function buildMapperClusters(projections: Omit<ReportTopologyNodeProjection, "mapperClusterIds">[], links: ReportTopologyGraphLink[]) {
+  const bins = 4;
+  const overlap = 0.12;
+  const adjacency = new Map<string, Set<string>>();
+  links.forEach((link) => {
+    const source = edgeEndpoint(link.source);
+    const target = edgeEndpoint(link.target);
+    if (!adjacency.has(source)) adjacency.set(source, new Set());
+    if (!adjacency.has(target)) adjacency.set(target, new Set());
+    adjacency.get(source)?.add(target);
+    adjacency.get(target)?.add(source);
+  });
+  const clusters: ReportTopologyMapperCluster[] = [];
+  const nodeClusters: Record<string, string[]> = {};
+  const binSize = 1 / bins;
+  for (let bx = 0; bx < bins; bx += 1) {
+    for (let by = 0; by < bins; by += 1) {
+      const minX = bx * binSize - overlap;
+      const maxX = (bx + 1) * binSize + overlap;
+      const minY = by * binSize - overlap;
+      const maxY = (by + 1) * binSize + overlap;
+      const members = projections.filter((node) => node.x >= minX && node.x <= maxX && node.y >= minY && node.y <= maxY);
+      const unvisited = new Set(members.map((node) => node.id));
+      while (unvisited.size > 0) {
+        const [start] = unvisited;
+        if (!start) break;
+        const queue = [start];
+        const component = new Set<string>();
+        unvisited.delete(start);
+        while (queue.length > 0) {
+          const current = queue.shift();
+          if (!current) continue;
+          component.add(current);
+          adjacency.get(current)?.forEach((next) => {
+            if (unvisited.has(next)) {
+              unvisited.delete(next);
+              queue.push(next);
+            }
+          });
+        }
+        const memberIds = [...component];
+        const memberNodes = memberIds.map((id) => projections.find((node) => node.id === id)).filter((node): node is Omit<ReportTopologyNodeProjection, "mapperClusterIds"> => Boolean(node));
+        if (memberNodes.length === 0) continue;
+        const cluster = {
+          id: `mapper:${bx}:${by}:${clusters.length}`,
+          label: `Mapper ${bx + 1}.${by + 1}`,
+          memberIds,
+          x: memberNodes.reduce((sum, node) => sum + node.x, 0) / memberNodes.length,
+          y: memberNodes.reduce((sum, node) => sum + node.y, 0) / memberNodes.length,
+          densityScore: clamp100(memberNodes.reduce((sum, node) => sum + node.densityScore, 0) / memberNodes.length),
+          attentionScore: clamp100(memberNodes.reduce((sum, node) => sum + node.attentionScore, 0) / memberNodes.length),
+        };
+        clusters.push(cluster);
+        memberIds.forEach((id) => {
+          nodeClusters[id] = [...(nodeClusters[id] ?? []), cluster.id];
+        });
+      }
+    }
+  }
+  const edges: Array<{ source: string; target: string; sharedMembers: number }> = [];
+  for (let i = 0; i < clusters.length; i += 1) {
+    for (let j = i + 1; j < clusters.length; j += 1) {
+      const a = clusters[i];
+      const b = clusters[j];
+      if (!a || !b) continue;
+      const sharedMembers = a.memberIds.filter((id) => new Set(b.memberIds).has(id)).length;
+      if (sharedMembers > 0) edges.push({ source: a.id, target: b.id, sharedMembers });
+    }
+  }
+  return { clusters, edges, nodeClusters };
+}
+
+function buildTopology(nodes: ReportTopologyGraphNode[], links: ReportTopologyGraphLink[], view: ReportTopologyViewMode) {
+  const rows = buildFeatureRows(nodes, links);
+  const matrix = rows.length > 1 ? covarianceMatrix(rows.map((row) => row.vector)) : [];
+  const first = matrix.length ? powerIteration(matrix, 0) : { vector: FEATURE_LABELS.map((_, index) => index === 0 ? 1 : 0), value: 0 };
+  const second = matrix.length ? powerIteration(deflate(matrix, first), 1) : { vector: FEATURE_LABELS.map((_, index) => index === 1 ? 1 : 0), value: 0 };
+  const pc1 = scaled(rows.map((row) => dot(row.vector, first.vector)));
+  const pc2 = scaled(rows.map((row) => dot(row.vector, second.vector)));
+  const centroid = rows[0]?.vector.map((_, column) => rows.reduce((sum, row) => sum + (row.vector[column] ?? 0), 0) / Math.max(1, rows.length)) ?? [];
+  const distances = rows.map((row) => Math.sqrt(row.vector.reduce((sum, value, column) => sum + Math.pow(value - (centroid[column] ?? 0), 2), 0)));
+  const distanceScaled = scaled(distances);
+  const densityScaled = scaled(rows.map((row) => {
+    const attention = row.vector[0] ?? 0;
+    const degree = row.vector[1] ?? 0;
+    const sources = row.vector[3] ?? 0;
+    const verified = row.vector[4] ?? 0;
+    const freshness = row.vector[5] ?? 0;
+    const causalSignal = row.vector[7] ?? 0;
+    return clamp01(attention * 0.34 + degree * 0.22 + sources * 0.16 + verified * 0.1 + freshness * 0.08 + causalSignal * 0.1);
+  }));
+  const withoutClusters = rows.map((row, index): Omit<ReportTopologyNodeProjection, "mapperClusterIds"> => {
+    const density = densityScaled[index] ?? 0.5;
+    const distance = distanceScaled[index] ?? 0;
+    const angle = Math.atan2((pc2[index] ?? 0.5) - 0.5, (pc1[index] ?? 0.5) - 0.5);
+    const radius = 0.08 + distance * 0.42;
+    const centroidX = 0.5 + Math.cos(angle) * radius;
+    const centroidY = 0.5 + Math.sin(angle) * radius;
+    const coordinates = view === "density"
+      ? { x: pc1[index] ?? 0.5, y: 1 - density }
+      : view === "pca"
+        ? { x: pc1[index] ?? 0.5, y: pc2[index] ?? 0.5 }
+        : { x: clamp01(centroidX), y: clamp01(centroidY) };
+    return {
+      id: row.node.id,
+      densityScore: clamp100(density * 100),
+      attentionScore: clamp100(row.raw[0] * 100),
+      degree: Math.round(row.raw[1] ?? 0),
+      pc1: Number((pc1[index] ?? 0.5).toFixed(4)),
+      pc2: Number((pc2[index] ?? 0.5).toFixed(4)),
+      centroidDistance: Number(distance.toFixed(4)),
+      outlierScore: clamp100(distance * 100),
+      x: Number(coordinates.x.toFixed(4)),
+      y: Number(coordinates.y.toFixed(4)),
+    };
+  });
+  const mapper = buildMapperClusters(withoutClusters, links);
+  const projected = withoutClusters.map((node) => ({ ...node, mapperClusterIds: mapper.nodeClusters[node.id] ?? [] }));
+  const hotNode = [...projected].sort((a, b) => b.densityScore - a.densityScore)[0] ?? null;
+  const centroidNode = [...projected].sort((a, b) => a.centroidDistance - b.centroidDistance)[0] ?? null;
+  const outlierNode = [...projected].sort((a, b) => b.centroidDistance - a.centroidDistance)[0] ?? null;
+  return {
+    nodes: projected,
+    nodesById: Object.fromEntries(projected.map((node) => [node.id, node])),
+    mapperClusters: mapper.clusters,
+    mapperEdges: mapper.edges,
+    summary: {
+      nodeCount: nodes.length,
+      edgeCount: links.length,
+      hotNodeId: hotNode?.id ?? null,
+      centroidNodeId: centroidNode?.id ?? null,
+      outlierNodeId: outlierNode?.id ?? null,
+      clusterCount: mapper.clusters.length,
+      viewRationale: view === "density"
+        ? "Density ranks where human and agent attention repeatedly accumulates."
+        : view === "pca"
+          ? "PCA exposes the dominant axes separating reports, entities, sources, and artifacts."
+          : "Centroid distance separates typical coverage-book nodes from edge-case outliers.",
+    },
+    pcaAxes: {
+      pc1: topLoadings(first.vector),
+      pc2: topLoadings(second.vector),
+    },
+  };
+}
+
+export function buildReportTopologySnapshot(args: {
+  posts: ReportTopologyArchivePost[];
+  latestMemory?: ReportTopologyDailyBriefMemory | null;
+  rootId?: string | null;
+  query?: string | null;
+  stage?: string | null;
+  kind?: string | null;
+  mode: ReportTopologyScaleMode;
+  view: ReportTopologyViewMode;
+  limit?: number | null;
+  now: number;
+  ttlMs?: number;
+}): ReportTopologySnapshot {
+  const graph = buildRuntimeReportGraph({
+    posts: args.posts,
+    latestMemory: args.latestMemory,
+    rootId: args.rootId,
+    mode: args.mode,
+    now: args.now,
+  });
+  const topology = buildTopology(graph.nodes, graph.links, args.view);
+  const graphHash = cleanTextHash(JSON.stringify({
+    nodes: graph.nodes.map((node) => [node.id, node.attentionScore, node.sources, node.verified, node.staleHours]),
+    links: graph.links.map((link) => [link.source, link.target, link.type, link.strength, link.confidence]),
+  }));
+  return {
+    snapshotKey: buildReportTopologyKey(args),
+    graphHash,
+    view: args.view,
+    mode: args.mode,
+    generatedAt: args.now,
+    expiresAt: args.now + (args.ttlMs ?? 5 * 60 * 1000),
+    persisted: false,
+    source: "convex-computed",
+    ...topology,
+    graph,
+  };
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7351,6 +7351,27 @@ export default defineSchema({
     .index("by_task", ["taskId"]),
 
   /* ------------------------------------------------------------------ */
+  /* REPORT TOPOLOGY SNAPSHOTS - Derived graph shape for UI + agents     */
+  /* Density/PCA/centroid projections over bounded report neighborhoods  */
+  /* ------------------------------------------------------------------ */
+  reportTopologySnapshots: defineTable({
+    snapshotKey: v.string(),
+    rootKey: v.string(),
+    view: v.union(v.literal("density"), v.literal("pca"), v.literal("centroid")),
+    mode: v.union(v.literal("focus"), v.literal("clustered"), v.literal("expanded")),
+    graphHash: v.string(),
+    generatedAt: v.number(),
+    expiresAt: v.number(),
+    nodeCount: v.number(),
+    edgeCount: v.number(),
+    clusterCount: v.number(),
+    snapshot: v.any(),
+  })
+    .index("by_snapshot_key", ["snapshotKey"])
+    .index("by_root_view", ["rootKey", "view"])
+    .index("by_generated_at", ["generatedAt"]),
+
+  /* ------------------------------------------------------------------ */
   /* DAILY BRIEF PERSONAL OVERLAYS - Per-user derived tasks/state        */
   /* Built from tracked hashtags, docs, teachings                        */
   /* ------------------------------------------------------------------ */

--- a/docs/architecture/HUMAN_AGENT_GRAPH_INTERFACE.md
+++ b/docs/architecture/HUMAN_AGENT_GRAPH_INTERFACE.md
@@ -1,0 +1,229 @@
+# Human-Agent Graph Interface
+
+Date: 2026-05-15
+Status: Graph Context Bridge v1 implemented
+
+## Goal
+
+NodeBench graphs are not decoration. They are the shared context interface between humans and agents.
+
+The next implementation goal is:
+
+```text
+When a human selects a graph node, NodeBench should produce the same durable context packet an agent would want before doing work.
+```
+
+Done means:
+
+- The human sees why the node matters, what evidence supports it, and what action is safe next.
+- The agent sees a bounded packet with root node, first-ring context, source refs, claim refs, token estimate, and allowed actions.
+- The right rail explains the runtime path: memory first, graph context packet, source verification, notebook/export writes only after approval when needed.
+- The graph stays bounded. Search and graph expansion should prioritize the nodes that matter instead of rendering every possible edge.
+
+## Questions This Answers
+
+These were the product questions driving the implementation:
+
+- How do human graph needs differ from agent graph needs?
+- How do we keep graphs useful when the corpus grows from dozens of nodes to thousands or tens of thousands?
+- How does the graph tie back to Convex, Typesense, search, agent tool calls, skills, and runtime context?
+- Are we doing unnecessary work by hand-building graph UI instead of using a graph vendor?
+- How do we focus attention on nodes that actually matter instead of showing messy graph hairballs?
+- How do correlations, causations, reports, artifacts, sources, and entities fit into one navigable model?
+
+## Product Principle
+
+Humans and agents both need context, but at different resolution.
+
+Humans prefer:
+
+- A small visible graph.
+- Strong labels and readable hierarchy.
+- Full report/notebook jumps.
+- Facets, search, and visual shelves.
+- Clear next actions.
+
+Agents prefer:
+
+- Bounded root neighborhoods.
+- Typed handles.
+- Source and claim references.
+- Hybrid retrieval: keyword, BM25, semantic, graph links, and recent runtime traces.
+- Explicit approval gates and allowed actions.
+
+The UI should therefore show fewer nodes than the agent can inspect.
+
+## Promotion Classes
+
+Every candidate graph item should fall into one of four classes:
+
+```text
+visible      shown in the graph immediately
+shelf        shown as a ranked row/card/list near the graph
+searchable   available through Cmd-K, Typesense, or filtered graph search
+on_demand    hidden until the agent or user expands a specific relationship
+```
+
+This is the main answer to scale. NodeBench should not render 10,000 nodes at once. It should render the working set and keep the rest queryable.
+
+## Graph Context Bridge Packet
+
+`src/features/redesign/lib/graphContextBridge.ts` defines the v1 packet.
+
+It produces:
+
+- `contextRef`
+- `rootUri`
+- `title`
+- `promotionClass`
+- `attentionScore`
+- `humanRank`
+- `agentRank`
+- `visibleNodes`
+- `packedNodes`
+- `edges`
+- `sourceRefs`
+- `claimRefs`
+- `estimatedTokens`
+- `approvalRequired`
+- `allowedActions`
+- `blockedActions`
+- `whySelected`
+- `humanSummary`
+- `agentSummary`
+
+The packet is intentionally conservative. It is a bridge object for UI and runtime traces, not a new source of truth.
+
+## Runtime Connection
+
+The runtime trace now includes graph context as a first-class step.
+
+Expected high-level path:
+
+```text
+User asks or selects a graph node
+  -> search_memory
+  -> resolve_report_graph_context
+  -> search_report_context
+  -> verify_sources
+  -> suggest_related
+  -> patch_notebook or create_followup only when safe
+```
+
+`convex/domains/redesign/chatRuns.ts` includes:
+
+- `graph_context_packet` as a context candidate.
+- `resolve_report_graph_context` as a low-risk, zero-cost tool decision.
+- `resolve bounded report graph context` as a success criterion.
+
+Fallback client traces in `useRedesignChatRun.ts` expose the same graph-context lane so the UI does not imply the runtime forgot graph context when no live run is available.
+
+## UI Surfaces
+
+### Reports Graph
+
+`ReportsSurface.tsx` now shows an Agent context packet in the graph peek card after a node is selected.
+
+The packet explains:
+
+- why the item entered context,
+- how many graph nodes were packed,
+- how many source and claim refs are attached,
+- estimated token footprint,
+- whether review is required before notebook/export writes.
+
+### Right Rail
+
+`RightInspector.tsx` now treats selected artifacts as graph packets, not just passive previews.
+
+The Graph tab shows:
+
+- patch-ready vs review-gated state,
+- agent summary,
+- human rank,
+- agent rank,
+- packed node count.
+
+### Chat Rail
+
+`ChatSurface.tsx` now shows graph context in agent progress and run details:
+
+- Resolve graph context packet.
+- Graph context bridge.
+- Graph context agent.
+- Cost/cache line includes graph node count when context exists.
+
+This makes the chat page explain how the agent used memory and graph context before live search or paid work.
+
+### Prototype Reports Rail
+
+`HomeV2PrototypeSurface.tsx` now exposes the same packet in the reports prototype rail so the static parity surface matches the runtime story.
+
+## Scaling Boundary
+
+For thousands or tens of thousands of graph objects, the right implementation direction is:
+
+```text
+Convex = source of truth and permissions
+Typesense = snappy text/vector/facet retrieval
+Graph query layer = bounded typed neighborhoods
+Frontend graph = working set only
+Agent packet = larger but still token-bounded context
+```
+
+Frontend graph rules:
+
+- Do not draw every node.
+- Start with root plus strongest first-ring relationships.
+- Cluster low-priority items.
+- Show hidden counts.
+- Let search/facets promote hidden items into the working set.
+- Prefer shelves and tables for bulk review.
+- Use graph layout only when relationships matter visually.
+
+## Vendor And Maintainability Decision
+
+For v1, keep the custom graph because it is already integrated with:
+
+- report cards,
+- artifact previews,
+- Convex live artifacts,
+- notebook actions,
+- prototype parity surfaces,
+- agent runtime traces.
+
+Do not over-invest in a bespoke graph engine. Reassess when any of these become true:
+
+- visible graph exceeds a few hundred nodes routinely,
+- layout work dominates product work,
+- edge filtering becomes hard to reason about,
+- collaboration or whiteboard interactions become core,
+- performance cannot stay smooth with bounded views.
+
+At that point, evaluate a dedicated graph/canvas library, but keep the context packet contract. The packet is more important than the renderer.
+
+## Verification
+
+Current v1 checks:
+
+- Unit test: compact packet from report/detail.
+- Unit test: approval gate on sparse or review-heavy packets.
+- Unit test: server-bounded neighborhood metadata appears in rationale.
+- Browser: Reports graph selection produces `data-active-context-ref` and visible packet.
+- Browser: Chat rail shows graph context progress, run detail, and graph context agent.
+- Build and TypeScript checks pass.
+
+## Next Boundary
+
+The next implementation should connect this packet to actual backend retrieval:
+
+```text
+resolve_report_graph_context(args)
+  -> load report / artifact from Convex
+  -> fetch bounded graph neighborhood
+  -> attach source refs and claim refs
+  -> return GraphContextBridgePacket-compatible data
+  -> persist in agent run trace
+```
+
+After that, Typesense can promote hidden graph nodes into the packet through search, rather than relying only on the current selected live artifact.

--- a/docs/architecture/REPORT_GRAPH_TOPOLOGY_RUNTIME.md
+++ b/docs/architecture/REPORT_GRAPH_TOPOLOGY_RUNTIME.md
@@ -1,0 +1,82 @@
+# Report Graph Topology Runtime
+
+## Goal
+
+Make the Reports graph topology a runtime primitive for both humans and agents.
+
+The graph has three views:
+
+- `density`: where attention keeps gravitating.
+- `pca`: dominant axes of variation across reports, entities, artifacts, sources, freshness, and causal links.
+- `centroid`: typical center versus outlier edge cases.
+
+## Runtime Path
+
+```text
+Convex report artifacts
+  -> reportGraphNeighborhood query
+  -> reportTopology runtime graph
+  -> density / PCA / centroid projection
+  -> Mapper clusters
+  -> reportTopologySnapshots table
+  -> Reports graph UI
+  -> graph context bridge
+  -> inspect_topology_shape MCP tool
+```
+
+## What Is Persisted
+
+`reportTopologySnapshots` stores a bounded, derived snapshot:
+
+- `snapshotKey`
+- `graphHash`
+- `view`
+- `mode`
+- node projections
+- Mapper clusters and cluster edges
+- PCA axis labels
+- bounded graph source metadata
+
+The snapshot is derived data. Convex report artifacts remain the source of truth.
+
+## Agent Contract
+
+Agents should use topology after memory/search and before live search:
+
+```text
+search_memory
+search_report_context
+inspect_topology_shape
+decide whether to expand cluster, inspect outlier, or reuse first-ring context
+```
+
+The `inspect_topology_shape` tool returns:
+
+- selected node projection
+- graph node metadata
+- Mapper clusters
+- first-ring neighbors
+- retrieval plan for human and agent use
+- recommended actions
+
+## UI Contract
+
+Reports graph consumes Convex topology when available and falls back to client projection when needed.
+
+DOM QA hooks:
+
+- `data-topology-view`
+- `data-topology-source`
+- `data-topology-persisted`
+- `data-topology-cluster-count`
+- `data-topology-hot-node`
+- `data-topology-outlier-node`
+
+## Design Grounding
+
+This preserves the product direction:
+
+- humans get readable views and clusters, not an unbounded node cloud
+- agents get a bounded retrieval strategy before expensive live search
+- Convex remains source of truth
+- topology snapshots are derived, refreshable, and safe to discard

--- a/packages/mcp-local/src/tools/federatedSearchTools.ts
+++ b/packages/mcp-local/src/tools/federatedSearchTools.ts
@@ -315,6 +315,77 @@ export const federatedSearchTools: McpTool[] = [
   },
 
   /* ------------------------------------------------------------------------ */
+  /* Tool: inspect_topology_shape                                               */
+  /* ------------------------------------------------------------------------ */
+  {
+    name: "inspect_topology_shape",
+    description:
+      "Inspect the persisted Convex topology shape for the Reports graph. Use this after search_memory/search_report_context when deciding whether to expand a dense Mapper cluster, inspect an outlier, or reuse first-ring graph context before live search. Returns density, PCA, centroid/outlier, clusters, neighbors, and recommended retrieval actions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        nodeId: {
+          type: "string",
+          description: "Optional graph node id to inspect. If omitted, the current hot/dense node is selected.",
+        },
+        rootId: {
+          type: "string",
+          description: "Optional report root id, e.g. daily_<id> or li_<id>.",
+        },
+        view: {
+          type: "string",
+          enum: ["density", "pca", "centroid"],
+          default: "density",
+          description: "Topology projection to inspect.",
+        },
+        mode: {
+          type: "string",
+          enum: ["focus", "clustered", "expanded"],
+          default: "clustered",
+          description: "Report graph scale mode.",
+        },
+        query: { type: "string", description: "Optional report search/filter query." },
+        stage: { type: "string", description: "Optional report stage filter." },
+        kind: { type: "string", description: "Optional report type filter." },
+        limit: {
+          type: "number",
+          minimum: 1,
+          maximum: 120,
+          default: 96,
+          description: "Bounded report graph limit.",
+        },
+      },
+    },
+    handler: async (args: {
+      nodeId?: string;
+      rootId?: string;
+      view?: "density" | "pca" | "centroid";
+      mode?: "focus" | "clustered" | "expanded";
+      query?: string;
+      stage?: string;
+      kind?: string;
+      limit?: number;
+    }) => {
+      const started = Date.now();
+      const result = await callGateway<any>("inspectReportTopologyShape", {
+        nodeId: args.nodeId,
+        rootId: args.rootId,
+        view: args.view ?? "density",
+        mode: args.mode ?? "clustered",
+        query: args.query,
+        stage: args.stage,
+        kind: args.kind,
+        limit: bound(args.limit, 1, 120, 96),
+      });
+      const elapsedMs = Date.now() - started;
+      if (!result.success) {
+        return { success: false, error: result.error, elapsedMs };
+      }
+      return { success: true, data: result.data, elapsedMs };
+    },
+  },
+
+  /* ------------------------------------------------------------------------ */
   /* Tool: suggest_related                                                      */
   /* ------------------------------------------------------------------------ */
   {

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -272,7 +272,7 @@ export default function RedesignShell() {
         prototypeMode={isPrototypeKit}
       />
       <div
-        className={`rd-shell ${usesV2Canvas ? "rd-shell--home-v2" : ""} ${surface === "reports" ? "rd-shell--reports-v3" : ""} ${suppressRightRail ? "rd-shell--single" : ""}`}
+        className={`rd-shell ${usesV2Canvas ? "rd-shell--home-v2" : ""} ${surface === "chat" && !isPrototypeKit ? "rd-shell--chat-v3" : ""} ${surface === "reports" ? "rd-shell--reports-v3" : ""} ${suppressRightRail ? "rd-shell--single" : ""}`}
         style={{ flex: 1, minHeight: 0 }}
       >
         {isPrototypeKit ? (

--- a/src/features/redesign/components/RightInspector.tsx
+++ b/src/features/redesign/components/RightInspector.tsx
@@ -213,6 +213,10 @@ function TraceContextPanel({
           <span className="chat-trace-model-val">{graphPacket ? `${graphPacket.packedNodes} nodes` : "not packed"}</span>
         </div>
         <div className="chat-trace-model-row">
+          <span className="chat-trace-model-name">Topology</span>
+          <span className="chat-trace-model-val">{graphPacket?.topology ? `${graphPacket.topology.view} ${graphPacket.topology.densityScore}` : "not attached"}</span>
+        </div>
+        <div className="chat-trace-model-row">
           <span className="chat-trace-model-name">Safe writes</span>
           <span className="chat-trace-model-val">{runDetailStatus(snapshot, "writes")}</span>
         </div>

--- a/src/features/redesign/components/RightInspector.tsx
+++ b/src/features/redesign/components/RightInspector.tsx
@@ -5,7 +5,7 @@
  * no prop is passed, it falls back to the live Convex-backed artifact list.
  */
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { Pill } from "./Pill";
 import { useLiveArtifacts, type LiveArtifactDetail } from "../hooks/useLiveArtifacts";
 import { VoiceCostBadge } from "@/features/voice";
@@ -42,17 +42,12 @@ export interface AgentRailSnapshot {
   metrics?: AgentRailMetric[];
 }
 
-const utilityTabs = [
-  { id: "agent", label: "Agent" },
-  { id: "entity", label: "Entity" },
-  { id: "graph", label: "Graph" },
-  { id: "sources", label: "Sources" },
-  { id: "threads", label: "Threads" },
-  { id: "notebook", label: "Notebook" },
-  { id: "report", label: "Report" },
+const chatContextTabs = [
+  { id: "session", label: "Session" },
+  { id: "trace", label: "Trace" },
 ] as const;
 
-type UtilityTab = typeof utilityTabs[number]["id"];
+type ChatContextTab = typeof chatContextTabs[number]["id"];
 
 interface RightInspectorProps {
   activeLiveArtifactDetail?: LiveArtifactDetail | null;
@@ -60,109 +55,322 @@ interface RightInspectorProps {
 }
 
 export function RightInspector({ activeLiveArtifactDetail, agentSnapshot }: RightInspectorProps = {}) {
-  const [activeTab, setActiveTab] = useState<UtilityTab>("agent");
+  const [activeTab, setActiveTab] = useState<ChatContextTab>("session");
   const liveArtifacts = useLiveArtifacts(12);
   const detail = activeLiveArtifactDetail === undefined
     ? liveArtifacts.details[0]
     : activeLiveArtifactDetail ?? undefined;
-  const title = detail?.title ?? "Current report";
-  const summary = detail?.summary ?? "Ask a question, capture a note, or open a live artifact to hydrate this inspector.";
-  const sources = detail?.sourceRows.slice(0, 6) ?? [];
-  const nodes = detail?.nodes.slice(0, 5) ?? [];
   const resolvedAgentSnapshot = agentSnapshot ?? buildFallbackAgentSnapshot(detail, liveArtifacts.isLoading);
+  const graphPacket = detail ? buildGraphContextBridgePacket({ detail, mode: "agent" }) : null;
   // HONEST_STATUS: only mount VoiceCostBadge for signed-in viewers.
   // `null` = signed out (skip), `undefined` = loading auth (skip until known).
   const userId = useCurrentUserId();
 
   return (
-    <aside className="rd-pane rd-pane--right" data-testid="right-inspector" style={{ padding: "20px 18px", gap: 16 }}>
-      {userId && <VoiceCostBadge userId={userId} />}
+    <aside
+      className="rd-pane rd-pane--right chat-context"
+      data-testid="right-inspector"
+      aria-label="Session context"
+      data-agent-context-ref={graphPacket?.contextRef ?? ""}
+      data-agent-context-rank={graphPacket?.agentRank ?? ""}
+    >
+      <div className="chat-ctx-tabs" role="tablist" aria-label="Chat context panels">
+        {chatContextTabs.map((tab) => (
+          <button
+            key={tab.id}
+            id={`chat-context-tab-${tab.id}`}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`chat-context-panel-${tab.id}`}
+            className={`chat-ctx-tab ${activeTab === tab.id ? "active" : ""}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
 
-      <section className="rd-card rd-card__pad-tight" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-        <div
-          className="rd-tabs"
-          role="tablist"
-          aria-label="Chat utility panels"
-          style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))", width: "100%" }}
-        >
-          {utilityTabs.map((tab) => (
-            <button
-              key={tab.id}
-              id={`right-inspector-tab-${tab.id}`}
-              type="button"
-              role="tab"
-              aria-selected={activeTab === tab.id}
-              aria-controls={`right-inspector-panel-${tab.id}`}
-              className="rd-tab"
-              style={{ minHeight: 30, padding: "6px 4px", fontSize: 11 }}
-              onClick={() => setActiveTab(tab.id)}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
+      <div
+        id="chat-context-panel-session"
+        className={`chat-ctx-panel ${activeTab === "session" ? "active" : ""}`}
+        role="tabpanel"
+        aria-labelledby="chat-context-tab-session"
+        hidden={activeTab !== "session"}
+      >
+        {userId && (
+          <div className="chat-ctx-section">
+            <VoiceCostBadge userId={userId} />
+          </div>
+        )}
+        <SessionContextPanel snapshot={resolvedAgentSnapshot} />
+      </div>
 
-        <div>
-          <div
-            id="right-inspector-panel-agent"
-            role="tabpanel"
-            aria-labelledby="right-inspector-tab-agent"
-            hidden={activeTab !== "agent"}
-          >
-            <AgentProgressPanel snapshot={resolvedAgentSnapshot} />
-          </div>
-          <div
-            id="right-inspector-panel-entity"
-            role="tabpanel"
-            aria-labelledby="right-inspector-tab-entity"
-            hidden={activeTab !== "entity"}
-          >
-            <EntityPanel detail={detail} title={title} summary={summary} />
-          </div>
-          <div
-            id="right-inspector-panel-graph"
-            role="tabpanel"
-            aria-labelledby="right-inspector-tab-graph"
-            hidden={activeTab !== "graph"}
-          >
-            <GraphPanel detail={detail} nodes={nodes} />
-          </div>
-          <div
-            id="right-inspector-panel-sources"
-            role="tabpanel"
-            aria-labelledby="right-inspector-tab-sources"
-            hidden={activeTab !== "sources"}
-          >
-            <SourcesPanel detail={detail} sources={sources} />
-          </div>
-          <div
-            id="right-inspector-panel-threads"
-            role="tabpanel"
-            aria-labelledby="right-inspector-tab-threads"
-            hidden={activeTab !== "threads"}
-          >
-            <ThreadsPanel detail={detail} />
-          </div>
-          <div
-            id="right-inspector-panel-notebook"
-            role="tabpanel"
-            aria-labelledby="right-inspector-tab-notebook"
-            hidden={activeTab !== "notebook"}
-          >
-            <NotebookPanel detail={detail} />
-          </div>
-          <div
-            id="right-inspector-panel-report"
-            role="tabpanel"
-            aria-labelledby="right-inspector-tab-report"
-            hidden={activeTab !== "report"}
-          >
-            <ReportPanel detail={detail} title={title} />
-          </div>
-        </div>
-      </section>
+      <div
+        id="chat-context-panel-trace"
+        className={`chat-ctx-panel ${activeTab === "trace" ? "active" : ""}`}
+        role="tabpanel"
+        aria-labelledby="chat-context-tab-trace"
+        hidden={activeTab !== "trace"}
+      >
+        <TraceContextPanel snapshot={resolvedAgentSnapshot} graphPacket={graphPacket} />
+      </div>
     </aside>
   );
+}
+
+function SessionContextPanel({ snapshot }: { snapshot: AgentRailSnapshot }) {
+  return (
+    <>
+      <ChatContextSection title="Progress">
+        {snapshot.progress.map((item) => (
+          <div className="chat-ctx-task" key={item.id}>
+            <span className={`chat-ctx-task-dot ${taskDotClass(item.status)}`} />
+            <span className="chat-ctx-task-text">
+              {item.label}
+              {item.detail && <small>{item.detail}</small>}
+            </span>
+          </div>
+        ))}
+      </ChatContextSection>
+
+      <ChatContextSection title="Artifacts">
+        {snapshot.artifacts.slice(0, 4).map((item) => (
+          <ContextArtifactRow key={item.id} item={item} />
+        ))}
+        {snapshot.artifacts.length > 4 && (
+          <div className="chat-ctx-more">Show {snapshot.artifacts.length - 4} more</div>
+        )}
+      </ChatContextSection>
+
+      <ChatContextSection title="Agents">
+        {snapshot.backgroundAgents.map((item, index) => (
+          <div className="chat-ctx-agent" key={item.id}>
+            <span className="chat-ctx-agent-dot" style={{ background: agentDotColor(item.status, index) }} />
+            <span className="chat-ctx-agent-name">{item.label}</span>
+            <span className="chat-ctx-agent-role">{agentRoleLabel(item)}</span>
+          </div>
+        ))}
+      </ChatContextSection>
+
+      <ChatContextSection title="Sources">
+        {snapshot.sources.map((item) => (
+          <ContextSourceRow key={item.id} item={item} />
+        ))}
+      </ChatContextSection>
+    </>
+  );
+}
+
+function TraceContextPanel({
+  snapshot,
+  graphPacket,
+}: {
+  snapshot: AgentRailSnapshot;
+  graphPacket: ReturnType<typeof buildGraphContextBridgePacket> | null;
+}) {
+  const traceItems = traceRowsForSnapshot(snapshot);
+  const toolCalls = metricValue(snapshot, "tools", String(traceItems.length));
+  const latency = metricValue(snapshot, "latency", traceLatencyFallback(snapshot));
+  const tokens = metricValue(snapshot, "tokens", graphPacket ? graphPacket.estimatedTokens.toLocaleString() : "0");
+  const cost = metricValue(snapshot, "cost", metricValue(snapshot, "paid", "$0.00"));
+
+  return (
+    <>
+      <div className="chat-trace-summary">
+        <TraceStat value={toolCalls} label="Tool calls" />
+        <TraceStat value={latency} label="Total latency" />
+        <TraceStat value={tokens} label="Tokens in" />
+        <TraceStat value={cost} label="Est. cost" />
+      </div>
+
+      <div className="chat-trace-list">
+        {traceItems.map((item, index) => (
+          <div className="chat-trace-item" key={`${item.id}-${index}`}>
+            <div className={`chat-trace-item-icon ${traceIconClass(item)}`}>{traceIconGlyph(item)}</div>
+            <div className="chat-trace-item-body">
+              <div className="chat-trace-item-name">{traceName(item)}</div>
+              <div className="chat-trace-item-meta">
+                <span>{traceDuration(item, index)}</span>
+                <span>{item.meta ?? traceMeta(item)}</span>
+              </div>
+            </div>
+            <div className="chat-trace-item-bar">
+              <div className="chat-trace-item-bar-fill" style={{ width: `${traceBarWidth(item, index)}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="chat-trace-model">
+        <div className="chat-ctx-label">Model usage</div>
+        <div className="chat-trace-model-row">
+          <span className="chat-trace-model-name">Router tier</span>
+          <span className="chat-trace-model-val">{runDetailValue(snapshot, "routing")}</span>
+        </div>
+        <div className="chat-trace-model-row">
+          <span className="chat-trace-model-name">Graph packet</span>
+          <span className="chat-trace-model-val">{graphPacket ? `${graphPacket.packedNodes} nodes` : "not packed"}</span>
+        </div>
+        <div className="chat-trace-model-row">
+          <span className="chat-trace-model-name">Safe writes</span>
+          <span className="chat-trace-model-val">{runDetailStatus(snapshot, "writes")}</span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ChatContextSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="chat-ctx-section">
+      <div className="chat-ctx-label">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function ContextArtifactRow({ item }: { item: AgentRailItem }) {
+  const content = (
+    <>
+      <span className="chat-ctx-artifact-icon" aria-hidden="true" />
+      <span className="chat-ctx-artifact-name">{item.label}</span>
+      <span className="chat-ctx-artifact-badge">{artifactBadge(item)}</span>
+    </>
+  );
+
+  return item.href ? (
+    <a className="chat-ctx-artifact" href={item.href}>{content}</a>
+  ) : (
+    <div className="chat-ctx-artifact">{content}</div>
+  );
+}
+
+function ContextSourceRow({ item }: { item: AgentRailItem }) {
+  const content = (
+    <>
+      <span className="chat-ctx-source-icon" aria-hidden="true" />
+      <span className="chat-ctx-source-name">{item.label}</span>
+    </>
+  );
+
+  return item.href ? (
+    <a className="chat-ctx-source" href={item.href}>{content}</a>
+  ) : (
+    <div className="chat-ctx-source">{content}</div>
+  );
+}
+
+function TraceStat({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="chat-trace-stat">
+      <div className="chat-trace-stat-val">{value}</div>
+      <div className="chat-trace-stat-key">{label}</div>
+    </div>
+  );
+}
+
+function taskDotClass(status?: AgentRailStatus): string {
+  if (status === "done") return "chat-ctx-task-dot--done";
+  if (status === "running") return "chat-ctx-task-dot--active";
+  if (status === "blocked") return "chat-ctx-task-dot--blocked";
+  return "";
+}
+
+function artifactBadge(item: AgentRailItem): string {
+  const text = `${item.label} ${item.detail ?? ""} ${item.href ?? ""}`.toLowerCase();
+  if (text.includes("notebook")) return "nb";
+  if (text.includes("json")) return "json";
+  if (text.includes("pdf")) return "pdf";
+  if (text.includes("image") || text.includes("snapshot") || text.includes("png")) return "img";
+  if (text.includes("answer")) return "ans";
+  if (text.includes("batch")) return "run";
+  return "ctx";
+}
+
+function agentDotColor(status: AgentRailStatus | undefined, index: number): string {
+  if (status === "running") return "var(--rd-accent)";
+  if (status === "blocked") return "var(--rd-amber)";
+  const colors = ["var(--rd-accent)", "var(--rd-green)", "#60a5fa", "#a78bfa", "var(--rd-ink-soft)"];
+  return colors[index % colors.length] ?? "var(--rd-ink-soft)";
+}
+
+function agentRoleLabel(item: AgentRailItem): string {
+  const id = item.id.toLowerCase();
+  if (id.includes("coordinator")) return "orchestrator";
+  if (id.includes("memory") || id.includes("graph")) return "retrieval";
+  if (id.includes("source") || id.includes("verify")) return "analyst";
+  if (id.includes("notebook")) return "worker";
+  if (id.includes("judge")) return "eval";
+  return item.status ?? "agent";
+}
+
+function metricValue(snapshot: AgentRailSnapshot, label: string, fallback: string): string {
+  return snapshot.metrics?.find((metric) => metric.label.toLowerCase() === label)?.value ?? fallback;
+}
+
+function traceRowsForSnapshot(snapshot: AgentRailSnapshot): AgentRailItem[] {
+  const preferred = [
+    ...snapshot.progress.filter((item) => ["memory", "graph-context", "tools", "verify", "packet", "telemetry"].includes(item.id)),
+    ...snapshot.runDetails.filter((item) => ["routing", "cost", "graph-packet"].includes(item.id)),
+  ];
+  return (preferred.length ? preferred : snapshot.progress).slice(0, 7);
+}
+
+function traceName(item: AgentRailItem): string {
+  return item.id
+    .replace(/^graph-context$/, "graph_context")
+    .replace(/^graph-packet$/, "graph_packet")
+    .replace(/-/g, "_");
+}
+
+function traceMeta(item: AgentRailItem): string {
+  if (item.detail?.includes(" - ")) return item.detail.split(" - ")[0].slice(0, 28);
+  return item.detail?.slice(0, 28) || item.label.slice(0, 28);
+}
+
+function traceDuration(item: AgentRailItem, index: number): string {
+  const detail = `${item.detail ?? ""} ${item.meta ?? ""}`;
+  const explicit = detail.match(/\b\d+(?:\.\d+)?(?:ms|s)\b/i)?.[0];
+  if (explicit) return explicit;
+  if (item.status === "running") return "live";
+  if (item.status === "queued" || item.status === "idle") return "queued";
+  return `${Math.max(120, 180 + index * 140)}ms`;
+}
+
+function traceBarWidth(item: AgentRailItem, index: number): number {
+  if (item.status === "queued" || item.status === "idle") return 12;
+  if (item.status === "running") return 58;
+  if (item.status === "blocked") return 38;
+  return Math.min(100, 28 + index * 11);
+}
+
+function traceIconClass(item: AgentRailItem): string {
+  const key = `${item.id} ${item.label}`.toLowerCase();
+  if (key.includes("search") || key.includes("source") || key.includes("memory")) return "chat-trace-item-icon--search";
+  if (key.includes("packet") || key.includes("model") || key.includes("routing")) return "chat-trace-item-icon--llm";
+  return "chat-trace-item-icon--tool";
+}
+
+function traceIconGlyph(item: AgentRailItem): string {
+  const key = `${item.id} ${item.label}`.toLowerCase();
+  if (key.includes("search") || key.includes("source") || key.includes("memory")) return "S";
+  if (key.includes("packet") || key.includes("model") || key.includes("routing")) return "M";
+  return "T";
+}
+
+function traceLatencyFallback(snapshot: AgentRailSnapshot): string {
+  const telemetry = snapshot.progress.find((item) => item.id === "telemetry")?.detail ?? "";
+  return telemetry.match(/\b\d+(?:\.\d+)?(?:ms|s)\b/i)?.[0] ?? "pending";
+}
+
+function runDetailValue(snapshot: AgentRailSnapshot, id: string): string {
+  const detail = snapshot.runDetails.find((item) => item.id === id);
+  return detail?.detail?.slice(0, 24) ?? "pending";
+}
+
+function runDetailStatus(snapshot: AgentRailSnapshot, id: string): string {
+  return snapshot.runDetails.find((item) => item.id === id)?.status ?? "idle";
 }
 
 function buildFallbackAgentSnapshot(detail: LiveArtifactDetail | undefined, isLoading: boolean): AgentRailSnapshot {
@@ -242,6 +450,9 @@ function buildFallbackAgentSnapshot(detail: LiveArtifactDetail | undefined, isLo
     metrics: [
       { label: "sources", value: String(detail?.sourceCount ?? 0), tone: "accent" },
       { label: "claims", value: String(detail?.claimCount ?? 0), tone: "green" },
+      { label: "tools", value: String(graphPacket ? Math.max(3, graphPacket.edges) : 0), tone: "green" },
+      { label: "latency", value: isLoading ? "live" : "0ms", tone: isLoading ? "accent" : "green" },
+      { label: "tokens", value: graphPacket ? graphPacket.estimatedTokens.toLocaleString() : "0", tone: "accent" },
       { label: "graph", value: graphPacket ? String(graphPacket.packedNodes) : "0", tone: "accent" },
       { label: "paid", value: "$0.00", tone: "green" },
     ],

--- a/src/features/redesign/components/RightInspector.tsx
+++ b/src/features/redesign/components/RightInspector.tsx
@@ -10,6 +10,7 @@ import { Pill } from "./Pill";
 import { useLiveArtifacts, type LiveArtifactDetail } from "../hooks/useLiveArtifacts";
 import { VoiceCostBadge } from "@/features/voice";
 import { useCurrentUserId } from "@/hooks/useCurrentUser";
+import { buildGraphContextBridgePacket } from "../lib/graphContextBridge";
 
 export type AgentRailStatus = "done" | "running" | "queued" | "blocked" | "idle";
 
@@ -167,6 +168,7 @@ export function RightInspector({ activeLiveArtifactDetail, agentSnapshot }: Righ
 function buildFallbackAgentSnapshot(detail: LiveArtifactDetail | undefined, isLoading: boolean): AgentRailSnapshot {
   const hasDetail = Boolean(detail);
   const status: AgentRailSnapshot["status"] = isLoading ? "thinking" : hasDetail ? "ok" : "idle";
+  const graphPacket = detail ? buildGraphContextBridgePacket({ detail, mode: "agent" }) : null;
   return {
     title: isLoading ? "Hydrating agent context" : hasDetail ? "Agent ready on live artifact" : "Agent idle",
     subtitle: hasDetail
@@ -187,6 +189,12 @@ function buildFallbackAgentSnapshot(detail: LiveArtifactDetail | undefined, isLo
         detail: hasDetail ? `${detail.sourceCount} source refs already attached.` : "Runs before any paid refresh.",
       },
       {
+        id: "graph-context",
+        label: "Resolve graph context packet",
+        status: graphPacket ? "done" : isLoading ? "running" : "queued",
+        detail: graphPacket?.agentSummary ?? "Packs the selected report, source refs, and first-ring graph nodes.",
+      },
+      {
         id: "sources",
         label: "Verify sources and evidence",
         status: hasDetail && detail.sourceCount > 0 ? "done" : "queued",
@@ -201,6 +209,14 @@ function buildFallbackAgentSnapshot(detail: LiveArtifactDetail | undefined, isLo
     ],
     runDetails: [
       { id: "state", label: "Run state", status, detail: isLoading ? "Subscribing to Convex live state." : "No active paid run in progress." },
+      {
+        id: "context-packet",
+        label: "Context packet",
+        status: graphPacket ? "done" : "queued",
+        detail: graphPacket
+          ? `${graphPacket.contextRef} - human ${graphPacket.humanRank}, agent ${graphPacket.agentRank}, ${graphPacket.estimatedTokens} estimated tokens.`
+          : "No graph context packet resolved yet.",
+      },
       { id: "writes", label: "Safe writes", status: "idle", detail: "Notebook, follow-up, and export writes require explicit user action." },
     ],
     artifacts: hasDetail
@@ -226,6 +242,7 @@ function buildFallbackAgentSnapshot(detail: LiveArtifactDetail | undefined, isLo
     metrics: [
       { label: "sources", value: String(detail?.sourceCount ?? 0), tone: "accent" },
       { label: "claims", value: String(detail?.claimCount ?? 0), tone: "green" },
+      { label: "graph", value: graphPacket ? String(graphPacket.packedNodes) : "0", tone: "accent" },
       { label: "paid", value: "$0.00", tone: "green" },
     ],
   };
@@ -390,8 +407,9 @@ function EntityPanel({ detail, title, summary }: { detail?: LiveArtifactDetail; 
 }
 
 function GraphPanel({ detail, nodes }: { detail?: LiveArtifactDetail; nodes: Array<{ title: string }> }) {
+  const graphPacket = detail ? buildGraphContextBridgePacket({ detail, mode: "agent" }) : null;
   return (
-    <div className="rd-stack" style={{ gap: 10 }}>
+    <div className="rd-stack" style={{ gap: 10 }} data-graph-context-ref={graphPacket?.contextRef ?? ""}>
       <div className="rd-row--between">
         <div className="rd-eyebrow">Graph preview</div>
         {detail ? (
@@ -412,6 +430,32 @@ function GraphPanel({ detail, nodes }: { detail?: LiveArtifactDetail; nodes: Arr
       <p className="rd-body" style={{ fontSize: 12, color: "var(--rd-ink-mute)", margin: 0 }}>
         {detail ? `${detail.nodes.length} nodes and ${detail.edges.length} relationships are attached to this artifact.` : "Pin or open a live artifact to hydrate first-ring relationships."}
       </p>
+      {graphPacket && (
+        <section
+          style={{
+            border: "1px solid var(--rd-line)",
+            borderRadius: 6,
+            padding: 10,
+            background: "var(--rd-muted)",
+          }}
+          aria-label="Agent graph context packet"
+        >
+          <div className="rd-row--between" style={{ gap: 8 }}>
+            <span className="rd-eyebrow">Agent packet</span>
+            <Pill tone={graphPacket.approvalRequired ? "amber" : "green"}>
+              {graphPacket.approvalRequired ? "Review gated" : "Patch ready"}
+            </Pill>
+          </div>
+          <p className="rd-body" style={{ fontSize: 11.5, color: "var(--rd-ink-mute)", margin: "6px 0 0" }}>
+            {graphPacket.agentSummary}
+          </p>
+          <div className="rd-row" style={{ gap: 6, flexWrap: "wrap", marginTop: 8 }}>
+            <MetricTile label="Human" value={graphPacket.humanRank} />
+            <MetricTile label="Agent" value={graphPacket.agentRank} />
+            <MetricTile label="Packed" value={graphPacket.packedNodes} />
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/features/redesign/hooks/useLiveArtifacts.ts
+++ b/src/features/redesign/hooks/useLiveArtifacts.ts
@@ -7,8 +7,8 @@
  * so production cannot mask broken wiring with starter fixtures.
  */
 
-import { useMemo } from "react";
-import { useQuery } from "convex/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useConvex, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import type { PulseMetric, PulseCard, PublicResearchCard, ReportCardData, SignalClass } from "../fixtures";
 
@@ -145,6 +145,7 @@ export interface LiveArtifactDetail {
 }
 
 type QueryRef = Parameters<typeof useQuery>[0];
+type ActionRef = Parameters<ReturnType<typeof useConvex>["action"]>[0];
 
 const liveArtifactApi = api as unknown as {
   domains: {
@@ -162,6 +163,10 @@ const liveArtifactApi = api as unknown as {
     redesign: {
       reportGraphNeighborhood: {
         getReportGraphNeighborhood: QueryRef;
+      };
+      reportTopology: {
+        getReportTopologySnapshot: QueryRef;
+        refreshReportTopologySnapshot: ActionRef;
       };
     };
   };
@@ -196,6 +201,82 @@ interface ReportGraphNeighborhoodPacket {
 
 export interface ReportGraphNeighborhoodResult extends LiveArtifactsResult {
   scope: ReportGraphNeighborhoodScope | null;
+}
+
+export type ReportTopologyViewMode = "density" | "pca" | "centroid";
+
+export interface ReportTopologySnapshotPacket {
+  snapshotKey: string;
+  graphHash: string;
+  view: ReportTopologyViewMode;
+  mode: "focus" | "clustered" | "expanded";
+  generatedAt: number;
+  expiresAt: number;
+  persisted: boolean;
+  persistedAt?: number;
+  source: "convex-computed" | "convex-persisted";
+  nodes: Array<{
+    id: string;
+    densityScore: number;
+    attentionScore: number;
+    degree: number;
+    pc1: number;
+    pc2: number;
+    centroidDistance: number;
+    outlierScore: number;
+    mapperClusterIds: string[];
+    x: number;
+    y: number;
+  }>;
+  nodesById: Record<string, {
+    id: string;
+    densityScore: number;
+    attentionScore: number;
+    degree: number;
+    pc1: number;
+    pc2: number;
+    centroidDistance: number;
+    outlierScore: number;
+    mapperClusterIds: string[];
+    x: number;
+    y: number;
+  }>;
+  mapperClusters: Array<{
+    id: string;
+    label: string;
+    memberIds: string[];
+    x: number;
+    y: number;
+    densityScore: number;
+    attentionScore: number;
+  }>;
+  mapperEdges: Array<{ source: string; target: string; sharedMembers: number }>;
+  summary: {
+    nodeCount: number;
+    edgeCount: number;
+    hotNodeId: string | null;
+    centroidNodeId: string | null;
+    outlierNodeId: string | null;
+    clusterCount: number;
+    viewRationale: string;
+  };
+  pcaAxes: {
+    pc1: Array<{ label: string; weight: number }>;
+    pc2: Array<{ label: string; weight: number }>;
+  };
+  graph?: {
+    sourceLabel: string;
+    sourceRows: number;
+    totalReportCount: number;
+    visibleReportCount: number;
+    hiddenReportCount: number;
+  };
+}
+
+export interface ReportTopologySnapshotResult {
+  snapshot: ReportTopologySnapshotPacket | null;
+  isLoading: boolean;
+  sourceLabel: string;
 }
 
 const POST_TYPE_LABELS: Record<string, string> = {
@@ -1068,6 +1149,100 @@ export function useLiveArtifacts(limit = 24, options: { enabled?: boolean } = {}
       briefFeatureCount,
     };
   }, [archive, archiveStats, enabled, latestMemory, limit]);
+}
+
+export function useReportTopologySnapshot(
+  args: {
+    rootId?: string | null;
+    query?: string;
+    stage?: string;
+    kind?: string;
+    mode?: "focus" | "clustered" | "expanded";
+    view?: ReportTopologyViewMode;
+    limit?: number;
+  },
+  options: { enabled?: boolean } = {},
+): ReportTopologySnapshotResult {
+  const enabled = options.enabled ?? true;
+  const convex = useConvex();
+  const [snapshot, setSnapshot] = useState<ReportTopologySnapshotPacket | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [sourceLabel, setSourceLabel] = useState("Topology disabled");
+  const refreshKeyRef = useRef<string>("");
+
+  useEffect(() => {
+    if (!enabled) {
+      setSnapshot(null);
+      setIsLoading(false);
+      setSourceLabel("Topology disabled");
+      return;
+    }
+
+    let isCancelled = false;
+    const payload = {
+      rootId: args.rootId ?? undefined,
+      query: args.query || undefined,
+      stage: args.stage || undefined,
+      kind: args.kind || undefined,
+      mode: args.mode ?? "clustered",
+      view: args.view ?? "density",
+      limit: args.limit,
+    };
+
+    setIsLoading(true);
+    setSourceLabel("Loading Convex topology");
+
+    void convex
+      .query(liveArtifactApi.domains.redesign.reportTopology.getReportTopologySnapshot, payload)
+      .then((nextSnapshot) => {
+        if (isCancelled) return;
+        const packet = nextSnapshot as ReportTopologySnapshotPacket;
+        setSnapshot(packet);
+        setSourceLabel(packet.persisted ? "Convex persisted topology" : "Convex topology computed, persistence queued");
+
+        if (packet.persisted) return undefined;
+
+        const key = `${packet.snapshotKey}:${packet.graphHash}`;
+        if (refreshKeyRef.current === key) return undefined;
+        refreshKeyRef.current = key;
+        return convex
+          .action(liveArtifactApi.domains.redesign.reportTopology.refreshReportTopologySnapshot, payload)
+          .then((persistedSnapshot) => {
+            if (isCancelled) return;
+            setSnapshot(persistedSnapshot as ReportTopologySnapshotPacket);
+            setSourceLabel("Convex persisted topology");
+          })
+          .catch(() => {
+            refreshKeyRef.current = "";
+          });
+      })
+      .catch(() => {
+        if (isCancelled) return;
+        setSnapshot(null);
+        setSourceLabel("Convex topology unavailable, using client fallback");
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [
+    args.kind,
+    args.limit,
+    args.mode,
+    args.query,
+    args.rootId,
+    args.stage,
+    args.view,
+    convex,
+    enabled,
+  ]);
+
+  return { snapshot, isLoading, sourceLabel };
 }
 
 export function useReportGraphNeighborhood(

--- a/src/features/redesign/hooks/useRedesignChatRun.ts
+++ b/src/features/redesign/hooks/useRedesignChatRun.ts
@@ -105,6 +105,13 @@ function fallbackContextCandidates(prompt: string): PlannerArtifact[] {
       confidence: 0,
       detail: "No report reference was available in the legacy run row.",
     },
+    {
+      id: "graph_context_packet",
+      label: "Graph context packet",
+      status: "deferred",
+      confidence: 0,
+      detail: "Legacy run row did not include a bounded report graph packet.",
+    },
   ];
 }
 
@@ -119,6 +126,14 @@ function fallbackToolDecisions(trace: TraceRow[]): PlannerArtifact[] {
       riskTier: "low",
       costUsd: 0,
       detail: "Legacy run stream did not emit a memory-search decision.",
+    },
+    {
+      id: "resolve_report_graph_context",
+      label: "resolve_report_graph_context",
+      status: "deferred",
+      riskTier: "low",
+      costUsd: 0,
+      detail: "Legacy run stream did not emit a graph-context decision.",
     },
     {
       id: hasFallback ? "fallback_source_search" : "google_search_grounding",

--- a/src/features/redesign/lib/graphContextBridge.test.ts
+++ b/src/features/redesign/lib/graphContextBridge.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { ReportCardData } from "../fixtures";
+import type { LiveArtifactDetail } from "../hooks/useLiveArtifacts";
+import { buildGraphContextBridgePacket } from "./graphContextBridge";
+
+const report: ReportCardData = {
+  id: "rep_anthropic",
+  entity: "Anthropic",
+  kind: "Company Report",
+  status: "verified",
+  description: "Enterprise agent momentum with source-backed claims.",
+  sources: 8,
+  claims: 5,
+  followUps: 0,
+  updatedAt: "2h ago",
+};
+
+const detail: LiveArtifactDetail = {
+  id: "rep_anthropic",
+  title: "Anthropic Company Report",
+  kind: "Company Report",
+  status: "verified",
+  summary: "Enterprise adoption signals are attached to evidence rows.",
+  updatedAt: "2h ago",
+  updatedAtMs: Date.now(),
+  sourceCount: 8,
+  claimCount: 5,
+  followUps: 0,
+  tags: ["ai-infra", "enterprise"],
+  sections: [],
+  sourceRows: Array.from({ length: 8 }, (_, index) => ({
+    id: `src-${index}`,
+    type: "Evidence",
+    title: `Source ${index}`,
+    refreshed: "today",
+    reused: 1,
+    excerpt: "Evidence row",
+    status: "verified",
+    confidence: 0.82,
+  })),
+  nodes: [
+    { id: "root", title: "Anthropic", subtitle: "Company", tone: "green", kind: "entity" },
+    { id: "artifact", title: "Pricing comparison", subtitle: "Artifact", tone: "blue", kind: "artifact" },
+  ],
+  edges: [{ from: "root", to: "artifact", type: "has_artifact", label: "artifact" }],
+  notebookHtml: "<p>Notebook</p>",
+  primaryAction: "Open notebook",
+};
+
+describe("buildGraphContextBridgePacket", () => {
+  it("creates a compact agent context packet from report and graph detail", () => {
+    const packet = buildGraphContextBridgePacket({ report, detail });
+
+    expect(packet.contextRef).toBe("graphctx:rep_anthropic");
+    expect(packet.rootUri).toBe("nodebench://report/rep_anthropic");
+    expect(packet.sourceRefs).toBe(8);
+    expect(packet.claimRefs).toBe(5);
+    expect(packet.packedNodes).toBeLessThanOrEqual(packet.visibleNodes);
+    expect(packet.allowedActions).toContain("resolve_report_graph_context");
+    expect(packet.allowedActions).toContain("patch_notebook");
+    expect(packet.blockedActions).toContain("entity_merge_without_approval");
+    expect(packet.whySelected.join(" ")).toContain("active report/entity context");
+  });
+
+  it("approval-gates review or sparse packets", () => {
+    const packet = buildGraphContextBridgePacket({
+      report: { ...report, status: "review", sources: 0, claims: 0, followUps: 2 },
+      detail: null,
+    });
+
+    expect(packet.approvalRequired).toBe(true);
+    expect(packet.allowedActions).not.toContain("patch_notebook");
+    expect(packet.blockedActions).toContain("blind_notebook_overwrite");
+    expect(packet.humanSummary).toContain("Needs review");
+  });
+
+  it("describes server-bounded neighborhoods when scope is present", () => {
+    const packet = buildGraphContextBridgePacket({
+      report,
+      detail,
+      scope: {
+        isServerBounded: true,
+        mode: "clustered",
+        reportLimit: 64,
+        scanLimit: 320,
+        scannedArchivePosts: 240,
+        totalCandidateReports: 180,
+        returnedReportCount: 64,
+        hiddenReportCount: 116,
+        hasMoreArchive: true,
+      },
+    });
+
+    expect(packet.whySelected.join(" ")).toContain("64/180 candidate reports");
+  });
+});

--- a/src/features/redesign/lib/graphContextBridge.test.ts
+++ b/src/features/redesign/lib/graphContextBridge.test.ts
@@ -93,4 +93,26 @@ describe("buildGraphContextBridgePacket", () => {
 
     expect(packet.whySelected.join(" ")).toContain("64/180 candidate reports");
   });
+
+  it("carries topology hints into the agent context packet", () => {
+    const packet = buildGraphContextBridgePacket({
+      report,
+      detail,
+      topology: {
+        view: "density",
+        mapperClusterIds: ["mapper:1:2:0"],
+        densityScore: 91,
+        pc1: 0.82,
+        pc2: 0.36,
+        centroidDistance: 0.21,
+        outlierScore: 19,
+        summary: "Density view puts Anthropic in the hot attention region.",
+      },
+    });
+
+    expect(packet.allowedActions).toContain("inspect_topology_shape");
+    expect(packet.topology?.view).toBe("density");
+    expect(packet.agentSummary).toContain("topology=density");
+    expect(packet.whySelected.join(" ")).toContain("mapper clusters 1");
+  });
 });

--- a/src/features/redesign/lib/graphContextBridge.ts
+++ b/src/features/redesign/lib/graphContextBridge.ts
@@ -1,5 +1,6 @@
 import type { ReportCardData } from "../fixtures";
 import type { LiveArtifactDetail, ReportGraphNeighborhoodScope } from "../hooks/useLiveArtifacts";
+import type { TopologyViewMode } from "./reportTopology";
 
 export type GraphContextMode = "human" | "agent";
 export type GraphContextPromotionClass = "visible" | "shelf" | "searchable" | "on_demand";
@@ -25,6 +26,18 @@ export interface GraphContextBridgePacket {
   whySelected: string[];
   humanSummary: string;
   agentSummary: string;
+  topology?: GraphContextTopologyHint;
+}
+
+export interface GraphContextTopologyHint {
+  view: TopologyViewMode;
+  mapperClusterIds: string[];
+  densityScore: number;
+  pc1: number;
+  pc2: number;
+  centroidDistance: number;
+  outlierScore: number;
+  summary: string;
 }
 
 interface GraphContextBridgeInput {
@@ -32,6 +45,7 @@ interface GraphContextBridgeInput {
   detail?: LiveArtifactDetail | null;
   scope?: ReportGraphNeighborhoodScope | null;
   mode?: GraphContextMode;
+  topology?: GraphContextTopologyHint | null;
 }
 
 const DEFAULT_ACTIONS = [
@@ -70,6 +84,7 @@ export function buildGraphContextBridgePacket({
   detail,
   scope,
   mode = "agent",
+  topology,
 }: GraphContextBridgeInput): GraphContextBridgePacket {
   const title = detail?.title ?? report?.entity ?? "Current graph context";
   const rootId = detail?.id ?? report?.id ?? "current";
@@ -97,6 +112,9 @@ export function buildGraphContextBridgePacket({
     `${title} is the active report/entity context.`,
     `${sourceRefs} source refs, ${claimRefs} claims, and ${followUps} follow-ups are attached.`,
     boundedReason,
+    topology
+      ? `Topology ${topology.view}: density ${topology.densityScore}, outlier ${topology.outlierScore}, mapper clusters ${topology.mapperClusterIds.length}.`
+      : "Topology shape is not attached to this packet yet.",
     needsReview
       ? "Review pressure is present, so notebook/export writes stay approval-gated."
       : "Evidence is strong enough for memory-first reuse before live search.",
@@ -118,12 +136,15 @@ export function buildGraphContextBridgePacket({
     claimRefs,
     estimatedTokens,
     approvalRequired,
-    allowedActions: approvalRequired ? DEFAULT_ACTIONS : [...DEFAULT_ACTIONS, "patch_notebook", "create_followup"],
+    allowedActions: approvalRequired
+      ? topology ? [...DEFAULT_ACTIONS, "inspect_topology_shape"] : DEFAULT_ACTIONS
+      : topology ? [...DEFAULT_ACTIONS, "inspect_topology_shape", "patch_notebook", "create_followup"] : [...DEFAULT_ACTIONS, "patch_notebook", "create_followup"],
     blockedActions: approvalRequired
       ? ["blind_notebook_overwrite", "auto_export_without_review", "entity_merge_without_approval"]
       : ["entity_merge_without_approval"],
     whySelected,
-    humanSummary: `${title}: ${sourceRefs} sources, ${claimRefs} claims, ${visibleNodes} visible graph nodes. ${needsReview ? "Needs review before writes." : "Ready for memory-first reuse."}`,
-    agentSummary: `Pack ${packedNodes} nodes, ${sourceRefs} source refs, ${claimRefs} claim refs; estimated ${estimatedTokens} tokens; approvalRequired=${approvalRequired}.`,
+    humanSummary: `${title}: ${sourceRefs} sources, ${claimRefs} claims, ${visibleNodes} visible graph nodes. ${topology ? `${topology.summary} ` : ""}${needsReview ? "Needs review before writes." : "Ready for memory-first reuse."}`,
+    agentSummary: `Pack ${packedNodes} nodes, ${sourceRefs} source refs, ${claimRefs} claim refs${topology ? `; topology=${topology.view}/density:${topology.densityScore}/outlier:${topology.outlierScore}` : ""}; estimated ${estimatedTokens} tokens; approvalRequired=${approvalRequired}.`,
+    topology: topology ?? undefined,
   };
 }

--- a/src/features/redesign/lib/graphContextBridge.ts
+++ b/src/features/redesign/lib/graphContextBridge.ts
@@ -1,0 +1,129 @@
+import type { ReportCardData } from "../fixtures";
+import type { LiveArtifactDetail, ReportGraphNeighborhoodScope } from "../hooks/useLiveArtifacts";
+
+export type GraphContextMode = "human" | "agent";
+export type GraphContextPromotionClass = "visible" | "shelf" | "searchable" | "on_demand";
+
+export interface GraphContextBridgePacket {
+  contextRef: string;
+  rootUri: string;
+  title: string;
+  mode: GraphContextMode;
+  promotionClass: GraphContextPromotionClass;
+  attentionScore: number;
+  humanRank: number;
+  agentRank: number;
+  visibleNodes: number;
+  packedNodes: number;
+  edges: number;
+  sourceRefs: number;
+  claimRefs: number;
+  estimatedTokens: number;
+  approvalRequired: boolean;
+  allowedActions: string[];
+  blockedActions: string[];
+  whySelected: string[];
+  humanSummary: string;
+  agentSummary: string;
+}
+
+interface GraphContextBridgeInput {
+  report?: ReportCardData | null;
+  detail?: LiveArtifactDetail | null;
+  scope?: ReportGraphNeighborhoodScope | null;
+  mode?: GraphContextMode;
+}
+
+const DEFAULT_ACTIONS = [
+  "search_memory",
+  "resolve_report_graph_context",
+  "search_report_context",
+  "verify_sources",
+  "suggest_related",
+];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+function freshnessScore(report?: ReportCardData | null, detail?: LiveArtifactDetail | null): number {
+  const text = `${detail?.updatedAt ?? ""} ${report?.updatedAt ?? ""}`.toLowerCase();
+  if (/just now|today|minute|hour|\bm ago|\bh ago/.test(text)) return 88;
+  if (/yesterday|1d|2d|day/.test(text)) return 72;
+  if (/week|w ago|stale|refresh/.test(text)) return 48;
+  return detail || report ? 62 : 30;
+}
+
+function promotionClass(score: number): GraphContextPromotionClass {
+  if (score >= 76) return "visible";
+  if (score >= 60) return "shelf";
+  if (score >= 42) return "searchable";
+  return "on_demand";
+}
+
+function reportStatus(report?: ReportCardData | null, detail?: LiveArtifactDetail | null): ReportCardData["status"] | undefined {
+  return detail?.status ?? report?.status;
+}
+
+export function buildGraphContextBridgePacket({
+  report,
+  detail,
+  scope,
+  mode = "agent",
+}: GraphContextBridgeInput): GraphContextBridgePacket {
+  const title = detail?.title ?? report?.entity ?? "Current graph context";
+  const rootId = detail?.id ?? report?.id ?? "current";
+  const sourceRefs = Math.max(detail?.sourceRows.length ?? 0, detail?.sourceCount ?? 0, report?.sources ?? 0);
+  const claimRefs = Math.max(detail?.claimCount ?? 0, report?.claims ?? 0);
+  const followUps = detail?.followUps ?? report?.followUps ?? 0;
+  const visibleNodes = Math.max(1, 1 + (detail?.nodes.length ?? 0) + Math.min(sourceRefs, 4));
+  const packedNodes = Math.min(visibleNodes, mode === "agent" ? 32 : 12);
+  const edges = detail?.edges.length ?? Math.max(0, visibleNodes - 1);
+  const evidenceScore = clamp(42 + sourceRefs * 5 + claimRefs * 2, 0, 100);
+  const freshScore = freshnessScore(report, detail);
+  const actionScore = clamp(45 + followUps * 8 + (reportStatus(report, detail) === "review" ? 12 : 0), 0, 100);
+  const graphScore = clamp(48 + visibleNodes * 3 + edges * 2, 0, 100);
+  const attentionScore = clamp((evidenceScore + freshScore + actionScore + graphScore) / 4, 0, 100);
+  const humanRank = clamp(attentionScore + (followUps > 0 ? 8 : 0) - (scope?.hiddenReportCount ? 3 : 0), 0, 100);
+  const agentRank = clamp(attentionScore + sourceRefs * 2 + claimRefs - Math.max(0, visibleNodes - 40), 0, 100);
+  const needsReview = reportStatus(report, detail) === "review" || followUps > 0 || sourceRefs === 0;
+  const approvalRequired = needsReview || claimRefs === 0;
+  const estimatedTokens = 220 + sourceRefs * 72 + claimRefs * 46 + packedNodes * 28 + edges * 12;
+  const boundedReason = scope?.isServerBounded
+    ? `Server-bounded neighborhood returned ${scope.returnedReportCount}/${scope.totalCandidateReports} candidate reports.`
+    : "Client packet is bounded to the selected report and first-ring artifact context.";
+
+  const whySelected = [
+    `${title} is the active report/entity context.`,
+    `${sourceRefs} source refs, ${claimRefs} claims, and ${followUps} follow-ups are attached.`,
+    boundedReason,
+    needsReview
+      ? "Review pressure is present, so notebook/export writes stay approval-gated."
+      : "Evidence is strong enough for memory-first reuse before live search.",
+  ];
+
+  return {
+    contextRef: `graphctx:${rootId}`,
+    rootUri: `nodebench://report/${rootId}`,
+    title,
+    mode,
+    promotionClass: promotionClass(attentionScore),
+    attentionScore,
+    humanRank,
+    agentRank,
+    visibleNodes,
+    packedNodes,
+    edges,
+    sourceRefs,
+    claimRefs,
+    estimatedTokens,
+    approvalRequired,
+    allowedActions: approvalRequired ? DEFAULT_ACTIONS : [...DEFAULT_ACTIONS, "patch_notebook", "create_followup"],
+    blockedActions: approvalRequired
+      ? ["blind_notebook_overwrite", "auto_export_without_review", "entity_merge_without_approval"]
+      : ["entity_merge_without_approval"],
+    whySelected,
+    humanSummary: `${title}: ${sourceRefs} sources, ${claimRefs} claims, ${visibleNodes} visible graph nodes. ${needsReview ? "Needs review before writes." : "Ready for memory-first reuse."}`,
+    agentSummary: `Pack ${packedNodes} nodes, ${sourceRefs} source refs, ${claimRefs} claim refs; estimated ${estimatedTokens} tokens; approvalRequired=${approvalRequired}.`,
+  };
+}

--- a/src/features/redesign/lib/reportTopology.test.ts
+++ b/src/features/redesign/lib/reportTopology.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { buildTopologySnapshot, type TopologyInputLink, type TopologyInputNode } from "./reportTopology";
+
+const nodes: TopologyInputNode[] = [
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    graphType: "company",
+    weight: 12,
+    attentionScore: 92,
+    staleHours: 2,
+    sources: "14 sources",
+    verified: "91%",
+    signals: ["pricing changed", "enterprise tier"],
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    graphType: "company",
+    weight: 11,
+    attentionScore: 88,
+    staleHours: 3,
+    sources: "12 sources",
+    verified: "87%",
+    signals: ["voice models"],
+  },
+  {
+    id: "brief",
+    label: "Daily Brief",
+    graphType: "brief",
+    weight: 8,
+    attentionScore: 76,
+    staleHours: 1,
+    sources: "8 sources",
+    verified: "ready",
+    signals: ["brief touched reports"],
+  },
+  {
+    id: "edge",
+    label: "Tiny Unknown Signal",
+    graphType: "artifact",
+    weight: 1,
+    attentionScore: 18,
+    staleHours: 240,
+    sources: "0 sources",
+    verified: "pending",
+    signals: [],
+  },
+];
+
+const links: TopologyInputLink[] = [
+  { source: "anthropic", target: "brief", type: "has_report", strength: 0.8, confidence: 0.9, sourceRefs: 4, claimRefs: 3 },
+  { source: "openai", target: "brief", type: "correlates_with", strength: 0.7, confidence: 0.74, sourceRefs: 3, claimRefs: 2 },
+  { source: "edge", target: "brief", type: "has_artifact", strength: 0.2, confidence: 0.3, sourceRefs: 0, claimRefs: 0 },
+];
+
+describe("buildTopologySnapshot", () => {
+  it("builds density topology with hot attention node and mapper clusters", () => {
+    const snapshot = buildTopologySnapshot(nodes, links, "density");
+
+    expect(snapshot.view).toBe("density");
+    expect(snapshot.summary.hotNodeId).not.toBe("edge");
+    expect(snapshot.nodesById.anthropic?.densityScore).toBeGreaterThan(snapshot.nodesById.edge?.densityScore ?? 0);
+    expect(snapshot.mapperClusters.length).toBeGreaterThan(0);
+    expect(snapshot.summary.viewRationale).toContain("attention");
+  });
+
+  it("builds PCA topology with named axes and bounded coordinates", () => {
+    const snapshot = buildTopologySnapshot(nodes, links, "pca");
+
+    expect(snapshot.pcaAxes.pc1.length).toBeGreaterThan(0);
+    expect(snapshot.pcaAxes.pc2.length).toBeGreaterThan(0);
+    snapshot.nodes.forEach((node) => {
+      expect(node.x).toBeGreaterThanOrEqual(0);
+      expect(node.x).toBeLessThanOrEqual(1);
+      expect(node.y).toBeGreaterThanOrEqual(0);
+      expect(node.y).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it("builds centroid topology that separates typical center from outlier edge", () => {
+    const snapshot = buildTopologySnapshot(nodes, links, "centroid");
+
+    expect(snapshot.summary.outlierNodeId).toBe("edge");
+    expect(snapshot.nodesById.edge?.outlierScore).toBeGreaterThan(snapshot.nodesById.brief?.outlierScore ?? 0);
+    expect(snapshot.summary.centroidNodeId).toBeTruthy();
+  });
+});

--- a/src/features/redesign/lib/reportTopology.ts
+++ b/src/features/redesign/lib/reportTopology.ts
@@ -1,0 +1,421 @@
+export type TopologyViewMode = "density" | "pca" | "centroid";
+
+export interface TopologyInputNode {
+  id: string;
+  label: string;
+  graphType?: string;
+  provenance?: string;
+  weight?: number;
+  attentionScore?: number;
+  staleHours?: number;
+  sources?: string;
+  verified?: string;
+  coverage?: string[];
+  signals?: string[];
+}
+
+export interface TopologyInputLink {
+  source: string;
+  target: string;
+  type?: string;
+  strength?: number;
+  confidence?: number;
+  sourceRefs?: number;
+  claimRefs?: number;
+}
+
+export interface TopologyNodeProjection {
+  id: string;
+  densityScore: number;
+  attentionScore: number;
+  degree: number;
+  pc1: number;
+  pc2: number;
+  centroidDistance: number;
+  outlierScore: number;
+  mapperClusterIds: string[];
+  x: number;
+  y: number;
+}
+
+export interface TopologyMapperCluster {
+  id: string;
+  label: string;
+  memberIds: string[];
+  x: number;
+  y: number;
+  densityScore: number;
+  attentionScore: number;
+}
+
+export interface TopologyPcaAxis {
+  label: string;
+  weight: number;
+}
+
+export interface TopologySnapshot {
+  view: TopologyViewMode;
+  nodes: TopologyNodeProjection[];
+  nodesById: Record<string, TopologyNodeProjection>;
+  mapperClusters: TopologyMapperCluster[];
+  mapperEdges: Array<{ source: string; target: string; sharedMembers: number }>;
+  summary: {
+    nodeCount: number;
+    edgeCount: number;
+    hotNodeId: string | null;
+    centroidNodeId: string | null;
+    outlierNodeId: string | null;
+    clusterCount: number;
+    viewRationale: string;
+  };
+  pcaAxes: {
+    pc1: TopologyPcaAxis[];
+    pc2: TopologyPcaAxis[];
+  };
+}
+
+const FEATURE_LABELS = [
+  "attention",
+  "degree",
+  "weight",
+  "sources",
+  "verified",
+  "freshness",
+  "signals",
+  "causal",
+] as const;
+
+type FeatureLabel = typeof FEATURE_LABELS[number];
+
+interface FeatureRow {
+  node: TopologyInputNode;
+  raw: number[];
+  vector: number[];
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function clamp100(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function sourceCount(value?: string): number {
+  return Number(value?.match(/\d+(?:\.\d+)?/)?.[0] ?? 0);
+}
+
+function verifiedScore(value?: string): number {
+  const text = (value ?? "").toLowerCase();
+  const pct = Number(text.match(/(\d+(?:\.\d+)?)%/)?.[1] ?? NaN);
+  if (Number.isFinite(pct)) return pct / 100;
+  if (/verified|passed|ready/.test(text)) return 0.86;
+  if (/review|pending|unknown/.test(text)) return 0.46;
+  if (/failing|blocked|stale/.test(text)) return 0.22;
+  return 0.58;
+}
+
+function normalizedColumns(rows: number[][]): number[][] {
+  if (rows.length === 0) return [];
+  const width = rows[0]?.length ?? 0;
+  const mins = Array.from({ length: width }, (_, column) => Math.min(...rows.map((row) => row[column] ?? 0)));
+  const maxs = Array.from({ length: width }, (_, column) => Math.max(...rows.map((row) => row[column] ?? 0)));
+  return rows.map((row) => row.map((value, column) => {
+    const range = maxs[column] - mins[column];
+    if (range <= 1e-9) return 0.5;
+    return (value - mins[column]) / range;
+  }));
+}
+
+function dot(a: number[], b: number[]): number {
+  return a.reduce((sum, value, index) => sum + value * (b[index] ?? 0), 0);
+}
+
+function normalizeVector(vector: number[]): number[] {
+  const magnitude = Math.sqrt(dot(vector, vector));
+  if (magnitude <= 1e-9) return vector.map(() => 0);
+  return vector.map((value) => value / magnitude);
+}
+
+function covarianceMatrix(rows: number[][]): number[][] {
+  const width = rows[0]?.length ?? 0;
+  const means = Array.from({ length: width }, (_, column) =>
+    rows.reduce((sum, row) => sum + (row[column] ?? 0), 0) / Math.max(1, rows.length),
+  );
+  return Array.from({ length: width }, (_, rowIndex) =>
+    Array.from({ length: width }, (_, columnIndex) => {
+      const variance = rows.reduce((sum, row) =>
+        sum + ((row[rowIndex] ?? 0) - means[rowIndex]) * ((row[columnIndex] ?? 0) - means[columnIndex]),
+      0);
+      return variance / Math.max(1, rows.length - 1);
+    }),
+  );
+}
+
+function matVec(matrix: number[][], vector: number[]): number[] {
+  return matrix.map((row) => dot(row, vector));
+}
+
+function powerIteration(matrix: number[][], seedShift = 0): { vector: number[]; value: number } {
+  const width = matrix.length;
+  let vector = normalizeVector(Array.from({ length: width }, (_, index) => 1 + ((index + seedShift) % 3) * 0.17));
+  for (let iteration = 0; iteration < 32; iteration += 1) {
+    const next = normalizeVector(matVec(matrix, vector));
+    if (next.every((value) => Math.abs(value) < 1e-9)) break;
+    vector = next;
+  }
+  const value = dot(vector, matVec(matrix, vector));
+  return { vector, value };
+}
+
+function deflate(matrix: number[][], eigen: { vector: number[]; value: number }): number[][] {
+  return matrix.map((row, rowIndex) =>
+    row.map((value, columnIndex) => value - eigen.value * eigen.vector[rowIndex] * eigen.vector[columnIndex]),
+  );
+}
+
+function pca(rows: FeatureRow[]): {
+  pc1: number[];
+  pc2: number[];
+  loadings1: number[];
+  loadings2: number[];
+} {
+  if (rows.length <= 1) {
+    return {
+      pc1: rows.map(() => 0),
+      pc2: rows.map(() => 0),
+      loadings1: FEATURE_LABELS.map((_, index) => index === 0 ? 1 : 0),
+      loadings2: FEATURE_LABELS.map((_, index) => index === 1 ? 1 : 0),
+    };
+  }
+  const matrix = covarianceMatrix(rows.map((row) => row.vector));
+  const first = powerIteration(matrix, 0);
+  const second = powerIteration(deflate(matrix, first), 1);
+  return {
+    pc1: rows.map((row) => dot(row.vector, first.vector)),
+    pc2: rows.map((row) => dot(row.vector, second.vector)),
+    loadings1: first.vector,
+    loadings2: second.vector,
+  };
+}
+
+function scale(values: number[]): number[] {
+  const min = Math.min(...values, 0);
+  const max = Math.max(...values, 0);
+  const range = max - min;
+  if (range <= 1e-9) return values.map(() => 0.5);
+  return values.map((value) => (value - min) / range);
+}
+
+function topLoadings(loadings: number[]): TopologyPcaAxis[] {
+  return loadings
+    .map((weight, index) => ({ label: FEATURE_LABELS[index] as FeatureLabel, weight }))
+    .sort((a, b) => Math.abs(b.weight) - Math.abs(a.weight))
+    .slice(0, 3);
+}
+
+function edgeEndpoint(value: string | { id?: string } | undefined): string {
+  if (typeof value === "object" && value?.id) return value.id;
+  return String(value ?? "");
+}
+
+function buildFeatureRows(nodes: TopologyInputNode[], links: TopologyInputLink[]): FeatureRow[] {
+  const degree = new Map<string, number>();
+  const causal = new Map<string, number>();
+  links.forEach((link) => {
+    const source = edgeEndpoint(link.source);
+    const target = edgeEndpoint(link.target);
+    degree.set(source, (degree.get(source) ?? 0) + 1);
+    degree.set(target, (degree.get(target) ?? 0) + 1);
+    if (link.type === "causes" || link.type === "correlates_with") {
+      const score = (link.strength ?? 0.5) + (link.confidence ?? 0.5);
+      causal.set(source, (causal.get(source) ?? 0) + score);
+      causal.set(target, (causal.get(target) ?? 0) + score);
+    }
+  });
+  const rawRows = nodes.map((node) => [
+    clamp01((node.attentionScore ?? 0) / 100),
+    degree.get(node.id) ?? 0,
+    Math.max(1, node.weight ?? 1),
+    sourceCount(node.sources),
+    verifiedScore(node.verified),
+    1 / (1 + Math.max(0, node.staleHours ?? 0) / 24),
+    (node.signals?.length ?? 0) + (node.coverage?.length ?? 0) * 0.5,
+    causal.get(node.id) ?? 0,
+  ]);
+  const normalized = normalizedColumns(rawRows);
+  return nodes.map((node, index) => ({ node, raw: rawRows[index] ?? [], vector: normalized[index] ?? [] }));
+}
+
+function buildMapperClusters(
+  projections: Omit<TopologyNodeProjection, "mapperClusterIds">[],
+  links: TopologyInputLink[],
+): { clusters: TopologyMapperCluster[]; edges: Array<{ source: string; target: string; sharedMembers: number }>; nodeClusters: Record<string, string[]> } {
+  const bins = 4;
+  const overlap = 0.12;
+  const adjacency = new Map<string, Set<string>>();
+  links.forEach((link) => {
+    const source = edgeEndpoint(link.source);
+    const target = edgeEndpoint(link.target);
+    if (!adjacency.has(source)) adjacency.set(source, new Set());
+    if (!adjacency.has(target)) adjacency.set(target, new Set());
+    adjacency.get(source)?.add(target);
+    adjacency.get(target)?.add(source);
+  });
+
+  const clusters: TopologyMapperCluster[] = [];
+  const nodeClusters: Record<string, string[]> = {};
+  const binSize = 1 / bins;
+
+  for (let bx = 0; bx < bins; bx += 1) {
+    for (let by = 0; by < bins; by += 1) {
+      const minX = bx * binSize - overlap;
+      const maxX = (bx + 1) * binSize + overlap;
+      const minY = by * binSize - overlap;
+      const maxY = (by + 1) * binSize + overlap;
+      const members = projections.filter((node) => node.x >= minX && node.x <= maxX && node.y >= minY && node.y <= maxY);
+      const unvisited = new Set(members.map((node) => node.id));
+      while (unvisited.size > 0) {
+        const [start] = unvisited;
+        if (!start) break;
+        const queue = [start];
+        const component = new Set<string>();
+        unvisited.delete(start);
+        while (queue.length > 0) {
+          const current = queue.shift();
+          if (!current) continue;
+          component.add(current);
+          adjacency.get(current)?.forEach((next) => {
+            if (unvisited.has(next)) {
+              unvisited.delete(next);
+              queue.push(next);
+            }
+          });
+        }
+        const memberIds = [...component];
+        if (memberIds.length === 0) continue;
+        const memberNodes = memberIds
+          .map((id) => projections.find((node) => node.id === id))
+          .filter((node): node is Omit<TopologyNodeProjection, "mapperClusterIds"> => Boolean(node));
+        const cluster: TopologyMapperCluster = {
+          id: `mapper:${bx}:${by}:${clusters.length}`,
+          label: `Mapper ${bx + 1}.${by + 1}`,
+          memberIds,
+          x: memberNodes.reduce((sum, node) => sum + node.x, 0) / memberNodes.length,
+          y: memberNodes.reduce((sum, node) => sum + node.y, 0) / memberNodes.length,
+          densityScore: clamp100(memberNodes.reduce((sum, node) => sum + node.densityScore, 0) / memberNodes.length),
+          attentionScore: clamp100(memberNodes.reduce((sum, node) => sum + node.attentionScore, 0) / memberNodes.length),
+        };
+        clusters.push(cluster);
+        memberIds.forEach((id) => {
+          nodeClusters[id] = [...(nodeClusters[id] ?? []), cluster.id];
+        });
+      }
+    }
+  }
+
+  const edges: Array<{ source: string; target: string; sharedMembers: number }> = [];
+  for (let i = 0; i < clusters.length; i += 1) {
+    for (let j = i + 1; j < clusters.length; j += 1) {
+      const a = clusters[i];
+      const b = clusters[j];
+      if (!a || !b) continue;
+      const bMembers = new Set(b.memberIds);
+      const sharedMembers = a.memberIds.filter((id) => bMembers.has(id)).length;
+      if (sharedMembers > 0) edges.push({ source: a.id, target: b.id, sharedMembers });
+    }
+  }
+
+  return { clusters, edges, nodeClusters };
+}
+
+export function buildTopologySnapshot(
+  nodes: TopologyInputNode[],
+  links: TopologyInputLink[],
+  view: TopologyViewMode,
+): TopologySnapshot {
+  const rows = buildFeatureRows(nodes, links);
+  const { pc1, pc2, loadings1, loadings2 } = pca(rows);
+  const pc1Scaled = scale(pc1);
+  const pc2Scaled = scale(pc2);
+  const centroid = rows[0]?.vector.map((_, column) =>
+    rows.reduce((sum, row) => sum + (row.vector[column] ?? 0), 0) / Math.max(1, rows.length),
+  ) ?? [];
+  const distances = rows.map((row) => Math.sqrt(row.vector.reduce((sum, value, column) => sum + Math.pow(value - (centroid[column] ?? 0), 2), 0)));
+  const distanceScaled = scale(distances);
+  const densityValues = rows.map((row) => {
+    const attention = row.vector[0] ?? 0;
+    const degree = row.vector[1] ?? 0;
+    const sources = row.vector[3] ?? 0;
+    const verified = row.vector[4] ?? 0;
+    const freshness = row.vector[5] ?? 0;
+    const causalSignal = row.vector[7] ?? 0;
+    return clamp01(attention * 0.34 + degree * 0.22 + sources * 0.16 + verified * 0.1 + freshness * 0.08 + causalSignal * 0.1);
+  });
+  const densityScaled = scale(densityValues);
+
+  const withoutClusters = rows.map((row, index): Omit<TopologyNodeProjection, "mapperClusterIds"> => {
+    const density = densityScaled[index] ?? 0.5;
+    const distance = distanceScaled[index] ?? 0;
+    const angle = Math.atan2((pc2Scaled[index] ?? 0.5) - 0.5, (pc1Scaled[index] ?? 0.5) - 0.5);
+    const radius = 0.08 + distance * 0.42;
+    const centroidX = 0.5 + Math.cos(angle) * radius;
+    const centroidY = 0.5 + Math.sin(angle) * radius;
+    const coordinates = view === "density"
+      ? { x: pc1Scaled[index] ?? 0.5, y: 1 - density }
+      : view === "pca"
+        ? { x: pc1Scaled[index] ?? 0.5, y: pc2Scaled[index] ?? 0.5 }
+        : { x: clamp01(centroidX), y: clamp01(centroidY) };
+    return {
+      id: row.node.id,
+      densityScore: clamp100(density * 100),
+      attentionScore: clamp100(row.raw[0] * 100),
+      degree: Math.round(row.raw[1] ?? 0),
+      pc1: Number((pc1Scaled[index] ?? 0.5).toFixed(4)),
+      pc2: Number((pc2Scaled[index] ?? 0.5).toFixed(4)),
+      centroidDistance: Number(distance.toFixed(4)),
+      outlierScore: clamp100(distance * 100),
+      x: Number(coordinates.x.toFixed(4)),
+      y: Number(coordinates.y.toFixed(4)),
+    };
+  });
+
+  const mapper = buildMapperClusters(withoutClusters, links);
+  const projected = withoutClusters.map((node) => ({
+    ...node,
+    mapperClusterIds: mapper.nodeClusters[node.id] ?? [],
+  }));
+  const nodesById = Object.fromEntries(projected.map((node) => [node.id, node]));
+  const hotNode = [...projected].sort((a, b) => b.densityScore - a.densityScore)[0] ?? null;
+  const centroidNode = [...projected].sort((a, b) => a.centroidDistance - b.centroidDistance)[0] ?? null;
+  const outlierNode = [...projected].sort((a, b) => b.centroidDistance - a.centroidDistance)[0] ?? null;
+  const viewRationale =
+    view === "density"
+      ? "Density ranks where human and agent attention repeatedly accumulates."
+      : view === "pca"
+        ? "PCA exposes the dominant axes separating reports, entities, sources, and artifacts."
+        : "Centroid distance separates typical coverage-book nodes from edge-case outliers.";
+
+  return {
+    view,
+    nodes: projected,
+    nodesById,
+    mapperClusters: mapper.clusters,
+    mapperEdges: mapper.edges,
+    summary: {
+      nodeCount: nodes.length,
+      edgeCount: links.length,
+      hotNodeId: hotNode?.id ?? null,
+      centroidNodeId: centroidNode?.id ?? null,
+      outlierNodeId: outlierNode?.id ?? null,
+      clusterCount: mapper.clusters.length,
+      viewRationale,
+    },
+    pcaAxes: {
+      pc1: topLoadings(loadings1),
+      pc2: topLoadings(loadings2),
+    },
+  };
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -8231,6 +8231,7 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-v3-graph-peek__children,
 [data-redesign] .rd-v3-graph-peek__relations,
 [data-redesign] .rd-v3-graph-peek__attention,
+[data-redesign] .rd-v3-graph-peek__topology,
 [data-redesign] .rd-v3-graph-peek__context {
   margin-top: 8px;
   padding-top: 8px;
@@ -8287,6 +8288,28 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   border: 1px solid var(--rd-line);
   padding: 8px;
   background: color-mix(in srgb, var(--rd-accent-soft) 42%, transparent);
+}
+
+[data-redesign] .rd-v3-graph-peek__topology {
+  border-radius: 7px;
+  border: 1px solid color-mix(in srgb, var(--rd-accent) 22%, var(--rd-line));
+  padding: 8px;
+  background: color-mix(in srgb, var(--rd-paper) 68%, var(--rd-accent-soft));
+}
+
+[data-redesign] .rd-v3-graph-peek__topology p {
+  margin: 6px 0 0;
+  color: var(--rd-ink-mute);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+
+[data-redesign] .rd-v3-graph-peek__topology small {
+  display: block;
+  margin-top: 6px;
+  color: var(--rd-ink-faint);
+  font-family: var(--rd-font-mono);
+  font-size: 9px;
 }
 
 [data-redesign] .rd-v3-graph-peek__context-head {
@@ -8509,6 +8532,17 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   flex-shrink: 0;
 }
 
+[data-redesign] .rd-v3-graph__topology {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid color-mix(in srgb, var(--rd-accent) 28%, var(--rd-line));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--rd-accent-soft) 30%, transparent);
+  flex-shrink: 0;
+}
+
 [data-redesign] .rd-v3-graph__scale button {
   border: 0;
   border-radius: 5px;
@@ -8520,9 +8554,46 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   cursor: pointer;
 }
 
-[data-redesign] .rd-v3-graph__scale button[aria-pressed="true"] {
+[data-redesign] .rd-v3-graph__topology button {
+  border: 0;
+  border-radius: 5px;
+  padding: 3px 7px;
+  background: transparent;
+  color: var(--rd-ink-faint);
+  font: inherit;
+  font-size: 9px;
+  cursor: pointer;
+}
+
+[data-redesign] .rd-v3-graph__scale button[aria-pressed="true"],
+[data-redesign] .rd-v3-graph__topology button[aria-pressed="true"] {
   background: var(--rd-ink);
   color: var(--rd-paper);
+}
+
+[data-redesign] .rd-v3-graph__topology-summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 7px 4px 10px;
+  color: var(--rd-ink-faint);
+  font-size: 9px;
+  line-height: 1.35;
+}
+
+[data-redesign] .rd-v3-graph__topology-summary strong {
+  color: var(--rd-ink);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v3-graph__topology-summary span {
+  padding-right: 8px;
+  border-right: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v3-graph__topology-summary span:last-child {
+  border-right: 0;
 }
 
 [data-redesign] .rd-v3-graph__search {
@@ -8577,6 +8648,14 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   stroke: var(--rd-accent);
   stroke-width: 1.5;
   opacity: 0;
+}
+
+[data-redesign] .rd-v3-graph-mapper-cluster {
+  fill: color-mix(in srgb, var(--rd-accent) 18%, transparent);
+  stroke: color-mix(in srgb, var(--rd-accent) 52%, var(--rd-line));
+  stroke-width: 1;
+  stroke-dasharray: 7 5;
+  pointer-events: none;
 }
 
 [data-redesign] .rd-v3-graph-node__dot {

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -8221,10 +8221,90 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 
 [data-redesign] .rd-v3-graph-peek__hierarchy,
 [data-redesign] .rd-v3-graph-peek__children,
-[data-redesign] .rd-v3-graph-peek__relations {
+[data-redesign] .rd-v3-graph-peek__relations,
+[data-redesign] .rd-v3-graph-peek__context {
   margin-top: 8px;
   padding-top: 8px;
   border-top: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v3-graph-peek__context {
+  border-radius: 7px;
+  border: 1px solid var(--rd-line);
+  padding: 8px;
+  background: color-mix(in srgb, var(--rd-accent-soft) 42%, transparent);
+}
+
+[data-redesign] .rd-v3-graph-peek__context-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+[data-redesign] .rd-v3-graph-peek__context-head .rd-v3-graph-peek__section-label {
+  margin-bottom: 0;
+}
+
+[data-redesign] .rd-v3-graph-peek__context-head b {
+  min-width: 28px;
+  border-radius: 5px;
+  padding: 2px 5px;
+  background: var(--rd-paper);
+  color: var(--rd-accent-strong);
+  font-family: var(--rd-font-mono);
+  font-size: 10px;
+  text-align: center;
+}
+
+[data-redesign] .rd-v3-graph-peek__context p {
+  margin: 6px 0 0;
+  color: var(--rd-ink-mute);
+  font-size: 11px;
+  line-height: 1.42;
+}
+
+[data-redesign] .rd-v3-graph-peek__context-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 4px;
+  margin-top: 7px;
+}
+
+[data-redesign] .rd-v3-graph-peek__context-grid span {
+  min-width: 0;
+  border: 1px solid var(--rd-line);
+  border-radius: 5px;
+  padding: 4px;
+  background: var(--rd-paper);
+  color: var(--rd-ink-faint);
+  font-size: 9px;
+  text-align: center;
+}
+
+[data-redesign] .rd-v3-graph-peek__context-grid strong {
+  display: block;
+  color: var(--rd-ink);
+  font-family: var(--rd-font-mono);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v3-graph-peek__why {
+  margin-top: 7px;
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v3-graph-peek__why summary {
+  cursor: pointer;
+  font-weight: 650;
+}
+
+[data-redesign] .rd-v3-graph-peek__why ol {
+  margin: 6px 0 0;
+  padding-left: 16px;
+  color: var(--rd-ink-mute);
+  line-height: 1.4;
 }
 
 [data-redesign] .rd-v3-graph-peek__section-label {
@@ -10237,6 +10317,59 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .ar-drawer-status[data-status="Verified"] { background: var(--rd-green-bg); color: var(--rd-green); }
 [data-redesign] .ar-drawer-status[data-status="Needs review"],
 [data-redesign] .ar-drawer-status[data-status="Review"] { background: var(--rd-amber-bg); color: var(--rd-amber); }
+[data-redesign] .ar-context-packet {
+  margin: 6px 0 7px;
+  border: 1px solid var(--rd-line);
+  border-radius: 7px;
+  padding: 8px;
+  background: color-mix(in srgb, var(--rd-accent-soft) 38%, transparent);
+}
+[data-redesign] .ar-context-packet__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--rd-accent-strong);
+  font-size: 9px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+[data-redesign] .ar-context-packet__head b {
+  border-radius: 4px;
+  padding: 1px 5px;
+  background: var(--rd-paper);
+  color: var(--rd-ink);
+  font-family: var(--rd-font-mono);
+  font-size: 10px;
+}
+[data-redesign] .ar-context-packet p {
+  margin: 5px 0 0;
+  color: var(--rd-ink-mute);
+  font-size: 10px;
+  line-height: 1.45;
+}
+[data-redesign] .ar-context-packet__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  margin-top: 7px;
+}
+[data-redesign] .ar-context-packet__grid span {
+  min-width: 0;
+  border-radius: 5px;
+  background: var(--rd-paper);
+  padding: 4px;
+  color: var(--rd-ink-faint);
+  font-size: 9px;
+  text-align: center;
+}
+[data-redesign] .ar-context-packet__grid strong {
+  display: block;
+  color: var(--rd-ink);
+  font-family: var(--rd-font-mono);
+  font-size: 10px;
+}
 [data-redesign] .ar-ctx-row { display: flex; gap: 6px; align-items: baseline; padding: 2px 0; }
 [data-redesign] .ar-ctx-lbl { width: 62px; flex-shrink: 0; }
 [data-redesign] .ar-ctx-val { flex: 1; color: var(--rd-ink-mute); font-size: 10px; line-height: 1.45; }

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -8222,10 +8222,56 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-v3-graph-peek__hierarchy,
 [data-redesign] .rd-v3-graph-peek__children,
 [data-redesign] .rd-v3-graph-peek__relations,
+[data-redesign] .rd-v3-graph-peek__attention,
 [data-redesign] .rd-v3-graph-peek__context {
   margin-top: 8px;
   padding-top: 8px;
   border-top: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v3-graph-peek__attention {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2px 9px;
+  align-items: center;
+}
+
+[data-redesign] .rd-v3-graph-peek__attention p {
+  margin: 0;
+  color: var(--rd-ink-mute);
+  font-size: 10.5px;
+  line-height: 1.35;
+}
+
+[data-redesign] .rd-v3-graph-peek__attention b {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  min-width: 34px;
+  border: 1px solid var(--rd-line);
+  border-radius: 7px;
+  padding: 5px 6px;
+  background: var(--rd-paper);
+  color: var(--rd-accent-strong);
+  font-family: var(--rd-font-mono);
+  font-size: 12px;
+  text-align: center;
+}
+
+[data-redesign] .rd-v3-graph-peek__attention small {
+  grid-column: 1 / -1;
+  color: var(--rd-ink-faint);
+  font-family: var(--rd-font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+[data-redesign] .rd-v3-graph-peek__attention[data-attention-tier="promoted"] b {
+  border-color: color-mix(in srgb, var(--rd-accent) 44%, var(--rd-line));
+}
+
+[data-redesign] .rd-v3-graph-peek__attention[data-attention-tier="agent_only"] b {
+  color: var(--rd-ink-faint);
 }
 
 [data-redesign] .rd-v3-graph-peek__context {
@@ -8382,6 +8428,17 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   line-height: 1.35;
 }
 
+[data-redesign] .rd-v3-graph-peek__relation-meta {
+  display: block;
+  margin-top: 2px;
+  color: var(--rd-ink-faint);
+  font-family: var(--rd-font-mono);
+  font-size: 8.5px;
+  font-style: normal;
+  line-height: 1.35;
+  opacity: 0.86;
+}
+
 [data-redesign] .rd-v3-graph-peek__actions {
   display: flex;
   flex-wrap: wrap;
@@ -8518,6 +8575,10 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   stroke-width: 0.8;
 }
 
+[data-redesign] .rd-v3-graph-node[data-attention-tier="promoted"] .rd-v3-graph-node__dot {
+  stroke-width: 1.8;
+}
+
 [data-redesign] .rd-v3-graph-node__icon {
   fill: var(--rd-ink);
   font-family: Manrope, Inter, sans-serif;
@@ -8559,6 +8620,11 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   opacity: 0.55;
   stroke: none;
   paint-order: normal;
+}
+
+[data-redesign] .rd-v3-graph-node[data-attention-tier="agent_only"] .rd-v3-graph-node__label,
+[data-redesign] .rd-v3-graph-node[data-attention-tier="agent_only"] .rd-v3-graph-node__meta {
+  opacity: 0.42;
 }
 
 [data-redesign] .rd-v3-graph-edge-label {
@@ -10349,6 +10415,36 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   font-size: 10px;
   line-height: 1.45;
 }
+[data-redesign] .ar-context-packet__attention {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 7px;
+  border-radius: 6px;
+  padding: 5px 6px;
+  background: var(--rd-paper);
+  color: var(--rd-ink-soft);
+  font-size: 9px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+[data-redesign] .ar-context-packet__attention strong {
+  margin-right: 4px;
+  color: var(--rd-ink);
+  font-family: var(--rd-font-mono);
+  font-size: 12px;
+}
+[data-redesign] .ar-context-packet__attention[data-promotion="visible"] {
+  color: var(--rd-green);
+}
+[data-redesign] .ar-context-packet__attention[data-promotion="shelf"] {
+  color: var(--rd-accent-strong);
+}
+[data-redesign] .ar-context-packet__attention[data-promotion="searchable"] {
+  color: var(--rd-amber);
+}
 [data-redesign] .ar-context-packet__grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -10369,6 +10465,29 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   color: var(--rd-ink);
   font-family: var(--rd-font-mono);
   font-size: 10px;
+}
+[data-redesign] .ar-context-packet__why {
+  margin-top: 7px;
+  border-top: 1px solid var(--rd-line-faint);
+  padding-top: 6px;
+}
+[data-redesign] .ar-context-packet__why summary {
+  cursor: pointer;
+  color: var(--rd-ink-soft);
+  font-size: 9px;
+  font-weight: 680;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+[data-redesign] .ar-context-packet__why ol {
+  margin: 5px 0 0;
+  padding-left: 15px;
+  color: var(--rd-ink-mute);
+  font-size: 10px;
+  line-height: 1.45;
+}
+[data-redesign] .ar-context-packet__why li + li {
+  margin-top: 3px;
 }
 [data-redesign] .ar-ctx-row { display: flex; gap: 6px; align-items: baseline; padding: 2px 0; }
 [data-redesign] .ar-ctx-lbl { width: 62px; flex-shrink: 0; }

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -507,6 +507,14 @@
   grid-template-columns: minmax(0, 1fr) 400px;
 }
 
+[data-redesign] .rd-shell--chat-v3 .rd-shell__main {
+  grid-template-columns: minmax(0, 1fr) 280px;
+}
+
+[data-redesign] .rd-shell--chat-v3 .rd-pane--right.chat-context {
+  width: 280px;
+}
+
 [data-redesign] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child {
   align-items: center;
   padding: 28px 48px 60px;
@@ -10517,6 +10525,376 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .ar-input-btn { padding: 2px 6px; color: var(--rd-ink-soft); font-size: 9px; font-weight: 590; }
 [data-redesign] .ar-input-send { margin-left: auto; color: var(--rd-ink-faint); font-size: 9px; }
 [data-redesign] .ar-input-send kbd { font-family: var(--rd-font-mono); }
+
+/* Chat v3 session context rail, ported from public/proto/home-v3.html. */
+[data-redesign] .chat-context {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  border-left: 1px solid var(--rd-line-faint);
+  background: var(--rd-panel);
+  padding: 0;
+}
+
+[data-redesign] .chat-ctx-tabs {
+  display: flex;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .chat-ctx-tab {
+  flex: 1;
+  border: 0;
+  border-bottom: 1.5px solid transparent;
+  background: none;
+  color: var(--rd-ink-faint);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 660;
+  letter-spacing: 0.06em;
+  padding: 8px 0;
+  text-transform: uppercase;
+  transition: color 100ms ease, border-color 100ms ease;
+}
+
+[data-redesign] .chat-ctx-tab:hover {
+  color: var(--rd-ink-mute);
+}
+
+[data-redesign] .chat-ctx-tab.active {
+  border-bottom-color: var(--rd-accent);
+  color: var(--rd-ink);
+}
+
+[data-redesign] .chat-ctx-panel {
+  display: none;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+[data-redesign] .chat-ctx-panel.active {
+  display: flex;
+  flex-direction: column;
+}
+
+[data-redesign] .chat-ctx-panel[hidden] {
+  display: none !important;
+}
+
+[data-redesign] .chat-ctx-section {
+  border-bottom: 1px solid var(--rd-line-faint);
+  padding: 10px 14px;
+}
+
+[data-redesign] .chat-ctx-label {
+  color: var(--rd-ink-faint);
+  font-size: 9px;
+  font-weight: 680;
+  letter-spacing: 0.06em;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+[data-redesign] .chat-ctx-task {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 3px 0;
+}
+
+[data-redesign] .chat-ctx-task-dot {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  margin-top: 2px;
+  border: 1.5px solid var(--rd-line-strong);
+  border-radius: 50%;
+}
+
+[data-redesign] .chat-ctx-task-dot--done {
+  border-color: var(--rd-green);
+  background: var(--rd-green);
+}
+
+[data-redesign] .chat-ctx-task-dot--active {
+  border-color: var(--rd-accent);
+  background: var(--rd-accent);
+}
+
+[data-redesign] .chat-ctx-task-dot--blocked {
+  border-color: var(--rd-amber);
+  background: var(--rd-amber);
+}
+
+[data-redesign] .chat-ctx-task-text {
+  min-width: 0;
+  color: var(--rd-ink-mute);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+[data-redesign] .chat-ctx-task-dot--done + .chat-ctx-task-text {
+  color: var(--rd-ink-faint);
+  text-decoration: line-through;
+  text-decoration-color: var(--rd-line);
+}
+
+[data-redesign] .chat-ctx-task-text small {
+  display: block;
+  margin-top: 1px;
+  color: var(--rd-ink-faint);
+  font-family: var(--rd-font-mono);
+  font-size: 9px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+[data-redesign] .chat-ctx-artifact,
+[data-redesign] .chat-ctx-source {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: inherit;
+  padding: 3px 0;
+  text-decoration: none;
+}
+
+[data-redesign] .chat-ctx-artifact:hover .chat-ctx-artifact-name,
+[data-redesign] .chat-ctx-source:hover .chat-ctx-source-name {
+  color: var(--rd-ink);
+}
+
+[data-redesign] .chat-ctx-artifact-icon,
+[data-redesign] .chat-ctx-source-icon {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  border: 1px solid var(--rd-line-strong);
+  border-radius: 2px;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  opacity: 0.62;
+}
+
+[data-redesign] .chat-ctx-source-icon {
+  border-radius: 50%;
+}
+
+[data-redesign] .chat-ctx-artifact-name {
+  min-width: 0;
+  flex: 1;
+  color: var(--rd-ink-mute);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .chat-ctx-artifact-badge {
+  flex-shrink: 0;
+  border-radius: 3px;
+  background: var(--rd-line-faint);
+  color: var(--rd-ink-faint);
+  font-family: var(--rd-font-mono);
+  font-size: 8px;
+  font-weight: 680;
+  padding: 1px 4px;
+  text-transform: uppercase;
+}
+
+[data-redesign] .chat-ctx-agent {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 0;
+}
+
+[data-redesign] .chat-ctx-agent-dot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+[data-redesign] .chat-ctx-agent-name {
+  color: var(--rd-ink-mute);
+  font-size: 11px;
+  font-weight: 590;
+}
+
+[data-redesign] .chat-ctx-agent-role {
+  color: var(--rd-ink-faint);
+  font-family: var(--rd-font-mono);
+  font-size: 9px;
+}
+
+[data-redesign] .chat-ctx-source {
+  gap: 5px;
+  padding: 2px 0;
+}
+
+[data-redesign] .chat-ctx-source-name {
+  min-width: 0;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .chat-ctx-more {
+  color: var(--rd-ink-faint);
+  cursor: default;
+  font-size: 9px;
+  padding: 4px 0;
+}
+
+[data-redesign] .chat-trace-summary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  border-bottom: 1px solid var(--rd-line-faint);
+  background: var(--rd-line-faint);
+}
+
+[data-redesign] .chat-trace-stat {
+  background: var(--rd-panel);
+  padding: 8px 12px;
+}
+
+[data-redesign] .chat-trace-stat-val {
+  color: var(--rd-ink);
+  font-family: var(--rd-font-mono);
+  font-size: 13px;
+  font-weight: 680;
+}
+
+[data-redesign] .chat-trace-stat-key {
+  color: var(--rd-ink-faint);
+  font-size: 8px;
+  font-weight: 680;
+  letter-spacing: 0.06em;
+  margin-top: 2px;
+  text-transform: uppercase;
+}
+
+[data-redesign] .chat-trace-list {
+  padding: 6px 0;
+}
+
+[data-redesign] .chat-trace-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 5px 14px;
+  transition: background 80ms ease;
+}
+
+[data-redesign] .chat-trace-item:hover {
+  background: var(--rd-muted);
+}
+
+[data-redesign] .chat-trace-item-icon {
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  border: 1px solid var(--rd-line);
+  border-radius: 4px;
+  color: var(--rd-ink-faint);
+  font-size: 8px;
+}
+
+[data-redesign] .chat-trace-item-icon--tool {
+  border-color: var(--rd-accent);
+  background: color-mix(in srgb, var(--rd-accent) 8%, transparent);
+  color: var(--rd-accent);
+}
+
+[data-redesign] .chat-trace-item-icon--llm {
+  border-color: #a78bfa;
+  background: color-mix(in srgb, #a78bfa 8%, transparent);
+  color: #a78bfa;
+}
+
+[data-redesign] .chat-trace-item-icon--search {
+  border-color: #60a5fa;
+  background: color-mix(in srgb, #60a5fa 8%, transparent);
+  color: #60a5fa;
+}
+
+[data-redesign] .chat-trace-item-body {
+  min-width: 0;
+  flex: 1;
+}
+
+[data-redesign] .chat-trace-item-name {
+  color: var(--rd-ink-mute);
+  font-size: 11px;
+  font-weight: 590;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .chat-trace-item-meta {
+  display: flex;
+  gap: 8px;
+  margin-top: 1px;
+  color: var(--rd-ink-faint);
+  font-family: var(--rd-font-mono);
+  font-size: 9px;
+}
+
+[data-redesign] .chat-trace-item-bar {
+  width: 44px;
+  height: 3px;
+  flex-shrink: 0;
+  margin-top: 7px;
+  overflow: hidden;
+  border-radius: 2px;
+  background: var(--rd-line-faint);
+}
+
+[data-redesign] .chat-trace-item-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--rd-accent);
+}
+
+[data-redesign] .chat-trace-model {
+  border-top: 1px solid var(--rd-line-faint);
+  padding: 10px 14px;
+}
+
+[data-redesign] .chat-trace-model-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 3px 0;
+}
+
+[data-redesign] .chat-trace-model-name {
+  color: var(--rd-ink-mute);
+  font-size: 10px;
+}
+
+[data-redesign] .chat-trace-model-val {
+  color: var(--rd-ink-faint);
+  font-family: var(--rd-font-mono);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 @media (max-width: 1100px) {
   [data-redesign] .rd-shell--reports-v3 { grid-template-columns: minmax(0, 1fr); }

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -579,6 +579,8 @@ function buildChatAgentRailSnapshot(args: {
     metrics: [
       { label: "sources", value: String(sourceCount), tone: "accent" },
       { label: "tools", value: String(toolCallCount), tone: "green" },
+      { label: "latency", value: formatLatency(latency), tone: latency ? "green" : "accent" },
+      { label: "tokens", value: graphPacket ? graphPacket.estimatedTokens.toLocaleString() : "0", tone: "accent" },
       { label: "graph", value: graphPacket ? String(graphPacket.packedNodes) : "0", tone: "accent" },
       { label: "cost", value: formatRailUsd(estimatedCost), tone: estimatedCost > 0 ? "amber" : "green" },
     ],

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -22,6 +22,7 @@ import { MessageActions } from "../components/MessageActions";
 import { ChatEmptyState } from "../components/ChatEmptyState";
 import { showToast } from "../components/Toast";
 import { normalizeRouterTierForChatRun, useRedesignChatRun, type ChatRunState, type RealChatRun } from "../hooks/useRedesignChatRun";
+import { buildGraphContextBridgePacket } from "../lib/graphContextBridge";
 import { useMutation, useQuery, useConvexAuth } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { LiveResearchChecklist, type ResearchStage, type ResearchStageId } from "../../research/LiveResearchChecklist";
@@ -297,6 +298,7 @@ function buildChatAgentRailSnapshot(args: {
   const latency = metrics?.timeToFinalMs ?? metrics?.totalLatencyMs ?? run?.totalLatencyMs;
   const memoryHitRate = typeof metrics?.memoryHitRate === "number" ? `${Math.round(metrics.memoryHitRate * 100)}%` : "pending";
   const cacheHitRate = typeof metrics?.sourceCacheHitRate === "number" ? `${Math.round(metrics.sourceCacheHitRate * 100)}%` : "pending";
+  const graphPacket = liveDetail ? buildGraphContextBridgePacket({ detail: liveDetail, mode: "agent" }) : null;
 
   const canRunLive = chatState.available && !skipLiveSeed;
   const authDetail = skipLiveSeed
@@ -328,6 +330,12 @@ function buildChatAgentRailSnapshot(args: {
       label: "Search memory and current reports",
       status: memoryStatus,
       detail: contextCandidates[0]?.detail ?? (liveDetail ? `${liveDetail.title} selected from live Convex memory.` : "Runs before any live source refresh."),
+    },
+    {
+      id: "graph-context",
+      label: "Resolve graph context packet",
+      status: graphPacket ? "done" : isRunning ? "running" : "queued",
+      detail: graphPacket?.agentSummary ?? "Packs first-ring report graph, source refs, and safe action handles.",
     },
     {
       id: "tools",
@@ -388,7 +396,15 @@ function buildChatAgentRailSnapshot(args: {
       id: "cost",
       label: "Cost and cache",
       status: estimatedCost > 0 || metrics ? "done" : "queued",
-      detail: `${formatRailUsd(estimatedCost)} estimated - memory ${memoryHitRate} - source cache ${cacheHitRate}.`,
+      detail: `${formatRailUsd(estimatedCost)} estimated - memory ${memoryHitRate} - source cache ${cacheHitRate}${graphPacket ? ` - graph ${graphPacket.packedNodes} nodes` : ""}.`,
+    },
+    {
+      id: "graph-packet",
+      label: "Graph context bridge",
+      status: graphPacket ? "done" : "queued",
+      detail: graphPacket
+        ? `${graphPacket.contextRef} - human ${graphPacket.humanRank}, agent ${graphPacket.agentRank}, approval ${graphPacket.approvalRequired ? "required" : "not required"}.`
+        : "No selected live report graph yet.",
     },
     {
       id: "writes",
@@ -468,7 +484,13 @@ function buildChatAgentRailSnapshot(args: {
       id: "memory",
       label: "Memory agent",
       status: memoryStatus,
-      detail: contextCandidates[0]?.label ?? "Reports, notebook blocks, prior chats, and sources.",
+      detail: graphPacket?.title ?? contextCandidates[0]?.label ?? "Reports, notebook blocks, prior chats, and sources.",
+    },
+    {
+      id: "graph",
+      label: "Graph context agent",
+      status: graphPacket ? "done" : "queued",
+      detail: graphPacket?.whySelected[2] ?? "Builds bounded neighborhoods before paid live search.",
     },
     {
       id: "source",
@@ -557,6 +579,7 @@ function buildChatAgentRailSnapshot(args: {
     metrics: [
       { label: "sources", value: String(sourceCount), tone: "accent" },
       { label: "tools", value: String(toolCallCount), tone: "green" },
+      { label: "graph", value: graphPacket ? String(graphPacket.packedNodes) : "0", tone: "accent" },
       { label: "cost", value: formatRailUsd(estimatedCost), tone: estimatedCost > 0 ? "amber" : "green" },
     ],
   };

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -2,6 +2,7 @@ import { useState, type KeyboardEvent, type ReactNode } from "react";
 import { showToast } from "../components/Toast";
 import type { LiveArtifactsResult, LiveArtifactSourceRow } from "../hooks/useLiveArtifacts";
 import type { ReportCardData } from "../fixtures";
+import { buildGraphContextBridgePacket } from "../lib/graphContextBridge";
 
 interface HomeV2SurfaceProps {
   onAsk?: (prompt: string) => void;
@@ -1597,6 +1598,20 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
   const claimCount = claimCountForEntity(entity);
   const contextEntityCount = Math.max(3, entity.related.length + 1);
   const selectedSources = `${entity.sources} sources`;
+  const contextPacket = buildGraphContextBridgePacket({
+    report: selectedReport ?? {
+      id: `proto-${entity.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+      entity: entity.name,
+      kind: entity.kind,
+      status: needsReview ? "review" : "verified",
+      description: entity.body,
+      sources: entity.sources,
+      claims: claimCount,
+      followUps: needsReview ? 2 : 0,
+      updatedAt: entity.meta,
+    },
+    mode: "agent",
+  });
   const ask = (prompt: string) => onAsk?.(prompt);
   const sendInput = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== "Enter") return;
@@ -1607,7 +1622,12 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
   };
 
   return (
-    <aside className="rd-pane rd-pane--right right-rail" aria-label="Agent chat">
+    <aside
+      className="rd-pane rd-pane--right right-rail"
+      aria-label="Agent chat"
+      data-agent-context-ref={contextPacket.contextRef}
+      data-agent-context-rank={contextPacket.agentRank}
+    >
       <div className="ar-head">
         <span className="ar-dot" />
         <div className="ar-head-info">
@@ -1670,6 +1690,7 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
               <span className="ar-tool-badge">source_scan</span>
               <span className="ar-tool-badge">claim_verify</span>
               <span className="ar-tool-badge">freshness_check</span>
+              <span className="ar-tool-badge">resolve_report_graph_context</span>
             </div>
           </div>
           <div className="ar-msg-actions">
@@ -1727,6 +1748,18 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
             <span className="ar-drawer-icon">{entity.initial}</span>
             <span className="ar-drawer-name">{entity.name}</span>
             <span className="ar-drawer-status" data-status={status}>{status}</span>
+          </div>
+          <div className="ar-context-packet">
+            <div className="ar-context-packet__head">
+              <span>Graph context packet</span>
+              <b>{contextPacket.agentRank}</b>
+            </div>
+            <p>{contextPacket.agentSummary}</p>
+            <div className="ar-context-packet__grid">
+              <span><strong>{contextPacket.sourceRefs}</strong> sources</span>
+              <span><strong>{contextPacket.claimRefs}</strong> claims</span>
+              <span><strong>{contextPacket.estimatedTokens}</strong> tok</span>
+            </div>
           </div>
           <div className="ar-ctx-row"><span className="ar-ctx-lbl">Evidence</span><span className="ar-ctx-val">{entityEvidenceText(entity)}</span></div>
           <div className="ar-ctx-row"><span className="ar-ctx-lbl">Freshness</span><span className="ar-ctx-val">{entityFreshnessText(entity)}</span></div>

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -1627,6 +1627,8 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
       aria-label="Agent chat"
       data-agent-context-ref={contextPacket.contextRef}
       data-agent-context-rank={contextPacket.agentRank}
+      data-agent-context-attention-score={contextPacket.attentionScore}
+      data-agent-context-promotion={contextPacket.promotionClass}
     >
       <div className="ar-head">
         <span className="ar-dot" />
@@ -1755,11 +1757,26 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
               <b>{contextPacket.agentRank}</b>
             </div>
             <p>{contextPacket.agentSummary}</p>
+            <div className="ar-context-packet__attention" data-promotion={contextPacket.promotionClass}>
+              <span>
+                <strong>{contextPacket.attentionScore}</strong>
+                attention
+              </span>
+              <span>{contextPacket.promotionClass.replace("_", " ")}</span>
+            </div>
             <div className="ar-context-packet__grid">
               <span><strong>{contextPacket.sourceRefs}</strong> sources</span>
               <span><strong>{contextPacket.claimRefs}</strong> claims</span>
               <span><strong>{contextPacket.estimatedTokens}</strong> tok</span>
             </div>
+            <details className="ar-context-packet__why">
+              <summary>Why the agent packed this</summary>
+              <ol>
+                {contextPacket.whySelected.slice(0, 4).map((reason, index) => (
+                  <li key={`${reason}-${index}`}>{reason}</li>
+                ))}
+              </ol>
+            </details>
           </div>
           <div className="ar-ctx-row"><span className="ar-ctx-lbl">Evidence</span><span className="ar-ctx-val">{entityEvidenceText(entity)}</span></div>
           <div className="ar-ctx-row"><span className="ar-ctx-lbl">Freshness</span><span className="ar-ctx-val">{entityFreshnessText(entity)}</span></div>

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -24,6 +24,7 @@ import {
   type ProductDecisionItem,
   sanitizeDecisionText,
 } from "./ProductDecisionQueue";
+import { buildGraphContextBridgePacket } from "../lib/graphContextBridge";
 
 type SortKey = "updated" | "entity" | "sources" | "claims" | "status";
 const SORT_OPTIONS: Array<{ id: SortKey; label: string }> = [
@@ -2762,6 +2763,14 @@ function ReportGraphPreviewD3({
   const activeCoveredChildren = activeNode ? childrenFor(activeNode, "covers") : [];
   const activeCausationRows = activeNode ? relationRowsFor(activeNode, "causes") : [];
   const activeCorrelationRows = activeNode ? relationRowsFor(activeNode, "correlates_with") : [];
+  const activeContextPacket = activeNode
+    ? buildGraphContextBridgePacket({
+        report: activeNode.report ?? graph.root?.report ?? null,
+        detail: activeNode.detail ?? graph.root?.detail ?? null,
+        scope: serverScope,
+        mode: "agent",
+      })
+    : null;
 
   return (
     <section
@@ -2787,6 +2796,9 @@ function ReportGraphPreviewD3({
       data-server-total-candidate-reports={serverScope?.totalCandidateReports ?? ""}
       data-server-returned-report-count={serverScope?.returnedReportCount ?? ""}
       data-server-hidden-report-count={serverScope?.hiddenReportCount ?? ""}
+      data-active-context-ref={activeContextPacket?.contextRef ?? ""}
+      data-active-context-attention-score={activeContextPacket?.attentionScore ?? ""}
+      data-active-context-agent-rank={activeContextPacket?.agentRank ?? ""}
     >
       <div className="rd-v3-graph__controls">
         <button type="button" className="rd-v3-graph__fit" onClick={resetGraph}>Fit</button>
@@ -2878,6 +2890,27 @@ function ReportGraphPreviewD3({
                 <p key={signal}>{signal}</p>
               ))}
             </div>
+            {activeContextPacket && (
+              <div className="rd-v3-graph-peek__context" data-context-ref={activeContextPacket.contextRef}>
+                <div className="rd-v3-graph-peek__context-head">
+                  <span className="rd-v3-graph-peek__section-label">Agent context packet</span>
+                  <b>{activeContextPacket.attentionScore}</b>
+                </div>
+                <p>{activeContextPacket.humanSummary}</p>
+                <div className="rd-v3-graph-peek__context-grid" aria-label="Agent context budget">
+                  <span><strong>{activeContextPacket.packedNodes}</strong> packed</span>
+                  <span><strong>{activeContextPacket.sourceRefs}</strong> sources</span>
+                  <span><strong>{activeContextPacket.claimRefs}</strong> claims</span>
+                  <span><strong>{activeContextPacket.estimatedTokens}</strong> tok</span>
+                </div>
+                <details className="rd-v3-graph-peek__why">
+                  <summary>Why this entered context</summary>
+                  <ol>
+                    {activeContextPacket.whySelected.map((reason) => <li key={reason}>{reason}</li>)}
+                  </ol>
+                </details>
+              </div>
+            )}
             <div className="rd-v3-graph-peek__hierarchy">
               <span className="rd-v3-graph-peek__section-label">Hierarchy</span>
               <div className="rd-v3-graph-peek__crumbs">

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -13,9 +13,11 @@ import { ReportNotebookView } from "../components/ReportNotebookView";
 import { useReportsLive } from "../hooks/useReportsLive";
 import {
   useReportGraphNeighborhood,
+  useReportTopologySnapshot,
   type LiveArtifactDetail,
   type LiveArtifactMapNode,
   type ReportGraphNeighborhoodScope,
+  type ReportTopologySnapshotPacket,
 } from "../hooks/useLiveArtifacts";
 import { showToast } from "../components/Toast";
 import {
@@ -564,6 +566,11 @@ export function ReportsSurface({ onOpen, onRunBatch, onSelectReport, inspectedRe
           details={graphDetails}
           selectedReport={graphSelectedReport}
           serverScope={!useGraphScaleQaData ? graphNeighborhood.scope : null}
+          topologyScope={!useGraphScaleQaData ? {
+            query,
+            stage: filter === "all" ? undefined : filter,
+            kind: kindFilter === "all" ? undefined : kindFilter,
+          } : null}
           scaleMode={graphScaleMode}
           onScaleModeChange={setGraphScaleMode}
           stageOverrides={stageOverrides}
@@ -2405,6 +2412,7 @@ function ReportGraphPreviewD3({
   details,
   selectedReport,
   serverScope,
+  topologyScope,
   scaleMode,
   onScaleModeChange,
   stageOverrides,
@@ -2416,6 +2424,7 @@ function ReportGraphPreviewD3({
   details: LiveArtifactDetail[];
   selectedReport: ReportCardData | null;
   serverScope?: ReportGraphNeighborhoodScope | null;
+  topologyScope?: { query?: string; stage?: string; kind?: string } | null;
   scaleMode: ReportGraphScaleMode;
   onScaleModeChange: (mode: ReportGraphScaleMode) => void;
   stageOverrides: Record<string, ReportStage>;
@@ -2439,10 +2448,31 @@ function ReportGraphPreviewD3({
   );
   const [graphQuery, setGraphQuery] = useState("");
   const [topologyView, setTopologyView] = useState<TopologyViewMode>("density");
-  const topology = useMemo(
+  const localTopology = useMemo(
     () => buildTopologySnapshot(graph.nodes, graph.links, topologyView),
     [graph.nodes, graph.links, topologyView],
   );
+  const serverTopology = useReportTopologySnapshot(
+    {
+      rootId: selectedReport?.id ?? graph.root?.id ?? undefined,
+      query: topologyScope?.query,
+      stage: topologyScope?.stage,
+      kind: topologyScope?.kind,
+      mode: scaleMode,
+      view: topologyView,
+      limit: graph.nodeBudget,
+    },
+    { enabled: Boolean(serverScope?.isServerBounded && graph.nodes.length > 0) },
+  );
+  const topology = useMemo(
+    () => mergeServerTopologySnapshot(localTopology, serverTopology.snapshot, graph.nodes),
+    [graph.nodes, localTopology, serverTopology.snapshot],
+  );
+  const topologySource = serverTopology.snapshot
+    ? serverTopology.snapshot.persisted
+      ? "convex-persisted"
+      : "convex-computed"
+    : "client-fallback";
   const [pinnedNodeId, setPinnedNodeId] = useState<string | null>(null);
   const [tooltip, setTooltip] = useState<{ nodeId: string; x: number; y: number } | null>(null);
   const [peekPosition, setPeekPosition] = useState<{ x: number; y: number } | null>(null);
@@ -2936,6 +2966,8 @@ function ReportGraphPreviewD3({
       data-topology-hot-node={topology.summary.hotNodeId ?? ""}
       data-topology-centroid-node={topology.summary.centroidNodeId ?? ""}
       data-topology-outlier-node={topology.summary.outlierNodeId ?? ""}
+      data-topology-source={topologySource}
+      data-topology-persisted={serverTopology.snapshot?.persisted ? "true" : "false"}
       data-artifact-node-count={graph.artifactNodeCount}
       data-artifact-edge-count={graph.artifactEdgeCount}
       data-total-report-count={graph.totalReportCount}
@@ -3020,6 +3052,7 @@ function ReportGraphPreviewD3({
         <strong>{topology.view === "density" ? "Attention density" : topology.view === "pca" ? "PCA axes" : "Center vs edge"}</strong>
         <span>{topology.summary.viewRationale}</span>
         <span>{topology.summary.clusterCount} mapper clusters</span>
+        <span>{serverTopology.sourceLabel}</span>
         <span>PC1: {topology.pcaAxes.pc1.map((axis) => axis.label).join(" / ")}</span>
         <span>PC2: {topology.pcaAxes.pc2.map((axis) => axis.label).join(" / ")}</span>
       </div>
@@ -3254,6 +3287,7 @@ function ReportGraphPreviewD3({
         {serverScope?.isServerBounded
           ? ` - server query returned ${serverScope.returnedReportCount}/${serverScope.totalCandidateReports} candidate reports from ${serverScope.scannedArchivePosts}/${serverScope.scanLimit} scanned archive rows`
           : ""}
+        {` - topology ${topologySource}`}
       </p>
     </section>
   );
@@ -3271,6 +3305,37 @@ function topologySummaryForNode(
     return `${node.label} projects to PC1 ${projection.pc1.toFixed(2)} / PC2 ${projection.pc2.toFixed(2)} along the dominant feature axes.`;
   }
   return `${node.label} is ${projection.outlierScore >= 70 ? "an edge/outlier node" : "nearer the typical center"} with centroid distance ${projection.centroidDistance.toFixed(2)}.`;
+}
+
+function mergeServerTopologySnapshot(
+  localTopology: TopologySnapshot,
+  serverSnapshot: ReportTopologySnapshotPacket | null,
+  graphNodes: ReportGraphNode[],
+): TopologySnapshot {
+  if (!serverSnapshot || graphNodes.length === 0) return localTopology;
+  const serverCoverage = graphNodes.filter((node) => serverSnapshot.nodesById[node.id]).length;
+  if (serverCoverage < Math.max(1, Math.ceil(graphNodes.length * 0.35))) return localTopology;
+  const nodesById: TopologySnapshot["nodesById"] = { ...localTopology.nodesById };
+  for (const node of serverSnapshot.nodes) {
+    if (!nodesById[node.id]) continue;
+    nodesById[node.id] = node;
+  }
+  const nodes = graphNodes
+    .map((node) => nodesById[node.id])
+    .filter((node): node is TopologyNodeProjection => Boolean(node));
+  return {
+    view: serverSnapshot.view,
+    nodes,
+    nodesById,
+    mapperClusters: serverSnapshot.mapperClusters,
+    mapperEdges: serverSnapshot.mapperEdges,
+    summary: {
+      ...serverSnapshot.summary,
+      nodeCount: localTopology.summary.nodeCount,
+      edgeCount: localTopology.summary.edgeCount,
+    },
+    pcaAxes: serverSnapshot.pcaAxes,
+  };
 }
 
 function ReportsLiveEmptyState() {

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -25,6 +25,12 @@ import {
   sanitizeDecisionText,
 } from "./ProductDecisionQueue";
 import { buildGraphContextBridgePacket } from "../lib/graphContextBridge";
+import {
+  buildTopologySnapshot,
+  type TopologyNodeProjection,
+  type TopologySnapshot,
+  type TopologyViewMode,
+} from "../lib/reportTopology";
 
 type SortKey = "updated" | "entity" | "sources" | "claims" | "status";
 const SORT_OPTIONS: Array<{ id: SortKey; label: string }> = [
@@ -159,6 +165,12 @@ const REPORT_GRAPH_SCALE_MODES: Array<{ id: ReportGraphScaleMode; label: string;
   { id: "focus", label: "Focus", hint: "Root report, closest neighbors, and core evidence only" },
   { id: "clustered", label: "Cluster", hint: "Bounded neighborhood plus overflow groups" },
   { id: "expanded", label: "Expand", hint: "Wider neighborhood, still capped for browser performance" },
+];
+
+const REPORT_TOPOLOGY_VIEW_MODES: Array<{ id: TopologyViewMode; label: string; hint: string }> = [
+  { id: "density", label: "Density", hint: "Where human and agent attention keeps gravitating" },
+  { id: "pca", label: "PCA", hint: "Dominant axes of variation across report graph features" },
+  { id: "centroid", label: "Centroid", hint: "Typical center versus outlier edge cases" },
 ];
 
 function reportViewFromUrl(): ReportViewMode {
@@ -2411,7 +2423,7 @@ function ReportGraphPreviewD3({
   onSelect?: (report: ReportCardData) => void;
   onRunBatch?: ReportsSurfaceProps["onRunBatch"];
 }) {
-  type D3GraphNode = ReportGraphNode & d3.SimulationNodeDatum;
+  type D3GraphNode = ReportGraphNode & d3.SimulationNodeDatum & { topologyProjection?: TopologyNodeProjection };
   type D3GraphLink = Omit<ReportGraphLink, "source" | "target"> & {
     source: string | D3GraphNode;
     target: string | D3GraphNode;
@@ -2426,6 +2438,11 @@ function ReportGraphPreviewD3({
     [reports, details, selectedReport, stageOverrides, scaleMode],
   );
   const [graphQuery, setGraphQuery] = useState("");
+  const [topologyView, setTopologyView] = useState<TopologyViewMode>("density");
+  const topology = useMemo(
+    () => buildTopologySnapshot(graph.nodes, graph.links, topologyView),
+    [graph.nodes, graph.links, topologyView],
+  );
   const [pinnedNodeId, setPinnedNodeId] = useState<string | null>(null);
   const [tooltip, setTooltip] = useState<{ nodeId: string; x: number; y: number } | null>(null);
   const [peekPosition, setPeekPosition] = useState<{ x: number; y: number } | null>(null);
@@ -2534,7 +2551,17 @@ function ReportGraphPreviewD3({
     const width = Math.max(560, Math.round(rect.width || 720));
     const visibleHeight = Math.max(420, Math.min(620, Math.round(window.innerHeight - rect.top - 24)));
     const height = Math.max(420, visibleHeight);
-    const nodes: D3GraphNode[] = graph.nodes.map((node) => ({ ...node, x: node.x, y: node.y }));
+    const projectX = (x: number) => 70 + x * Math.max(220, width - 140);
+    const projectY = (y: number) => 58 + y * Math.max(260, visibleHeight - 116);
+    const nodes: D3GraphNode[] = graph.nodes.map((node) => {
+      const topologyProjection = topology.nodesById[node.id];
+      return {
+        ...node,
+        topologyProjection,
+        x: topologyProjection ? projectX(topologyProjection.x) : node.x,
+        y: topologyProjection ? projectY(topologyProjection.y) : node.y,
+      };
+    });
     const nodeIds = new Set(nodes.map((node) => node.id));
     const links: D3GraphLink[] = graph.links
       .filter((link) => nodeIds.has(link.source) && nodeIds.has(link.target))
@@ -2634,10 +2661,23 @@ function ReportGraphPreviewD3({
       }))
       .force("charge", d3.forceManyBody<D3GraphNode>().strength(-420))
       .force("center", d3.forceCenter(width / 2, visibleHeight * 0.45))
-      .force("x", d3.forceX<D3GraphNode>(width / 2).strength(0.04))
-      .force("y", d3.forceY<D3GraphNode>(visibleHeight * 0.45).strength(0.06))
+      .force("x", d3.forceX<D3GraphNode>((node) => node.topologyProjection ? projectX(node.topologyProjection.x) : width / 2).strength(0.16))
+      .force("y", d3.forceY<D3GraphNode>((node) => node.topologyProjection ? projectY(node.topologyProjection.y) : visibleHeight * 0.45).strength(0.18))
       .force("collide", d3.forceCollide<D3GraphNode>().radius((node) => radiusFor(node) + 20))
       .alphaDecay(0.018);
+
+    const clusterEl = g.append("g")
+      .attr("class", "rd-v3-graph-mapper-layer")
+      .selectAll<SVGCircleElement, TopologySnapshot["mapperClusters"][number]>("circle")
+      .data(topology.mapperClusters.filter((cluster) => cluster.memberIds.length > 1).slice(0, 32))
+      .join("circle")
+      .attr("class", "rd-v3-graph-mapper-cluster")
+      .attr("cx", (cluster) => projectX(cluster.x))
+      .attr("cy", (cluster) => projectY(cluster.y))
+      .attr("r", (cluster) => 22 + Math.min(34, cluster.memberIds.length * 4))
+      .attr("data-density-score", (cluster) => cluster.densityScore)
+      .attr("data-attention-score", (cluster) => cluster.attentionScore)
+      .attr("opacity", topology.view === "density" ? 0.2 : 0.12);
 
     const linkEl = g.append("g").selectAll<SVGLineElement, D3GraphLink>("line").data(links).join("line")
       .attr("stroke", (link) => edgeStyle[link.type]?.stroke ?? "var(--rd-ink-faint)")
@@ -2660,6 +2700,9 @@ function ReportGraphPreviewD3({
       .attr("data-stage", (node) => node.stage)
       .attr("data-attention-tier", (node) => node.attentionTier)
       .attr("data-attention-score", (node) => node.attentionScore)
+      .attr("data-topology-density", (node) => node.topologyProjection?.densityScore ?? "")
+      .attr("data-topology-outlier", (node) => node.topologyProjection?.outlierScore ?? "")
+      .attr("data-topology-clusters", (node) => node.topologyProjection?.mapperClusterIds.join(" ") ?? "")
       .attr("tabindex", 0)
       .attr("role", "button")
       .attr("aria-label", (node) => `${node.label}, ${node.type}, ${node.verified}, attention ${node.attentionScore}, ${node.reasonSelected}`)
@@ -2811,6 +2854,15 @@ function ReportGraphPreviewD3({
       edgeLabelEl
         .attr("x", (link) => (((link.source as D3GraphNode).x ?? 0) + ((link.target as D3GraphNode).x ?? 0)) / 2)
         .attr("y", (link) => (((link.source as D3GraphNode).y ?? 0) + ((link.target as D3GraphNode).y ?? 0)) / 2);
+      clusterEl
+        .attr("cx", (cluster) => {
+          const memberNodes = cluster.memberIds.map((id) => nodeById.get(id)).filter((node): node is D3GraphNode => Boolean(node));
+          return memberNodes.length ? memberNodes.reduce((sum, node) => sum + (node.x ?? 0), 0) / memberNodes.length : projectX(cluster.x);
+        })
+        .attr("cy", (cluster) => {
+          const memberNodes = cluster.memberIds.map((id) => nodeById.get(id)).filter((node): node is D3GraphNode => Boolean(node));
+          return memberNodes.length ? memberNodes.reduce((sum, node) => sum + (node.y ?? 0), 0) / memberNodes.length : projectY(cluster.y);
+        });
       nodeEl.attr("transform", (node) => `translate(${node.x ?? 0},${node.y ?? 0})`);
     });
 
@@ -2821,7 +2873,7 @@ function ReportGraphPreviewD3({
       svg.on(".zoom", null);
       svg.on("click", null);
     };
-  }, [graph, normalizedGraphQuery, onSelect]);
+  }, [graph, normalizedGraphQuery, onSelect, topology]);
 
   const resetGraph = () => {
     pinnedNodeIdRef.current = null;
@@ -2845,12 +2897,30 @@ function ReportGraphPreviewD3({
   const activeCoveredChildren = activeNode ? childrenFor(activeNode, "covers") : [];
   const activeCausationRows = activeNode ? relationRowsFor(activeNode, "causes") : [];
   const activeCorrelationRows = activeNode ? relationRowsFor(activeNode, "correlates_with") : [];
+  const activeTopology = activeNode ? topology.nodesById[activeNode.id] : null;
+  const activeMapperClusters = activeTopology
+    ? activeTopology.mapperClusterIds
+      .map((clusterId) => topology.mapperClusters.find((cluster) => cluster.id === clusterId))
+      .filter((cluster): cluster is TopologySnapshot["mapperClusters"][number] => Boolean(cluster))
+    : [];
   const activeContextPacket = activeNode
     ? buildGraphContextBridgePacket({
         report: activeNode.report ?? graph.root?.report ?? null,
         detail: activeNode.detail ?? graph.root?.detail ?? null,
         scope: serverScope,
         mode: "agent",
+        topology: activeTopology
+          ? {
+              view: topology.view,
+              mapperClusterIds: activeTopology.mapperClusterIds,
+              densityScore: activeTopology.densityScore,
+              pc1: activeTopology.pc1,
+              pc2: activeTopology.pc2,
+              centroidDistance: activeTopology.centroidDistance,
+              outlierScore: activeTopology.outlierScore,
+              summary: topologySummaryForNode(activeNode, activeTopology, topology),
+            }
+          : null,
       })
     : null;
 
@@ -2861,6 +2931,11 @@ function ReportGraphPreviewD3({
       data-graph-source={graph.sourceLabel}
       data-node-count={graph.nodes.length}
       data-edge-count={graph.links.length}
+      data-topology-view={topology.view}
+      data-topology-cluster-count={topology.summary.clusterCount}
+      data-topology-hot-node={topology.summary.hotNodeId ?? ""}
+      data-topology-centroid-node={topology.summary.centroidNodeId ?? ""}
+      data-topology-outlier-node={topology.summary.outlierNodeId ?? ""}
       data-artifact-node-count={graph.artifactNodeCount}
       data-artifact-edge-count={graph.artifactEdgeCount}
       data-total-report-count={graph.totalReportCount}
@@ -2903,6 +2978,25 @@ function ReportGraphPreviewD3({
             </button>
           ))}
         </span>
+        <span className="rd-v3-graph__topology" role="group" aria-label="Topology view">
+          {REPORT_TOPOLOGY_VIEW_MODES.map((mode) => (
+            <button
+              key={mode.id}
+              type="button"
+              aria-pressed={topologyView === mode.id}
+              title={mode.hint}
+              onClick={() => {
+                setTopologyView(mode.id);
+                pinnedNodeIdRef.current = null;
+                setPinnedNodeId(null);
+                setTooltip(null);
+                setPeekPosition(null);
+              }}
+            >
+              {mode.label}
+            </button>
+          ))}
+        </span>
         <label className="rd-v3-graph__search">
           <span aria-hidden="true">⌕</span>
           <input value={graphQuery} onChange={(event) => setGraphQuery(event.target.value)} placeholder="Search graph..." aria-label="Search graph nodes" />
@@ -2921,6 +3015,13 @@ function ReportGraphPreviewD3({
           <span><i data-edge="correlates_with" />Correlates</span>
           <span><i data-edge="cluster" />Cluster</span>
         </span>
+      </div>
+      <div className="rd-v3-graph__topology-summary" data-view={topology.view}>
+        <strong>{topology.view === "density" ? "Attention density" : topology.view === "pca" ? "PCA axes" : "Center vs edge"}</strong>
+        <span>{topology.summary.viewRationale}</span>
+        <span>{topology.summary.clusterCount} mapper clusters</span>
+        <span>PC1: {topology.pcaAxes.pc1.map((axis) => axis.label).join(" / ")}</span>
+        <span>PC2: {topology.pcaAxes.pc2.map((axis) => axis.label).join(" / ")}</span>
       </div>
       <div className="rd-v3-graph__canvas" ref={containerRef}>
         <svg ref={svgRef} className="rd-v3-graph-svg" role="img" aria-label={`Force-directed report graph for ${graph.root?.label ?? "the active universe"}`} />
@@ -2980,6 +3081,28 @@ function ReportGraphPreviewD3({
               <b>{activeNode.attentionScore}</b>
               <small>{activeNode.attentionTier.replace("_", " ")}</small>
             </div>
+            {activeTopology && (
+              <div className="rd-v3-graph-peek__topology" data-topology-view={topology.view}>
+                <div className="rd-v3-graph-peek__context-head">
+                  <span className="rd-v3-graph-peek__section-label">
+                    {topology.view === "density" ? "Density" : topology.view === "pca" ? "PCA" : "Centroid"}
+                  </span>
+                  <b>{topology.view === "centroid" ? activeTopology.outlierScore : activeTopology.densityScore}</b>
+                </div>
+                <p>{topologySummaryForNode(activeNode, activeTopology, topology)}</p>
+                <div className="rd-v3-graph-peek__context-grid" aria-label="Topology metrics">
+                  <span><strong>{activeTopology.densityScore}</strong> density</span>
+                  <span><strong>{activeTopology.pc1.toFixed(2)}</strong> PC1</span>
+                  <span><strong>{activeTopology.pc2.toFixed(2)}</strong> PC2</span>
+                  <span><strong>{activeTopology.outlierScore}</strong> edge</span>
+                </div>
+                {activeMapperClusters.length > 0 && (
+                  <small>
+                    Mapper: {activeMapperClusters.slice(0, 2).map((cluster) => `${cluster.label} (${cluster.memberIds.length})`).join(", ")}
+                  </small>
+                )}
+              </div>
+            )}
             {activeContextPacket && (
               <div className="rd-v3-graph-peek__context" data-context-ref={activeContextPacket.contextRef}>
                 <div className="rd-v3-graph-peek__context-head">
@@ -3135,6 +3258,21 @@ function ReportGraphPreviewD3({
     </section>
   );
 }
+
+function topologySummaryForNode(
+  node: ReportGraphNode,
+  projection: TopologyNodeProjection,
+  topology: TopologySnapshot,
+): string {
+  if (topology.view === "density") {
+    return `${node.label} sits in density score ${projection.densityScore}, showing where attention keeps gravitating.`;
+  }
+  if (topology.view === "pca") {
+    return `${node.label} projects to PC1 ${projection.pc1.toFixed(2)} / PC2 ${projection.pc2.toFixed(2)} along the dominant feature axes.`;
+  }
+  return `${node.label} is ${projection.outlierScore >= 70 ? "an edge/outlier node" : "nearer the typical center"} with centroid distance ${projection.centroidDistance.toFixed(2)}.`;
+}
+
 function ReportsLiveEmptyState() {
   return (
     <section className="rd-universe">

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -939,6 +939,9 @@ type ReportGraphNode = {
   verified: string;
   coverage: string[];
   signals: string[];
+  attentionScore: number;
+  reasonSelected: string;
+  attentionTier: "promoted" | "shelf" | "searchable" | "agent_only";
 };
 
 type ReportGraphLink = {
@@ -963,6 +966,11 @@ type ReportGraphLink = {
   label: string;
   basis?: string;
   strength?: number;
+  confidence?: number;
+  sourceRefs?: number;
+  claimRefs?: number;
+  timeWindow?: string;
+  directionNote?: string;
 };
 
 type ReportGraphData = {
@@ -1220,6 +1228,38 @@ function sharedSourceRows(a?: LiveArtifactDetail, b?: LiveArtifactDetail): strin
     .slice(0, 2);
 }
 
+function defaultGraphAttention(node: Omit<ReportGraphNode, "attentionScore" | "reasonSelected" | "attentionTier">): Pick<ReportGraphNode, "attentionScore" | "reasonSelected" | "attentionTier"> {
+  const sourceCount = Number(node.sources.match(/\d+/)?.[0] ?? 0);
+  const evidenceScore = Math.min(38, sourceCount * 3);
+  const stageScore =
+    node.stage === "verified" ? 24 :
+    node.stage === "review" || node.stage === "stale" ? 18 :
+    node.stage === "drafting" ? 12 :
+    14;
+  const provenanceScore =
+    node.provenance === "artifact" ? 20 :
+    node.provenance === "report" ? 18 :
+    node.provenance === "portfolio" ? 16 :
+    node.provenance === "entity" ? 14 :
+    node.provenance === "cluster" ? 10 :
+    8;
+  const actionScore = node.signals.length > 0 ? 12 : 4;
+  const attentionScore = Math.max(0, Math.min(100, Math.round(18 + evidenceScore + stageScore + provenanceScore + actionScore - Math.min(16, node.staleHours / 12))));
+  const attentionTier =
+    attentionScore >= 78 ? "promoted" :
+    attentionScore >= 62 ? "shelf" :
+    attentionScore >= 42 ? "searchable" :
+    "agent_only";
+  const reasonSelected =
+    node.provenance === "artifact" ? "Generated artifact can become report work, evidence review, or chat context." :
+    node.provenance === "report" ? "Report notebook is the durable artifact for this graph node." :
+    node.provenance === "portfolio" ? "Portfolio node summarizes cross-entity movement and review order." :
+    node.provenance === "cluster" ? "Cluster keeps low-priority report volume searchable without creating a node cloud." :
+    node.stage === "review" || node.stage === "stale" ? "Needs review or freshness work before the agent can safely patch outputs." :
+    "Promoted from source, claim, freshness, and graph-context signals.";
+  return { attentionScore, reasonSelected, attentionTier };
+}
+
 function buildReportGraph(
   reports: ReportCardData[],
   details: LiveArtifactDetail[],
@@ -1268,10 +1308,16 @@ function buildReportGraph(
   const nodeIds = new Set<string>();
   const artifactNodeIds: string[] = [];
   const liveArtifactNodeIds = new Map<string, string>();
-  const addNode = (node: ReportGraphNode) => {
+  const addNode = (node: Omit<ReportGraphNode, "attentionScore" | "reasonSelected" | "attentionTier"> & Partial<Pick<ReportGraphNode, "attentionScore" | "reasonSelected" | "attentionTier">>) => {
     if (nodeIds.has(node.id)) return;
+    const attention = defaultGraphAttention(node);
     nodeIds.add(node.id);
-    nodes.push(node);
+    nodes.push({
+      ...node,
+      attentionScore: node.attentionScore ?? attention.attentionScore,
+      reasonSelected: node.reasonSelected ?? attention.reasonSelected,
+      attentionTier: node.attentionTier ?? attention.attentionTier,
+    });
   };
 
   visible.forEach((report, index) => {
@@ -1532,8 +1578,42 @@ function buildReportGraph(
   const pushLink = (link: ReportGraphLink) => {
     const key = `${link.source}->${link.target}:${link.type}:${link.label}`;
     if (link.source === link.target || linkKeys.has(key)) return;
+    const sourceNode = nodes.find((node) => node.id === link.source);
+    const targetNode = nodes.find((node) => node.id === link.target);
+    const sourceRefs =
+      link.sourceRefs ??
+      sourceNode?.detail?.sourceRows.length ??
+      targetNode?.detail?.sourceRows.length ??
+      Number(sourceNode?.sources.match(/\d+/)?.[0] ?? targetNode?.sources.match(/\d+/)?.[0] ?? 0);
+    const claimRefs =
+      link.claimRefs ??
+      sourceNode?.detail?.claimCount ??
+      targetNode?.detail?.claimCount ??
+      Number(sourceNode?.verified.match(/\d+/)?.[0] ?? targetNode?.verified.match(/\d+/)?.[0] ?? 0);
+    const relationStrength =
+      link.strength ??
+      (link.type === "causes" ? 0.72 :
+        link.type === "correlates_with" ? 0.64 :
+        link.type === "has_report" || link.type === "has_artifact" ? 0.82 :
+        link.type === "covers" ? 0.68 :
+        0.55);
+    const confidence =
+      link.confidence ??
+      Math.max(0.35, Math.min(0.96, relationStrength + Math.min(0.14, sourceRefs * 0.015) + Math.min(0.08, claimRefs * 0.01)));
     linkKeys.add(key);
-    links.push(link);
+    links.push({
+      sourceRefs,
+      claimRefs,
+      strength: relationStrength,
+      confidence,
+      timeWindow: link.timeWindow ?? sourceNode?.freshness ?? targetNode?.freshness,
+      directionNote: link.directionNote ?? (
+        link.type === "causes" ? "Directional relation: source artifact changes downstream action order." :
+        link.type === "correlates_with" ? "Associative relation: shared timing, entities, or source overlap." :
+        undefined
+      ),
+      ...link,
+    });
   };
 
   visible.forEach((report) => {
@@ -1790,7 +1870,7 @@ function ReportCardV3({
       <p className="rd-v3-card__kind">{report.kind}</p>
       <p className="rd-v3-card__thesis v3-thesis">{displayReportDescription(report.description)}</p>
       <div className="rd-v3-signals v3-signals">
-        {signals.map((signal, index) => <span className="v3-signal" data-color={signalColor(index)} key={signal}>{signal}</span>)}
+        {signals.map((signal, index) => <span className="v3-signal" data-color={signalColor(index)} key={`${signal}-${index}`}>{signal}</span>)}
       </div>
       <div className="rd-v3-sources v3-sources">
         <span className="v3-src">{evidenceText(report, stage)}</span>
@@ -1799,7 +1879,7 @@ function ReportCardV3({
       </div>
       {backlinks.length > 0 && (
         <div className="rd-v3-backlinks v3-backlinks">
-          {backlinks.map((item) => <span key={item}>→ {item}</span>)}
+          {backlinks.map((item, index) => <span key={`${item}-${index}`}>→ {item}</span>)}
         </div>
       )}
       </div>
@@ -2276,13 +2356,13 @@ function ReportGraphPreview({
             <div>
               <dt>Coverage</dt>
               <dd className="rd-v3-graph-peek__tags">
-                {(activeNode?.coverage ?? ["reports"]).map((tag) => <span key={tag}>{tag}</span>)}
+                {(activeNode?.coverage ?? ["reports"]).map((tag, index) => <span key={`${tag}-${index}`}>{tag}</span>)}
               </dd>
             </div>
           </dl>
           <ul>
-            {(activeNode?.signals ?? ["Select a report node to inspect the relationship context."]).slice(0, 3).map((signal) => (
-              <li key={signal}>{signal}</li>
+            {(activeNode?.signals ?? ["Select a report node to inspect the relationship context."]).slice(0, 3).map((signal, index) => (
+              <li key={`${signal}-${index}`}>{signal}</li>
             ))}
           </ul>
           <div className="rd-v3-graph-peek__actions">
@@ -2578,9 +2658,11 @@ function ReportGraphPreviewD3({
       .attr("class", "rd-v3-graph-node")
       .attr("data-graph-type", (node) => node.graphType)
       .attr("data-stage", (node) => node.stage)
+      .attr("data-attention-tier", (node) => node.attentionTier)
+      .attr("data-attention-score", (node) => node.attentionScore)
       .attr("tabindex", 0)
       .attr("role", "button")
-      .attr("aria-label", (node) => `${node.label}, ${node.type}, ${node.verified}`)
+      .attr("aria-label", (node) => `${node.label}, ${node.type}, ${node.verified}, attention ${node.attentionScore}, ${node.reasonSelected}`)
       .style("cursor", "pointer");
 
     nodeEl.append("circle")
@@ -2881,14 +2963,22 @@ function ReportGraphPreviewD3({
               <div>
                 <dt>Coverage</dt>
                 <dd className="rd-v3-graph-peek__tags">
-                  {(activeNode.coverage.length > 0 ? activeNode.coverage : ["reports"]).map((tag) => <span key={tag}>{tag}</span>)}
+                  {(activeNode.coverage.length > 0 ? activeNode.coverage : ["reports"]).map((tag, index) => <span key={`${tag}-${index}`}>{tag}</span>)}
                 </dd>
               </div>
             </dl>
             <div className="rd-v3-graph-peek__signals">
-              {(activeNode.signals.length > 0 ? activeNode.signals : ["Select a report node to inspect the relationship context."]).slice(0, 3).map((signal) => (
-                <p key={signal}>{signal}</p>
+              {(activeNode.signals.length > 0 ? activeNode.signals : ["Select a report node to inspect the relationship context."]).slice(0, 3).map((signal, index) => (
+                <p key={`${signal}-${index}`}>{signal}</p>
               ))}
+            </div>
+            <div className="rd-v3-graph-peek__attention" data-attention-tier={activeNode.attentionTier}>
+              <div>
+                <span className="rd-v3-graph-peek__section-label">Attention</span>
+                <p>{activeNode.reasonSelected}</p>
+              </div>
+              <b>{activeNode.attentionScore}</b>
+              <small>{activeNode.attentionTier.replace("_", " ")}</small>
             </div>
             {activeContextPacket && (
               <div className="rd-v3-graph-peek__context" data-context-ref={activeContextPacket.contextRef}>
@@ -2906,7 +2996,7 @@ function ReportGraphPreviewD3({
                 <details className="rd-v3-graph-peek__why">
                   <summary>Why this entered context</summary>
                   <ol>
-                    {activeContextPacket.whySelected.map((reason) => <li key={reason}>{reason}</li>)}
+                    {activeContextPacket.whySelected.map((reason, index) => <li key={`${reason}-${index}`}>{reason}</li>)}
                   </ol>
                 </details>
               </div>
@@ -2969,6 +3059,14 @@ function ReportGraphPreviewD3({
                         <strong>{verb}</strong>
                         <span>{node.label}</span>
                         {link.basis && <small>{link.basis}</small>}
+                        <em className="rd-v3-graph-peek__relation-meta">
+                          {Math.round((link.confidence ?? 0) * 100)}% confidence
+                          {" - "}
+                          {Math.round((link.strength ?? 0) * 100)} strength
+                          {" - "}
+                          {link.sourceRefs ?? 0} sources / {link.claimRefs ?? 0} claims
+                          {link.timeWindow ? ` - ${link.timeWindow}` : ""}
+                        </em>
                       </button>
                     ))}
                   </div>
@@ -2981,6 +3079,14 @@ function ReportGraphPreviewD3({
                         <strong>{verb}</strong>
                         <span>{node.label}</span>
                         {link.basis && <small>{link.basis}</small>}
+                        <em className="rd-v3-graph-peek__relation-meta">
+                          {Math.round((link.confidence ?? 0) * 100)}% confidence
+                          {" - "}
+                          {Math.round((link.strength ?? 0) * 100)} strength
+                          {" - "}
+                          {link.sourceRefs ?? 0} sources / {link.claimRefs ?? 0} claims
+                          {link.timeWindow ? ` - ${link.timeWindow}` : ""}
+                        </em>
                       </button>
                     ))}
                   </div>


### PR DESCRIPTION
## Summary
- add Convex-backed report topology snapshots for density, PCA, and centroid graph views
- wire Reports graph to consume persisted topology when available with safe client fallback
- expose topology inspection through the MCP gateway and local MCP toolset
- document the human-agent graph topology runtime contract

## Verification
- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
- npx vitest run convex/domains/redesign/reportTopologyRuntime.test.ts src/features/redesign/lib/reportTopology.test.ts src/features/redesign/lib/graphContextBridge.test.ts
- npm --prefix packages/mcp-local test
- npm run build
- Browser QA: http://127.0.0.1:5231/redesign/reports?view=graph&qa=topology-runtime renders graph, switches Density/PCA/Centroid, no console errors