### PR TITLE
feat(redesign): wire home v3 context runtime

### DIFF
--- a/convex/domains/redesign/chatRuns.ts
+++ b/convex/domains/redesign/chatRuns.ts
@@ -73,6 +73,55 @@ type PlannerArtifact = {
   costUsd?: number;
 };
 
+type ContextRefDescription = {
+  hasContext: boolean;
+  raw: string | null;
+  reportId: string | null;
+  artifactKey: string | null;
+  kind: "graph_packet" | "report" | "none";
+  label: string;
+};
+
+type RuntimeSourceRef = {
+  title: string;
+  url?: string;
+  source?: string;
+  publishedAt?: string;
+  excerpt?: string;
+};
+
+type RuntimeContextPacket = {
+  hasContext: boolean;
+  contextRef: string | null;
+  contextKind: "graph_packet" | "report" | "none";
+  reportId: string | null;
+  artifactKey: string | null;
+  title: string;
+  summary: string;
+  selectedContext: string[];
+  rejectedContext: string[];
+  sourceRefs: RuntimeSourceRef[];
+  graph: {
+    mode: "bounded_packet";
+    nodeCount: number;
+    edgeCount: number;
+    clusters: Array<{ name: "used" | "changed" | "needs_review" | "blocked"; count: number; sample: string[] }>;
+  };
+  notebook: {
+    sectionTitles: string[];
+    htmlPreview?: string;
+  };
+  verification: {
+    tier: "deterministic" | "retrieval" | "judge_required";
+    decisions: string[];
+  };
+  telemetry: {
+    memoryHit: boolean;
+    sourceCacheHit: boolean;
+    candidateCount: number;
+  };
+};
+
 // ───────── Constants ─────────
 
 const MAX_PROMPT_CHARS = 4_000;
@@ -255,6 +304,307 @@ function classifyPrompt(prompt: string): { kind: string; entity?: string } {
   return { kind: "general" };
 }
 
