### PR TITLE
fix(redesign): declutter report graph labels

### DIFF
--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -2494,11 +2494,13 @@ function ReportGraphPreviewD3({
   }, [graph.nodes, pinnedNodeId]);
 
   useEffect(() => {
+    const currentPinned = pinnedNodeIdRef.current;
+    if (currentPinned && graph.nodes.some((node) => node.id === currentPinned)) return;
     pinnedNodeIdRef.current = null;
     setPinnedNodeId(null);
     setTooltip(null);
     setPeekPosition(null);
-  }, [graph.root?.id]);
+  }, [graph.nodes, graph.root?.id]);
 
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
@@ -2642,6 +2644,76 @@ function ReportGraphPreviewD3({
       if (node.graphType === "cluster") return "C";
       return node.label.slice(0, 1).toUpperCase();
     };
+    const middleEllipsis = (value: string, maxLength: number) => {
+      const clean = value.replace(/\s+/g, " ").trim();
+      if (clean.length <= maxLength) return clean;
+      const head = Math.max(4, Math.ceil((maxLength - 1) * 0.58));
+      const tail = Math.max(3, maxLength - head - 1);
+      return `${clean.slice(0, head).trim()}…${clean.slice(-tail).trim()}`;
+    };
+    const compactReportLabel = (value: string) => {
+      const clean = value
+        .replace(/\s+/g, " ")
+        .replace(/\s+[-|]\s+Funding tracker$/i, "")
+        .replace(/,\s*and today'?s\s+top.*$/i, "")
+        .replace(/\s+and today'?s\s+top.*$/i, "")
+        .replace(/\s+in\s+(?:a|an)\s+(?:Series|Seed|Pre Seed|undisclosed).*$/i, "")
+        .replace(/\s+just\s+raised.*$/i, "")
+        .replace(/\s+raised\s+\$[\d.,]+[BMK]?\b.*$/i, "")
+        .replace(/\s+--\s+\$[\d.,]+[BMK]?\b.*$/i, "")
+        .trim();
+      if (/^daily brief\b/i.test(clean)) return clean.replace(/\s+-\s+20\d{2}-\d{2}-\d{2}$/i, "");
+      const words = clean.split(" ").filter(Boolean);
+      const compact = words.length > 4 ? words.slice(0, 4).join(" ") : clean;
+      return middleEllipsis(compact || value, 26);
+    };
+    const canvasLabelFor = (node: D3GraphNode) => {
+      if (node.graphType === "artifact") {
+        const artifactName = node.artifactKey ?? node.label;
+        const basename = artifactName.split(/[\\/]/).pop() ?? artifactName;
+        return middleEllipsis(basename, 20);
+      }
+      if (node.graphType === "report") return compactReportLabel(node.label);
+      if (node.graphType === "portfolio") return middleEllipsis(node.label, 22);
+      if (node.graphType === "cluster") return middleEllipsis(node.label.replace(/^Cluster:\s*/i, ""), 18);
+      if (node.graphType === "brief") return middleEllipsis(node.label.replace(/\s+-\s+20\d{2}-\d{2}-\d{2}$/i, ""), 18);
+      return middleEllipsis(node.label, 20);
+    };
+    const metaLabelFor = (node: D3GraphNode) => {
+      if (node.graphType === "artifact") return node.artifactType ?? "artifact";
+      if (node.graphType === "report") return "report";
+      if (node.graphType === "portfolio") return "portfolio";
+      if (node.graphType === "cluster") return `${connectionCount(node.id)} nodes`;
+      return node.stage === "universe" ? "monitoring" : node.stage;
+    };
+    const shouldPromoteLabel = (node: D3GraphNode) => (
+      node.id === graph.root?.id ||
+      node.id === "__universe__" ||
+      node.graphType === "portfolio" ||
+      node.graphType === "cluster" ||
+      node.attentionTier === "promoted" ||
+      (node.topologyProjection?.densityScore ?? 0) >= 82 ||
+      (node.topologyProjection?.outlierScore ?? 0) >= 86
+    );
+    const defaultLabelOpacity = (node: D3GraphNode) => {
+      if (graph.scaleMode === "focus") {
+        if (node.graphType === "artifact" || node.provenance === "source") return 0;
+        return shouldPromoteLabel(node) ? 1 : 0;
+      }
+      if (graph.scaleMode === "clustered") {
+        if (node.graphType === "artifact" || node.provenance === "source") return 0;
+        if (node.graphType === "report") return shouldPromoteLabel(node) ? 1 : 0;
+        return shouldPromoteLabel(node) ? 1 : 0.72;
+      }
+      if (node.provenance === "source") return 0;
+      if (node.graphType === "artifact") return shouldPromoteLabel(node) ? 0.76 : 0;
+      return 1;
+    };
+    const defaultMetaOpacity = (node: D3GraphNode) => {
+      if (defaultLabelOpacity(node) <= 0) return 0;
+      if (graph.scaleMode !== "expanded" && node.graphType !== "portfolio" && node.graphType !== "cluster") return 0;
+      return 0.5;
+    };
     const endpointId = (endpoint: string | D3GraphNode | undefined) => (typeof endpoint === "object" && endpoint ? endpoint.id : String(endpoint ?? ""));
     const nodeById = new Map(nodes.map((node) => [node.id, node]));
     const searchMatch = (node: D3GraphNode) => {
@@ -2683,17 +2755,24 @@ function ReportGraphPreviewD3({
 
     const simulation = d3.forceSimulation<D3GraphNode>(nodes)
       .force("link", d3.forceLink<D3GraphNode, D3GraphLink>(links).id((node) => node.id).distance((link) => {
-        if (link.type === "has_artifact") return 82;
-        if (link.type === "has_report") return 92;
-        if (link.type === "covers") return 125;
-        if (link.type === "causes" || link.type === "correlates_with") return 150;
+        if (link.type === "has_artifact") return 55;
+        if (link.type === "has_report") return 70;
+        if (link.type === "covers") return 110;
+        if (link.type === "causes") return 95;
+        if (link.type === "correlates_with") return 105;
         return 130;
       }))
-      .force("charge", d3.forceManyBody<D3GraphNode>().strength(-420))
+      .force("charge", d3.forceManyBody<D3GraphNode>().strength((node) => {
+        if (node.graphType === "artifact") return -55;
+        if (node.provenance === "source") return -45;
+        if (node.graphType === "report") return -150;
+        if (node.graphType === "portfolio" || node.graphType === "cluster") return -240;
+        return -320;
+      }))
       .force("center", d3.forceCenter(width / 2, visibleHeight * 0.45))
       .force("x", d3.forceX<D3GraphNode>((node) => node.topologyProjection ? projectX(node.topologyProjection.x) : width / 2).strength(0.16))
       .force("y", d3.forceY<D3GraphNode>((node) => node.topologyProjection ? projectY(node.topologyProjection.y) : visibleHeight * 0.45).strength(0.18))
-      .force("collide", d3.forceCollide<D3GraphNode>().radius((node) => radiusFor(node) + 20))
+      .force("collide", d3.forceCollide<D3GraphNode>().radius((node) => radiusFor(node) + (defaultLabelOpacity(node) > 0 ? 30 : 16)))
       .alphaDecay(0.018);
 
     const clusterEl = g.append("g")
@@ -2759,22 +2838,35 @@ function ReportGraphPreviewD3({
       .attr("text-anchor", "middle")
       .attr("dy", "0.33em");
 
-    nodeEl.append("text")
+    nodeEl.append("title")
+      .text((node) => `${node.label} - ${node.type} - ${node.verified}`);
+
+    const labelEl = nodeEl.append("text")
       .attr("class", "rd-v3-graph-node__label")
-      .text((node) => node.label)
+      .text((node) => canvasLabelFor(node))
       .attr("dx", (node) => radiusFor(node) + 6)
       .attr("dy", "0.35em")
-      .attr("opacity", (node) => graph.scaleMode === "focus" && node.graphType === "artifact" ? 0 : 1);
+      .attr("data-full-label", (node) => node.label)
+      .attr("data-canvas-label", (node) => canvasLabelFor(node))
+      .attr("opacity", defaultLabelOpacity);
 
-    nodeEl.append("text")
+    const metaEl = nodeEl.append("text")
       .attr("class", "rd-v3-graph-node__meta")
-      .text((node) => node.stage === "universe" ? "monitoring" : node.stage)
+      .text((node) => metaLabelFor(node))
       .attr("dx", (node) => radiusFor(node) + 6)
       .attr("dy", "1.5em")
-      .attr("opacity", (node) => graph.scaleMode === "expanded" || node.graphType === "report" || node.graphType === "cluster" ? 0.55 : 0);
+      .attr("opacity", defaultMetaOpacity);
 
     const applySearch = () => {
       nodeEl.attr("opacity", (node) => (!normalizedGraphQuery || searchMatch(node)) ? 1 : 0.12);
+      labelEl.attr("opacity", (node) => {
+        if (!normalizedGraphQuery) return defaultLabelOpacity(node);
+        return searchMatch(node) ? 1 : 0.04;
+      });
+      metaEl.attr("opacity", (node) => {
+        if (!normalizedGraphQuery) return defaultMetaOpacity(node);
+        return searchMatch(node) ? 0.55 : 0;
+      });
       linkEl.attr("opacity", (link) => {
         if (!normalizedGraphQuery) return 0.5;
         const source = typeof link.source === "object" ? link.source : nodeById.get(String(link.source));
@@ -2785,6 +2877,8 @@ function ReportGraphPreviewD3({
     const highlight = (nodeId: string) => {
       const connected = connectedSet(nodeId);
       nodeEl.attr("opacity", (node) => connected.has(node.id) ? 1 : 0.08);
+      labelEl.attr("opacity", (node) => connected.has(node.id) ? 1 : Math.min(0.12, defaultLabelOpacity(node)));
+      metaEl.attr("opacity", (node) => connected.has(node.id) ? 0.58 : 0);
       nodeEl.selectAll<SVGCircleElement, D3GraphNode>(".rd-v3-graph-node__ring")
         .attr("opacity", (node) => node.id === nodeId ? 0.7 : 0);
       linkEl
@@ -2797,6 +2891,8 @@ function ReportGraphPreviewD3({
     };
     const resetHighlight = () => {
       nodeEl.selectAll<SVGCircleElement, D3GraphNode>(".rd-v3-graph-node__ring").attr("opacity", 0);
+      labelEl.attr("opacity", defaultLabelOpacity);
+      metaEl.attr("opacity", defaultMetaOpacity);
       linkEl.attr("opacity", 0.5).attr("stroke-width", (link) => edgeStyle[link.type]?.width ?? 0.7);
       edgeLabelEl.attr("opacity", 0);
       applySearch();

--- a/tests/e2e/redesign-graph-readability.spec.ts
+++ b/tests/e2e/redesign-graph-readability.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL?.replace(/\/$/, "") ?? "http://localhost:5173";
+
+async function visibleSvgTextCount(page: import("@playwright/test").Page, selector: string) {
+  return page.locator(selector).evaluateAll((els) =>
+    els.filter((el) => {
+      const styleOpacity = Number(getComputedStyle(el).opacity || "1");
+      const attrOpacity = Number(el.getAttribute("opacity") ?? styleOpacity);
+      return styleOpacity * attrOpacity > 0.05;
+    }).length,
+  );
+}
+
+test.describe("redesign reports graph readability", () => {
+  test.setTimeout(45_000);
+
+  test("keeps graph labels bounded and moves long titles into disclosure", async ({ page }) => {
+    await page.goto(`${BASE_URL}/redesign/reports?view=graph&qa=graph-scale-controls`);
+    const graph = page.locator(".rd-v3-graph");
+    await expect(graph).toBeVisible({ timeout: 20_000 });
+    await expect(graph).toHaveAttribute("data-scale-mode", /focus|clustered|expanded/);
+
+    await expect(page.locator(".rd-v3-graph-node").first()).toBeVisible({ timeout: 20_000 });
+    await page.waitForTimeout(1_000);
+
+    const nodeCount = Number(await graph.getAttribute("data-node-count"));
+    expect(nodeCount).toBeGreaterThan(0);
+
+    const visibleLabels = await visibleSvgTextCount(page, ".rd-v3-graph-node__label");
+    const visibleEdgeLabels = await visibleSvgTextCount(page, ".rd-v3-graph-edge-label");
+    expect(visibleLabels).toBeLessThanOrEqual(Math.ceil(nodeCount * 0.55));
+    expect(visibleEdgeLabels).toBe(0);
+
+    const tooLongVisibleLabels = await page.locator(".rd-v3-graph-node__label").evaluateAll((els) =>
+      els
+        .filter((el) => {
+          const styleOpacity = Number(getComputedStyle(el).opacity || "1");
+          const attrOpacity = Number(el.getAttribute("opacity") ?? styleOpacity);
+          return styleOpacity * attrOpacity > 0.05;
+        })
+        .map((el) => el.textContent?.trim() ?? "")
+        .filter((text) => text.length > 28),
+    );
+    expect(tooLongVisibleLabels).toEqual([]);
+
+    const firstNode = page.locator(".rd-v3-graph-node").nth(Math.min(6, nodeCount - 1));
+    const box = await firstNode.boundingBox();
+    expect(box).not.toBeNull();
+    await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+
+    await expect(page.locator(".rd-v3-graph-peek")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(".rd-v3-graph-peek")).toContainText(/Sources|Freshness|Verified/);
+
+    const afterClickEdgeLabels = await visibleSvgTextCount(page, ".rd-v3-graph-edge-label");
+    expect(afterClickEdgeLabels).toBeLessThanOrEqual(Math.max(8, Math.ceil(nodeCount * 0.25)));
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
﻿## Summary
- Replaces always-on full report titles in the Reports graph with compact canvas labels while preserving full titles in SVG title/data attributes and the peek/right-rail disclosure.
- Hides artifact/source and low-priority report labels by default in clustered/focus modes, then promotes labels on search, hover, and selection.
- Retunes force distances/charges/collision so the graph reads like the home-v3 hierarchy instead of a text cloud.
- Fixes the selected-node peek from being cleared immediately when the selected report root changes.
- Adds a focused Playwright regression that asserts label density, visible label length, edge label collapse, disclosure behavior, and horizontal overflow.

## Root Cause
The graph renderer was binding `node.label` directly into every SVG text element. Live Convex report/archive titles can be long article-like chunks, and SVG text does not ellipsize through CSS, so the canvas became a dense wall of labels. The readable details belonged in hover/peek/right-rail disclosure, not on every node.

## Verification
- `npx tsc --noEmit --pretty false`
- `npx vitest run src/features/redesign/lib/reportTopology.test.ts src/features/redesign/lib/graphContextBridge.test.ts`
- `$env:BASE_URL='http://127.0.0.1:5194'; npx playwright test tests/e2e/redesign-graph-readability.spec.ts --project=chromium --workers=1`
- `npx tsc -p convex --noEmit --pretty false`
- `npm run build`

## Browser Evidence
Local graph route: `http://127.0.0.1:5194/redesign/reports?view=graph&qa=graph-label-readability`

Measured after patch:
- 49 visible graph nodes
- 17 visible node labels by default
- 0 visible edge labels by default
- 0 visible labels over 28 characters
- selected node opens `.rd-v3-graph-peek` with Sources/Freshness/Verified details
- no document horizontal overflow
