### PR TITLE
fix(deploy): unblock public surface health checks

### DIFF
--- a/.github/workflows/attrition-qa.yml
+++ b/.github/workflows/attrition-qa.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Crawl all surfaces
         run: |
-          BASE="${{ github.event.inputs.api_url || github.event.deployment_status.environment_url || github.event.deployment_status.target_url || 'https://scratchnode.live' }}"
+          BASE="${{ github.event.inputs.api_url || 'https://scratchnode.live' }}"
           if [[ "$BASE" == https://vercel.com/* ]]; then
             BASE="https://scratchnode.live"
           fi
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run golden queries
         env:
-          NODEBENCH_API_URL: ${{ github.event.inputs.api_url || github.event.deployment_status.environment_url || github.event.deployment_status.target_url || 'https://scratchnode.live' }}
+          NODEBENCH_API_URL: ${{ github.event.inputs.api_url || 'https://scratchnode.live' }}
         run: |
           if [[ "$NODEBENCH_API_URL" == https://vercel.com/* ]]; then
             export NODEBENCH_API_URL="https://scratchnode.live"

--- a/vercel.json
+++ b/vercel.json
@@ -63,17 +63,6 @@
       ],
       "destination": "https://scratchnode.live/$1",
       "permanent": true
-    },
-    {
-      "source": "/(.*)",
-      "has": [
-        {
-          "type": "host",
-          "value": "www.nodebenchai.com"
-        }
-      ],
-      "destination": "https://nodebenchai.com/$1",
-      "permanent": true
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary
- remove the conflicting www.nodebenchai.com -> nodebenchai.com redirect that fights the Vercel canonical-domain redirect
- make Attrition QA crawl the public scratchnode.live surface by default instead of protected Vercel preview URLs

## Verification
- scratchnode.live surface crawl returns 200 for ask, library, connect, and telemetry
- scratchnode.live/docs raw HTML contains the merged Live prod plan section
