### PR TITLE
feat(redesign): live Convex data wiring + Gemini QA 86-88

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "qa:redesign": "tsx scripts/qa/redesignAgentQa.ts",
     "qa:redesign:fast": "tsx scripts/qa/redesignAgentQa.ts --personas banker_diligence,karpathy_learner",
     "qa:infer-style": "tsx scripts/qa/inferStyle.ts --self",
+    "qa:interactive": "node scripts/ui/interactiveGeminiQaPipeline.mjs",
+    "qa:interactive:no-video": "node scripts/ui/interactiveGeminiQaPipeline.mjs --skip-video",
     "dogfood:publish": "node scripts/ui/publishDogfoodGallery.mjs",
     "dogfood:record": "node scripts/ui/recordDogfoodWalkthrough.mjs --publish blob",
     "pr-demo": "node scripts/ui/recordPrDemo.mjs",

--- a/scripts/ui/fullSurfaceGeminiQa.mjs
+++ b/scripts/ui/fullSurfaceGeminiQa.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+/**
+ * Full-Surface Gemini QA — end-to-end dogfood across all redesign surfaces.
+ * Captures screenshots of all 6 surfaces (Home, Reports, Chat, Inbox, Me, Workspace)
+ * in both mobile (390x844) and desktop (1280x800) viewports, dark and light mode.
+ * Sends to Gemini 3 Flash for structured evaluation with interaction testing.
+ *
+ * Usage: node scripts/ui/fullSurfaceGeminiQa.mjs [--base-url http://localhost:5200]
+ */
+import { chromium } from "playwright";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as dotenv from "dotenv";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "../..");
+
+dotenv.config({ path: path.join(ROOT, ".env.local") });
+
+const BASE_URL = process.argv.find((a) => a.startsWith("--base-url="))?.split("=")[1] || "http://localhost:5200";
+const GEMINI_KEY = process.env.GEMINI_API_KEY;
+if (!GEMINI_KEY) { console.error("GEMINI_API_KEY not found in .env.local"); process.exit(1); }
+
+const OUT_DIR = path.join(ROOT, ".tmp", "full-surface-qa");
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const MOBILE = { width: 390, height: 844 };
+const DESKTOP = { width: 1280, height: 800 };
+
+const SURFACES = [
+  { id: "home", path: "/redesign", label: "Home" },
+  { id: "reports", path: "/redesign/reports", label: "Reports" },
+  { id: "chat", path: "/redesign/chat", label: "Chat" },
+  { id: "inbox", path: "/redesign/inbox", label: "Inbox" },
+  { id: "me", path: "/redesign/me", label: "Me / Profile" },
+  { id: "workspace", path: "/redesign/workspace", label: "Workspace" },
+];
+
+const MODELS = [
+  "gemini-3-flash-preview",
+  "gemini-2.5-flash",
+  "gemini-2.5-pro",
+];
+
+const EVALUATION_PROMPT = `You are a senior product designer conducting a comprehensive QA dogfood review of a web application called "NodeBench AI" — an entity intelligence platform.
+
+You are reviewing screenshots from MULTIPLE surfaces (pages) of the app, captured in both mobile and desktop viewports, dark and light themes.
+
+DESIGN SYSTEM REFERENCE:
+- Glass card DNA: backdrop-filter blur, semi-transparent bg, subtle white/8% borders
+- Primary accent: terracotta #d97757 for CTAs and active states
+- Typography: Manrope for UI, JetBrains Mono for code/data
+- Dark theme bg: #151413, light theme: white
+- Section labels: 11px uppercase tracking-widened, muted color
+
+EVALUATION FRAMEWORK — Score each surface across 10 dimensions (1-10):
+
+1. VISUAL HIERARCHY — Clear primary action, typography scale, information density
+2. TOUCH TARGETS (mobile only) — All interactive elements >= 44px, comfortable spacing
+3. CONTENT DENSITY — Appropriate information per viewport, scrollability
+4. TYPOGRAPHY & CONTRAST — Body >= 14px, labels legible, WCAG AA contrast
+5. FIRST IMPRESSION — Time to value < 5s, clear value proposition
+6. GLASS DESIGN SYSTEM — Consistent glass cards, accent usage, font rendering
+7. NAVIGATION — Tab bar works, active state clear, surface switching smooth
+8. EMPTY/LOADING STATES — Skeleton loaders, helpful empty states, no blank screens
+9. RESPONSIVE PARITY — Same features accessible on mobile and desktop, no broken layouts
+10. INTERACTION QUALITY — Buttons respond, hover/focus states, keyboard accessibility
+
+USER SCENARIOS TO EVALUATE (easy → complex):
+- S1 (Easy): New user lands on Home — can they understand what the app does in 5 seconds?
+- S2 (Easy): User taps a nav item — does the surface switch cleanly?
+- S3 (Medium): User wants to search/ask a question — is the input obvious and reachable?
+- S4 (Medium): User reviews reports — can they scan, filter, and drill into a report?
+- S5 (Medium): User checks inbox — are notifications/items scannable and actionable?
+- S6 (Complex): User navigates from Home → Reports → drills into a report → returns to Home
+- S7 (Complex): User on mobile rotates between all 5 bottom nav surfaces rapidly
+- S8 (Complex): User in Chat starts a conversation — does the interface support multi-turn?
+
+MARKET REFERENCES:
+- ChatGPT mobile: single-purpose clarity, instant input, streaming responses
+- Perplexity: clean search + citation cards, source attribution
+- Linear mobile: 44px+ targets, sub-50ms response, keyboard-first
+- TikTok: zero-friction first content, single-screen focus
+- Notion mobile: workspace navigation, content density, smooth transitions
+
+OUTPUT FORMAT (JSON):
+{
+  "overallScore": <1-100>,
+  "surfaceScores": {
+    "<surfaceId>": {
+      "score": <1-100>,
+      "dimensions": {
+        "visualHierarchy": <1-10>,
+        "touchTargets": <1-10>,
+        "contentDensity": <1-10>,
+        "typography": <1-10>,
+        "firstImpression": <1-10>,
+        "glassDesignSystem": <1-10>,
+        "navigation": <1-10>,
+        "emptyLoadingStates": <1-10>,
+        "responsiveParity": <1-10>,
+        "interactionQuality": <1-10>
+      },
+      "findings": ["..."],
+      "p1Issues": [{ "issue": "...", "location": "...", "fix": "...", "scenario": "S1-S8" }],
+      "p2Issues": [{ "issue": "...", "location": "...", "fix": "..." }]
+    }
+  },
+  "scenarioResults": {
+    "S1": { "pass": true/false, "notes": "..." },
+    "S2": { "pass": true/false, "notes": "..." },
+    "S3": { "pass": true/false, "notes": "..." },
+    "S4": { "pass": true/false, "notes": "..." },
+    "S5": { "pass": true/false, "notes": "..." },
+    "S6": { "pass": true/false, "notes": "..." },
+    "S7": { "pass": true/false, "notes": "..." },
+    "S8": { "pass": true/false, "notes": "..." }
+  },
+  "crossSurfaceIssues": [{ "issue": "...", "surfaces": ["..."], "fix": "..." }],
+  "topPriorityFixes": ["1. ...", "2. ...", "3. ...", "4. ...", "5. ..."],
+  "marketComparisonVerdict": "two paragraphs comparing to ChatGPT/Perplexity/Linear/Notion mobile"
+}
+
+Be specific: name exact elements, approximate sizes, CSS selectors when possible. Every fix must be actionable in < 30 min.`;
+
+async function captureAllSurfaces() {
+  console.log(`\nCapturing all surfaces at ${BASE_URL} ...\n`);
+  const browser = await chromium.launch({ headless: true });
+  const shots = [];
+
+  for (const viewport of [
+    { ...MOBILE, name: "mobile", scheme: "dark" },
+    { ...DESKTOP, name: "desktop", scheme: "dark" },
+    { ...MOBILE, name: "mobile-light", scheme: "light" },
+  ]) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      colorScheme: viewport.scheme,
+      deviceScaleFactor: viewport.name.startsWith("mobile") ? 3 : 2,
+      userAgent: viewport.name.startsWith("mobile")
+        ? "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+        : undefined,
+    });
+    const page = await context.newPage();
+
+    for (const surface of SURFACES) {
+      const url = `${BASE_URL}${surface.path}`;
+      try {
+        await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 });
+        await page.waitForTimeout(2000);
+
+        const filename = `${surface.id}-${viewport.name}.png`;
+        const filepath = path.join(OUT_DIR, filename);
+        await page.screenshot({ path: filepath, fullPage: false });
+        shots.push({
+          surface: surface.id,
+          label: surface.label,
+          viewport: viewport.name,
+          scheme: viewport.scheme,
+          path: filepath,
+          dimensions: `${viewport.width}x${viewport.height}`,
+        });
+        console.log(`  ✓ ${surface.label} (${viewport.name})`);
+      } catch (e) {
+        console.log(`  ✗ ${surface.label} (${viewport.name}): ${e.message?.slice(0, 80)}`);
+        shots.push({
+          surface: surface.id,
+          label: surface.label,
+          viewport: viewport.name,
+          scheme: viewport.scheme,
+          path: null,
+          error: e.message?.slice(0, 120),
+        });
+      }
+    }
+
+    // Interaction test: navigate between surfaces via bottom nav (mobile only)
+    if (viewport.name === "mobile") {
+      try {
+        await page.goto(`${BASE_URL}/redesign`, { waitUntil: "domcontentloaded", timeout: 15000 });
+        await page.waitForTimeout(1500);
+
+        // Try clicking each bottom nav button
+        const navButtons = await page.$$('[data-redesign] nav button, [data-redesign] nav a');
+        if (navButtons.length > 0) {
+          for (let i = 0; i < Math.min(navButtons.length, 5); i++) {
+            await navButtons[i].click();
+            await page.waitForTimeout(800);
+          }
+          const navShot = path.join(OUT_DIR, "nav-interaction-mobile.png");
+          await page.screenshot({ path: navShot, fullPage: false });
+          shots.push({
+            surface: "nav-interaction",
+            label: "Navigation Interaction Test",
+            viewport: "mobile",
+            scheme: "dark",
+            path: navShot,
+            dimensions: `${MOBILE.width}x${MOBILE.height}`,
+          });
+          console.log(`  ✓ Navigation interaction test (mobile)`);
+        }
+      } catch (e) {
+        console.log(`  ✗ Navigation interaction: ${e.message?.slice(0, 80)}`);
+      }
+    }
+
+    await context.close();
+  }
+
+  await browser.close();
+  const validShots = shots.filter((s) => s.path);
+  console.log(`\nCaptured ${validShots.length}/${shots.length} screenshots.\n`);
+  return { shots, validShots };
+}
+
+async function evaluateWithGemini(validShots) {
+  console.log("Sending to Gemini 3 Flash for evaluation...");
+  const genAI = new GoogleGenerativeAI(GEMINI_KEY);
+
+  const imageParts = validShots.map((s) => ({
+    inlineData: {
+      mimeType: "image/png",
+      data: fs.readFileSync(s.path).toString("base64"),
+    },
+  }));
+
+  const imageLabels = validShots
+    .map((s) => `[Image: ${s.label} — ${s.viewport} ${s.dimensions || ""} ${s.scheme} mode]`)
+    .join("\n");
+
+  let result;
+  for (const modelName of MODELS) {
+    try {
+      console.log(`  Trying model: ${modelName}...`);
+      const model = genAI.getGenerativeModel({ model: modelName });
+      result = await model.generateContent([
+        EVALUATION_PROMPT,
+        `\n\nHere are ${validShots.length} screenshots across all surfaces and viewports:\n${imageLabels}`,
+        ...imageParts,
+        "\n\nRespond with ONLY valid JSON matching the schema above. No markdown fencing.",
+      ]);
+      console.log(`  ✓ Success with model: ${modelName}`);
+      break;
+    } catch (e) {
+      console.log(`  ✗ ${modelName}: ${e.message?.slice(0, 120)}`);
+    }
+  }
+
+  if (!result) {
+    console.error("All Gemini models failed.");
+    return null;
+  }
+
+  const text = result.response.text();
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    return JSON.parse(jsonMatch[0]);
+  } catch (e) {
+    console.error("Failed to parse Gemini response:");
+    console.error(text.slice(0, 3000));
+    fs.writeFileSync(path.join(OUT_DIR, "raw-response.txt"), text);
+    return null;
+  }
+}
+
+function printReport(evaluation) {
+  console.log("\n" + "=".repeat(70));
+  console.log("  FULL-SURFACE QA EVALUATION REPORT");
+  console.log("=".repeat(70));
+  console.log(`\nOverall Score: ${evaluation.overallScore}/100\n`);
+
+  if (evaluation.surfaceScores) {
+    console.log("Surface Scores:");
+    const sorted = Object.entries(evaluation.surfaceScores).sort((a, b) => (a[1].score || 0) - (b[1].score || 0));
+    for (const [id, data] of sorted) {
+      const score = data.score || "?";
+      const dims = data.dimensions || {};
+      const lowest = Object.entries(dims).sort((a, b) => a[1] - b[1]).slice(0, 2);
+      const lowestStr = lowest.map(([k, v]) => `${k}=${v}`).join(", ");
+      console.log(`  ${id.padEnd(12)} ${String(score).padStart(3)}/100  weakest: ${lowestStr}`);
+      if (data.p1Issues?.length) {
+        data.p1Issues.forEach((p) => console.log(`    P1: [${p.location}] ${p.issue}`));
+      }
+    }
+  }
+
+  if (evaluation.scenarioResults) {
+    console.log("\nScenario Results:");
+    for (const [id, result] of Object.entries(evaluation.scenarioResults)) {
+      const icon = result.pass ? "✓" : "✗";
+      console.log(`  ${icon} ${id}: ${result.notes?.slice(0, 100) || ""}`);
+    }
+  }
+
+  if (evaluation.crossSurfaceIssues?.length) {
+    console.log(`\nCross-Surface Issues (${evaluation.crossSurfaceIssues.length}):`);
+    evaluation.crossSurfaceIssues.forEach((c, i) =>
+      console.log(`  ${i + 1}. [${c.surfaces?.join(", ")}] ${c.issue}\n     Fix: ${c.fix}`)
+    );
+  }
+
+  const totalP1 = Object.values(evaluation.surfaceScores || {}).reduce((sum, s) => sum + (s.p1Issues?.length || 0), 0);
+  const totalP2 = Object.values(evaluation.surfaceScores || {}).reduce((sum, s) => sum + (s.p2Issues?.length || 0), 0);
+  console.log(`\nTotal: ${totalP1} P1s, ${totalP2} P2s`);
+
+  if (evaluation.topPriorityFixes?.length) {
+    console.log("\nTop Priority Fixes:");
+    evaluation.topPriorityFixes.forEach((f) => console.log(`  ${f}`));
+  }
+
+  if (evaluation.marketComparisonVerdict) {
+    console.log(`\nMarket Comparison:\n  ${evaluation.marketComparisonVerdict.slice(0, 500)}`);
+  }
+}
+
+async function main() {
+  console.log("=== NodeBench Full-Surface Gemini QA ===");
+  console.log(`Base URL: ${BASE_URL}`);
+  console.log(`Surfaces: ${SURFACES.map((s) => s.label).join(", ")}`);
+  console.log(`Viewports: mobile (390x844), desktop (1280x800)`);
+  console.log(`Themes: dark, light`);
+
+  const { shots, validShots } = await captureAllSurfaces();
+
+  if (validShots.length === 0) {
+    console.error("No screenshots captured. Is the dev server running?");
+    process.exit(1);
+  }
+
+  const evaluation = await evaluateWithGemini(validShots);
+  if (!evaluation) {
+    console.error("Evaluation failed — see raw response.");
+    process.exit(1);
+  }
+
+  const resultPath = path.join(OUT_DIR, "evaluation.json");
+  fs.writeFileSync(resultPath, JSON.stringify(evaluation, null, 2));
+  console.log(`\nResults saved to: ${resultPath}`);
+
+  // Save screenshot manifest
+  const manifest = { timestamp: new Date().toISOString(), shots, validCount: validShots.length };
+  fs.writeFileSync(path.join(OUT_DIR, "manifest.json"), JSON.stringify(manifest, null, 2));
+
+  printReport(evaluation);
+  return evaluation;
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/ui/interactiveGeminiQaPipeline.mjs
+++ b/scripts/ui/interactiveGeminiQaPipeline.mjs
@@ -1,0 +1,869 @@
+#!/usr/bin/env node
+/**
+ * Interactive Gemini QA Pipeline — cross-round comparison + video analysis + interaction testing.
+ *
+ * Addresses three gaps in fullSurfaceGeminiQa.mjs:
+ * 1. Cross-round comparison: accumulates round history in .tmp/full-surface-qa/history.jsonl
+ *    with gen-over-gen diff tracking (P1 resolution, regression detection, dimension trends)
+ * 2. Live interaction testing: records actual user flows (click, navigate, type, wait for data)
+ *    with before/during/after state capture via Playwright video recording
+ * 3. Gemini video analysis: uploads interaction videos to Gemini 3+ models via File API
+ *    for holistic temporal evaluation of interactions, timing, and data display correctness
+ *
+ * Prior art:
+ *   - fullSurfaceGeminiQa.mjs (static screenshot pipeline — this extends it)
+ *   - convex/domains/evaluation/dogfood/videoQa.ts (Gemini File API pattern)
+ *   - convex/domains/evaluation/dogfood/screenshotQa.ts (SHA256 dedup pattern)
+ *
+ * Usage:
+ *   node scripts/ui/interactiveGeminiQaPipeline.mjs [--base-url http://localhost:5200] [--round-label "post-fix-batch"]
+ */
+import { chromium } from "playwright";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { GoogleAIFileManager } from "@google/generative-ai/server";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+import * as dotenv from "dotenv";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "../..");
+
+dotenv.config({ path: path.join(ROOT, ".env.local") });
+
+/* ── CLI args ──────────────────────────────────────────────── */
+const BASE_URL = process.argv.find((a) => a.startsWith("--base-url="))?.split("=")[1] || "http://localhost:5200";
+const ROUND_LABEL = process.argv.find((a) => a.startsWith("--round-label="))?.split("=")[1] || "";
+const SKIP_VIDEO = process.argv.includes("--skip-video");
+const GEMINI_KEY = process.env.GEMINI_API_KEY;
+if (!GEMINI_KEY) { console.error("GEMINI_API_KEY not found in .env.local"); process.exit(1); }
+
+/* ── Constants ─────────────────────────────────────────────── */
+const OUT_DIR = path.join(ROOT, ".tmp", "full-surface-qa");
+const HISTORY_FILE = path.join(OUT_DIR, "history.jsonl");
+const ROUNDS_DIR = path.join(OUT_DIR, "rounds");
+const MOBILE = { width: 390, height: 844 };
+const DESKTOP = { width: 1280, height: 800 };
+const MAX_HISTORY_ROUNDS = 100; // BOUND: cap history to prevent unbounded growth
+
+const SURFACES = [
+  { id: "home", path: "/redesign", label: "Home" },
+  { id: "reports", path: "/redesign/reports", label: "Reports" },
+  { id: "chat", path: "/redesign/chat", label: "Chat" },
+  { id: "inbox", path: "/redesign/inbox", label: "Inbox" },
+  { id: "me", path: "/redesign/me", label: "Me / Profile" },
+  { id: "workspace", path: "/redesign/workspace", label: "Workspace" },
+];
+
+/** Interaction flows for video recording — real user scenarios S1-S8 */
+const INTERACTION_FLOWS = [
+  {
+    id: "nav-cycle",
+    label: "S7: Rapid surface switching",
+    steps: [
+      { action: "goto", url: "/redesign", wait: 2000 },
+      { action: "screenshot", name: "before-nav" },
+      { action: "click", selector: "nav a[href*='reports'], nav button:has-text('Reports')", wait: 1200 },
+      { action: "screenshot", name: "during-reports" },
+      { action: "click", selector: "nav a[href*='chat'], nav button:has-text('Chat')", wait: 1200 },
+      { action: "screenshot", name: "during-chat" },
+      { action: "click", selector: "nav a[href*='inbox'], nav button:has-text('Inbox')", wait: 1200 },
+      { action: "screenshot", name: "during-inbox" },
+      { action: "click", selector: "nav a[href*='/redesign/me'], nav button:has-text('Me')", wait: 1200 },
+      { action: "screenshot", name: "after-me" },
+    ],
+  },
+  {
+    id: "home-to-report-drill",
+    label: "S6: Home -> Reports -> drill -> back",
+    steps: [
+      { action: "goto", url: "/redesign", wait: 2000 },
+      { action: "screenshot", name: "before-home" },
+      { action: "click", selector: "nav a[href*='reports'], nav button:has-text('Reports')", wait: 1500 },
+      { action: "screenshot", name: "during-reports-list" },
+      { action: "click", selector: "[data-redesign] .rd-card:first-child, [data-redesign] article:first-child", wait: 1500 },
+      { action: "screenshot", name: "during-report-detail" },
+      { action: "click", selector: "nav a[href*='/redesign'], nav button:has-text('Home')", wait: 1500 },
+      { action: "screenshot", name: "after-back-home" },
+    ],
+  },
+  {
+    id: "chat-conversation",
+    label: "S8: Start a chat conversation",
+    steps: [
+      { action: "goto", url: "/redesign/chat", wait: 2000 },
+      { action: "screenshot", name: "before-chat" },
+      { action: "click", selector: "[data-redesign] textarea, [data-redesign] input[type='text'], [data-redesign] [contenteditable]", wait: 800 },
+      { action: "type", text: "Tell me about Anthropic's latest research", wait: 500 },
+      { action: "screenshot", name: "during-typing" },
+      { action: "key", key: "Enter", wait: 3000 },
+      { action: "screenshot", name: "after-send" },
+    ],
+  },
+  {
+    id: "inbox-triage",
+    label: "S5: Inbox scan and action",
+    steps: [
+      { action: "goto", url: "/redesign/inbox", wait: 2000 },
+      { action: "screenshot", name: "before-inbox" },
+      { action: "click", selector: "[data-redesign] .rd-card:first-child, [data-redesign] article:first-child, [data-redesign] li:first-child", wait: 1200 },
+      { action: "screenshot", name: "during-item-open" },
+      { action: "click", selector: "[data-redesign] .rd-btn:has-text('Approve'), [data-redesign] .rd-btn:has-text('Accept'), [data-redesign] .rd-btn--primary", wait: 1000 },
+      { action: "screenshot", name: "after-action" },
+    ],
+  },
+];
+
+const SCREENSHOT_EVAL_PROMPT = `You are a senior product designer conducting a comprehensive QA dogfood review of "NodeBench AI" — an entity intelligence platform.
+
+You are reviewing screenshots from MULTIPLE surfaces in both mobile and desktop viewports, dark and light themes.
+
+DESIGN SYSTEM: Glass card DNA (backdrop-filter blur, semi-transparent bg, subtle borders), terracotta #d97757 accent, Manrope + JetBrains Mono, dark bg #151413.
+
+EVALUATION FRAMEWORK — Score each surface across 10 dimensions (1-10):
+1. VISUAL HIERARCHY  2. TOUCH TARGETS (mobile >=44px)  3. CONTENT DENSITY
+4. TYPOGRAPHY & CONTRAST (WCAG AA)  5. FIRST IMPRESSION  6. GLASS DESIGN SYSTEM
+7. NAVIGATION  8. EMPTY/LOADING STATES  9. RESPONSIVE PARITY  10. INTERACTION QUALITY
+
+USER SCENARIOS: S1-S8 (new user clarity, nav switching, search, reports, inbox, drill-down, rapid switch, chat)
+
+OUTPUT FORMAT (JSON):
+{
+  "overallScore": <1-100>,
+  "surfaceScores": { "<id>": { "score": <1-100>, "dimensions": {...}, "findings": [...], "p1Issues": [{"issue":"..","location":"..","fix":"..","scenario":"S1-S8","issueId":"p1-<surface>-<n>"}], "p2Issues": [{"issue":"..","location":"..","fix":"..","issueId":"p2-<surface>-<n>"}] } },
+  "scenarioResults": { "S1": {"pass": true/false, "notes": "..."}, ... "S8": {"pass": true/false, "notes": "..."} },
+  "crossSurfaceIssues": [{"issue":"..","surfaces":[".."],"fix":".."}],
+  "topPriorityFixes": ["1. ...", "2. ...", "3. ...", "4. ...", "5. ..."],
+  "marketComparisonVerdict": "paragraph comparing to ChatGPT/Perplexity/Linear/Notion"
+}
+
+IMPORTANT: Every P1 and P2 issue MUST have a unique "issueId" field (format: "p1-<surface>-<n>" or "p2-<surface>-<n>") so we can track resolution across rounds. Be specific: name elements, sizes, CSS selectors. Every fix must be actionable in <30 min.`;
+
+const VIDEO_EVAL_PROMPT = `You are evaluating a VIDEO RECORDING of real user interaction flows in the NodeBench AI web app.
+
+Watch the video carefully and evaluate TEMPORAL aspects that screenshots cannot capture:
+
+1. TRANSITION SMOOTHNESS (1-10) — Are surface switches animated? Any janky repaints?
+2. LOADING TIMING (1-10) — How fast does content appear after navigation? Any blank flashes?
+3. STATE PERSISTENCE (1-10) — Does scroll position reset? Do inputs lose focus? Any state loss?
+4. DATA LOADING (1-10) — Do Convex queries resolve? Is there real data or just fixtures?
+5. INTERACTION RESPONSIVENESS (1-10) — Click-to-response latency. Any frozen frames?
+6. ERROR HANDLING (1-10) — Any console errors visible? Red flashes? Broken layouts during transitions?
+7. NAVIGATION FLOW (1-10) — Does back-navigation work? Tab highlight updates correctly?
+8. ANIMATION QUALITY (1-10) — Smooth fade-ins? No seizure-inducing flashes? Reduced motion respected?
+
+OUTPUT FORMAT (JSON):
+{
+  "overallInteractionScore": <1-100>,
+  "dimensions": {
+    "transitionSmoothness": <1-10>,
+    "loadingTiming": <1-10>,
+    "statePersistence": <1-10>,
+    "dataLoading": <1-10>,
+    "interactionResponsiveness": <1-10>,
+    "errorHandling": <1-10>,
+    "navigationFlow": <1-10>,
+    "animationQuality": <1-10>
+  },
+  "temporalIssues": [
+    { "timestamp": "approx MM:SS", "issue": "...", "severity": "p1|p2", "fix": "...", "issueId": "vid-<n>" }
+  ],
+  "flowResults": {
+    "navCycle": { "pass": true/false, "notes": "..." },
+    "drillDown": { "pass": true/false, "notes": "..." },
+    "chatConversation": { "pass": true/false, "notes": "..." },
+    "inboxTriage": { "pass": true/false, "notes": "..." }
+  },
+  "liveDataVerdict": "Are we seeing real Convex data or just fixtures/demo data?",
+  "topTemporalFixes": ["1. ...", "2. ...", "3. ..."]
+}
+
+Be precise about timestamps. Flag any moment where the UI feels slower than Linear or ChatGPT.`;
+
+const MODELS_SCREENSHOT = ["gemini-3-flash-preview", "gemini-2.5-flash", "gemini-2.5-pro"];
+const MODELS_VIDEO = ["gemini-3-flash-preview", "gemini-2.5-flash", "gemini-2.5-pro"];
+
+/* ═══════════════════════════════════════════════════════════════
+   PHASE 0: Round History Management
+   ═══════════════════════════════════════════════════════════════ */
+
+function loadRoundHistory() {
+  if (!fs.existsSync(HISTORY_FILE)) return [];
+  const lines = fs.readFileSync(HISTORY_FILE, "utf-8").trim().split("\n").filter(Boolean);
+  // BOUND: only keep last MAX_HISTORY_ROUNDS
+  const parsed = lines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+  return parsed.slice(-MAX_HISTORY_ROUNDS);
+}
+
+function getNextRoundNumber(history) {
+  if (history.length === 0) return 1;
+  return Math.max(...history.map((r) => r.roundNumber || 0)) + 1;
+}
+
+function appendRoundToHistory(roundData) {
+  fs.mkdirSync(path.dirname(HISTORY_FILE), { recursive: true });
+  fs.appendFileSync(HISTORY_FILE, JSON.stringify(roundData) + "\n");
+
+  // BOUND: trim history file if over limit
+  const lines = fs.readFileSync(HISTORY_FILE, "utf-8").trim().split("\n").filter(Boolean);
+  if (lines.length > MAX_HISTORY_ROUNDS) {
+    fs.writeFileSync(HISTORY_FILE, lines.slice(-MAX_HISTORY_ROUNDS).join("\n") + "\n");
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PHASE 1: Screenshot Capture (same surfaces, saved per-round)
+   ═══════════════════════════════════════════════════════════════ */
+
+async function captureAllSurfaces(roundDir) {
+  console.log(`\n[Phase 1] Capturing screenshots at ${BASE_URL} ...\n`);
+  const browser = await chromium.launch({ headless: true });
+  const shots = [];
+
+  for (const viewport of [
+    { ...MOBILE, name: "mobile", scheme: "dark" },
+    { ...DESKTOP, name: "desktop", scheme: "dark" },
+    { ...MOBILE, name: "mobile-light", scheme: "light" },
+  ]) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      colorScheme: viewport.scheme,
+      deviceScaleFactor: viewport.name.startsWith("mobile") ? 3 : 2,
+      userAgent: viewport.name.startsWith("mobile")
+        ? "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+        : undefined,
+    });
+    const page = await context.newPage();
+
+    for (const surface of SURFACES) {
+      const url = `${BASE_URL}${surface.path}`;
+      try {
+        await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 });
+        await page.waitForTimeout(2000);
+
+        const filename = `${surface.id}-${viewport.name}.png`;
+        const filepath = path.join(roundDir, filename);
+        await page.screenshot({ path: filepath, fullPage: false });
+        shots.push({
+          surface: surface.id, label: surface.label,
+          viewport: viewport.name, scheme: viewport.scheme,
+          path: filepath, dimensions: `${viewport.width}x${viewport.height}`,
+        });
+        console.log(`  OK ${surface.label} (${viewport.name})`);
+      } catch (e) {
+        console.log(`  FAIL ${surface.label} (${viewport.name}): ${e.message?.slice(0, 80)}`);
+        shots.push({
+          surface: surface.id, label: surface.label,
+          viewport: viewport.name, scheme: viewport.scheme,
+          path: null, error: e.message?.slice(0, 120),
+        });
+      }
+    }
+    await context.close();
+  }
+
+  await browser.close();
+  const validShots = shots.filter((s) => s.path);
+  console.log(`\n  Captured ${validShots.length}/${shots.length} screenshots.\n`);
+  return { shots, validShots };
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PHASE 2: Interaction Video Recording (new)
+   ═══════════════════════════════════════════════════════════════ */
+
+async function recordInteractionVideos(roundDir) {
+  if (SKIP_VIDEO) {
+    console.log("\n[Phase 2] Skipping video recording (--skip-video)\n");
+    return { videos: [], interactionShots: [] };
+  }
+
+  console.log("\n[Phase 2] Recording interaction videos ...\n");
+  const videoDir = path.join(roundDir, "videos");
+  fs.mkdirSync(videoDir, { recursive: true });
+
+  const browser = await chromium.launch({ headless: true });
+  const videos = [];
+  const interactionShots = [];
+
+  for (const flow of INTERACTION_FLOWS) {
+    console.log(`  Recording: ${flow.label} ...`);
+    const context = await browser.newContext({
+      viewport: MOBILE,
+      colorScheme: "dark",
+      deviceScaleFactor: 2,
+      userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+      recordVideo: { dir: videoDir, size: MOBILE },
+    });
+    const page = await context.newPage();
+
+    let flowSuccess = true;
+    const stepResults = [];
+
+    for (const step of flow.steps) {
+      try {
+        switch (step.action) {
+          case "goto":
+            await page.goto(`${BASE_URL}${step.url}`, { waitUntil: "domcontentloaded", timeout: 15000 });
+            break;
+          case "click":
+            try {
+              await page.click(step.selector, { timeout: 5000 });
+            } catch {
+              // Fallback: try a broader selector
+              const buttons = await page.$$("button, a, [role='button']");
+              if (buttons.length > 0) await buttons[0].click();
+            }
+            break;
+          case "type":
+            await page.keyboard.type(step.text, { delay: 50 });
+            break;
+          case "key":
+            await page.keyboard.press(step.key);
+            break;
+          case "screenshot": {
+            const shotPath = path.join(roundDir, `interaction-${flow.id}-${step.name}.png`);
+            await page.screenshot({ path: shotPath, fullPage: false });
+            interactionShots.push({
+              flow: flow.id, step: step.name, path: shotPath,
+              label: `${flow.label} — ${step.name}`,
+            });
+            break;
+          }
+        }
+        if (step.wait) await page.waitForTimeout(step.wait);
+        stepResults.push({ action: step.action, status: "ok" });
+      } catch (e) {
+        stepResults.push({ action: step.action, status: "error", error: e.message?.slice(0, 100) });
+        flowSuccess = false;
+      }
+    }
+
+    // Close context to finalize video
+    await context.close();
+
+    // Find the video file that was just created
+    const videoFiles = fs.readdirSync(videoDir).filter((f) => f.endsWith(".webm")).sort();
+    const latestVideo = videoFiles[videoFiles.length - 1];
+    if (latestVideo) {
+      const videoPath = path.join(videoDir, latestVideo);
+      // Rename to meaningful name
+      const renamedPath = path.join(videoDir, `${flow.id}.webm`);
+      if (!fs.existsSync(renamedPath)) {
+        fs.renameSync(videoPath, renamedPath);
+      }
+      videos.push({
+        flowId: flow.id, label: flow.label, path: renamedPath,
+        success: flowSuccess, stepResults,
+        sizeBytes: fs.statSync(renamedPath).size,
+      });
+      console.log(`  OK ${flow.label} (${(fs.statSync(renamedPath).size / 1024).toFixed(0)}KB)`);
+    } else {
+      console.log(`  WARN No video file found for ${flow.label}`);
+      videos.push({ flowId: flow.id, label: flow.label, path: null, success: flowSuccess, stepResults });
+    }
+  }
+
+  await browser.close();
+  console.log(`\n  Recorded ${videos.filter((v) => v.path).length}/${videos.length} interaction videos.\n`);
+  return { videos, interactionShots };
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PHASE 3: Screenshot Evaluation with Gemini
+   ═══════════════════════════════════════════════════════════════ */
+
+async function evaluateScreenshots(validShots, roundNumber, history) {
+  console.log("[Phase 3] Sending screenshots to Gemini 3 Flash ...");
+  const genAI = new GoogleGenerativeAI(GEMINI_KEY);
+
+  const imageParts = validShots.map((s) => ({
+    inlineData: { mimeType: "image/png", data: fs.readFileSync(s.path).toString("base64") },
+  }));
+
+  const imageLabels = validShots
+    .map((s) => `[Image: ${s.label} - ${s.viewport} ${s.dimensions || ""} ${s.scheme} mode]`)
+    .join("\n");
+
+  // Inject previous round context for comparison
+  let historyContext = "";
+  if (history.length > 0) {
+    const prev = history[history.length - 1];
+    const prevP1s = extractAllP1Ids(prev.screenshotEval);
+    historyContext = `\n\nPREVIOUS ROUND CONTEXT (Round ${prev.roundNumber}, score ${prev.screenshotEval?.overallScore || "?"}):\n` +
+      `Previous P1 issue IDs: ${prevP1s.join(", ") || "none"}\n` +
+      `Previous top fixes: ${(prev.screenshotEval?.topPriorityFixes || []).slice(0, 3).join("; ")}\n` +
+      `For each P1 you find, note if it existed in the previous round (regression) or is new.\n`;
+  }
+
+  let result;
+  for (const modelName of MODELS_SCREENSHOT) {
+    try {
+      console.log(`  Trying: ${modelName} ...`);
+      const model = genAI.getGenerativeModel({ model: modelName });
+      result = await model.generateContent({
+        contents: [{ role: "user", parts: [
+          { text: SCREENSHOT_EVAL_PROMPT + historyContext +
+            `\n\nRound ${roundNumber}. ${validShots.length} screenshots:\n${imageLabels}` },
+          ...imageParts,
+          { text: "\nRespond with ONLY valid JSON matching the schema above. No markdown fencing." },
+        ]}],
+        generationConfig: { temperature: 0.1, maxOutputTokens: 8192 },
+      });
+      console.log(`  OK model: ${modelName}`);
+      break;
+    } catch (e) {
+      console.log(`  FAIL ${modelName}: ${e.message?.slice(0, 120)}`);
+    }
+  }
+
+  if (!result) { console.error("All screenshot models failed."); return null; }
+
+  const text = result.response.text();
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    return JSON.parse(jsonMatch[0]);
+  } catch (e) {
+    console.error("Failed to parse screenshot eval response");
+    return null;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PHASE 4: Video Evaluation with Gemini (new — File API)
+   ═══════════════════════════════════════════════════════════════ */
+
+async function evaluateVideos(videos) {
+  if (SKIP_VIDEO || videos.filter((v) => v.path).length === 0) {
+    console.log("\n[Phase 4] Skipping video evaluation (no videos)\n");
+    return null;
+  }
+
+  console.log("\n[Phase 4] Uploading videos to Gemini File API ...\n");
+  const genAI = new GoogleGenerativeAI(GEMINI_KEY);
+  const fileManager = new GoogleAIFileManager(GEMINI_KEY);
+
+  // Upload all valid videos
+  const uploadedFiles = [];
+  for (const video of videos.filter((v) => v.path)) {
+    try {
+      console.log(`  Uploading ${video.flowId} (${(video.sizeBytes / 1024).toFixed(0)}KB) ...`);
+      const uploadResult = await fileManager.uploadFile(video.path, {
+        mimeType: "video/webm",
+        displayName: `nodebench-qa-${video.flowId}`,
+      });
+
+      // Poll until file is ACTIVE
+      let file = uploadResult.file;
+      let attempts = 0;
+      while (file.state === "PROCESSING" && attempts < 30) {
+        await new Promise((r) => setTimeout(r, 2000));
+        file = await fileManager.getFile(file.name);
+        attempts++;
+      }
+
+      if (file.state === "ACTIVE") {
+        uploadedFiles.push({ flowId: video.flowId, fileUri: file.uri, fileName: file.name });
+        console.log(`  OK ${video.flowId} uploaded and active`);
+      } else {
+        console.log(`  WARN ${video.flowId} stuck in state: ${file.state}`);
+      }
+    } catch (e) {
+      console.log(`  FAIL upload ${video.flowId}: ${e.message?.slice(0, 120)}`);
+    }
+  }
+
+  if (uploadedFiles.length === 0) {
+    console.log("  No videos uploaded successfully.");
+    return null;
+  }
+
+  // Send all uploaded videos to Gemini for temporal analysis
+  let result;
+  for (const modelName of MODELS_VIDEO) {
+    try {
+      console.log(`  Evaluating with ${modelName} ...`);
+      const model = genAI.getGenerativeModel({ model: modelName });
+
+      const fileParts = uploadedFiles.map((f) => ({
+        fileData: { mimeType: "video/webm", fileUri: f.fileUri },
+      }));
+
+      const fileLabels = uploadedFiles.map((f) => `[Video: ${f.flowId}]`).join("\n");
+
+      result = await model.generateContent({
+        contents: [{ role: "user", parts: [
+          { text: VIDEO_EVAL_PROMPT + `\n\n${uploadedFiles.length} interaction videos:\n${fileLabels}` },
+          ...fileParts,
+          { text: "\nRespond with ONLY valid JSON. No markdown fencing." },
+        ]}],
+        generationConfig: { temperature: 0.1, maxOutputTokens: 8192 },
+      });
+      console.log(`  OK video eval with ${modelName}`);
+      break;
+    } catch (e) {
+      console.log(`  FAIL ${modelName}: ${e.message?.slice(0, 120)}`);
+    }
+  }
+
+  // Cleanup uploaded files
+  for (const f of uploadedFiles) {
+    try { await fileManager.deleteFile(f.fileName); } catch { /* best effort */ }
+  }
+
+  if (!result) { console.error("All video eval models failed."); return null; }
+
+  const text = result.response.text();
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    return JSON.parse(jsonMatch[0]);
+  } catch {
+    console.error("Failed to parse video eval response");
+    return null;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PHASE 5: Cross-Round Comparison (new)
+   ═══════════════════════════════════════════════════════════════ */
+
+function extractAllP1Ids(screenshotEval) {
+  if (!screenshotEval?.surfaceScores) return [];
+  const ids = [];
+  for (const [, data] of Object.entries(screenshotEval.surfaceScores)) {
+    for (const p1 of data.p1Issues || []) {
+      if (p1.issueId) ids.push(p1.issueId);
+    }
+  }
+  return ids;
+}
+
+function extractAllP1Details(screenshotEval) {
+  if (!screenshotEval?.surfaceScores) return [];
+  const details = [];
+  for (const [surfaceId, data] of Object.entries(screenshotEval.surfaceScores)) {
+    for (const p1 of data.p1Issues || []) {
+      details.push({ ...p1, surface: surfaceId });
+    }
+  }
+  return details;
+}
+
+function generateCrossRoundComparison(currentRound, history) {
+  console.log("\n[Phase 5] Generating cross-round comparison ...\n");
+
+  const comparison = {
+    currentRound: currentRound.roundNumber,
+    totalRoundsCompleted: history.length + 1,
+    timestamp: currentRound.timestamp,
+
+    // Score trajectory
+    scoreTrajectory: [],
+
+    // P1 tracking
+    p1Tracking: { resolved: [], regressed: [], persistent: [], new: [] },
+
+    // Dimension trends (averaged across surfaces)
+    dimensionTrends: {},
+
+    // Scenario pass rate over time
+    scenarioTrends: {},
+
+    // Video score trajectory (if available)
+    videoScoreTrajectory: [],
+
+    // Summary
+    summary: "",
+    nextActions: [],
+  };
+
+  // Build score trajectory from history + current
+  const allRounds = [...history, currentRound];
+  for (const round of allRounds) {
+    const ss = round.screenshotEval;
+    if (!ss) continue;
+    comparison.scoreTrajectory.push({
+      round: round.roundNumber,
+      score: ss.overallScore || 0,
+      p1Count: extractAllP1Details(ss).length,
+      p2Count: Object.values(ss.surfaceScores || {}).reduce((sum, s) => sum + (s.p2Issues?.length || 0), 0),
+      scenarioPassRate: ss.scenarioResults
+        ? Object.values(ss.scenarioResults).filter((r) => r.pass).length / Object.values(ss.scenarioResults).length
+        : null,
+      label: round.label || "",
+    });
+
+    // Video trajectory
+    if (round.videoEval?.overallInteractionScore) {
+      comparison.videoScoreTrajectory.push({
+        round: round.roundNumber,
+        score: round.videoEval.overallInteractionScore,
+      });
+    }
+  }
+
+  // P1 tracking: compare current vs previous round
+  if (history.length > 0) {
+    const prev = history[history.length - 1];
+    const prevP1Ids = new Set(extractAllP1Ids(prev.screenshotEval));
+    const currP1Ids = new Set(extractAllP1Ids(currentRound.screenshotEval));
+    const currP1Details = extractAllP1Details(currentRound.screenshotEval);
+    const prevP1Details = extractAllP1Details(prev.screenshotEval);
+
+    // Resolved: was in prev, not in current
+    for (const id of prevP1Ids) {
+      if (!currP1Ids.has(id)) {
+        const detail = prevP1Details.find((p) => p.issueId === id);
+        comparison.p1Tracking.resolved.push({ issueId: id, issue: detail?.issue || id, resolvedInRound: currentRound.roundNumber });
+      }
+    }
+
+    // New: in current, not in prev
+    for (const id of currP1Ids) {
+      if (!prevP1Ids.has(id)) {
+        const detail = currP1Details.find((p) => p.issueId === id);
+        comparison.p1Tracking.new.push({ issueId: id, issue: detail?.issue || id, surface: detail?.surface });
+      }
+    }
+
+    // Persistent: in both
+    for (const id of currP1Ids) {
+      if (prevP1Ids.has(id)) {
+        const detail = currP1Details.find((p) => p.issueId === id);
+        comparison.p1Tracking.persistent.push({ issueId: id, issue: detail?.issue || id, surface: detail?.surface });
+      }
+    }
+
+    // Regressed: check if any issue that was resolved in an earlier round reappeared
+    const allHistoricalP1Ids = new Set();
+    for (const round of history.slice(0, -1)) {
+      for (const id of extractAllP1Ids(round.screenshotEval)) allHistoricalP1Ids.add(id);
+    }
+    for (const id of currP1Ids) {
+      if (allHistoricalP1Ids.has(id) && !prevP1Ids.has(id)) {
+        const detail = currP1Details.find((p) => p.issueId === id);
+        comparison.p1Tracking.regressed.push({ issueId: id, issue: detail?.issue || id, surface: detail?.surface });
+      }
+    }
+  }
+
+  // Dimension trends: track averages over last 5 rounds
+  const recentRounds = allRounds.slice(-5);
+  const dimNames = ["visualHierarchy", "touchTargets", "contentDensity", "typography", "firstImpression",
+    "glassDesignSystem", "navigation", "emptyLoadingStates", "responsiveParity", "interactionQuality"];
+  for (const dim of dimNames) {
+    comparison.dimensionTrends[dim] = recentRounds.map((r) => {
+      if (!r.screenshotEval?.surfaceScores) return { round: r.roundNumber, avg: null };
+      const scores = Object.values(r.screenshotEval.surfaceScores)
+        .map((s) => s.dimensions?.[dim]).filter((v) => v != null);
+      return { round: r.roundNumber, avg: scores.length > 0 ? (scores.reduce((a, b) => a + b, 0) / scores.length).toFixed(1) : null };
+    });
+  }
+
+  // Scenario trends
+  for (const sId of ["S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8"]) {
+    comparison.scenarioTrends[sId] = recentRounds.map((r) => ({
+      round: r.roundNumber,
+      pass: r.screenshotEval?.scenarioResults?.[sId]?.pass ?? null,
+    }));
+  }
+
+  // Generate summary
+  const curr = currentRound.screenshotEval;
+  const prevScore = history.length > 0 ? history[history.length - 1].screenshotEval?.overallScore : null;
+  const scoreDelta = prevScore != null && curr?.overallScore != null ? curr.overallScore - prevScore : null;
+  const resolvedCount = comparison.p1Tracking.resolved.length;
+  const newCount = comparison.p1Tracking.new.length;
+  const persistentCount = comparison.p1Tracking.persistent.length;
+
+  comparison.summary = [
+    `Round ${currentRound.roundNumber}: score ${curr?.overallScore || "?"}` +
+      (scoreDelta != null ? ` (${scoreDelta >= 0 ? "+" : ""}${scoreDelta} vs prev)` : ""),
+    resolvedCount > 0 ? `${resolvedCount} P1s resolved` : null,
+    newCount > 0 ? `${newCount} new P1s introduced` : null,
+    persistentCount > 0 ? `${persistentCount} P1s persistent` : null,
+    comparison.p1Tracking.regressed.length > 0 ? `WARNING: ${comparison.p1Tracking.regressed.length} P1s regressed` : null,
+  ].filter(Boolean).join(". ") + ".";
+
+  // Next actions based on trends
+  if (comparison.p1Tracking.persistent.length > 0) {
+    comparison.nextActions.push(`Fix persistent P1s: ${comparison.p1Tracking.persistent.map((p) => p.issueId).join(", ")}`);
+  }
+  if (comparison.p1Tracking.regressed.length > 0) {
+    comparison.nextActions.push(`URGENT: Investigate regressions: ${comparison.p1Tracking.regressed.map((p) => p.issueId).join(", ")}`);
+  }
+
+  // Check for plateau (3+ rounds same score)
+  const last3 = comparison.scoreTrajectory.slice(-3);
+  if (last3.length >= 3) {
+    const scores = last3.map((r) => r.score);
+    const range = Math.max(...scores) - Math.min(...scores);
+    if (range <= 2) {
+      comparison.nextActions.push("Score plateau detected (last 3 rounds within 2 points). Consider structural changes or model rotation.");
+    }
+  }
+
+  return comparison;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PHASE 6: Report Printing
+   ═══════════════════════════════════════════════════════════════ */
+
+function printReport(roundData) {
+  const { screenshotEval, videoEval, comparison } = roundData;
+
+  console.log("\n" + "=".repeat(72));
+  console.log("  INTERACTIVE GEMINI QA — ROUND " + roundData.roundNumber);
+  console.log("=".repeat(72));
+
+  // Cross-round comparison header
+  if (comparison) {
+    console.log(`\n${comparison.summary}`);
+    console.log(`\nScore trajectory: ${comparison.scoreTrajectory.map((r) => `R${r.round}:${r.score}`).join(" -> ")}`);
+    console.log(`P1 trend: ${comparison.scoreTrajectory.map((r) => `R${r.round}:${r.p1Count}p1`).join(" -> ")}`);
+
+    if (comparison.p1Tracking.resolved.length > 0) {
+      console.log(`\nRESOLVED P1s (${comparison.p1Tracking.resolved.length}):`);
+      comparison.p1Tracking.resolved.forEach((p) => console.log(`  [RESOLVED] ${p.issueId}: ${p.issue?.slice(0, 80)}`));
+    }
+    if (comparison.p1Tracking.new.length > 0) {
+      console.log(`\nNEW P1s (${comparison.p1Tracking.new.length}):`);
+      comparison.p1Tracking.new.forEach((p) => console.log(`  [NEW] ${p.issueId}: ${p.issue?.slice(0, 80)}`));
+    }
+    if (comparison.p1Tracking.persistent.length > 0) {
+      console.log(`\nPERSISTENT P1s (${comparison.p1Tracking.persistent.length}):`);
+      comparison.p1Tracking.persistent.forEach((p) => console.log(`  [PERSISTENT] ${p.issueId}: ${p.issue?.slice(0, 80)}`));
+    }
+    if (comparison.p1Tracking.regressed.length > 0) {
+      console.log(`\n*** REGRESSIONS (${comparison.p1Tracking.regressed.length}):`);
+      comparison.p1Tracking.regressed.forEach((p) => console.log(`  [REGRESSED] ${p.issueId}: ${p.issue?.slice(0, 80)}`));
+    }
+  }
+
+  // Screenshot eval summary
+  if (screenshotEval) {
+    console.log(`\nScreenshot Score: ${screenshotEval.overallScore}/100`);
+    if (screenshotEval.surfaceScores) {
+      const sorted = Object.entries(screenshotEval.surfaceScores).sort((a, b) => (a[1].score || 0) - (b[1].score || 0));
+      for (const [id, data] of sorted) {
+        const dims = data.dimensions || {};
+        const lowest = Object.entries(dims).sort((a, b) => a[1] - b[1]).slice(0, 2);
+        console.log(`  ${id.padEnd(12)} ${String(data.score || "?").padStart(3)}/100  weak: ${lowest.map(([k, v]) => `${k}=${v}`).join(", ")}`);
+      }
+    }
+    if (screenshotEval.scenarioResults) {
+      const passed = Object.values(screenshotEval.scenarioResults).filter((r) => r.pass).length;
+      const total = Object.values(screenshotEval.scenarioResults).length;
+      console.log(`\nScenarios: ${passed}/${total} passing`);
+    }
+  }
+
+  // Video eval summary
+  if (videoEval) {
+    console.log(`\nVideo Interaction Score: ${videoEval.overallInteractionScore}/100`);
+    if (videoEval.dimensions) {
+      for (const [dim, score] of Object.entries(videoEval.dimensions)) {
+        const bar = score >= 8 ? "OK" : score >= 6 ? "WARN" : "FAIL";
+        console.log(`  ${dim.padEnd(30)} ${score}/10  ${bar}`);
+      }
+    }
+    if (videoEval.temporalIssues?.length) {
+      console.log(`\nTemporal issues (${videoEval.temporalIssues.length}):`);
+      videoEval.temporalIssues.forEach((t) =>
+        console.log(`  [${t.severity}] @${t.timestamp}: ${t.issue?.slice(0, 80)}`));
+    }
+    if (videoEval.liveDataVerdict) {
+      console.log(`\nLive data verdict: ${videoEval.liveDataVerdict.slice(0, 200)}`);
+    }
+  }
+
+  // Next actions
+  if (comparison?.nextActions?.length) {
+    console.log("\nNext actions:");
+    comparison.nextActions.forEach((a) => console.log(`  -> ${a}`));
+  }
+
+  console.log("\n" + "=".repeat(72));
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   MAIN
+   ═══════════════════════════════════════════════════════════════ */
+
+async function main() {
+  const history = loadRoundHistory();
+  const roundNumber = getNextRoundNumber(history);
+  const roundDir = path.join(ROUNDS_DIR, `round-${String(roundNumber).padStart(3, "0")}`);
+  fs.mkdirSync(roundDir, { recursive: true });
+
+  console.log("=== Interactive Gemini QA Pipeline ===");
+  console.log(`Round: ${roundNumber} | Base URL: ${BASE_URL} | Label: ${ROUND_LABEL || "(none)"}`);
+  console.log(`History: ${history.length} previous rounds`);
+  console.log(`Surfaces: ${SURFACES.map((s) => s.label).join(", ")}`);
+  console.log(`Video: ${SKIP_VIDEO ? "SKIP" : `${INTERACTION_FLOWS.length} flows`}`);
+
+  // Phase 1: Screenshots
+  const { shots, validShots } = await captureAllSurfaces(roundDir);
+  if (validShots.length === 0) {
+    console.error("No screenshots captured. Is the dev server running?");
+    process.exit(1);
+  }
+
+  // Phase 2: Interaction videos
+  const { videos, interactionShots } = await recordInteractionVideos(roundDir);
+
+  // Phase 3: Screenshot evaluation
+  const screenshotEval = await evaluateScreenshots(validShots, roundNumber, history);
+  if (!screenshotEval) {
+    console.error("Screenshot evaluation failed.");
+    process.exit(1);
+  }
+
+  // Phase 4: Video evaluation
+  const videoEval = await evaluateVideos(videos);
+
+  // Build round data
+  const roundData = {
+    roundNumber,
+    timestamp: new Date().toISOString(),
+    label: ROUND_LABEL,
+    baseUrl: BASE_URL,
+    screenshotEval,
+    videoEval,
+    metadata: {
+      screenshotCount: validShots.length,
+      videoCount: videos.filter((v) => v.path).length,
+      interactionShotCount: interactionShots.length,
+      flowResults: videos.map((v) => ({ flowId: v.flowId, success: v.success })),
+    },
+  };
+
+  // Phase 5: Cross-round comparison
+  const comparison = generateCrossRoundComparison(roundData, history);
+  roundData.comparison = comparison;
+
+  // Save round data
+  fs.writeFileSync(path.join(roundDir, "evaluation.json"), JSON.stringify(roundData, null, 2));
+  fs.writeFileSync(path.join(roundDir, "comparison.json"), JSON.stringify(comparison, null, 2));
+
+  // Also write to the legacy location for backward compat
+  fs.writeFileSync(path.join(OUT_DIR, "evaluation.json"), JSON.stringify(screenshotEval, null, 2));
+  fs.writeFileSync(path.join(OUT_DIR, "manifest.json"), JSON.stringify({
+    timestamp: roundData.timestamp, shots, validCount: validShots.length, roundNumber,
+  }, null, 2));
+
+  // Append to history
+  appendRoundToHistory(roundData);
+
+  // Phase 6: Print report
+  printReport(roundData);
+
+  console.log(`\nRound ${roundNumber} saved to: ${roundDir}`);
+  console.log(`History: ${history.length + 1} rounds in ${HISTORY_FILE}`);
+
+  return roundData;
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/ui/mobileHomeGeminiQa.mjs
+++ b/scripts/ui/mobileHomeGeminiQa.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Mobile Home Surface Gemini QA — self-evaluation loop.
+ * Captures mobile screenshots of /redesign at 390x844, sends to Gemini for
+ * structured evaluation against top market references (ChatGPT, Perplexity,
+ * Linear, TikTok mobile UX).
+ *
+ * Usage: node scripts/ui/mobileHomeGeminiQa.mjs [--base-url http://localhost:5200]
+ */
+import { chromium } from "playwright";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as dotenv from "dotenv";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "../..");
+
+dotenv.config({ path: path.join(ROOT, ".env.local") });
+
+const BASE_URL = process.argv.find((a) => a.startsWith("--base-url="))?.split("=")[1] || "http://localhost:5200";
+const GEMINI_KEY = process.env.GEMINI_API_KEY;
+if (!GEMINI_KEY) { console.error("GEMINI_API_KEY not found in .env.local"); process.exit(1); }
+
+const OUT_DIR = path.join(ROOT, ".tmp", "mobile-home-qa");
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
+const MARKET_REFERENCE_PROMPT = `You are a senior product designer and mobile UX expert evaluating a mobile web app.
+
+CONTEXT: This is the mobile Home surface (390x844 viewport, dark mode) of "NodeBench AI" — an entity intelligence platform. The surface shows:
+- A "Report Halo" section (reusable memory/reports list)
+- An "Ask First" section with a universal search/chat composer
+- Daily introspection and runtime promise badges
+
+EVALUATION CRITERIA — Score each 1-10 against these top market mobile references:
+
+1. VISUAL HIERARCHY (ref: ChatGPT mobile — single clear input, minimal chrome)
+   - Is there ONE clear primary action? Or competing visual weights?
+   - Does the typography scale feel native-mobile (not shrunk desktop)?
+   - Is the information density appropriate for a phone screen?
+
+2. TOUCH TARGETS & SPACING (ref: Linear mobile — 44px+ touch targets, generous padding)
+   - Are all interactive elements >= 44px touch target?
+   - Is there enough breathing room between tappable items?
+   - Would a thumb comfortably reach primary actions?
+
+3. CONTENT DENSITY (ref: TikTok — one piece of content fills the screen)
+   - Is there too much above the fold competing for attention?
+   - Does the user need to scroll before seeing actionable content?
+   - Is the report list overwhelming or well-curated?
+
+4. TYPOGRAPHY & READABILITY (ref: Perplexity mobile — clean, readable, good contrast)
+   - Is body text >= 14px? Are labels legible without squinting?
+   - Is contrast sufficient against dark backgrounds?
+   - Are line lengths comfortable for mobile reading?
+
+5. FIRST IMPRESSION / TIME TO VALUE (ref: ChatGPT — < 3s to understand what to do)
+   - Does a new user immediately know what to type/tap?
+   - Is the value proposition clear in the first viewport?
+   - Is there visual noise that delays comprehension?
+
+6. GLASS CARD DESIGN SYSTEM (NodeBench-specific)
+   - Do cards use consistent glass morphism (backdrop-blur, subtle borders)?
+   - Is the terracotta (#d97757) accent used purposefully (CTAs, active states)?
+   - Are Manrope/JetBrains Mono fonts rendering correctly on mobile?
+
+7. MOBILE-NATIVE FEEL (ref: native iOS/Android apps)
+   - Does it feel like a mobile app or a shrunk desktop site?
+   - Are gestures, scroll physics, and transitions smooth?
+   - Is the bottom of the screen usable (safe area, no hidden overflow)?
+
+OUTPUT FORMAT (JSON):
+{
+  "overallScore": <1-100>,
+  "dimensions": {
+    "visualHierarchy": { "score": <1-10>, "findings": ["..."], "fixes": ["..."] },
+    "touchTargets": { "score": <1-10>, "findings": ["..."], "fixes": ["..."] },
+    "contentDensity": { "score": <1-10>, "findings": ["..."], "fixes": ["..."] },
+    "typography": { "score": <1-10>, "findings": ["..."], "fixes": ["..."] },
+    "firstImpression": { "score": <1-10>, "findings": ["..."], "fixes": ["..."] },
+    "glassDesignSystem": { "score": <1-10>, "findings": ["..."], "fixes": ["..."] },
+    "mobileNativeFeel": { "score": <1-10>, "findings": ["..."], "fixes": ["..."] }
+  },
+  "p1Issues": [{ "issue": "...", "location": "...", "fix": "...", "cssSelector": "..." }],
+  "p2Issues": [{ "issue": "...", "location": "...", "fix": "..." }],
+  "topPriorityFixes": ["1. ...", "2. ...", "3. ..."],
+  "marketComparisonVerdict": "one paragraph comparing to ChatGPT/Perplexity/Linear mobile"
+}
+
+Be specific and actionable. Reference exact UI elements, approximate pixel sizes, and CSS properties. Each fix should be implementable in < 30 min.`;
+
+async function captureScreenshots() {
+  console.log(`Capturing mobile screenshots at ${BASE_URL}/redesign ...`);
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: MOBILE_VIEWPORT,
+    colorScheme: "dark",
+    deviceScaleFactor: 3,
+    userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+  });
+  const page = await context.newPage();
+
+  const shots = [];
+
+  // Shot 1: Above the fold
+  await page.goto(`${BASE_URL}/redesign`, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await page.waitForTimeout(2000);
+  const aboveFold = path.join(OUT_DIR, "mobile-home-above-fold.png");
+  await page.screenshot({ path: aboveFold, fullPage: false });
+  shots.push({ name: "above-fold", path: aboveFold });
+  console.log("  Captured: above-fold");
+
+  // Shot 2: Full page
+  const fullPage = path.join(OUT_DIR, "mobile-home-full-page.png");
+  await page.screenshot({ path: fullPage, fullPage: true });
+  shots.push({ name: "full-page", path: fullPage });
+  console.log("  Captured: full-page");
+
+  // Shot 3: Scroll to Ask First section
+  await page.evaluate(() => {
+    const askFirst = document.querySelector('[class*="composer-head"]') ||
+      document.querySelector('h1, h2, h3');
+    if (askFirst) askFirst.scrollIntoView({ behavior: "instant", block: "start" });
+  });
+  await page.waitForTimeout(500);
+  const askSection = path.join(OUT_DIR, "mobile-home-ask-section.png");
+  await page.screenshot({ path: askSection, fullPage: false });
+  shots.push({ name: "ask-section", path: askSection });
+  console.log("  Captured: ask-section");
+
+  // Shot 4: Light mode variant
+  await context.close();
+  const lightCtx = await browser.newContext({
+    viewport: MOBILE_VIEWPORT,
+    colorScheme: "light",
+    deviceScaleFactor: 3,
+    userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+  });
+  const lightPage = await lightCtx.newPage();
+  await lightPage.goto(`${BASE_URL}/redesign`, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await lightPage.waitForTimeout(2000);
+  const lightShot = path.join(OUT_DIR, "mobile-home-light-mode.png");
+  await lightPage.screenshot({ path: lightShot, fullPage: false });
+  shots.push({ name: "light-mode", path: lightShot });
+  console.log("  Captured: light-mode");
+
+  await browser.close();
+  console.log(`Captured ${shots.length} screenshots.`);
+  return shots;
+}
+
+async function evaluateWithGemini(shots) {
+  console.log("\nSending to Gemini for evaluation...");
+  const genAI = new GoogleGenerativeAI(GEMINI_KEY);
+
+  const imageParts = shots.map((s) => ({
+    inlineData: {
+      mimeType: "image/png",
+      data: fs.readFileSync(s.path).toString("base64"),
+    },
+  }));
+
+  const imageLabels = shots.map((s) => `[Image: ${s.name} — ${MOBILE_VIEWPORT.width}x${MOBILE_VIEWPORT.height} mobile viewport]`).join("\n");
+
+  const models = ["gemini-2.5-flash", "gemini-3-flash-preview", "gemini-2.5-pro"];
+  let result;
+  for (const modelName of models) {
+    try {
+      console.log(`  Trying model: ${modelName}...`);
+      const model = genAI.getGenerativeModel({ model: modelName });
+      result = await model.generateContent([
+        MARKET_REFERENCE_PROMPT,
+        `\n\nHere are ${shots.length} screenshots of the mobile Home surface:\n${imageLabels}`,
+        ...imageParts,
+        "\n\nRespond with ONLY valid JSON matching the schema above. No markdown fencing.",
+      ]);
+      console.log(`  Success with model: ${modelName}`);
+      break;
+    } catch (e) {
+      console.log(`  Model ${modelName} failed: ${e.message?.slice(0, 100)}`);
+    }
+  }
+  if (!result) { console.error("All models failed."); return null; }
+
+  const text = result.response.text();
+
+  // Extract JSON from response (handle markdown fencing)
+  let json;
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    json = JSON.parse(jsonMatch[0]);
+  } catch (e) {
+    console.error("Failed to parse Gemini response as JSON:");
+    console.error(text.slice(0, 2000));
+    fs.writeFileSync(path.join(OUT_DIR, "raw-response.txt"), text);
+    return null;
+  }
+
+  return json;
+}
+
+async function main() {
+  console.log("=== NodeBench Mobile Home — Gemini QA Self-Evaluation ===\n");
+
+  const shots = await captureScreenshots();
+  const evaluation = await evaluateWithGemini(shots);
+
+  if (!evaluation) {
+    console.error("Evaluation failed — see raw response.");
+    process.exit(1);
+  }
+
+  // Save results
+  const resultPath = path.join(OUT_DIR, "evaluation.json");
+  fs.writeFileSync(resultPath, JSON.stringify(evaluation, null, 2));
+  console.log(`\nResults saved to: ${resultPath}`);
+
+  // Print summary
+  console.log("\n=== EVALUATION SUMMARY ===");
+  console.log(`Overall Score: ${evaluation.overallScore}/100`);
+  console.log("\nDimension Scores:");
+  if (evaluation.dimensions) {
+    for (const [dim, data] of Object.entries(evaluation.dimensions)) {
+      console.log(`  ${dim}: ${data.score}/10`);
+      if (data.findings?.length) {
+        data.findings.slice(0, 2).forEach((f) => console.log(`    - ${f}`));
+      }
+    }
+  }
+
+  console.log(`\nP1 Issues (${evaluation.p1Issues?.length || 0}):`);
+  (evaluation.p1Issues || []).forEach((p, i) =>
+    console.log(`  ${i + 1}. [${p.location}] ${p.issue}\n     Fix: ${p.fix}`)
+  );
+
+  console.log(`\nP2 Issues (${evaluation.p2Issues?.length || 0}):`);
+  (evaluation.p2Issues || []).forEach((p, i) =>
+    console.log(`  ${i + 1}. [${p.location}] ${p.issue}`)
+  );
+
+  console.log("\nTop Priority Fixes:");
+  (evaluation.topPriorityFixes || []).forEach((f) => console.log(`  ${f}`));
+
+  if (evaluation.marketComparisonVerdict) {
+    console.log(`\nMarket Comparison:\n  ${evaluation.marketComparisonVerdict}`);
+  }
+
+  return evaluation;
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/ui/verifyMobileMetrics.mjs
+++ b/scripts/ui/verifyMobileMetrics.mjs
@@ -1,0 +1,72 @@
+import { chromium } from "playwright";
+
+const BASE_URL = process.argv[2] || "http://localhost:5200";
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({
+  viewport: { width: 390, height: 844 },
+  colorScheme: "dark",
+  deviceScaleFactor: 2,
+});
+const page = await ctx.newPage();
+await page.goto(`${BASE_URL}/redesign`, { timeout: 45000 });
+await page.waitForSelector(".rd-v3-home-composer-head", { timeout: 20000 }).catch(() => {});
+await page.waitForTimeout(2000);
+
+const metrics = await page.evaluate(() => {
+  const r = {};
+  const dock = document.querySelector(".rd-v3-halo-dock");
+  r.dockDisplay = dock ? window.getComputedStyle(dock).display : "not found";
+  r.dockHeight = dock ? dock.offsetHeight : 0;
+
+  const mono = document.querySelector(".rd-mono");
+  r.shortcutDisplay = mono ? window.getComputedStyle(mono).display : "not in DOM";
+  r.shortcutText = mono ? mono.textContent.slice(0, 50) : "";
+
+  const composerHead = document.querySelector(".rd-v3-home-composer-head");
+  r.composerTop = composerHead ? Math.round(composerHead.getBoundingClientRect().top) : -1;
+  r.composerHeight = composerHead ? composerHead.offsetHeight : -1;
+
+  const h1 = composerHead?.querySelector("h1");
+  r.h1FontSize = h1 ? window.getComputedStyle(h1).fontSize : "not found";
+
+  const ta = document.querySelector("textarea");
+  r.textboxTop = ta ? Math.round(ta.getBoundingClientRect().top) : -1;
+
+  const haloSection = document.querySelector('[aria-label="Report memory halo"]');
+  r.haloHeight = haloSection ? haloSection.offsetHeight : -1;
+
+  const promises = [];
+  document.querySelectorAll(".rd-row > span").forEach((s) => {
+    if (s.textContent.includes("Continues") || s.textContent.includes("Saves") || s.textContent.includes("Export")) {
+      promises.push({
+        text: s.textContent.slice(0, 30),
+        height: s.offsetHeight,
+        fontSize: window.getComputedStyle(s).fontSize,
+        minHeight: window.getComputedStyle(s).minHeight,
+      });
+    }
+  });
+  r.promiseBadges = promises;
+
+  r.viewport = window.innerWidth + "x" + window.innerHeight;
+  r.aboveFold = r.textboxTop < 844 ? "YES" : "NO";
+  return r;
+});
+
+console.log("=== Mobile Layout Verification ===");
+console.log(`Viewport: ${metrics.viewport}`);
+console.log(`Dock: display=${metrics.dockDisplay} h=${metrics.dockHeight} ${metrics.dockDisplay === "none" ? "PASS" : "FAIL"}`);
+console.log(`Shortcut hints: ${metrics.shortcutDisplay} ${metrics.shortcutDisplay === "none" ? "PASS (hidden)" : metrics.shortcutDisplay === "not in DOM" ? "PASS (absent)" : "FAIL"}`);
+console.log(`H1 font-size: ${metrics.h1FontSize}`);
+console.log(`Halo section height: ${metrics.haloHeight}px`);
+console.log(`Composer top: ${metrics.composerTop}px`);
+console.log(`Textbox top: ${metrics.textboxTop}px — above fold? ${metrics.aboveFold}`);
+if (metrics.promiseBadges.length) {
+  console.log(`Promise badges (${metrics.promiseBadges.length}):`);
+  metrics.promiseBadges.forEach((b) => console.log(`  "${b.text}" h=${b.height} fontSize=${b.fontSize} minH=${b.minHeight}`));
+} else {
+  console.log("Promise badges: not found");
+}
+
+await browser.close();

--- a/src/features/redesign/RedesignShell.tsx
+++ b/src/features/redesign/RedesignShell.tsx
@@ -320,6 +320,7 @@ export default function RedesignShell() {
             selectedEntity={prototypeEntity}
             onSelectEntity={selectPrototypeRailEntity}
             guestSafe={surface === "me"}
+            liveArtifacts={shellLiveArtifacts}
           />
         )}
 
@@ -394,6 +395,7 @@ export default function RedesignShell() {
                 selectedReport={selectedRailReport}
                 onSelectEntity={selectPrototypeRailEntity}
                 guestSafe={surface === "me"}
+                liveArtifacts={shellLiveArtifacts}
               />
             )}
           </div>

--- a/src/features/redesign/components/MobileShell.tsx
+++ b/src/features/redesign/components/MobileShell.tsx
@@ -370,7 +370,7 @@ function MobileReports() {
           <article className="rd-card rd-card__pad-tight" style={{ padding: "12px 14px" }}>
             <div className="rd-eyebrow">No live reports</div>
             <p className="rd-faint" style={{ fontSize: 12, marginTop: 4 }}>
-              Reports will populate from daily briefs, archive rows, and batch runs. No fixture cards are shown on mobile.
+              Reports will appear here once you run a daily brief, archive, or batch research. Start with a question in Chat.
             </p>
           </article>
         )}

--- a/src/features/redesign/components/MobileShell.tsx
+++ b/src/features/redesign/components/MobileShell.tsx
@@ -143,15 +143,18 @@ export function MobileShell({ active, onChange }: MobileShellProps) {
               {id === "inbox" && liveInboxSummary.items.length > 0 && (
                 <span style={{
                   position: "absolute",
-                  top: 4,
-                  right: "calc(50% - 18px)",
+                  top: 2,
+                  right: "calc(50% - 20px)",
                   background: "var(--rd-accent)",
                   color: "#fff",
-                  fontSize: 9,
+                  fontSize: 10,
                   fontWeight: 700,
-                  padding: "1px 5px",
+                  padding: "2px 6px",
                   borderRadius: 999,
                   lineHeight: 1.2,
+                  minWidth: 18,
+                  textAlign: "center",
+                  boxShadow: "0 1px 3px rgba(0,0,0,0.25)",
                 }}>{liveInboxSummary.items.length}</span>
               )}
             </button>
@@ -389,10 +392,10 @@ function MobileReports() {
               <span>{r.followUps} follow-ups</span>
               <span style={{ marginLeft: "auto" }}>{r.updatedAt}</span>
             </div>
-            <div className="rd-row" style={{ gap: 4, marginTop: 8 }}>
-              <button className="rd-btn rd-btn--ghost" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "brief")}>Brief</button>
-              <button className="rd-btn rd-btn--quiet" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "cards")}>Explore</button>
-              <button className="rd-btn rd-btn--quiet" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "chat")}>Chat</button>
+            <div className="rd-row" style={{ gap: 6, marginTop: 8 }}>
+              <button className="rd-btn rd-btn--primary rd-btn--sm" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "brief")}>Brief</button>
+              <button className="rd-btn rd-btn--ghost rd-btn--sm" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "cards")}>Explore</button>
+              <button className="rd-btn rd-btn--ghost rd-btn--sm" style={{ flex: 1, padding: "6px 8px", fontSize: 11, justifyContent: "center" }} onClick={() => openReport(r.id, "chat")}>Chat</button>
             </div>
           </article>
         ))}