+function describeContextRef(contextRef?: string): ContextRefDescription {
+  if (!contextRef) {
+    return {
+      hasContext: false,
+      raw: null,
+      reportId: null,
+      artifactKey: null,
+      kind: "none",
+      label: "No active context",
+    };
+  }
+  if (contextRef.startsWith("graphctx:")) {
+    const body = contextRef.slice("graphctx:".length);
+    const artifactMarker = "::artifact:";
+    const artifactIndex = body.indexOf(artifactMarker);
+    const rawReportId = artifactIndex >= 0 ? body.slice(0, artifactIndex) : body;
+    const rawArtifactKey = artifactIndex >= 0 ? body.slice(artifactIndex + artifactMarker.length) : null;
+    let artifactKey: string | null = rawArtifactKey;
+    if (rawArtifactKey) {
+      try {
+        artifactKey = decodeURIComponent(rawArtifactKey);
+      } catch {
+        artifactKey = rawArtifactKey;
+      }
+    }
+    return {
+      hasContext: true,
+      raw: contextRef,
+      reportId: rawReportId || null,
+      artifactKey,
+      kind: "graph_packet",
+      label: `Graph context packet ${rawReportId}${artifactKey ? ` / ${artifactKey}` : ""}`,
+    };
+  }
+  return {
+    hasContext: true,
+    raw: contextRef,
+    reportId: contextRef,
+    artifactKey: null,
+    kind: "report",
+    label: `Active report ${contextRef}`,
+  };
+}
+
+function asRecord(value: unknown): Record<string, any> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, any> : null;
+}
+
+function normalizeForContext(value: unknown): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function firstMeaningfulLine(value: unknown): string {
+  const text = String(value ?? "");
+  return text
+    .split(/\r?\n/)
+    .map((line) => normalizeForContext(line.replace(/^#+\s*/, "").replace(/^[-*]\s*/, "")))
+    .find(Boolean) ?? "";
+}
+
+function recordArray(value: unknown): Array<Record<string, any>> {
+  return Array.isArray(value) ? value.flatMap((item) => {
+    const record = asRecord(item);
+    return record ? [record] : [];
+  }) : [];
+}
+
+function collectRuntimeSourceRefs(value: unknown, max = 12): RuntimeSourceRef[] {
+  const refs: RuntimeSourceRef[] = [];
+  const seen = new Set<string>();
+  const visit = (item: unknown) => {
+    if (refs.length >= max || item == null) return;
+    if (Array.isArray(item)) {
+      for (const child of item) visit(child);
+      return;
+    }
+    const record = asRecord(item);
+    if (!record) return;
+    const url = typeof record.url === "string"
+      ? record.url
+      : typeof record.href === "string"
+        ? record.href
+        : undefined;
+    const title = normalizeForContext(record.title ?? record.headline ?? record.source ?? record.sourceDomain ?? "");
+    const source = normalizeForContext(record.source ?? record.sourceDomain ?? record.domain ?? "");
+    if (url || title || source) {
+      const key = normalizeForContext(url ?? `${title}|${source}`).toLowerCase();
+      if (key && !seen.has(key)) {
+        seen.add(key);
+        refs.push({
+          title: clipText(title || source || url || "Source reference", 120),
+          url,
+          source: source || undefined,
+          publishedAt: typeof record.publishedAt === "string"
+            ? record.publishedAt
+            : typeof record.publishedAtIso === "string"
+              ? record.publishedAtIso
+              : undefined,
+          excerpt: normalizeForContext(record.relevance ?? record.excerpt ?? record.snippet ?? record.summary ?? "").slice(0, 220) || undefined,
+        });
+      }
+      return;
+    }
+    for (const child of Object.values(record)) visit(child);
+  };
+  visit(value);
+  return refs;
+}
+
+function emptyRuntimeContextPacket(context: ContextRefDescription): RuntimeContextPacket {
+  return {
+    hasContext: context.hasContext,
+    contextRef: context.raw,
+    contextKind: context.kind,
+    reportId: context.reportId,
+    artifactKey: context.artifactKey,
+    title: context.label,
+    summary: context.hasContext
+      ? "Context reference was supplied but no matching Convex record was resolved."
+      : "No selected report, entity, or graph packet was attached.",
+    selectedContext: [],
+    rejectedContext: context.hasContext ? ["No canonical Convex record matched the supplied context reference."] : [],
+    sourceRefs: [],
+    graph: {
+      mode: "bounded_packet",
+      nodeCount: 0,
+      edgeCount: 0,
+      clusters: [
+        { name: "used", count: 0, sample: [] },
+        { name: "changed", count: 0, sample: [] },
+        { name: "needs_review", count: 0, sample: [] },
+        { name: "blocked", count: context.hasContext ? 1 : 0, sample: context.hasContext ? ["Context record unresolved."] : [] },
+      ],
+    },
+    notebook: { sectionTitles: [] },
+    verification: {
+      tier: context.hasContext ? "retrieval" : "deterministic",
+      decisions: context.hasContext
+        ? ["Require live retrieval before treating this context as memory-backed."]
+        : ["Prompt-only run; no report memory loaded."],
+    },
+    telemetry: {
+      memoryHit: false,
+      sourceCacheHit: false,
+      candidateCount: 0,
+    },
+  };
+}
+
+export const resolveContextRuntimePacket = internalQuery({
+  args: { contextRef: v.optional(v.string()) },
+  returns: v.any(),
+  handler: async (ctx, args): Promise<RuntimeContextPacket> => {
+    const context = describeContextRef(args.contextRef);
+    if (!context.hasContext || !context.reportId) return emptyRuntimeContextPacket(context);
+
+    if (context.reportId.startsWith("daily_")) {
+      const memoryId = (ctx.db as any).normalizeId("dailyBriefMemories", context.reportId.slice("daily_".length));
+      const memory = memoryId ? await ctx.db.get(memoryId) as any : null;
+      if (!memory) return emptyRuntimeContextPacket(context);
+      const memoryContext = asRecord(memory.context) ?? {};
+      const executiveRecord = asRecord(memoryContext.executiveBriefRecord);
+      const brief = asRecord(executiveRecord?.brief) ?? asRecord(memoryContext.executiveBrief) ?? {};
+      const actI = asRecord(brief.actI) ?? {};
+      const actII = asRecord(brief.actII) ?? {};
+      const actIII = asRecord(brief.actIII) ?? {};
+      const meta = asRecord(brief.meta) ?? {};
+      const signals = recordArray(actII.signals);
+      const actions = recordArray(actIII.actions);
+      const features = Array.isArray(memory.features) ? memory.features as any[] : [];
+      const sourceRefs = collectRuntimeSourceRefs({ brief, features }, 12);
+      const changedSamples = signals
+        .map((signal) => normalizeForContext(signal.headline ?? signal.title ?? signal.synthesis))
+        .filter(Boolean)
+        .slice(0, 5);
+      const actionSamples = actions
+        .map((action) => normalizeForContext(action.title ?? action.action ?? action.summary ?? action.description))
+        .filter(Boolean)
+        .slice(0, 5);
+      const blockedSamples = features
+        .filter((feature) => feature?.status && feature.status !== "passing")
+        .map((feature) => normalizeForContext(feature.name ?? feature.testCriteria))
+        .filter(Boolean)
+        .slice(0, 5);
+      const summary = normalizeForContext(meta.summary ?? actI.synthesis ?? memory.goal ?? "Daily brief report context.");
+      const sectionTitles = [
+        actI.synthesis ? "What changed" : null,
+        signals.length ? "Signals" : null,
+        actions.length ? "Actions" : null,
+        sourceRefs.length ? "Sources" : null,
+      ].filter(Boolean) as string[];
+
+      return {
+        hasContext: true,
+        contextRef: context.raw,
+        contextKind: context.kind,
+        reportId: context.reportId,
+        artifactKey: context.artifactKey,
+        title: `Daily Brief - ${memory.dateString}`,
+        summary: clipText(summary, 360),
+        selectedContext: [
+          `Daily Brief ${memory.dateString}: ${clipText(summary, 240)}`,
+          ...changedSamples.map((item) => `Changed: ${clipText(item, 180)}`),
+          ...actionSamples.map((item) => `Action: ${clipText(item, 180)}`),
+          context.artifactKey ? `Selected artifact: ${context.artifactKey}` : "",
+        ].filter(Boolean).slice(0, 12),
+        rejectedContext: blockedSamples.map((item) => `Needs review before write: ${clipText(item, 160)}`),
+        sourceRefs,
+        graph: {
+          mode: "bounded_packet",
+          nodeCount: 1 + signals.length + actions.length + sourceRefs.length,
+          edgeCount: signals.length + actions.length + sourceRefs.length,
+          clusters: [
+            { name: "used", count: sourceRefs.length, sample: sourceRefs.slice(0, 3).map((ref) => ref.title) },
+            { name: "changed", count: signals.length, sample: changedSamples.slice(0, 3) },
+            { name: "needs_review", count: Math.max(blockedSamples.length, actions.length), sample: [...blockedSamples, ...actionSamples].slice(0, 3) },
+            { name: "blocked", count: blockedSamples.length, sample: blockedSamples.slice(0, 3) },
+          ],
+        },
+        notebook: {
+          sectionTitles,
+          htmlPreview: summary ? `<p>${clipText(summary, 220)}</p>` : undefined,
+        },
+        verification: {
+          tier: blockedSamples.length > 0 ? "judge_required" : sourceRefs.length > 0 ? "retrieval" : "deterministic",
+          decisions: [
+            sourceRefs.length > 0
+              ? `Loaded ${sourceRefs.length} source refs from Convex memory.`
+              : "No source refs found in the memory packet.",
+            blockedSamples.length > 0
+              ? `${blockedSamples.length} memory features need review before notebook writes.`
+              : "No failing memory features detected in this bounded packet.",
+          ],
+        },
+        telemetry: {
+          memoryHit: true,
+          sourceCacheHit: sourceRefs.length > 0,
+          candidateCount: 1 + signals.length + actions.length + sourceRefs.length,
+        },
+      };
+    }
+
+    if (context.reportId.startsWith("li_")) {
+      const postId = (ctx.db as any).normalizeId("linkedinPostArchive", context.reportId.slice("li_".length));
+      const post = postId ? await ctx.db.get(postId) as any : null;
+      if (!post) return emptyRuntimeContextPacket(context);
+      const metadata = asRecord(post.metadata) ?? {};
+      const sourceRefs = collectRuntimeSourceRefs(metadata.sourcesUsed ?? metadata.sourceRefs ?? metadata.sources, 12);
+      const title = firstMeaningfulLine(post.content) || `${post.postType ?? "Archive"} - ${post.dateString}`;
+      const summary = clipText(normalizeForContext(post.content), 360);
+
+      return {
+        hasContext: true,
+        contextRef: context.raw,
+        contextKind: context.kind,
+        reportId: context.reportId,
+        artifactKey: context.artifactKey,
+        title: clipText(title, 140),
+        summary,
+        selectedContext: [
+          `Archive report ${post.dateString}: ${clipText(title, 180)}`,
+          clipText(summary, 280),
+          context.artifactKey ? `Selected artifact: ${context.artifactKey}` : "",
+        ].filter(Boolean),
+        rejectedContext: [],
+        sourceRefs,
+        graph: {
+          mode: "bounded_packet",
+          nodeCount: 1 + sourceRefs.length,
+          edgeCount: sourceRefs.length,
+          clusters: [
+            { name: "used", count: sourceRefs.length, sample: sourceRefs.slice(0, 3).map((ref) => ref.title) },
+            { name: "changed", count: 1, sample: [clipText(title, 120)] },
+            { name: "needs_review", count: sourceRefs.length === 0 ? 1 : 0, sample: sourceRefs.length === 0 ? ["No source refs in archive metadata."] : [] },
+            { name: "blocked", count: 0, sample: [] },
+          ],
+        },
+        notebook: {
+          sectionTitles: ["Archive summary", "Evidence", "Next action"],
+          htmlPreview: `<p>${clipText(summary, 220)}</p>`,
+        },
+        verification: {
+          tier: sourceRefs.length > 0 ? "retrieval" : "deterministic",
+          decisions: [
+            sourceRefs.length > 0
+              ? `Loaded ${sourceRefs.length} archive source refs.`
+              : "Archive context loaded without explicit source refs.",
+          ],
+        },
+        telemetry: {
+          memoryHit: true,
+          sourceCacheHit: sourceRefs.length > 0,
+          candidateCount: 1 + sourceRefs.length,
+        },
+      };
+    }
+
+    return emptyRuntimeContextPacket(context);
+  },
+});
+
 function buildBoardState(args: {
   runId: string;
   prompt: string;
@@ -268,7 +618,8 @@ function buildBoardState(args: {
   toolDecisions: PlannerArtifact[];
 } {
   const entityLabel = args.classification.entity ?? "unresolved entity";
-  const hasReportContext = Boolean(args.contextRef);
+  const context = describeContextRef(args.contextRef);
+  const hasReportContext = context.hasContext;
   const contextCandidates: PlannerArtifact[] = [
     {
       id: "user_prompt",
@@ -279,21 +630,30 @@ function buildBoardState(args: {
     },
     {
       id: "active_report",
-      label: hasReportContext ? `Active report ${args.contextRef}` : "Active report",
+      label: hasReportContext ? context.label : "Active report",
       status: hasReportContext ? "selected" : "deferred",
       confidence: hasReportContext ? 0.86 : 0,
       detail: hasReportContext
-        ? "Composer supplied a live report/context reference."
+        ? `Composer supplied a ${context.kind === "graph_packet" ? "bounded graph context packet" : "live report reference"}.`
         : "No active report reference was supplied, so the run stays answer-first.",
     },
     {
       id: "graph_context_packet",
-      label: hasReportContext ? `Graph context for ${args.contextRef}` : "Graph context packet",
+      label: hasReportContext ? `Graph context for ${context.reportId ?? context.raw}` : "Graph context packet",
       status: hasReportContext ? "selected" : "deferred",
       confidence: hasReportContext ? 0.82 : 0,
       detail: hasReportContext
         ? "Resolve a bounded report graph packet before live search: root, first-ring neighbors, source refs, claim refs, and safe action handles."
         : "No report context was supplied, so graph context stays on demand.",
+    },
+    {
+      id: "context_runtime_packet",
+      label: "ContextRuntimePacket",
+      status: hasReportContext ? "selected" : "deferred",
+      confidence: hasReportContext ? 0.8 : 0,
+      detail: hasReportContext
+        ? "Carry selected report, graph neighbors, source refs, verification lane, and write-proposal handles through the run trace."
+        : "No selected report/entity, so the packet starts from prompt-only recall lanes.",
     },
     {
       id: "entity_mention",
@@ -324,7 +684,7 @@ function buildBoardState(args: {
       riskTier: "low",
       costUsd: 0,
       detail: hasReportContext
-        ? "Pack the selected report graph into a token-bounded context packet with source and claim refs."
+        ? "Pack the selected report graph into a token-bounded context packet with human-readable clusters and agent-scored candidates."
         : "Requires a selected report/context reference.",
     },
     {
@@ -362,7 +722,9 @@ function buildBoardState(args: {
       entity: args.classification.entity ?? null,
       tier: args.tier,
       model: args.model,
-      targetReport: args.contextRef ?? null,
+      targetReport: context.reportId,
+      contextRef: context.raw,
+      contextKind: context.kind,
       successCriteria: [
         "classify intent",
         "select available memory/context",
@@ -709,12 +1071,33 @@ export const runStreamingChat = internalAction({
 
       // Stage 2 — context
       const t2 = Date.now();
+      const runtimeContext = await ctx.runQuery(
+        internal.domains.redesign.chatRuns.resolveContextRuntimePacket,
+        { contextRef: args.contextRef },
+      ) as RuntimeContextPacket;
+      await append("context_runtime_packet", runtimeContext);
       const contextBundle = {
         role: "operator",
         style: "evidence-first banker memo",
-        report: args.contextRef ?? "no live artifact selected",
+        report: runtimeContext.hasContext ? runtimeContext.title : "no live artifact selected",
+        contextRef: runtimeContext.contextRef,
+        reportId: runtimeContext.reportId,
+        artifactKey: runtimeContext.artifactKey,
+        summary: runtimeContext.summary,
+        selectedContext: runtimeContext.selectedContext,
+        sourceRefs: runtimeContext.sourceRefs.slice(0, 8),
+        graph: runtimeContext.graph,
+        notebook: runtimeContext.notebook,
+        verification: runtimeContext.verification,
       };
-      const tr2 = { step: "Build context bundle", detail: `${contextBundle.role} · ${contextBundle.style}`, status: "ok" as const, durationMs: Date.now() - t2 };
+      const tr2 = {
+        step: "Build context bundle",
+        detail: runtimeContext.telemetry.memoryHit
+          ? `${contextBundle.role} · ${runtimeContext.title} · ${runtimeContext.sourceRefs.length} source refs`
+          : `${contextBundle.role} · prompt-only context`,
+        status: "ok" as const,
+        durationMs: Date.now() - t2,
+      };
       trace.push(tr2);
       await append("tool_call", tr2);
 
@@ -723,6 +1106,7 @@ export const runStreamingChat = internalAction({
         text: `Plan
 - Prompt: ${args.prompt.slice(0, 80)}${args.prompt.length > 80 ? "…" : ""}
 - Classified as ${classification.kind}${classification.entity ? ` (entity: ${classification.entity})` : ""}
+- Context: ${runtimeContext.telemetry.memoryHit ? `resolved ${runtimeContext.title}` : "prompt-only, no memory hit"}
 - Calling ${args.model} with web-search grounding`,
       });
 
@@ -968,8 +1352,8 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
           sourceCount: evidence.length,
           toolCallCount: trace.length,
           liveSearchCalls: 1,
-          memoryHitRate: args.contextRef ? 1 : 0,
-          sourceCacheHitRate: 0,
+          memoryHitRate: runtimeContext.telemetry.memoryHit ? 1 : 0,
+          sourceCacheHitRate: runtimeContext.telemetry.sourceCacheHit ? 1 : 0,
           timeToFirstSourceMs: firstSourceAt ? firstSourceAt - t0 : null,
           timeToFinalMs: totalLatencyMs,
         },
@@ -990,7 +1374,7 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
         nextAction: parsed.nextAction,
         sourceCount: evidence.length,
         paidCalls: 1,
-        fromMemory: false,
+        fromMemory: runtimeContext.telemetry.memoryHit,
         trace,
         runtime,
       };
@@ -1012,8 +1396,8 @@ Context: ${JSON.stringify(contextBundle)}${pinnedSection}${probeSection}`;
         sourceCount: evidence.length,
         toolCallCount: trace.length,
         liveSearchCalls: 1,
-        memoryHitRate: args.contextRef ? 1 : 0,
-        sourceCacheHitRate: 0,
+        memoryHitRate: runtimeContext.telemetry.memoryHit ? 1 : 0,
+        sourceCacheHitRate: runtimeContext.telemetry.sourceCacheHit ? 1 : 0,
         timeToFirstSourceMs: firstSourceAt ? firstSourceAt - t0 : null,
         timeToFinalMs: totalLatencyMs,
       });

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -100,6 +100,10 @@ export default function RedesignShell() {
   const navigate = useNavigate();
   const [theme, setTheme] = useState<"light" | "dark">("light");
   const [forceMobile, setForceMobile] = useState(false);
+  const [wideMode, setWideMode] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem("nodebench:redesign:wide-mode") === "1";
+  });
   // Phase 7d preserves the redesign-specific 760px phone breakpoint.
   // The shared hook is parameterized so other call-sites (CockpitLayout,
   // ExactKit) can opt into their own breakpoint without forking.
@@ -139,7 +143,11 @@ export default function RedesignShell() {
     const query = params.toString();
     navigate(`/redesign/chat?${query}`);
   };
-  const openTouchedReports = () => {
+  const openTouchedReports = (reportId?: string) => {
+    if (reportId && !isPrototypeKit) {
+      navigate(`/redesign/reports/${encodeURIComponent(reportId)}`);
+      return;
+    }
     navigate(isPrototypeKit ? "/redesign/reports?qa=home-v2-implementation" : "/redesign/reports");
   };
   const selectPrototypeRailEntity = (entity: string) => {
@@ -154,12 +162,15 @@ export default function RedesignShell() {
     setSelectedReport(report);
     if (report) setPrototypeEntity(report.entity);
   };
+  const routeReport = surface === "reports" && reportId
+    ? shellLiveArtifacts.reports.find((report) => report.id === reportId) ?? null
+    : null;
   const selectedRailReport =
-    surface === "reports" &&
-    !reportsRailEntityMode &&
-    selectedReport &&
-    normalizeEntityKey(selectedReport.entity) === normalizeEntityKey(prototypeEntity)
-      ? selectedReport
+    surface === "reports" && !reportsRailEntityMode
+      ? routeReport ??
+        (selectedReport && normalizeEntityKey(selectedReport.entity) === normalizeEntityKey(prototypeEntity)
+          ? selectedReport
+          : null)
       : null;
 
   // Optionally lock body scroll while shell is mounted
@@ -169,6 +180,23 @@ export default function RedesignShell() {
     return () => {
       document.body.style.overflow = prev;
     };
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem("nodebench:redesign:wide-mode", wideMode ? "1" : "0");
+  }, [wideMode]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+      if (event.key.toLowerCase() !== "w") return;
+      const target = event.target as HTMLElement | null;
+      if (target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable) return;
+      event.preventDefault();
+      setWideMode((current) => !current);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
   }, []);
 
   // Phase 7d (2026-05-08): editorial is the default at /redesign on
@@ -196,8 +224,8 @@ export default function RedesignShell() {
       return (
         <div data-redesign data-redesign-theme={theme} style={{ minHeight: "100dvh", overflow: "auto" }}>
           <HomeV2Surface
-            onAsk={(text) => navigate(`/redesign/chat?q=${encodeURIComponent(text)}`)}
-            onOpenReports={() => navigate("/redesign/reports")}
+            onAsk={sendPromptToChat}
+            onOpenReports={openTouchedReports}
             liveArtifacts={shellLiveArtifacts}
           />
           {showQaChrome && <ThemeFab theme={theme} setTheme={setTheme} />}
@@ -256,6 +284,7 @@ export default function RedesignShell() {
     <div
       data-redesign
       data-redesign-theme={theme}
+      data-wide={wideMode ? "true" : undefined}
       style={{
         height: "100vh",
         overflow: "hidden",
@@ -269,6 +298,8 @@ export default function RedesignShell() {
         onOpenPalette={() => cmdk.setOpen(true)}
         theme={theme}
         onToggleTheme={() => setTheme(theme === "light" ? "dark" : "light")}
+        wideMode={wideMode}
+        onToggleWideMode={() => setWideMode((current) => !current)}
         prototypeMode={isPrototypeKit}
       />
       <div
@@ -384,7 +415,7 @@ export default function RedesignShell() {
 function ReportDetailRoute({ reportId }: { reportId: string }) {
   const liveArtifacts = useLiveArtifacts(60);
   const liveDetail = liveArtifacts.details.find((detail) => detail.id === reportId);
-  return <ReportNotebookView reportId={reportId} liveDetail={liveDetail} showSidebar />;
+  return <ReportNotebookView reportId={reportId} liveDetail={liveDetail} showSidebar={false} />;
 }
 
 function useQaChromeFlag(search: string): boolean {

--- a/src/features/redesign/components/TopNav.tsx
+++ b/src/features/redesign/components/TopNav.tsx
@@ -35,6 +35,8 @@ interface TopNavProps {
   onOpenPalette: () => void;
   theme: "light" | "dark";
   onToggleTheme: () => void;
+  wideMode?: boolean;
+  onToggleWideMode?: () => void;
   prototypeMode?: boolean;
 }
 
@@ -59,6 +61,8 @@ export function TopNav({
   onOpenPalette,
   theme,
   onToggleTheme,
+  wideMode = false,
+  onToggleWideMode,
   prototypeMode = false,
 }: TopNavProps) {
   const { isAuthenticated, isLoading } = useConvexAuth();
@@ -246,6 +250,34 @@ export function TopNav({
           flexShrink: 0,
         }}
       >
+        <button
+          type="button"
+          onClick={onToggleWideMode}
+          aria-pressed={wideMode}
+          aria-label={wideMode ? "Use standard width" : "Use wide mode"}
+          title={wideMode ? "Use standard width (W)" : "Use wide mode (W)"}
+          className="rd-btn rd-btn--quiet"
+          style={{
+            width: 34,
+            height: 34,
+            padding: 0,
+            borderRadius: "50%",
+            border: "1px solid var(--rd-line)",
+            background: wideMode ? "var(--rd-accent-soft)" : "var(--rd-panel)",
+            display: "grid",
+            placeItems: "center",
+            color: wideMode ? "var(--rd-accent-strong)" : "var(--rd-ink-mute)",
+          }}
+        >
+          <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M4 8V5h3" />
+            <path d="M20 8V5h-3" />
+            <path d="M4 16v3h3" />
+            <path d="M20 16v3h-3" />
+            <path d="M9 12h6" />
+          </svg>
+        </button>
+
         <button
           type="button"
           onClick={onToggleTheme}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -452,7 +452,7 @@
 /* The kernel layout: open-design's .split pattern, generalised for 3 zones */
 [data-redesign] .rd-shell {
   display: grid;
-  grid-template-columns: 184px minmax(0, 1fr);
+  grid-template-columns: 200px minmax(0, 1fr);
   height: 100%;
   min-height: 0;
   overflow: hidden;
@@ -460,7 +460,7 @@
 
 [data-redesign] .rd-shell__main {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 400px;
+  grid-template-columns: minmax(0, 1fr) 360px;
   overflow: hidden;
 }
 
@@ -500,25 +500,58 @@
 
 /* Home v2 prototype parity */
 [data-redesign] .rd-shell--home-v2 {
-  grid-template-columns: 184px minmax(0, 1fr);
+  grid-template-columns: 200px minmax(0, 1fr);
 }
 
 [data-redesign] .rd-shell--home-v2 .rd-shell__main {
-  grid-template-columns: minmax(0, 1fr) 400px;
+  grid-template-columns: minmax(0, 1fr) 360px;
 }
 
 [data-redesign] .rd-shell--chat-v3 .rd-shell__main {
-  grid-template-columns: minmax(0, 1fr) 280px;
+  grid-template-columns: minmax(0, 1fr) 360px;
 }
 
 [data-redesign] .rd-shell--chat-v3 .rd-pane--right.chat-context {
-  width: 280px;
+  width: 360px;
 }
 
 [data-redesign] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child {
   align-items: center;
-  padding: 28px 48px 60px;
+  padding: 24px 32px 60px;
   border-right: none;
+}
+
+[data-redesign][data-wide="true"] .rd-shell {
+  grid-template-columns: 168px minmax(0, 1fr);
+}
+
+[data-redesign][data-wide="true"] .rd-shell__main,
+[data-redesign][data-wide="true"] .rd-shell--home-v2 .rd-shell__main,
+[data-redesign][data-wide="true"] .rd-shell--reports-v3 .rd-shell__main,
+[data-redesign][data-wide="true"] .rd-shell--chat-v3 .rd-shell__main {
+  grid-template-columns: minmax(0, 1fr) 320px;
+}
+
+[data-redesign][data-wide="true"] .rd-shell--chat-v3 .rd-pane--right.chat-context {
+  width: 320px;
+}
+
+[data-redesign][data-wide="true"] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child,
+[data-redesign][data-wide="true"] .rd-shell--reports-v3 .rd-shell__main > .rd-pane:first-child {
+  padding-left: 40px;
+  padding-right: 40px;
+}
+
+[data-redesign][data-wide="true"] .rd-v2-home {
+  max-width: 1180px;
+}
+
+[data-redesign][data-wide="true"] .rd-v3-halo-card {
+  flex-basis: 188px;
+}
+
+[data-redesign][data-wide="true"] .rd-shell--reports-v3 .rd-v3-grid {
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
 }
 
 [data-redesign] .rd-v2-left {
@@ -652,7 +685,275 @@
 
 [data-redesign] .rd-v2-home {
   width: 100%;
-  max-width: 820px;
+  max-width: 960px;
+}
+
+[data-redesign] .rd-v3-home-front {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin: 0 0 34px;
+}
+
+[data-redesign] .rd-v3-home-halo {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  padding: 4px 0 0;
+}
+
+[data-redesign] .rd-v3-home-halo-head {
+  max-width: 620px;
+}
+
+[data-redesign] .rd-v3-home-halo-head span,
+[data-redesign] .rd-v3-home-composer-head span {
+  display: inline-flex;
+  margin: 0 0 4px;
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v3-home-halo-head strong {
+  display: block;
+  color: var(--rd-ink-strong);
+  font-size: 20px;
+  font-weight: 760;
+  line-height: 1.1;
+}
+
+[data-redesign] .rd-v3-home-halo-head p,
+[data-redesign] .rd-v3-home-composer-head p {
+  max-width: 620px;
+  margin: 6px 0 0;
+  color: var(--rd-ink-mute);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+[data-redesign] .rd-v3-halo-track {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding: 4px 2px 12px;
+  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
+}
+
+[data-redesign] .rd-v3-halo-card {
+  flex: 0 0 172px;
+  min-height: 168px;
+  padding: 0 0 12px;
+  border: 1px solid var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-panel);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  scroll-snap-align: start;
+  overflow: hidden;
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+[data-redesign] .rd-v3-halo-card:hover,
+[data-redesign] .rd-v3-halo-card:focus-visible,
+[data-redesign] .rd-v3-halo-card[data-active="true"] {
+  transform: translateY(-3px);
+  border-color: var(--rd-accent);
+  box-shadow: var(--rd-shadow-soft);
+  outline: none;
+}
+
+[data-redesign] .rd-v3-halo-card:nth-child(odd) {
+  margin-top: 6px;
+}
+
+[data-redesign] .rd-v3-halo-card-cover {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 8px 10px;
+  background: var(--rd-accent-tint);
+}
+
+[data-redesign] .rd-v3-halo-card[data-hue="blue"] .rd-v3-halo-card-cover { background: rgba(91, 138, 240, 0.1); }
+[data-redesign] .rd-v3-halo-card[data-hue="green"] .rd-v3-halo-card-cover { background: rgba(74, 222, 128, 0.1); }
+[data-redesign] .rd-v3-halo-card[data-hue="purple"] .rd-v3-halo-card-cover { background: rgba(167, 139, 250, 0.1); }
+[data-redesign] .rd-v3-halo-card[data-hue="teal"] .rd-v3-halo-card-cover { background: rgba(45, 212, 191, 0.1); }
+[data-redesign] .rd-v3-halo-card[data-hue="red"] .rd-v3-halo-card-cover { background: rgba(248, 113, 113, 0.1); }
+
+[data-redesign] .rd-v3-halo-card-cover b {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border-radius: 6px;
+  background: var(--rd-panel);
+  color: var(--rd-accent-strong);
+  font-size: 11px;
+}
+
+[data-redesign] .rd-v3-halo-card-cover em {
+  min-width: 0;
+  color: var(--rd-ink-soft);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 640;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-redesign] .rd-v3-halo-card > strong,
+[data-redesign] .rd-v3-halo-card > small,
+[data-redesign] .rd-v3-halo-card > p {
+  display: block;
+  margin-left: 12px;
+  margin-right: 12px;
+}
+
+[data-redesign] .rd-v3-halo-card > strong {
+  margin-top: 10px;
+  color: var(--rd-ink-strong);
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+[data-redesign] .rd-v3-halo-card > small {
+  margin-top: 5px;
+  color: var(--rd-ink-faint);
+  font-size: 10px;
+}
+
+[data-redesign] .rd-v3-halo-card > p {
+  display: -webkit-box;
+  min-height: 42px;
+  margin-top: 8px;
+  color: var(--rd-ink-mute);
+  font-size: 11px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
+[data-redesign] .rd-v3-halo-dock {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(220px, 0.9fr);
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--rd-accent-soft);
+  border-radius: 8px;
+  background: var(--rd-panel);
+  box-shadow: var(--rd-shadow-soft);
+}
+
+[data-redesign] .rd-v3-halo-dock span {
+  color: var(--rd-accent-strong);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v3-halo-dock h3 {
+  margin: 6px 0 8px;
+  color: var(--rd-ink-strong);
+  font-size: 24px;
+  line-height: 1.1;
+}
+
+[data-redesign] .rd-v3-halo-dock p {
+  margin: 0;
+  color: var(--rd-ink-mute);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+[data-redesign] .rd-v3-halo-dock dl {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin: 0;
+}
+
+[data-redesign] .rd-v3-halo-dock dl div {
+  padding: 8px 0;
+  border-top: 1px solid var(--rd-line-faint);
+}
+
+[data-redesign] .rd-v3-halo-dock dt {
+  color: var(--rd-ink-faint);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+[data-redesign] .rd-v3-halo-dock dd {
+  margin: 4px 0 0;
+  color: var(--rd-ink-mute);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+[data-redesign] .rd-v3-halo-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+[data-redesign] .rd-v3-halo-actions button,
+[data-redesign] .rd-v3-home-halo--empty button {
+  border: 1px solid var(--rd-line);
+  border-radius: var(--rd-r-pill);
+  background: var(--rd-panel);
+  color: var(--rd-ink-mute);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 650;
+  padding: 7px 12px;
+  cursor: pointer;
+}
+
+[data-redesign] .rd-v3-halo-actions .rd-v2-btn-primary {
+  background: var(--rd-ink-strong);
+  border-color: var(--rd-ink-strong);
+  color: var(--rd-paper);
+}
+
+[data-redesign] .rd-v3-home-halo--empty {
+  padding: 18px;
+  border: 1px dashed var(--rd-line);
+  border-radius: 8px;
+  background: var(--rd-panel-soft);
+}
+
+[data-redesign] .rd-v3-home-composer-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 4px 0 0;
+}
+
+[data-redesign] .rd-v3-home-composer-head h1 {
+  max-width: 700px;
+  margin: 0;
+  color: var(--rd-ink-strong);
+  font-size: 54px;
+  font-weight: 810;
+  letter-spacing: 0;
+  line-height: 1.02;
+}
+
+[data-redesign] .rd-v3-home-composer-shell .rd-card {
+  border-radius: 12px;
+  box-shadow: var(--rd-shadow-soft);
 }
 
 [data-redesign] .rd-v2-edition-row {
@@ -2142,7 +2443,7 @@
   }
 
   [data-redesign] .rd-shell--home-v2 .rd-shell__main > .rd-pane:first-child {
-    padding: 28px 48px 60px;
+    padding: 24px 32px 60px;
   }
 
   [data-redesign] .rd-v2-briefing {

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -249,6 +249,12 @@ function formatRailUsd(value?: number | null): string {
   return `$${value.toFixed(2)}`;
 }
 
+function buildLiveContextRef(detail: LiveArtifactDetail | null, artifactKey?: string | null): string | undefined {
+  if (!detail) return undefined;
+  const base = buildGraphContextBridgePacket({ detail, mode: "agent" }).contextRef;
+  return artifactKey ? `${base}::artifact:${encodeURIComponent(artifactKey)}` : base;
+}
+
 function formatLatency(value?: number | null): string {
   if (!value || !Number.isFinite(value)) return "pending";
   if (value < 1000) return `${Math.round(value)}ms`;
@@ -847,8 +853,11 @@ export function ChatSurface({
   const requestedReportId = typeof window !== "undefined"
     ? new URLSearchParams(window.location.search).get("report")
     : null;
+  const requestedArtifactKey = typeof window !== "undefined"
+    ? new URLSearchParams(window.location.search).get("artifact")
+    : null;
   const _rawLiveDetail = requestedReportId
-    ? liveArtifacts.details.find((detail) => detail.id === requestedReportId) ?? liveArtifacts.details[0]
+    ? liveArtifacts.details.find((detail) => detail.id === requestedReportId) ?? null
     : liveArtifacts.details[0];
   // Phase 1 — real LLM chat behind the composer for authenticated users.
   const chatRun = useRedesignChatRun();
@@ -1161,7 +1170,10 @@ export function ChatSurface({
       const pinnedClaims = pinned.length > 0
         ? pinned.map((p) => ({ text: p.label || "pinned claim", source: undefined as string | undefined }))
         : undefined;
-      void chatRun.submit(text, submittedTier, liveDetail?.id, pinnedClaims).then((runId) => {
+      const contextRef = liveDetail
+        ? buildLiveContextRef(liveDetail, requestedArtifactKey)
+        : undefined;
+      void chatRun.submit(text, submittedTier, contextRef, pinnedClaims).then((runId) => {
         if (runId) {
           setTurns((prev) => prev.map((t) =>
             t.id === assistantId
@@ -1229,7 +1241,10 @@ export function ChatSurface({
       const pinnedClaims = pinned.length > 0
         ? pinned.map((p) => ({ text: p.label || "pinned claim", source: undefined as string | undefined }))
         : undefined;
-      void chatRun.submit(prompt, requestedTier, liveDetail?.id, pinnedClaims).then((runId) => {
+      const contextRef = liveDetail
+        ? buildLiveContextRef(liveDetail, requestedArtifactKey)
+        : undefined;
+      void chatRun.submit(prompt, requestedTier, contextRef, pinnedClaims).then((runId) => {
         setTurns((prev) => prev.map((t) =>
           t.id === turnId
             ? runId
@@ -1688,7 +1703,7 @@ function ChatV2ReportBanner({
 }) {
   const savedLabel = liveDetail ? `Saved to ${liveDetail.title}` : "Ready for a live report packet";
   const meta = liveDetail
-    ? `${liveDetail.sectionCount} sections · ${liveDetail.claimCount} claims · ${liveDetail.sourceCount} sources · notebook context loaded`
+    ? `${liveDetail.sections.length} sections · ${liveDetail.claimCount} claims · ${liveDetail.sourceCount} sources · notebook context loaded`
     : `${turns.length} messages · ${isLive ? "memory hot" : "memory warming"} · ${paidEligible ? "paid eligible" : "free-first"} · ${runStatus ?? "idle"}`;
 
   return (

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -1,12 +1,18 @@
 import { useState, type KeyboardEvent, type ReactNode } from "react";
 import { showToast } from "../components/Toast";
+import { UniversalComposer, type RouterTier } from "../components/UniversalComposer";
 import type { LiveArtifactsResult, LiveArtifactSourceRow } from "../hooks/useLiveArtifacts";
 import type { ReportCardData } from "../fixtures";
 import { buildGraphContextBridgePacket } from "../lib/graphContextBridge";
 
+interface HomeAskContext {
+  reportId?: string;
+  artifactKey?: string;
+}
+
 interface HomeV2SurfaceProps {
-  onAsk?: (prompt: string) => void;
-  onOpenReports?: () => void;
+  onAsk?: (prompt: string, context?: HomeAskContext) => void;
+  onOpenReports?: (reportId?: string) => void;
   liveArtifacts?: LiveArtifactsResult;
 }
 
@@ -878,7 +884,7 @@ const inboxRows = [
 
 function requestHomeV2Share(
   channel: "email" | "linkedin" | "slack",
-  onAsk?: (prompt: string) => void,
+  onAsk?: (prompt: string, context?: HomeAskContext) => void,
 ) {
   const promptByChannel = {
     email: "Draft an email digest from today's agent brief. Keep it source-backed, concise, and action-oriented.",
@@ -912,7 +918,7 @@ function openHomeV2PrintView() {
   }
 }
 
-function HomeV2ShareBar({ onAsk, pulse = false }: { onAsk?: (prompt: string) => void; pulse?: boolean }) {
+function HomeV2ShareBar({ onAsk, pulse = false }: { onAsk?: (prompt: string, context?: HomeAskContext) => void; pulse?: boolean }) {
   return (
     <div className={`rd-v2-share-bar${pulse ? " rd-v2-share-bar--pulse" : ""}`} aria-label="Share edition">
       <span>Share</span>
@@ -2093,14 +2099,208 @@ function countFromText(value: string | undefined, fallback: string): string {
   return match?.[0] ?? fallback;
 }
 
+interface HomeHaloReport {
+  id: string;
+  title: string;
+  kind: string;
+  status: ReportCardData["status"];
+  summary: string;
+  sources: number;
+  claims: number;
+  followUps: number;
+  updatedAt: string;
+  graphHint: string;
+  sourceHint: string;
+  hue: "orange" | "blue" | "green" | "purple" | "teal" | "red";
+}
+
+const homeHaloHues: HomeHaloReport["hue"][] = ["orange", "blue", "green", "purple", "teal", "red"];
+
+function statusCopy(status: ReportCardData["status"]): string {
+  if (status === "verified") return "Verified";
+  if (status === "review") return "Needs review";
+  return "Watching";
+}
+
+function buildHomeHaloReports(liveArtifacts?: LiveArtifactsResult): HomeHaloReport[] {
+  const reports = liveArtifacts?.reports ?? [];
+  return reports.slice(0, 8).map((report, index) => {
+    const detail = liveArtifacts?.details.find((item) => item.id === report.id);
+    const source = detail?.sourceRows[0];
+    return {
+      id: report.id,
+      title: report.entity,
+      kind: report.kind,
+      status: report.status,
+      summary: trimSentence(detail?.summary ?? report.description, report.description, 180),
+      sources: report.sources,
+      claims: report.claims,
+      followUps: report.followUps,
+      updatedAt: report.updatedAt,
+      graphHint: detail
+        ? `${detail.nodes.length} nodes · ${detail.edges.length} edges`
+        : `${report.claims} claims · ${report.followUps} follow-ups`,
+      sourceHint: source
+        ? `${sourceLabel(source.type)} · ${source.reused}x reused`
+        : `${report.sources} source rows`,
+      hue: homeHaloHues[index % homeHaloHues.length],
+    };
+  });
+}
+
+function HomeReportHalo({
+  reports,
+  activeReportId,
+  onActiveReportChange,
+  onAsk,
+  onOpenReports,
+}: {
+  reports: HomeHaloReport[];
+  activeReportId?: string | null;
+  onActiveReportChange?: (reportId: string) => void;
+  onAsk?: (prompt: string, context?: HomeAskContext) => void;
+  onOpenReports?: (reportId?: string) => void;
+}) {
+  const active = reports.find((report) => report.id === activeReportId) ?? reports[0];
+  const selectReport = (reportId: string) => onActiveReportChange?.(reportId);
+  const askReport = (report: HomeHaloReport) => {
+    onAsk?.(
+      `Use the ${report.title} report packet. Summarize what changed, source support, open claims, and the next report or notebook action.`,
+      { reportId: report.id },
+    );
+  };
+
+  if (reports.length === 0) {
+    return (
+      <section className="rd-v3-home-halo rd-v3-home-halo--empty" data-testid="home-v3-report-halo">
+        <div className="rd-v3-home-halo-head">
+          <span>Report memory</span>
+          <strong>No live report halo yet</strong>
+          <p>Run or refresh a report so Home can preview reusable context before Chat asks the model to search again.</p>
+        </div>
+        <button type="button" onClick={() => onAsk?.("Create the first report packet from live memory and attach sources before drafting.")}>
+          Create first packet
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rd-v3-home-halo" data-testid="home-v3-report-halo" aria-label="Report memory halo">
+      <div className="rd-v3-home-halo-head">
+        <span>Report halo</span>
+        <strong>Reusable memory is already in the room.</strong>
+        <p>Hover or select a report, then ask with its Convex-backed context attached.</p>
+      </div>
+
+      <div className="rd-v3-halo-track" role="list">
+        {reports.map((report) => (
+          <button
+            key={report.id}
+            type="button"
+            role="listitem"
+            className="rd-v3-halo-card"
+            data-hue={report.hue}
+            data-active={active?.id === report.id ? "true" : undefined}
+            onMouseEnter={() => selectReport(report.id)}
+            onFocus={() => selectReport(report.id)}
+            onClick={() => selectReport(report.id)}
+          >
+            <span className="rd-v3-halo-card-cover">
+              <b>{monogram(report.title)}</b>
+              <em>{report.kind}</em>
+            </span>
+            <strong>{report.title}</strong>
+            <small>{statusCopy(report.status)} · {report.updatedAt}</small>
+            <p>{report.summary}</p>
+          </button>
+        ))}
+      </div>
+
+      {active && (
+        <aside className="rd-v3-halo-dock" data-testid="home-v3-halo-dock" aria-label={`${active.title} preview`}>
+          <div>
+            <span>{active.kind}</span>
+            <h3>{active.title}</h3>
+            <p>{active.summary}</p>
+          </div>
+          <dl>
+            <div><dt>Status</dt><dd>{statusCopy(active.status)}</dd></div>
+            <div><dt>Evidence</dt><dd>{active.sources} sources · {active.claims} claims</dd></div>
+            <div><dt>Graph</dt><dd>{active.graphHint}</dd></div>
+            <div><dt>Source</dt><dd>{active.sourceHint}</dd></div>
+          </dl>
+          <div className="rd-v3-halo-actions">
+            <button type="button" className="rd-v2-btn-primary" onClick={() => askReport(active)}>Ask with context</button>
+            <button type="button" onClick={() => onOpenReports?.(active.id)}>Open report</button>
+            <button
+              type="button"
+              onClick={() => onAsk?.(`Explore the graph neighborhood for ${active.title} and identify used, changed, needs-review, and blocked clusters.`, { reportId: active.id })}
+            >
+              Explore graph
+            </button>
+          </div>
+        </aside>
+      )}
+    </section>
+  );
+}
+
+function HomeV3FrontPage({
+  model,
+  haloReports,
+  onAsk,
+  onOpenReports,
+}: {
+  model: HomeV2Model;
+  haloReports: HomeHaloReport[];
+  onAsk?: (prompt: string, context?: HomeAskContext) => void;
+  onOpenReports?: (reportId?: string) => void;
+}) {
+  const [activeReportId, setActiveReportId] = useState<string | null>(haloReports[0]?.id ?? null);
+  const activeReport = haloReports.find((report) => report.id === activeReportId) ?? haloReports[0];
+  const contextLabel = activeReport
+    ? `Using ${activeReport.title} · ${activeReport.sources} sources · ${activeReport.claims} claims`
+    : model.editionLine;
+  const submit = (text: string, _tier: RouterTier) => {
+    onAsk?.(text, activeReport ? { reportId: activeReport.id } : undefined);
+  };
+
+  return (
+    <section className="rd-v3-home-front" data-testid="home-v3-chat-first-frontpage" aria-label="Chat-first intelligence front page">
+      <HomeReportHalo
+        reports={haloReports}
+        activeReportId={activeReport?.id ?? null}
+        onActiveReportChange={setActiveReportId}
+        onAsk={onAsk}
+        onOpenReports={onOpenReports}
+      />
+      <div className="rd-v3-home-composer-shell">
+        <div className="rd-v3-home-composer-head">
+          <span>Ask first</span>
+          <h1>What are we researching today?</h1>
+          <p>{model.heroSub}</p>
+        </div>
+        <UniversalComposer
+          contextLabel={contextLabel}
+          placeholder="Ask about a company, person, event, market, report, or source packet..."
+          showRuntimeRibbon
+          onSubmit={submit}
+          onChatNow={submit}
+        />
+      </div>
+    </section>
+  );
+}
+
 function LivePulseLanding({
   model,
   onAsk,
   onOpenReports,
 }: {
   model: HomeV2Model;
-  onAsk?: (text: string) => void;
-  onOpenReports?: () => void;
+  onAsk?: (text: string, context?: HomeAskContext) => void;
+  onOpenReports?: (reportId?: string) => void;
 }) {
   const whatChanged = findBriefSection(model, "changed", 0);
   const reportsTouched = findBriefSection(model, "reports", 3);
@@ -2218,8 +2418,15 @@ function LivePulseLanding({
 export function HomeV2Surface({ onAsk, onOpenReports, liveArtifacts }: HomeV2SurfaceProps) {
   const model = buildHomeV2Model(liveArtifacts);
   const isLiveHome = Boolean(liveArtifacts);
+  const haloReports = buildHomeHaloReports(liveArtifacts);
   return (
     <div className="rd-v2-home">
+      <HomeV3FrontPage
+        model={model}
+        haloReports={haloReports}
+        onAsk={onAsk}
+        onOpenReports={onOpenReports}
+      />
       {isLiveHome ? (
         <LivePulseLanding model={model} onAsk={onAsk} onOpenReports={onOpenReports} />
       ) : (


### PR DESCRIPTION
## Summary
- Resolve Chat graph context refs into bounded Convex ContextRuntimePacket data before model calls.
- Prevent stale report URLs from silently attaching the first live artifact; carry artifact keys through graphctx refs.
- Add Home v3 report halo selection, chat-first composer context handoff, normalized rails, and Streamlit-style wide mode.
- Keep Reports graph and report notebook routes live-wired against existing Convex artifacts.

## Verification
- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
- npx vitest run src/features/redesign/hooks/useRedesignChatRun.test.ts src/features/redesign/lib/graphContextBridge.test.ts src/features/redesign/surfaces/EditorialHomeSurface.audience.test.ts src/features/redesign/components/TopNav.test.tsx
- npm run build
- Browser verified Home halo/dock/composer, Home Ask context handoff, stale report no-fallback behavior, Reports graph SVG, and report notebook detail.

## Screenshots
Local verification screenshots saved under .tmp/home-v3-merge-*.png in the worktree.