### PR TITLE
refactor(scratchnode): rename askAgent -> composeAnswer

### DIFF
--- a/convex/events.ts
+++ b/convex/events.ts
@@ -547,7 +547,20 @@ export const sendMessage = mutation({
   },
 });
 
-export const askAgent = mutation({
+/**
+ * composeAnswer — Phase 2 deterministic synthesis for /ask in live events.
+ *
+ * Ranks event sources by source-token-overlap against the question, then
+ * stitches a citation-grounded answer together with NO LLM call. This is the
+ * Phase 2 wiring that runs today.
+ *
+ * The future LLM-backed action (vector search + Anthropic) will ship as a
+ * separate function named `askAgent` when the Anthropic integration lands —
+ * see public/proto/docs.html "Live prod plan / Phase 2". Renaming this
+ * function frees the `askAgent` name for that real-LLM caller and prevents
+ * future readers from assuming LLM behavior that isn't here.
+ */
+export const composeAnswer = mutation({
   args: {
     eventId: v.id("liveEvents"),
     sessionId: v.string(),

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -3032,7 +3032,7 @@ setTimeout(refreshNotesCounter, 100);
       kind: intent.kind === 'agent_ask' ? 'ask' : 'chat',
     }).then((res) => {
       if (intent.kind !== 'agent_ask') return null;
-      return client.mutation('events:askAgent', {
+      return client.mutation('events:composeAnswer', {
         eventId,
         sessionId,
         questionMessageId: res.messageId,


### PR DESCRIPTION
## Summary

Pure rename. The function exported as `askAgent` in `convex/events.ts` does
**deterministic source-token-overlap synthesis with zero LLM calls**.
The name "askAgent" sets up future readers to assume LLM behavior that
isn't there.

When real Anthropic-backed `/ask` ships (see `public/proto/docs.html`
"Live prod plan / Phase 2"), it will be a new function and we want the
`askAgent` name available. Renaming now prevents meaning drift.

## What changed

- `convex/events.ts` — `export const askAgent` -> `export const composeAnswer`
  + JSDoc explaining why this function is deterministic and reserving the
  `askAgent` name for the future LLM caller.
- `public/proto/home-v5.html` — single Convex client callsite updated:
  `client.mutation('events:askAgent', ...)` -> `client.mutation('events:composeAnswer', ...)`
- `convex/_generated/api.d.ts` — picked up via `npx convex codegen`
  (autogen, not hand-edited).

## What intentionally was NOT renamed

- `public/proto/docs.html` — the `askAgent` references in the live-prod-plan
  section describe the **future** Anthropic-backed action. Those should
  keep the `askAgent` name — that is exactly the name this rename frees up.
- `tests/e2e/exact-kit-parity-prod.spec.ts` — `askAgentButton` matches DOM
  text "ask agent" in a UI button label, unrelated to the Convex function.

## Verification

- `npx convex codegen` clean
- `npx tsc --noEmit --pretty false` clean (0 errors)
- 2 files changed, 15 insertions, 2 deletions

## Test plan

- [ ] CI green (Typecheck, Runtime smoke, Build)
- [ ] No console errors on `/e/ai-infra-summit-2026`
- [ ] `/ask` still functional — sourced answer renders with citations
