### PR TITLE
fix(runtime): gate exact chat history hydration

### DIFF
--- a/src/features/designKit/exact/ExactKit.tsx
+++ b/src/features/designKit/exact/ExactKit.tsx
@@ -2983,6 +2983,7 @@ export function ExactChatSurface() {
       : "skip",
   );
   const liveThreadTurns: ChatTurn[] | null = (() => {
+    if (!realChat.state.available) return null;
     if (!liveThread || !(liveThread as any)?.live) return null;
     const lt = liveThread as any;
     if (!Array.isArray(lt.turns) || lt.turns.length === 0) return null;


### PR DESCRIPTION
﻿## Summary
- prevents anonymous/non-email sessions from hydrating the saved ExactKit chat thread
- keeps the cockpit chat page on the honest live-ready Context Runtime state until a user is eligible for live research
- fixes the production parity gap found after PR #380 merged, where the new bundle was live but old Convex seed thread data still rendered for anonymous users

## Verification
- `npx tsc --noEmit --pretty false`
- `npx vitest run src/features/redesign/hooks/useRedesignChatRun.test.ts src/layouts/ActiveSurfaceHost.test.tsx`
- `BASE_URL=http://127.0.0.1:5192 npx playwright test tests/e2e/exact-kit-parity-prod.spec.ts -g "Chat renders ExactChatSurface" --project=chromium`
- `npm run build`