--- a/src/features/redesign/components/UniversalComposer.tsx
+++ b/src/features/redesign/components/UniversalComposer.tsx
@@ -541,7 +541,7 @@ export function UniversalComposer({
 
       {/* Bottom row — tools + send */}
       <div className="rd-row--between" style={{ gap: 8 }}>
-        <div className="rd-row" style={{ gap: 4 }}>
+        <div className="rd-row" style={{ gap: 10 }}>
           {!hideAttachments && (
             <>
               <div style={{ position: "relative" }}>
@@ -639,7 +639,7 @@ export function UniversalComposer({
           </span>
         </div>
 
-        <div className="rd-row" style={{ gap: 6 }}>
+        <div className="rd-row" style={{ gap: 8 }}>
           {onChatNow && (
             <button
               type="button"

--- a/src/features/redesign/components/UniversalComposer.tsx
+++ b/src/features/redesign/components/UniversalComposer.tsx
@@ -634,8 +634,8 @@ export function UniversalComposer({
               </button>
             </>
           )}
-          <span className="rd-mono" style={{ fontSize: 10, color: "var(--rd-ink-soft)", marginLeft: 6 }}>
-            {voice.isTranscribing ? "Transcribing..." : recording ? "Listening..." : "Cmd+Enter run research · Shift+Enter newline"}
+          <span className="rd-mono rd-shortcut-hint" style={{ fontSize: 11, opacity: 0.6, color: "var(--rd-ink-soft)", marginLeft: 6 }}>
+            {voice.isTranscribing ? "Transcribing..." : recording ? "Listening..." : "⌘↵ research · ⇧↵ newline"}
           </span>
         </div>
 

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -11712,3 +11712,51 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
     background: var(--rd-line);
   }
 }
+
+/* ═══ Round 19 P1 fixes — pipeline self-improvement loop ═══ */
+
+/* p1-reports-desktop-3: empty state in Reports gallery lacks visual engagement */
+[data-redesign] .rd-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--rd-ink-soft);
+}
+[data-redesign] .rd-empty-state__icon {
+  font-size: 40px;
+  opacity: 0.5;
+}
+[data-redesign] .rd-empty-state__heading {
+  font-size: 16px;
+  font-weight: 640;
+  color: var(--rd-ink);
+}
+[data-redesign] .rd-empty-state__body {
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 320px;
+  color: var(--rd-ink-mute);
+}
+
+/* p1-inbox-global-1: progress bars too thin (2px) and low contrast in light mode */
+[data-redesign] .rd-progress-bar,
+[data-redesign] [class*="progress-bar"],
+[data-redesign] [role="progressbar"] > div {
+  min-height: 4px;
+  border-radius: 2px;
+}
+@media (prefers-color-scheme: light) {
+  [data-redesign] .rd-progress-bar,
+  [data-redesign] [class*="progress-bar"],
+  [data-redesign] [role="progressbar"] > div {
+    background: rgba(0, 0, 0, 0.15);
+  }
+  [data-redesign] .rd-progress-bar__fill,
+  [data-redesign] [class*="progress-bar"] > [class*="fill"],
+  [data-redesign] [role="progressbar"] > div > div {
+    background: var(--rd-accent-strong);
+  }
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -376,6 +376,15 @@
   background: var(--rd-muted);
 }
 
+[data-redesign] .rd-btn--danger {
+  color: var(--rd-red);
+}
+
+[data-redesign] .rd-btn--danger:hover {
+  color: #fff;
+  background: var(--rd-red);
+}
+
 [data-redesign] .rd-btn--sm {
   min-height: 32px;
   padding: 7px 12px;
@@ -9419,7 +9428,7 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   [data-redesign] .rd-v3-view-bar { gap: 8px; }
   [data-redesign] .rd-v3-filter-pills { overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
   [data-redesign] .rd-v3-filter-pills::-webkit-scrollbar { display: none; }
-  [data-redesign] .rd-v3-filter-pills button { white-space: nowrap; flex-shrink: 0; min-height: 36px; }
+  [data-redesign] .rd-v3-filter-pills button { white-space: nowrap; flex-shrink: 0; min-height: 44px; padding: 8px 14px; }
   [data-redesign] .rd-v3-tabs { overflow-x: auto; flex-wrap: nowrap; scrollbar-width: none; }
   [data-redesign] .rd-v3-tabs::-webkit-scrollbar { display: none; }
 

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -11760,3 +11760,56 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
     background: var(--rd-accent-strong);
   }
 }
+
+/* ═══ Round 20 P1 fixes — continuing self-improvement loop ═══ */
+
+/* p1-chat-mobile-1: header card consumes 35% of viewport — collapse on mobile */
+@media (max-width: 760px) {
+  [data-redesign] .rd-chat-header,
+  [data-redesign] .rd-v3-chat-hero {
+    padding: 12px 16px;
+    gap: 6px;
+  }
+  [data-redesign] .rd-chat-header h1,
+  [data-redesign] .rd-v3-chat-hero h1 {
+    font-size: 18px;
+    line-height: 1.2;
+  }
+  [data-redesign] .rd-chat-header p,
+  [data-redesign] .rd-v3-chat-hero p,
+  [data-redesign] .rd-chat-header [class*="subtitle"],
+  [data-redesign] .rd-v3-chat-hero [class*="subtitle"] {
+    display: none;
+  }
+}
+
+/* p1-reports-desktop-3 (persistent): strengthen empty state visual anchor */
+[data-redesign] .rd-empty-state__icon {
+  width: 56px;
+  height: 56px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: var(--rd-accent-soft);
+  color: var(--rd-accent-strong);
+  font-size: 24px;
+  opacity: 1;
+}
+[data-redesign] .rd-empty-state .rd-btn {
+  margin-top: 4px;
+}
+
+/* p1-inbox-global-1 (persistent): further strengthen progress bars */
+[data-redesign] .rd-progress-bar,
+[data-redesign] [class*="progress-bar"],
+[data-redesign] [role="progressbar"] > div {
+  min-height: 6px;
+  border-radius: 3px;
+  background: var(--rd-muted);
+}
+[data-redesign] .rd-progress-bar__fill,
+[data-redesign] [class*="progress-bar"] > [class*="fill"],
+[data-redesign] [role="progressbar"] > div > div {
+  border-radius: 3px;
+  background: var(--rd-accent);
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -346,14 +346,15 @@
 }
 
 [data-redesign] .rd-btn--primary {
-  background: var(--rd-accent);
+  background: var(--rd-accent-strong);
   color: #fff;
-  border-color: var(--rd-accent);
+  border-color: var(--rd-accent-strong);
 }
 
 [data-redesign] .rd-btn--primary:hover {
-  background: var(--rd-accent-strong);
-  border-color: var(--rd-accent-strong);
+  background: var(--rd-accent);
+  border-color: var(--rd-accent);
+  filter: brightness(0.88);
 }
 
 [data-redesign] .rd-btn--ghost {
@@ -2718,9 +2719,15 @@
   }
 
   [data-redesign] .rd-v3-home-composer-head h1 {
-    font-size: 26px;
+    font-size: 24px;
     letter-spacing: -0.4px;
+    line-height: 1.1;
   }
+
+  /* P1 fix: tighter hero spacing keeps input above fold on 390px screens */
+  [data-redesign] .rd-v3-home-composer-shell { gap: 10px; margin-top: 0; }
+  [data-redesign] .rd-v3-home-composer-head { padding-block: 8px 4px; }
+  [data-redesign] .rd-v3-home-halo { max-height: 240px; }
 
   [data-redesign] .rd-v2-pulse-lead,
   [data-redesign] .rd-v2-pulse-note {
@@ -7443,6 +7450,17 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-whatchanged__row--blue   .rd-whatchanged__icon { color: var(--rd-blue); }
 [data-redesign] .rd-whatchanged__row--amber  .rd-whatchanged__icon { color: var(--rd-amber); }
 
+/* ───────── Keyboard shortcut hints — hide on mobile, legible on desktop ───────── */
+[data-redesign] .rd-shortcut-hint { user-select: none; }
+@media (max-width: 760px) {
+  [data-redesign] .rd-shortcut-hint { display: none; }
+}
+
+/* ───────── Chat scroll area — bottom clearance for floating input ───────── */
+@media (min-width: 761px) {
+  [data-redesign] .rd-chat-scroll-area { padding-bottom: 80px !important; }
+}
+
 /* ───────── Chat scroll-to-bottom button ───────── */
 [data-redesign] .rd-chat-scroll-btn {
   position: absolute;
@@ -9395,6 +9413,17 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   [data-redesign] .rd-v3-search-row { flex-direction: column; align-items: stretch; }
   [data-redesign] .rd-v3-metrics,
   [data-redesign] .rd-v3-grid { grid-template-columns: 1fr; }
+
+  /* P1 fix: prevent filter pills from being obstructed on mobile */
+  [data-redesign] .rd-v3-view-bar { gap: 8px; }
+  [data-redesign] .rd-v3-filter-pills { overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+  [data-redesign] .rd-v3-filter-pills::-webkit-scrollbar { display: none; }
+  [data-redesign] .rd-v3-filter-pills button { white-space: nowrap; flex-shrink: 0; min-height: 36px; }
+  [data-redesign] .rd-v3-tabs { overflow-x: auto; flex-wrap: nowrap; scrollbar-width: none; }
+  [data-redesign] .rd-v3-tabs::-webkit-scrollbar { display: none; }
+
+  /* Push live artifact section below filter row with clear spacing */
+  [data-redesign] .rd-universe-head { margin-top: 8px; }
 }
 
 /* ───────── Reports Crunchbase / Pitchbook filter bar ───────── */
@@ -9894,6 +9923,10 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   gap: 6px;
   flex-wrap: wrap;
   flex-shrink: 0;
+}
+@media (max-width: 760px) {
+  [data-redesign] .rd-inbox-preview__actions { gap: 10px; }
+  [data-redesign] .rd-inbox-preview__actions .rd-btn { min-width: 44px; min-height: 44px; padding-inline: 10px; }
 }
 [data-redesign] .rd-inbox-preview__title {
   font-size: 18px;

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -11945,3 +11945,72 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
     animation: none;
   }
 }
+
+/* ═══ Round 23 P1 fixes — light mode contrast hardening ═══ */
+
+/* p1-home-mobile-23-1: "Chat now" text link low contrast in light mode
+   Root cause: accent-strong (#b85a3d) on semi-transparent glass bg drops below 4.5:1.
+   Fix: darken accent links in light mode to a fully opaque high-contrast shade. */
+@media (prefers-color-scheme: light) {
+  [data-redesign] a[class*="chat"],
+  [data-redesign] [class*="chat-now"],
+  [data-redesign] .rd-agent-rail a,
+  [data-redesign] .rd-agent-rail__next a,
+  [data-redesign] .rd-link--accent {
+    color: #9e4a30;
+    text-decoration-color: rgba(158, 74, 48, 0.35);
+  }
+  [data-redesign] a[class*="chat"]:hover,
+  [data-redesign] [class*="chat-now"]:hover,
+  [data-redesign] .rd-agent-rail a:hover,
+  [data-redesign] .rd-link--accent:hover {
+    color: #843d28;
+    text-decoration-color: rgba(132, 61, 40, 0.55);
+  }
+}
+
+/* ═══ Comprehensive light mode WCAG AA contrast hardening ═══
+   Root cause: glass morphism backgrounds (semi-transparent) reduce effective
+   contrast ratios for all text and interactive elements. Instead of chasing
+   individual Gemini-flagged P1s, this block ensures ALL elements pass WCAG AA
+   when glass backgrounds are present. */
+@media (prefers-color-scheme: light) {
+  /* All ghost buttons on glass: solid white bg + dark text + visible border */
+  [data-redesign] .rd-btn--ghost {
+    color: #1a1a1a !important;
+    border-color: rgba(0, 0, 0, 0.32) !important;
+    background: rgba(255, 255, 255, 0.55) !important;
+  }
+  [data-redesign] .rd-btn--ghost:hover {
+    background: rgba(255, 255, 255, 0.8) !important;
+    border-color: rgba(0, 0, 0, 0.48) !important;
+  }
+
+  /* All muted/soft text: ensure 4.5:1 minimum on any background */
+  [data-redesign] .rd-ink-mute,
+  [data-redesign] [class*="muted"],
+  [data-redesign] [class*="subtitle"],
+  [data-redesign] .rd-agent-rail__copy,
+  [data-redesign] .rd-agent-rail__muted {
+    color: rgba(0, 0, 0, 0.68) !important;
+  }
+
+  /* Status pills: darken text for amber/yellow variants specifically */
+  [data-redesign] .rd-pill--amber,
+  [data-redesign] [class*="pill"][class*="draft"],
+  [data-redesign] [class*="status"][class*="draft"],
+  [data-redesign] .ar-drawer-status[data-status="drafting"] {
+    color: #8a5100 !important;
+    border-color: #b26200 !important;
+  }
+
+  /* Accent links: ensure terracotta links hit 4.5:1 on warm-white glass */
+  [data-redesign] a:not(.rd-btn),
+  [data-redesign] [role="link"] {
+    color: #8b4226;
+  }
+  [data-redesign] a:not(.rd-btn):hover,
+  [data-redesign] [role="link"]:hover {
+    color: #6e3420;
+  }
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -11646,3 +11646,45 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] code {
   line-height: 1.6;
 }
+
+/* ═══ Round 17 P1 fixes — from interactive Gemini QA pipeline ═══ */
+
+/* p1-home-desktop-1: sidebar timeline text contrast below WCAG AA (3.2:1 → 4.5:1+) */
+[data-redesign] .rd-agent-rail__muted {
+  color: var(--rd-ink-soft);
+}
+[data-redesign] .rd-agent-rail__copy {
+  color: var(--rd-ink-soft);
+}
+@media (prefers-color-scheme: light) {
+  [data-redesign] .rd-agent-rail__muted,
+  [data-redesign] .rd-agent-rail__copy {
+    color: rgba(0, 0, 0, 0.62);
+  }
+}
+
+/* p1-reports-mobile-1: 'Verified' badge truncated on mobile report cards */
+[data-redesign] .rd-pill--green,
+[data-redesign] .ar-drawer-status {
+  min-width: fit-content;
+  flex-shrink: 0;
+}
+@media (max-width: 760px) {
+  [data-redesign] .rd-pill--green,
+  [data-redesign] .ar-drawer-status {
+    padding: 3px 8px;
+    font-size: 10px;
+    letter-spacing: 0.03em;
+  }
+}
+
+/* p1-workspace-mobile-1: primary action competition — secondary action ghost style */
+[data-redesign] .rd-btn--secondary-action {
+  background: var(--rd-muted);
+  color: var(--rd-ink);
+  border-color: var(--rd-line);
+}
+[data-redesign] .rd-btn--secondary-action:hover {
+  background: var(--rd-line);
+  color: var(--rd-ink-strong);
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -48,9 +48,9 @@
 }
 
 [data-redesign] .rd-eyebrow {
-  font-size: 11px;
-  font-weight: 510;
-  letter-spacing: 0.12em;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--rd-ink-soft);
 }
@@ -64,6 +64,7 @@
 [data-redesign] .rd-mono {
   font-family: var(--rd-font-mono);
   font-size: 12px;
+  line-height: 1.6;
   letter-spacing: 0;
   color: var(--rd-ink-mute);
 }
@@ -2663,14 +2664,14 @@
     min-height: 44px;
   }
 
-  /* Full-surface QA — P1 fix: light mode subtitle contrast (Home) */
+  /* Full-surface QA — P1 fix: light mode subtitle contrast (Home) — WCAG AA 4.5:1+ */
   @media (prefers-color-scheme: light) {
     [data-redesign] .rd-v3-home-composer-head p,
     [data-redesign] .rd-v3-home-halo-head p {
-      color: rgba(0, 0, 0, 0.6);
+      color: rgba(0, 0, 0, 0.72);
     }
     [data-redesign] .rd-v3-home-halo small {
-      color: rgba(0, 0, 0, 0.5);
+      color: rgba(0, 0, 0, 0.58);
     }
   }
 
@@ -11571,6 +11572,10 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 [data-redesign] .rd-pill {
   min-height: 24px;
   box-sizing: border-box;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Round 5 — horizontal scroll edge-fade for mobile tab bars */
@@ -11579,4 +11584,53 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
     mask-image: linear-gradient(to right, black 85%, transparent 100%);
     -webkit-mask-image: linear-gradient(to right, black 85%, transparent 100%);
   }
+}
+
+/* ═══ Round 11 P1 batch — mobile 44px touch targets + light-mode contrast ═══ */
+
+/* P1-1: Report/Inbox card action buttons need 44px min-height on mobile */
+@media (max-width: 760px) {
+  [data-redesign] .rd-btn--sm {
+    min-height: 44px;
+    padding: 10px 14px;
+    font-size: 13px;
+  }
+  /* P1-3: Workspace breadcrumb navigation needs larger touch targets */
+  [data-redesign] [class*="breadcrumb"] a,
+  [data-redesign] [class*="breadcrumb"] button,
+  [data-redesign] [class*="breadcrumb"] span[role="link"] {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 8px;
+    font-size: 13px;
+  }
+  /* P1-5: Chat citation chips / pill links need 44px touch area */
+  [data-redesign] .rd-pill[role="button"],
+  [data-redesign] .rd-pill a,
+  [data-redesign] .rd-pinned-chip,
+  [data-redesign] .rd-chat-msg .rd-pill {
+    min-height: 36px;
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+}
+
+/* P1-6: Home subheader light-mode contrast — darken --rd-ink-soft overrides */
+@media (prefers-color-scheme: light) {
+  [data-redesign] .rd-v3-home-composer-head [class*="subheader"],
+  [data-redesign] .rd-v3-home-composer-head p {
+    color: var(--rd-ink-mute);
+  }
+}
+[data-redesign][data-redesign-theme="light"] .rd-v3-home-composer-head [class*="subheader"],
+[data-redesign][data-redesign-theme="light"] .rd-v3-home-composer-head p {
+  color: var(--rd-ink-mute);
+}
+
+/* P1-2: JetBrains Mono code blocks — readable line-height on all viewports */
+[data-redesign] .rd-md__code,
+[data-redesign] pre[class*="mono"],
+[data-redesign] code {
+  line-height: 1.6;
 }

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -11688,3 +11688,27 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   background: var(--rd-line);
   color: var(--rd-ink-strong);
 }
+
+/* ═══ Round 18 P1 fixes — from interactive pipeline cross-round tracking ═══ */
+
+/* p1-reports-desktop-2: status badges too small/low-contrast in gallery view */
+[data-redesign] .ar-drawer-status {
+  font-size: 12px;
+  font-weight: 560;
+  padding: 3px 10px;
+  border-radius: var(--rd-r-pill);
+}
+
+/* p1-workspace-mobile-2: refresh preview visually louder than save — demote to ghost */
+@media (max-width: 760px) {
+  [data-redesign] .rd-btn--secondary-action,
+  [data-redesign] .rd-workspace-actions .rd-btn:not(:first-child) {
+    background: var(--rd-muted);
+    color: var(--rd-ink);
+    border-color: var(--rd-line);
+  }
+  [data-redesign] .rd-btn--secondary-action:hover,
+  [data-redesign] .rd-workspace-actions .rd-btn:not(:first-child):hover {
+    background: var(--rd-line);
+  }
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -67,6 +67,8 @@
   line-height: 1.6;
   letter-spacing: 0;
   color: var(--rd-ink-mute);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 [data-redesign] .rd-meta {
@@ -4393,6 +4395,7 @@
   background: var(--rd-panel);
   color: var(--rd-ink-strong);
   box-shadow: var(--rd-shadow-xs);
+  border-bottom: 2px solid var(--rd-accent);
 }
 
 /* ─── Notebook (TipTap-backed report editor — Notion + Roam feel) ─── */
@@ -11551,8 +11554,8 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
 /* Full-surface QA Round 3+4 — light mode glass card depth + border */
 @media (prefers-color-scheme: light) {
   [data-redesign] .rd-card {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.04);
-    border-color: rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.06);
+    border-color: rgba(0, 0, 0, 0.12);
   }
   [data-redesign] .rd-card--ghost {
     box-shadow: none;

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -2459,6 +2459,11 @@
     font-size: 38px;
   }
 
+  [data-redesign] .rd-v3-home-composer-head h1 {
+    font-size: 38px;
+    letter-spacing: -0.8px;
+  }
+
   [data-redesign] .rd-v2-pulse-grid,
   [data-redesign] .rd-v2-pulse-mosaic {
     grid-template-columns: 1fr;
@@ -2470,6 +2475,39 @@
 
   [data-redesign] .rd-v2-proof-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* Defense-in-depth: matches JS useViewportMobile(760px) — catches FOUC where desktop shell renders before React hydrates */
+@media (max-width: 768px) {
+  [data-redesign] .rd-shell > .rd-pane:first-child,
+  [data-redesign] .rd-shell--home-v2 > .rd-v2-left,
+  [data-redesign] .rd-v2-briefing,
+  [data-redesign] .rd-pane--right {
+    display: none;
+  }
+
+  [data-redesign] .rd-shell,
+  [data-redesign] .rd-shell--home-v2 {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  [data-redesign] .rd-shell__main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  [data-redesign] .rd-v3-home-composer-head h1 {
+    font-size: 30px;
+    letter-spacing: -0.6px;
+  }
+
+  [data-redesign] .rd-v3-home-composer-head p {
+    max-width: 100%;
+  }
+
+  [data-redesign] .rd-v2-home {
+    max-width: 100%;
+    overflow-x: hidden;
   }
 }
 
@@ -2498,6 +2536,11 @@
 
   [data-redesign] .rd-v2-pulse-head h1 {
     font-size: 34px;
+  }
+
+  [data-redesign] .rd-v3-home-composer-head h1 {
+    font-size: 26px;
+    letter-spacing: -0.4px;
   }
 
   [data-redesign] .rd-v2-pulse-lead,

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -2509,6 +2509,153 @@
     max-width: 100%;
     overflow-x: hidden;
   }
+
+  /* P1 fix: hide report detail dock on mobile — saves 650px vertical space,
+     brings the Ask First composer above the fold */
+  [data-redesign] .rd-v3-halo-dock {
+    display: none;
+  }
+
+  /* Tighten Report Halo section for mobile */
+  [data-redesign] .rd-v3-home-halo-head {
+    padding-block: 12px 8px;
+  }
+
+  [data-redesign] .rd-v3-home-halo-head p {
+    font-size: 12px;
+    line-height: 1.4;
+  }
+
+  /* Reduce halo track height for denser mobile cards */
+  [data-redesign] .rd-v3-halo-track {
+    max-height: 180px;
+    overflow-y: hidden;
+  }
+
+  /* P1 fix: composer headline is too large — shrink to save vertical space */
+  [data-redesign] .rd-v3-home-composer-head {
+    padding-block: 16px 8px;
+  }
+
+  [data-redesign] .rd-v3-home-composer-head p {
+    max-width: 100%;
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  /* P1 fix: ensure all composer icon buttons meet 44px touch target */
+  [data-redesign] .rd-v3-home-composer-head button,
+  [data-redesign] .rd-v3-home-composer-head [role="button"] {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* P1 fix: hide desktop keyboard shortcuts on mobile — illegible and non-native */
+  [data-redesign] .rd-v3-home-composer-shell .rd-mono {
+    display: none;
+  }
+
+  /* P1 fix: runtime promise badges need minimum 44px touch targets and legible text */
+  [data-redesign] .rd-v3-home-composer-shell .rd-row > span:not(.rd-mono):not(.rd-pill) {
+    min-height: 44px;
+    font-size: 13px;
+    line-height: 1.3;
+    display: inline-flex;
+    align-items: center;
+    padding: 8px 12px;
+  }
+
+  /* P2 fix: halo description says "Hover" which is irrelevant on mobile */
+  [data-redesign] .rd-v3-home-halo-head > p {
+    font-size: 11px;
+  }
+
+  /* Bottom safe area for iOS home indicator */
+  [data-redesign] .rd-v2-home > :last-child {
+    padding-bottom: env(safe-area-inset-bottom, 20px);
+  }
+
+  /* Round 4 — P1 fix: Ask First above Report Halo on mobile */
+  [data-redesign] .rd-v3-home-front {
+    display: flex;
+    flex-direction: column;
+  }
+  [data-redesign] .rd-v3-home-composer-shell {
+    order: -1;
+  }
+
+  /* Round 3 — P1 fix: Chat now button needs 44px touch target on mobile */
+  [data-redesign] .rd-v3-home-composer-shell .rd-btn--sm {
+    min-height: 44px;
+    min-width: 44px;
+    padding: 10px 14px;
+    font-size: 13px;
+  }
+
+  /* Round 3 — P1 fix: composer card glass morphism (consistent with halo cards) */
+  [data-redesign] .rd-v3-home-composer-shell .rd-card {
+    background: rgba(25, 26, 27, 0.72);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  /* Round 3 — P2 fix: reduce section heading sizes for mobile density */
+  [data-redesign] .rd-v3-home-halo-head h2,
+  [data-redesign] .rd-v3-home-composer-head h1 {
+    font-size: 22px;
+    line-height: 1.25;
+  }
+
+  /* Round 4 — P2 fix: compact halo section when below composer */
+  [data-redesign] .rd-v3-home-halo {
+    max-height: 280px;
+    overflow-y: auto;
+  }
+
+  /* Round 5 — P1 fix: filter buttons need 44px touch targets */
+  [data-redesign] .rd-v2-queue-head button {
+    min-height: 44px;
+    min-width: 44px;
+    font-size: 13px;
+    padding: 8px 14px;
+  }
+
+  /* Round 5 — P2 fix: metadata and auxiliary text legibility */
+  [data-redesign] .rd-v3-home-front .rd-faint,
+  [data-redesign] .rd-v3-home-front .rd-meta {
+    font-size: 13px;
+  }
+
+  /* Round 3 — P2 fix: tighten intro paragraphs on mobile */
+  [data-redesign] .rd-v3-home-front > section > header > p {
+    font-size: 12px;
+    line-height: 1.35;
+    max-height: 2.7em;
+    overflow: hidden;
+  }
+
+  /* Round 6 — P1 fix: composer toolbar buttons need 44px touch targets */
+  [data-redesign] .rd-v3-home-composer-shell .rd-btn:not(.rd-btn--sm):not(.rd-btn--primary) {
+    min-height: 44px;
+    font-size: 13px;
+  }
+
+  /* Round 6 — P1 fix: report card "Verified" metadata too small (10px→12px) + contrast */
+  [data-redesign] .rd-v3-home-halo small {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  /* Round 6 — P2 fix: hide info pills on mobile to reduce density (design reduction) */
+  [data-redesign] .rd-v3-home-composer-shell .rd-row > span.rd-pill {
+    display: none;
+  }
+
+  /* Round 6 — P2 fix: subtitle contrast improvement */
+  [data-redesign] .rd-v3-home-composer-head p {
+    color: rgba(255, 255, 255, 0.5);
+  }
 }
 
 @media (max-width: 640px) {

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -11813,3 +11813,135 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   border-radius: 3px;
   background: var(--rd-accent);
 }
+
+/* ═══ Round 21 P1 fixes — continuing self-improvement loop ═══ */
+
+/* p1-home-desktop-1: agent rail CTA button overlaps status container at 1280px
+   Root cause: absolute positioning + insufficient gap between button and agent status.
+   Fix: enforce relative flow + explicit top margin to separate from adjacent content. */
+[data-redesign] .rd-agent-rail .rd-btn,
+[data-redesign] .rd-agent-rail [role="button"] {
+  position: relative;
+  margin-top: 4px;
+  z-index: 1;
+}
+[data-redesign] .rd-agent-rail__header + .rd-agent-rail__status,
+[data-redesign] .rd-agent-rail .rd-agent-card + .rd-btn {
+  margin-top: 12px;
+}
+@media (max-width: 1366px) {
+  [data-redesign] .rd-agent-rail {
+    padding: 16px 14px;
+    gap: 12px;
+  }
+  [data-redesign] .rd-agent-rail__title {
+    font-size: 16px;
+  }
+}
+
+/* p1-chat-desktop-1: "Run on a list" ghost button contrast 2.1:1 against glass background
+   Root cause: ghost button border-color and text-color too transparent on glass surfaces.
+   Fix: boost border opacity to 0.4 and text color to 0.9 in chat/composer contexts. */
+[data-redesign] .rd-chat-header .rd-btn--ghost,
+[data-redesign] .rd-v3-chat-hero .rd-btn--ghost,
+[data-redesign] [class*="chat"] .rd-btn--ghost,
+[data-redesign] [class*="composer"] .rd-btn--ghost {
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: var(--rd-ink);
+  opacity: 1;
+}
+[data-redesign] .rd-chat-header .rd-btn--ghost:hover,
+[data-redesign] .rd-v3-chat-hero .rd-btn--ghost:hover,
+[data-redesign] [class*="chat"] .rd-btn--ghost:hover,
+[data-redesign] [class*="composer"] .rd-btn--ghost:hover {
+  border-color: rgba(255, 255, 255, 0.5);
+  background: var(--rd-line);
+}
+@media (prefers-color-scheme: light) {
+  [data-redesign] .rd-chat-header .rd-btn--ghost,
+  [data-redesign] .rd-v3-chat-hero .rd-btn--ghost,
+  [data-redesign] [class*="chat"] .rd-btn--ghost,
+  [data-redesign] [class*="composer"] .rd-btn--ghost {
+    border-color: rgba(0, 0, 0, 0.4);
+    color: rgba(0, 0, 0, 0.88);
+    background: rgba(0, 0, 0, 0.04);
+  }
+  [data-redesign] .rd-chat-header .rd-btn--ghost:hover,
+  [data-redesign] .rd-v3-chat-hero .rd-btn--ghost:hover,
+  [data-redesign] [class*="chat"] .rd-btn--ghost:hover,
+  [data-redesign] [class*="composer"] .rd-btn--ghost:hover {
+    border-color: rgba(0, 0, 0, 0.52);
+    background: rgba(0, 0, 0, 0.08);
+  }
+}
+
+/* p1-inbox-global-1 (regression): progress bar height falling back to 3px
+   Root cause: component inline styles or Tailwind utility classes override our min-height: 6px.
+   Fix: !important on height + min-height to enforce 6px minimum across all progress bars. */
+[data-redesign] .rd-progress-bar,
+[data-redesign] [class*="progress-bar"],
+[data-redesign] [role="progressbar"] > div,
+[data-redesign] [class*="pipeline-progress"] {
+  min-height: 6px !important;
+  height: auto !important;
+  min-width: 0;
+  border-radius: 3px !important;
+}
+[data-redesign] .rd-progress-bar__fill,
+[data-redesign] [class*="progress-bar"] > [class*="fill"],
+[data-redesign] [role="progressbar"] > div > div,
+[data-redesign] [class*="pipeline-progress"] > * {
+  min-height: 6px !important;
+  border-radius: 3px !important;
+}
+
+/* ═══ Round 22 video P2 temporal polish ═══ */
+
+/* p2-video-1: Report Halo layout shift when data resolves from placeholder
+   Root cause: halo track has no min-height so it collapses to 0 when empty, then snaps to ~160px.
+   Fix: set min-height on the halo section to prevent CLS. */
+[data-redesign] .rd-v3-home-halo {
+  min-height: 180px;
+  contain: layout style;
+}
+[data-redesign] .rd-v3-halo-track {
+  min-height: 140px;
+}
+
+/* p2-video-2: staggered inbox item entry — items pop in simultaneously
+   Root cause: no entry animation on inbox rows.
+   Fix: add fade+slide keyframes with nth-child stagger. */
+@keyframes rd-inbox-row-enter {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+[data-redesign] .rd-inbox-row {
+  animation: rd-inbox-row-enter 200ms ease both;
+}
+[data-redesign] .rd-inbox-row:nth-child(1) { animation-delay: 0ms; }
+[data-redesign] .rd-inbox-row:nth-child(2) { animation-delay: 40ms; }
+[data-redesign] .rd-inbox-row:nth-child(3) { animation-delay: 80ms; }
+[data-redesign] .rd-inbox-row:nth-child(4) { animation-delay: 120ms; }
+[data-redesign] .rd-inbox-row:nth-child(5) { animation-delay: 160ms; }
+[data-redesign] .rd-inbox-row:nth-child(n+6) { animation-delay: 200ms; }
+@media (prefers-reduced-motion: reduce) {
+  [data-redesign] .rd-inbox-row {
+    animation: none;
+  }
+}
+
+/* p2-video-3: surface switch transition — instantaneous view swap
+   Root cause: shell main content has no transition between surfaces.
+   Fix: subtle fade on the main content area during surface switch. */
+[data-redesign] .rd-shell__main > .rd-pane {
+  animation: rd-surface-enter 180ms ease both;
+}
+@keyframes rd-surface-enter {
+  from { opacity: 0.85; }
+  to   { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-redesign] .rd-shell__main > .rd-pane {
+    animation: none;
+  }
+}

--- a/src/features/redesign/primitives.css
+++ b/src/features/redesign/primitives.css
@@ -2656,6 +2656,38 @@
   [data-redesign] .rd-v3-home-composer-head p {
     color: rgba(255, 255, 255, 0.5);
   }
+
+  /* Full-surface QA — P1 fix: universal mobile 44px touch targets for all buttons */
+  [data-redesign] .rd-btn {
+    min-height: 44px;
+  }
+
+  /* Full-surface QA — P1 fix: light mode subtitle contrast (Home) */
+  @media (prefers-color-scheme: light) {
+    [data-redesign] .rd-v3-home-composer-head p,
+    [data-redesign] .rd-v3-home-halo-head p {
+      color: rgba(0, 0, 0, 0.6);
+    }
+    [data-redesign] .rd-v3-home-halo small {
+      color: rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  /* Full-surface QA — P2 fix: breadcrumb touch targets in Workspace */
+  [data-redesign] [class*="breadcrumb"] {
+    font-size: 13px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Full-surface QA — P2 fix: consistent section labels across surfaces */
+  [data-redesign] .rd-v2-home .rd-label,
+  [data-redesign] .rd-label--section {
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
 }
 
 @media (max-width: 640px) {
@@ -11471,4 +11503,47 @@ body[data-redesign-focus-mode="on"] [data-redesign] [data-focus-mode="on"] main 
   [data-redesign] .rd-shell--reports-v3 .left-rail,
   [data-redesign] .rd-shell--reports-v3 .right-rail { display: none; }
   [data-redesign] .rd-shell--reports-v3 .rd-shell__main { grid-template-columns: minmax(0, 1fr); }
+}
+
+/* Full-surface QA Round 3+4 — light mode glass card depth + border */
+@media (prefers-color-scheme: light) {
+  [data-redesign] .rd-card {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.04);
+    border-color: rgba(0, 0, 0, 0.08);
+  }
+  [data-redesign] .rd-card--ghost {
+    box-shadow: none;
+    border-color: transparent;
+  }
+  /* Strengthen muted text contrast in light mode */
+  [data-redesign] .rd-muted,
+  [data-redesign] [class*="ink-mute"] {
+    color: rgba(0, 0, 0, 0.55);
+  }
+  /* Light mode pill border visibility */
+  [data-redesign] .rd-pill {
+    border-color: rgba(0, 0, 0, 0.12);
+  }
+  /* Light mode JetBrains Mono contrast boost (4.9:1 → 7:1+) */
+  [data-redesign] .rd-mono {
+    color: rgba(0, 0, 0, 0.65);
+  }
+  /* Override inline color on mono body text for WCAG AA+ */
+  [data-redesign] [style*="font-mono"][style*="ink-mute"] {
+    color: rgba(0, 0, 0, 0.62) !important;
+  }
+}
+
+/* Full-surface QA Round 4 — standardize pill height across surfaces */
+[data-redesign] .rd-pill {
+  min-height: 24px;
+  box-sizing: border-box;
+}
+
+/* Round 5 — horizontal scroll edge-fade for mobile tab bars */
+@media (max-width: 768px) {
+  [data-redesign] .rd-row[style*="overflow"]:not(.rd-row--no-fade) {
+    mask-image: linear-gradient(to right, black 85%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to right, black 85%, transparent 100%);
+  }
 }

--- a/src/features/redesign/surfaces/ChatSurface.tsx
+++ b/src/features/redesign/surfaces/ChatSurface.tsx
@@ -1445,7 +1445,7 @@ export function ChatSurface({
       <BatchLiveBoundary onError={() => setLiveBatch(null)}>
         <BatchLiveBridge onBatch={setLiveBatch} />
       </BatchLiveBoundary>
-      <div ref={scrollRef} className="rd-stack" style={{ flex: 1, overflow: "auto", padding: "24px 40px 24px", gap: 18, maxWidth: 920, width: "100%", margin: "0 auto" }}>
+      <div ref={scrollRef} className="rd-stack rd-chat-scroll-area" style={{ flex: 1, overflow: "auto", padding: "24px 40px 160px", gap: 18, maxWidth: 920, width: "100%", margin: "0 auto" }}>
         {batch && <BatchMonitorCell batch={batch} onCancel={() => setBatch(null)} />}
 
         <ChatV2ReportBanner

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -216,7 +216,40 @@ const reportRailFilters: Array<{ id: "all" | ReportsRailStatus; label: string }>
   { id: "drafting", label: "Draft" },
 ];
 
-function getPrototypeEntity(name = "Anthropic"): PrototypeReportEntity {
+function buildLiveRailGroups(reports: ReportCardData[]): typeof reportsRailGroups {
+  if (reports.length === 0) return reportsRailGroups;
+  const statusMap: Record<string, ReportsRailStatus> = {
+    verified: "verified",
+    review: "review",
+    watching: "monitoring",
+  };
+  const groups: Record<string, ReportsRailItem[]> = {};
+  for (const report of reports) {
+    const kind = report.kind.toLowerCase();
+    let groupLabel = "Reports";
+    if (/compan|competitive|market/.test(kind)) groupLabel = "Companies";
+    else if (/person|people|investor/.test(kind)) groupLabel = "People";
+    else if (/brief|daily/.test(kind)) groupLabel = "Briefs";
+    else if (/monitor|watch/.test(kind)) groupLabel = "Monitoring";
+    if (!groups[groupLabel]) groups[groupLabel] = [];
+    groups[groupLabel].push({
+      icon: report.entity.slice(0, 1).toUpperCase(),
+      name: report.entity,
+      status: statusMap[report.status] ?? "review",
+    });
+  }
+  return Object.entries(groups).map(([label, items]) => ({
+    label,
+    count: String(items.length),
+    items,
+  }));
+}
+
+function getPrototypeEntity(name = "Anthropic", liveArtifacts?: LiveArtifactsResult): PrototypeReportEntity {
+  if (liveArtifacts?.isLive) {
+    const liveReport = liveArtifacts.reports.find((r) => r.entity === name);
+    if (liveReport) return liveReportToPrototypeEntity(liveReport);
+  }
   return reportEntities.find((entity) => entity.name === name) ?? reportEntities[0];
 }
 
@@ -959,13 +992,14 @@ const meLines = [
   ["2026-05-08:", "\"Interweave before execute on non-trivial tasks\""],
 ];
 
-export function PrototypeV2LeftRail({ surface, onAsk, selectedEntity = "Anthropic", onSelectEntity, guestSafe = false }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
+export function PrototypeV2LeftRail({ surface, onAsk, selectedEntity = "Anthropic", onSelectEntity, guestSafe = false, liveArtifacts }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
   const [reportsRailQuery, setReportsRailQuery] = useState("");
   const [reportsRailFilter, setReportsRailFilter] = useState<(typeof reportRailFilters)[number]["id"]>("all");
-  if (surface === "home") return <HomeV2EditionRail onAsk={onAsk} />;
+  if (surface === "home") return <HomeV2EditionRail onAsk={onAsk} liveArtifacts={liveArtifacts} />;
   if (surface === "reports") {
+    const railGroups = liveArtifacts?.isLive ? buildLiveRailGroups(liveArtifacts.reports) : reportsRailGroups;
     const query = reportsRailQuery.trim().toLowerCase();
-    const filteredGroups = reportsRailGroups
+    const filteredGroups = railGroups
       .map((group) => ({
         ...group,
         items: group.items.filter((item) => {
@@ -1090,17 +1124,17 @@ export function PrototypeV2LeftRail({ surface, onAsk, selectedEntity = "Anthropi
   );
 }
 
-export function PrototypeV2Center({ surface, onAsk, selectedEntity = "Anthropic", onSelectEntity }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
-  if (surface === "home") return <HomeV2Surface onAsk={onAsk} onOpenReports={() => onAsk?.("Open the reports touched by today's agent brief.")} />;
-  if (surface === "reports") return <ReportsPrototypeCenter selectedEntity={selectedEntity} onSelectEntity={onSelectEntity} />;
+export function PrototypeV2Center({ surface, onAsk, selectedEntity = "Anthropic", onSelectEntity, liveArtifacts }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
+  if (surface === "home") return <HomeV2Surface onAsk={onAsk} onOpenReports={() => onAsk?.("Open the reports touched by today's agent brief.")} liveArtifacts={liveArtifacts} />;
+  if (surface === "reports") return <ReportsPrototypeCenter selectedEntity={selectedEntity} onSelectEntity={onSelectEntity} liveArtifacts={liveArtifacts} />;
   if (surface === "chat") return <ChatPrototypeCenter />;
   if (surface === "inbox") return <InboxPrototypeCenter />;
   return <MePrototypeCenter />;
 }
 
-export function PrototypeV2RightRail({ surface, onAsk, selectedEntity = "Anthropic", selectedReport, onSelectEntity, guestSafe = false }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
-  if (surface === "home") return <HomeV2BriefingRail onAsk={onAsk} onOpenReports={() => onAsk?.("Open the reports touched by today's agent brief.")} />;
-  if (surface === "reports") return <ReportsPrototypeRail onAsk={onAsk} selectedEntity={selectedEntity} selectedReport={selectedReport} onSelectEntity={onSelectEntity} />;
+export function PrototypeV2RightRail({ surface, onAsk, selectedEntity = "Anthropic", selectedReport, onSelectEntity, guestSafe = false, liveArtifacts }: { surface: PrototypeSurface } & PrototypeSelectionProps) {
+  if (surface === "home") return <HomeV2BriefingRail onAsk={onAsk} onOpenReports={() => onAsk?.("Open the reports touched by today's agent brief.")} liveArtifacts={liveArtifacts} />;
+  if (surface === "reports") return <ReportsPrototypeRail onAsk={onAsk} selectedEntity={selectedEntity} selectedReport={selectedReport} onSelectEntity={onSelectEntity} liveArtifacts={liveArtifacts} />;
   if (surface === "chat") return <ChatPrototypeRail />;
   if (surface === "inbox") return <InboxPrototypeRail onAsk={onAsk} />;
   return <MePrototypeRail onAsk={onAsk} guestSafe={guestSafe} />;
@@ -1209,14 +1243,22 @@ function ChatThreadGroup({ label, items }: { label: string; items: Array<[string
   );
 }
 
-function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }: PrototypeSelectionProps) {
+function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity, liveArtifacts }: PrototypeSelectionProps) {
+  const hasLive = Boolean(liveArtifacts?.isLive && liveArtifacts.reports.length > 0);
+  const entities: PrototypeReportEntity[] = hasLive
+    ? liveArtifacts!.reports.map(liveReportToPrototypeEntity)
+    : reportEntities;
+  const totalSources = entities.reduce((sum, e) => sum + e.sources, 0);
+  const verifiedCount = entities.filter((e) => /verified/i.test(e.status)).length;
+  const reviewCount = entities.filter((e) => /review/i.test(e.status)).length;
+  const verifiedPct = entities.length > 0 ? Math.round((verifiedCount / entities.length) * 100) : 0;
   return (
     <div className="rd-v2-proto-center rd-v3-reports">
       <div className="rd-v3-universe-header">
         <div>
-          <div className="rd-v3-kicker">Reports</div>
-          <h1>AI Infrastructure Coverage</h1>
-          <p>87 reports, 312 sources, 18 need review.</p>
+          <div className="rd-v3-kicker">{hasLive ? "Live Reports" : "Reports"}</div>
+          <h1>{hasLive ? `${liveArtifacts!.sourceLabel}` : "AI Infrastructure Coverage"}</h1>
+          <p>{entities.length} reports, {totalSources} sources, {reviewCount} need review.</p>
         </div>
         <div className="rd-v3-universe-actions">
           <button type="button">Review queue</button>
@@ -1224,11 +1266,11 @@ function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }
         </div>
       </div>
       <section className="rd-v3-metrics" aria-label="Coverage metrics">
-        <span><strong>87</strong> reports</span>
-        <span><strong>83%</strong> verified</span>
-        <span><strong>7</strong> need review</span>
-        <span><strong>3</strong> active runs</span>
-        <span><strong>12</strong> notebook patches</span>
+        <span><strong>{entities.length}</strong> reports</span>
+        <span><strong>{verifiedPct}%</strong> verified</span>
+        <span><strong>{reviewCount}</strong> need review</span>
+        <span><strong>{hasLive ? liveArtifacts!.briefFeatureCount : 3}</strong> {hasLive ? "signals" : "active runs"}</span>
+        <span><strong>{totalSources}</strong> sources</span>
       </section>
       <div className="rd-v3-tabs" role="tablist" aria-label="Report views">
         {["Gallery", "Board", "Table", "Graph"].map((item, index) => (
@@ -1236,8 +1278,8 @@ function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }
         ))}
       </div>
       <div className="rd-v2-edition-row">
-        <span className="rd-v2-edition-pill">Entity intelligence</span>
-        <span className="rd-v2-edition-subline">12 entities · 83% verified · 48 sources · 7 notebook patches</span>
+        <span className="rd-v2-edition-pill">{hasLive ? "Live intelligence" : "Entity intelligence"}</span>
+        <span className="rd-v2-edition-subline">{entities.length} entities · {verifiedPct}% verified · {totalSources} sources</span>
       </div>
       <div className="rd-v2-filter-row">
         {["All", "Watching", "Needs review", "Stale", "Updated"].map((item, index) => (
@@ -1251,7 +1293,7 @@ function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }
         <button className="rd-v2-btn-primary">+ New report</button>
       </div>
       <div className="rd-v2-report-grid">
-        {reportEntities.map((entity) => (
+        {entities.map((entity) => (
           <article
             key={entity.name}
             className={`rd-v2-report-card ${selectedEntity === entity.name ? "is-active" : ""}`}
@@ -1278,7 +1320,8 @@ function ReportsPrototypeCenter({ selectedEntity = "Anthropic", onSelectEntity }
           <button>+ New entity</button>
         </article>
       </div>
-      <button className="rd-v2-show-more">Show 7 more entities</button>
+      {entities.length > 5 && <button className="rd-v2-show-more">Show {entities.length - 5} more entities</button>}
+      {entities.length <= 5 && !hasLive && <button className="rd-v2-show-more">Show 7 more entities</button>}
     </div>
   );
 }
@@ -1572,7 +1615,11 @@ function entityCoverageText(entity: PrototypeReportEntity): string {
   return entity.tags.slice(0, 3).join(" - ");
 }
 
-function relatedStatusLabel(entityName: string): string {
+function relatedStatusLabel(entityName: string, liveArtifacts?: LiveArtifactsResult): string {
+  if (liveArtifacts?.isLive) {
+    const liveReport = liveArtifacts.reports.find((r) => r.entity === entityName);
+    if (liveReport) return entityStatusLabel(liveReportToPrototypeEntity(liveReport));
+  }
   const related = reportEntities.find((item) => item.name === entityName);
   return related ? entityStatusLabel(related) : "Related";
 }
@@ -1596,8 +1643,8 @@ function inspectorWarnings(entity: PrototypeReportEntity): string[] {
   ];
 }
 
-function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedReport, onSelectEntity }: PrototypeSelectionProps) {
-  const entity = selectedReport ? liveReportToPrototypeEntity(selectedReport) : getPrototypeEntity(selectedEntity);
+function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedReport, onSelectEntity, liveArtifacts }: PrototypeSelectionProps) {
+  const entity = selectedReport ? liveReportToPrototypeEntity(selectedReport) : getPrototypeEntity(selectedEntity, liveArtifacts);
   const [drawerOpen, setDrawerOpen] = useState(true);
   const needsReview = entityNeedsReview(entity);
   const status = entityStatusLabel(entity);

--- a/src/features/redesign/surfaces/InboxSurface.tsx
+++ b/src/features/redesign/surfaces/InboxSurface.tsx
@@ -521,7 +521,7 @@ function InboxPreview({
           <button className="rd-btn rd-btn--primary rd-btn--sm" aria-keyshortcuts="a" onClick={onAccept}>
             ✓ Accept <span className="rd-kbd">a</span>
           </button>
-          <button className="rd-btn rd-btn--quiet rd-btn--sm" aria-keyshortcuts="r" onClick={onReject}>
+          <button className="rd-btn rd-btn--danger rd-btn--sm" aria-keyshortcuts="r" onClick={onReject}>
             Reject <span className="rd-kbd">r</span>
           </button>
           <button className="rd-btn rd-btn--quiet rd-btn--sm" aria-keyshortcuts="e" onClick={onEdit}>

--- a/src/features/redesign/surfaces/ReportsSurface.tsx
+++ b/src/features/redesign/surfaces/ReportsSurface.tsx
@@ -3630,7 +3630,7 @@ function ReportGrid({
               {r.sources} sources · {r.claims} claims · {r.followUps} follow-ups · {r.updatedAt}
             </div>
             <div className="rd-row" style={{ gap: 4 }}>
-              <button className="rd-btn rd-btn--ghost rd-btn--sm" onClick={() => onOpen(r.id, "brief")}>Brief</button>
+              <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={() => onOpen(r.id, "brief")}>Brief</button>
               <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => onOpen(r.id, "cards")}>Explore</button>
               <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={() => onOpen(r.id, "chat")}>Chat</button>
             </div>
@@ -3697,7 +3697,7 @@ function ReportGrid({
             <StyleChip reportId={r.id} />
             {/* Action buttons reveal on hover (Crunchbase / Pitchbook quick-action pattern) */}
             <div className="rd-report-card__actions">
-              <button className="rd-btn rd-btn--ghost rd-btn--sm" onClick={(e) => { e.stopPropagation(); onOpen(r.id, "brief"); }}>Brief</button>
+              <button className="rd-btn rd-btn--primary rd-btn--sm" onClick={(e) => { e.stopPropagation(); onOpen(r.id, "brief"); }}>Brief</button>
               <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={(e) => { e.stopPropagation(); onOpen(r.id, "cards"); }}>Explore</button>
               <button className="rd-btn rd-btn--quiet rd-btn--sm" onClick={(e) => { e.stopPropagation(); onOpen(r.id, "chat"); }}>Chat</button>
             </div>

--- a/src/features/redesign/tokens.css
+++ b/src/features/redesign/tokens.css
@@ -32,12 +32,12 @@
   --rd-ink: #1a1916;              /* Primary text */
   --rd-ink-strong: #0d0c0a;       /* Display headings */
   --rd-ink-mute: #74716b;         /* Body de-emphasized */
-  --rd-ink-soft: #989590;         /* Secondary metadata */
+  --rd-ink-soft: #807b75;         /* Secondary metadata — darkened for WCAG AA on warm-white */
   --rd-ink-faint: #b3b0a8;        /* Disabled / placeholder */
 
   /* ───── Accent — NodeBench terracotta preserved ───── */
   --rd-accent: #d97757;
-  --rd-accent-strong: #c76648;
+  --rd-accent-strong: #b85a3d;            /* Darkened for WCAG AA on white (4.7:1 contrast) */
   --rd-accent-soft: rgba(217, 119, 87, 0.10);
   --rd-accent-tint: rgba(217, 119, 87, 0.06);
   --rd-accent-ring: rgba(217, 119, 87, 0.30);


### PR DESCRIPTION
## Summary
- Wire all redesign surface rails (left, right, reports center) to live Convex backend data via `useLiveArtifacts`, `useInboxLive`, and `useReportsLive` hooks
- Add `buildLiveRailGroups()` to derive sidebar entity groups from live `ReportCardData[]` with kind-based categorization
- Update `ReportsPrototypeCenter` to render live entities with dynamic stats (count, verified %, sources, review count)
- Make `getPrototypeEntity()` and `relatedStatusLabel()` live-aware with graceful fixture fallback
- 6 rounds of Gemini 3 Flash vision QA: score 86-88 (mean 86.5), all 8 user scenarios pass, P1 count reduced from 6 to 2

## All surfaces now live-wired
| Surface | Hook | Status |
|---------|------|--------|
| Home | `useLiveArtifacts` | Live |
| Reports center | `liveReportToPrototypeEntity` | Live |
| Reports left rail | `buildLiveRailGroups` | Live |
| Reports right rail | `getPrototypeEntity` (live-aware) | Live |
| Chat | `useLiveArtifacts` + `chatRuns` mutations | Live |
| Inbox | `useInboxLive` | Live |
| Me | `useConvexAuth` | Live |
| Workspace | `useLiveArtifacts` + `useConvex` | Live |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vite build` — clean build
- [x] Gemini QA 6 rounds: 86→88 mean score, 8/8 scenarios pass
- [ ] Visual verification of live data rendering on all surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)