### PR TITLE
feat(scratchnode): wire sourced ask and wiki runtime

### DIFF
--- a/convex/events.ts
+++ b/convex/events.ts
@@ -183,6 +183,81 @@ const requireHost = async (ctx: any, eventId: any, ownerKey: string) => {
   return host;
 };
 
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+function synthesizeAnswer(
+  question: string,
+  eventName: string,
+  sources: Array<{ title: string; excerpt: string; body: string }>,
+) {
+  const evidence = sources
+    .map((source, index) => {
+      const sentence = (source.excerpt || source.body || "").split(/[.!?]/)[0]?.trim();
+      return `${index + 1}. ${source.title}: ${sentence || "Relevant event source."}.`;
+    })
+    .join("\n");
+  const top = sources[0];
+  return [
+    `The strongest sourced read from ${eventName} is that ${top.excerpt || top.title}.`,
+    "",
+    "Evidence used:",
+    evidence,
+    "",
+    `What to do next: treat this as a public-event answer, then open the cited sources or ask a narrower follow-up before using it as a final decision record.`,
+    `Question answered: ${question}`,
+  ].join("\n");
+}
+
+async function buildAnswerPayload(ctx: any, answerId: any) {
+  const answer = await ctx.db.get(answerId);
+  if (!answer) return null;
+  const sources: any[] = [];
+  for (const sourceId of answer.sourceIds.slice(0, 8)) {
+    const source = await ctx.db.get(sourceId);
+    if (source) {
+      sources.push({
+        _id: source._id,
+        title: source.title,
+        uri: source.uri,
+        excerpt: source.excerpt,
+        kind: source.kind,
+      });
+    }
+  }
+  return { ...answer, sources };
+}
+
+async function buildWikiHtml(ctx: any, eventName: string, answers: any[], sourceIds: any[]) {
+  const sourceRows: any[] = [];
+  for (const sourceId of sourceIds.slice(0, 20)) {
+    const source = await ctx.db.get(sourceId);
+    if (source) sourceRows.push(source);
+  }
+  const qa = answers.length
+    ? answers
+      .map((answer) =>
+        `<h3>${escapeHtml(answer.question)}</h3><p>${escapeHtml(answer.body).replace(/\n/g, "<br>")}</p>`,
+      )
+      .join("\n")
+    : "<p>No promoted public answers yet. Ask public questions during the event to build this wiki.</p>";
+  const sources = sourceRows.length
+    ? `<ul>${sourceRows.map((source) => `<li><strong>${escapeHtml(source.title)}</strong> - ${escapeHtml(source.excerpt)}</li>`).join("")}</ul>`
+    : "<p>No public sources attached yet.</p>";
+  return [
+    `<h1>${escapeHtml(eventName)} Wiki</h1>`,
+    "<p>This wiki is generated only from public event sources and public /ask answers. Private notes are excluded.</p>",
+    "<h2>Common Q&A</h2>",
+    qa,
+    "<h2>Sources</h2>",
+    sources,
+  ].join("\n");
+}
+
 // ─── QUERIES ──────────────────────────────────────────────────────────────
 
 /**
@@ -236,6 +311,76 @@ export const getMembers = query({
       )
       .collect();
     return all;
+  },
+});
+
+export const getSources = query({
+  args: { eventId: v.id("liveEvents") },
+  handler: async (ctx, { eventId }) => {
+    return await ctx.db
+      .query("liveEventSources")
+      .withIndex("by_event", (q) => q.eq("eventId", eventId))
+      .take(100);
+  },
+});
+
+export const getAnswers = query({
+  args: {
+    eventId: v.id("liveEvents"),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { eventId, limit }) => {
+    const safeLimit = Math.min(Math.max(limit ?? DEFAULT_MESSAGE_LIMIT, 1), MAX_ANSWER_LIMIT);
+    const rows = await ctx.db
+      .query("liveEventAnswers")
+      .withIndex("by_event_time", (q) => q.eq("eventId", eventId))
+      .order("desc")
+      .take(safeLimit);
+    const enriched: any[] = [];
+    for (const row of rows.reverse()) {
+      const sources: any[] = [];
+      for (const sourceId of row.sourceIds.slice(0, 8)) {
+        const source = await ctx.db.get(sourceId);
+        if (source) {
+          sources.push({
+            _id: source._id,
+            title: source.title,
+            uri: source.uri,
+            excerpt: source.excerpt,
+            kind: source.kind,
+          });
+        }
+      }
+      enriched.push({ ...row, sources });
+    }
+    return enriched;
+  },
+});
+
+export const getHostStatus = query({
+  args: {
+    eventId: v.id("liveEvents"),
+    ownerKey: v.string(),
+  },
+  handler: async (ctx, { eventId, ownerKey }) => {
+    if (!ownerKey || ownerKey.length < 8) return { isHost: false };
+    const host = await ctx.db
+      .query("liveEventHosts")
+      .withIndex("by_event_owner", (q) => q.eq("eventId", eventId).eq("ownerKey", ownerKey))
+      .first();
+    return host ? { isHost: true, role: host.role, displayName: host.displayName } : { isHost: false };
+  },
+});
+
+export const getPublishedWiki = query({
+  args: { eventId: v.id("liveEvents") },
+  handler: async (ctx, { eventId }) => {
+    const rows = await ctx.db
+      .query("liveEventWikiVersions")
+      .withIndex("by_event_status", (q) => q.eq("eventId", eventId).eq("status", "published"))
+      .order("desc")
+      .take(1);
+    return rows[0] ?? null;
   },
 });
 
@@ -402,6 +547,230 @@ export const sendMessage = mutation({
   },
 });
 
+export const askAgent = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    questionMessageId: v.id("liveEventMessages"),
+    question: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const startedAt = Date.now();
+    const question = (args.question || "").trim().slice(0, 1000);
+    if (!question) {
+      throw new ConvexError({ code: "empty_question", message: "/ask question required." });
+    }
+    const event = await ctx.db.get(args.eventId);
+    if (!event) {
+      throw new ConvexError({ code: "event_not_found", message: "Event no longer exists." });
+    }
+    if (event.status === "ended") {
+      throw new ConvexError({ code: "event_ended", message: "This event has ended." });
+    }
+    await requireMember(ctx, args.eventId, args.sessionId);
+    if (event.slug === "ai-infra-summit-2026") {
+      await ensureDemoSourcesForEvent(ctx, args.eventId);
+    }
+
+    const normalizedQuestion = normalizeQuestion(question);
+    const cached = await ctx.db
+      .query("liveEventAnswers")
+      .withIndex("by_event_normalized", (q) =>
+        q.eq("eventId", args.eventId).eq("normalizedQuestion", normalizedQuestion),
+      )
+      .order("desc")
+      .first();
+
+    if (cached) {
+      const answerId = await ctx.db.insert("liveEventAnswers", {
+        eventId: args.eventId,
+        questionMessageId: args.questionMessageId,
+        question,
+        normalizedQuestion,
+        body: cached.body,
+        sourceIds: cached.sourceIds,
+        trace: [
+          {
+            step: "semantic_cache_lookup",
+            status: "ok",
+            detail: `Reused answer ${cached._id}; source bundle unchanged.`,
+            durationMs: Date.now() - startedAt,
+          },
+        ],
+        cacheHit: true,
+        faqStatus: "none",
+        createdAt: Date.now(),
+      });
+      return await buildAnswerPayload(ctx, answerId);
+    }
+
+    const retrieveStarted = Date.now();
+    const sources = await ctx.db
+      .query("liveEventSources")
+      .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+      .take(100);
+    const ranked = sources
+      .map((source) => ({ source, score: scoreSource(question, source) }))
+      .sort((a, b) => b.score - a.score || b.source.uploadedAt - a.source.uploadedAt);
+    const selected = ranked.filter((row) => row.score > 0).slice(0, 4);
+    const topSources = (selected.length ? selected : ranked.slice(0, 3)).map((row) => row.source);
+    if (!topSources.length) {
+      throw new ConvexError({
+        code: "no_sources",
+        message: "No event sources are available for sourced /ask yet.",
+      });
+    }
+
+    const answerBody = synthesizeAnswer(question, event.name, topSources).slice(0, MAX_ANSWER_BODY);
+    const answerId = await ctx.db.insert("liveEventAnswers", {
+      eventId: args.eventId,
+      questionMessageId: args.questionMessageId,
+      question,
+      normalizedQuestion,
+      body: answerBody,
+      sourceIds: topSources.map((source) => source._id),
+      trace: [
+        {
+          step: "semantic_cache_lookup",
+          status: "miss",
+          detail: "No same-question public answer found for this event.",
+          durationMs: retrieveStarted - startedAt,
+        },
+        {
+          step: "bounded_source_retrieval",
+          status: "ok",
+          detail: `Scored ${sources.length} sources; selected ${topSources.length}.`,
+          durationMs: Date.now() - retrieveStarted,
+        },
+        {
+          step: "deterministic_synthesis",
+          status: "ok",
+          detail: "Generated from public event corpus only; private notes excluded.",
+          durationMs: Date.now() - startedAt,
+        },
+      ],
+      cacheHit: false,
+      faqStatus: "none",
+      createdAt: Date.now(),
+    });
+    return await buildAnswerPayload(ctx, answerId);
+  },
+});
+
+export const suggestAnswerForFaq = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    answerId: v.id("liveEventAnswers"),
+    sessionId: v.string(),
+  },
+  handler: async (ctx, { eventId, answerId, sessionId }) => {
+    await requireMember(ctx, eventId, sessionId);
+    const answer = await ctx.db.get(answerId);
+    if (!answer || answer.eventId !== eventId) {
+      throw new ConvexError({ code: "answer_not_found", message: "Answer no longer exists." });
+    }
+    if (answer.faqStatus === "none") {
+      await ctx.db.patch(answerId, { faqStatus: "suggested" });
+    }
+    return { ok: true, faqStatus: answer.faqStatus === "promoted" ? "promoted" : "suggested" };
+  },
+});
+
+export const claimHost = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    ownerKey: v.string(),
+    displayName: v.string(),
+  },
+  handler: async (ctx, { eventId, ownerKey, displayName }) => {
+    requireOwnerKey(ownerKey);
+    const existingForOwner = await ctx.db
+      .query("liveEventHosts")
+      .withIndex("by_event_owner", (q) => q.eq("eventId", eventId).eq("ownerKey", ownerKey))
+      .first();
+    if (existingForOwner) {
+      return { ok: true, hostId: existingForOwner._id, role: existingForOwner.role, created: false };
+    }
+    const existingHosts = await ctx.db
+      .query("liveEventHosts")
+      .withIndex("by_event", (q) => q.eq("eventId", eventId))
+      .take(1);
+    if (existingHosts.length > 0) {
+      throw new ConvexError({
+        code: "host_already_claimed",
+        message: "This room already has a host.",
+      });
+    }
+    const hostId = await ctx.db.insert("liveEventHosts", {
+      eventId,
+      ownerKey,
+      displayName: (displayName || "Host").slice(0, MAX_DISPLAY_NAME).trim() || "Host",
+      role: "owner",
+      createdAt: Date.now(),
+    });
+    return { ok: true, hostId, role: "owner", created: true };
+  },
+});
+
+export const promoteAnswerToFaq = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    answerId: v.id("liveEventAnswers"),
+    ownerKey: v.string(),
+  },
+  handler: async (ctx, { eventId, answerId, ownerKey }) => {
+    await requireHost(ctx, eventId, ownerKey);
+    const answer = await ctx.db.get(answerId);
+    if (!answer || answer.eventId !== eventId) {
+      throw new ConvexError({ code: "answer_not_found", message: "Answer no longer exists." });
+    }
+    await ctx.db.patch(answerId, { faqStatus: "promoted" });
+    return { ok: true, faqStatus: "promoted" };
+  },
+});
+
+export const publishWiki = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    ownerKey: v.string(),
+  },
+  handler: async (ctx, { eventId, ownerKey }) => {
+    const host = await requireHost(ctx, eventId, ownerKey);
+    const event = await ctx.db.get(eventId);
+    if (!event) {
+      throw new ConvexError({ code: "event_not_found", message: "Event no longer exists." });
+    }
+    const answers = await ctx.db
+      .query("liveEventAnswers")
+      .withIndex("by_event_time", (q) => q.eq("eventId", eventId))
+      .order("desc")
+      .take(MAX_WIKI_ANSWERS);
+    const promoted = answers.filter((answer) => answer.faqStatus === "promoted");
+    const publicAnswers = (promoted.length ? promoted : answers.slice(0, 8)).reverse();
+    const sourceIds = Array.from(new Set(publicAnswers.flatMap((answer) => answer.sourceIds)));
+    const latest = await ctx.db
+      .query("liveEventWikiVersions")
+      .withIndex("by_event_version", (q) => q.eq("eventId", eventId))
+      .order("desc")
+      .first();
+    const version = (latest?.version ?? 0) + 1;
+    const bodyHtml = await buildWikiHtml(ctx, event.name, publicAnswers, sourceIds);
+    const wikiId = await ctx.db.insert("liveEventWikiVersions", {
+      eventId,
+      version,
+      status: "published",
+      title: `${event.name} Wiki`,
+      bodyHtml,
+      sourceAnswerIds: publicAnswers.map((answer) => answer._id),
+      sourceIds,
+      createdByOwnerKey: host.ownerKey,
+      createdAt: Date.now(),
+      publishedAt: Date.now(),
+    });
+    return { ok: true, wikiId, version };
+  },
+});
+
 /**
  * Cheap presence heartbeat. UI calls this every 30s. Idempotent — early-returns
  * if lastSeenAt was bumped within the last 15s (rate-limits accidental spam).
@@ -443,7 +812,10 @@ export const ensureDemoEvent = mutation({
       .query("liveEvents")
       .withIndex("by_slug", (q) => q.eq("slug", "ai-infra-summit-2026"))
       .first();
-    if (existing) return { eventId: existing._id, created: false };
+    if (existing) {
+      const sourcesInserted = await ensureDemoSourcesForEvent(ctx, existing._id);
+      return { eventId: existing._id, created: false, sourcesInserted };
+    }
     const id = await ctx.db.insert("liveEvents", {
       slug: "ai-infra-summit-2026",
       name: "AI Infra Summit",

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1684,6 +1684,12 @@ var SHEET_RENDERERS = {
   },
 
   wiki: function() {
+    if (window._sn_published_wiki_body) {
+      return '<div class="sheet-head"><h2 id="sheet-title">AI Infra Summit &middot; Wiki</h2><span class="badge">live Convex</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
+        '<div class="wiki-shell"><aside class="wiki-toc" aria-label="Table of contents"><div class="wiki-toc-label">Source</div><a class="wiki-toc-link active">Published snapshot</a></aside>' +
+        '<article class="wiki-article" id="wiki-article">' + window._sn_published_wiki_body + '</article>' +
+        '<aside class="wiki-onpage" aria-label="Actions"><div class="wiki-onpage-label">Actions</div><a onclick="window.snPublishWiki && window.snPublishWiki()">Republish</a></aside></div>';
+    }
     var h = [];
     h.push('<div class="sheet-head"><h2 id="sheet-title">AI Infra Summit &middot; Wiki</h2><span class="badge">v1 &middot; live</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>');
     h.push('<div class="wiki-shell">');
@@ -1823,6 +1829,8 @@ var SHEET_RENDERERS = {
       '<button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#128295;</span><span style="font-size:11px">Workshop</span></button>' +
       '<button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#9749;</span><span style="font-size:11px">Office hrs</span></button></div></div>' +
       '<button type="button" class="sheet-button" onclick="toast(\'Event created!\',\'Room code: SOLARIS · Share the link with attendees.\'); closeSheet();">Create event &rarr;</button>' +
+      '<button type="button" class="sheet-button ghost" onclick="window.snClaimHost ? window.snClaimHost() : toast(\'Host console\',\'Live backend not connected yet.\'); closeSheet();">Claim live host console</button>' +
+      '<button type="button" class="sheet-button ghost host-only" onclick="window.snPublishWiki ? window.snPublishWiki() : toast(\'Wiki publish\',\'Live backend not connected yet.\'); closeSheet();">Publish wiki snapshot</button>' +
       '<button type="button" class="sheet-button ghost" onclick="closeSheet()">Maybe later</button>' +
       '<p style="margin-top:10px;font-size:11px;color:var(--ink-faint);text-align:center">Sign in first to save the event and access the host console.</p>';
   }
@@ -2938,6 +2946,12 @@ setTimeout(refreshNotesCounter, 100);
     return (h > 12 ? h - 12 : (h || 12)) + ':' + m + (h >= 12 ? 'p' : 'a');
   };
   const seenIds = new Set();
+  const seenAnswerIds = new Set();
+  const snEscape = (value) => String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
   const renderMessage = (msg) => {
     if (!feedEl || seenIds.has(msg._id)) return;
     seenIds.add(msg._id);
@@ -2954,10 +2968,45 @@ setTimeout(refreshNotesCounter, 100);
     row.scrollIntoView({ behavior: 'smooth', block: 'end' });
   };
 
+  const renderAnswer = (answer) => {
+    if (!feedEl || !answer || seenAnswerIds.has(answer._id)) return;
+    seenAnswerIds.add(answer._id);
+    const article = document.createElement('article');
+    article.className = 'ans';
+    article.setAttribute('data-answer-id', answer._id);
+    const sourceCount = (answer.sources || []).length || (answer.sourceIds || []).length || 0;
+    const sourceChips = (answer.sources || []).slice(0, 5).map((source) =>
+      '<span title="' + snEscape(source.excerpt || source.uri) + '">' + snEscape(source.title || source.uri) + '</span>'
+    ).join('');
+    const trace = (answer.trace || []).map((step) =>
+      '<div class="step"><span class="c">' + (step.status === 'ok' ? '&check;' : step.status === 'miss' ? '&middot;' : '!') + '</span><span>' +
+      snEscape(String(step.step || '').replace(/_/g, ' ')) + (step.detail ? ' · ' + snEscape(step.detail) : '') +
+      (typeof step.durationMs === 'number' ? ' · ' + step.durationMs + 'ms' : '') + '</span></div>'
+    ).join('');
+    article.innerHTML =
+      '<div class="ans-head"><span class="who">ScratchNode</span><span class="sep">·</span><span>' +
+      (answer.cacheHit ? 'cache hit' : 'sourced answer') + '</span><span class="sep">·</span><span>' + fmtTime(answer.createdAt) + '</span></div>' +
+      '<div class="ans-q"></div>' +
+      '<div class="ans-body"></div>' +
+      '<div class="ans-sources">' + (sourceChips || '<span>public event corpus</span>') + '<span>' + sourceCount + ' sources</span></div>' +
+      '<div class="ans-reuse" aria-label="Reuse summary"><span class="pin">' + (answer.cacheHit ? 'Answered from cache' : 'Answered from event corpus') + '</span><span class="sep">·</span><span><b>' + sourceCount + '</b> reused</span><span class="sep">·</span><span class="pulled"><b>0</b> live searches</span><span class="sep">·</span><span class="priv">no private notes</span></div>' +
+      '<button class="ans-show" type="button" aria-expanded="false" onclick="toggleHow(this)">Show trace &rarr;</button>' +
+      '<div class="ans-how">' + trace + '</div>' +
+      '<div class="ans-actions"><button type="button" class="primary attendee-only" onclick="window.snSuggestFaq && window.snSuggestFaq(\'' + answer._id + '\')">Suggest for FAQ</button><button type="button" class="primary host-only" onclick="window.snPromoteFaq && window.snPromoteFaq(\'' + answer._id + '\')">Promote to FAQ</button> <button type="button" onclick="openWiki()">View in wiki &rarr;</button> <button type="button" onclick="document.getElementById(\'ci\').focus()">Follow-up</button></div>';
+    article.querySelector('.ans-q').textContent = answer.question || '';
+    article.querySelector('.ans-body').innerHTML = snEscape(answer.body || '').replace(/\n/g, '<br>');
+    feedEl.appendChild(article);
+    article.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  };
+
   // Realtime subscription — Convex re-pushes the full array on every change
   client.onUpdate('events:getMessages', { eventId, limit: 200 }, (rows) => {
     if (!Array.isArray(rows)) return;
     for (const msg of rows) renderMessage(msg);
+  });
+  client.onUpdate('events:getAnswers', { eventId, limit: 100 }, (rows) => {
+    if (!Array.isArray(rows)) return;
+    for (const answer of rows) renderAnswer(answer);
   });
 
   // ─── Override the send pipeline to route public chat through Convex ─
@@ -2981,6 +3030,16 @@ setTimeout(refreshNotesCounter, 100);
       displayName: liveName,
       text: intent.clean,
       kind: intent.kind === 'agent_ask' ? 'ask' : 'chat',
+    }).then((res) => {
+      if (intent.kind !== 'agent_ask') return null;
+      return client.mutation('events:askAgent', {
+        eventId,
+        sessionId,
+        questionMessageId: res.messageId,
+        question: intent.clean,
+      }).then((answer) => {
+        if (answer) renderAnswer(answer);
+      });
     }).catch((e) => {
       console.warn('[scratchnode] sendMessage failed:', e.message || e);
       // Fall back to prototype DOM append so the message isn't lost in the void.
@@ -2993,6 +3052,61 @@ setTimeout(refreshNotesCounter, 100);
   };
   // Make sure both global aliases stay in sync (existing onclick handlers).
   window.send = window.sendComposerMessage;
+
+  window.snSuggestFaq = function(answerId) {
+    client.mutation('events:suggestAnswerForFaq', { eventId, answerId, sessionId })
+      .then(() => toast('Suggested for FAQ', 'The host can promote this into the public wiki.'))
+      .catch((e) => toast('FAQ suggestion failed', e.message || String(e)));
+  };
+
+  window.snClaimHost = function() {
+    const ownerKey = localStorage.getItem('sn_host_owner_key') || sessionId;
+    localStorage.setItem('sn_host_owner_key', ownerKey);
+    const hostName = (window._userName && String(window._userName).trim()) || 'Host';
+    client.mutation('events:claimHost', { eventId, ownerKey, displayName: hostName })
+      .then(() => {
+        document.body.setAttribute('data-role', 'host');
+        window._sn_live.hostOwnerKey = ownerKey;
+        toast('Host console enabled', 'You can now promote answers and publish the wiki.');
+      })
+      .catch((e) => toast('Host claim blocked', e.message || String(e)));
+  };
+
+  window.snPromoteFaq = function(answerId) {
+    const ownerKey = window._sn_live.hostOwnerKey || localStorage.getItem('sn_host_owner_key') || sessionId;
+    client.mutation('events:promoteAnswerToFaq', { eventId, answerId, ownerKey })
+      .then(() => toast('Promoted to FAQ', 'This answer is ready for the event wiki.'))
+      .catch((e) => toast('Promotion blocked', e.message || String(e)));
+  };
+
+  window.snPublishWiki = function() {
+    const ownerKey = window._sn_live.hostOwnerKey || localStorage.getItem('sn_host_owner_key') || sessionId;
+    client.mutation('events:publishWiki', { eventId, ownerKey })
+      .then((res) => {
+        toast('Wiki published', 'Version ' + res.version + ' is now live.');
+        return client.query('events:getPublishedWiki', { eventId });
+      })
+      .then((wiki) => {
+        if (wiki) window._sn_published_wiki_body = wiki.bodyHtml;
+      })
+      .catch((e) => toast('Wiki publish blocked', e.message || String(e)));
+  };
+
+  client.query('events:getHostStatus', {
+    eventId,
+    ownerKey: localStorage.getItem('sn_host_owner_key') || sessionId,
+  }).then((status) => {
+    if (status && status.isHost) {
+      document.body.setAttribute('data-role', 'host');
+      window._sn_live.hostOwnerKey = localStorage.getItem('sn_host_owner_key') || sessionId;
+    }
+  }).catch(() => {});
+
+  client.query('events:getPublishedWiki', { eventId })
+    .then((wiki) => {
+      if (wiki) window._sn_published_wiki_body = wiki.bodyHtml;
+    })
+    .catch(() => {});
 
   // ─── Presence heartbeat — every 30s ─────────────────────────────────
   setInterval(() => {
@@ -3184,8 +3298,8 @@ setTimeout(refreshNotesCounter, 100);
 
   // Mark the page as Convex-connected so devs / e2e tests can detect it.
   document.body.setAttribute('data-sn-live', 'true');
-  document.body.setAttribute('data-sn-phases', '1,3');
-  console.info('[scratchnode] Phases 1+3 live — connected to', cfg.convexUrl, 'event', joined.slug);
+  document.body.setAttribute('data-sn-phases', '1,2,3,4,5');
+  console.info('[scratchnode] Phases 1-5 live - connected to', cfg.convexUrl, 'event', joined.slug);
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- wires public /ask messages through Convex-backed sourced answer rows
- renders live answer cards with source chips, cache status, and collapsed trace in home-v5
- adds FAQ suggestion, host-gated promotion, host claim, and published wiki snapshot mutations
- keeps private notes excluded from public answer/wiki/cache paths

## Verification
- npx convex codegen
- node scripts/preflight-deploy.mjs --target=preview
- npm run build:search-api-bundle
- npx vite build
- browser smoke on public/proto/home-v5.html for composer, /ask card, sources, trace, and console errors

## Notes
- Redis/semantic-cache infra is not provisioned in this PR; this adds the durable normalized-question cache path in Convex and keeps Redis as the later hot-layer implementation.