### PR TITLE
fix(redesign): clarify runtime route ownership

### DIFF
--- a/convex/events.runtime-boundary.test.ts
+++ b/convex/events.runtime-boundary.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const eventsSource = readFileSync(join(here, "events.ts"), "utf8");
+
+function functionBlock(name: string): string {
+  const start = eventsSource.indexOf(`export const ${name} = mutation({`);
+  expect(start, `${name} mutation should exist`).toBeGreaterThanOrEqual(0);
+  const next = eventsSource.indexOf("\nexport const ", start + 1);
+  return eventsSource.slice(start, next > start ? next : undefined);
+}
+
+describe("scratchnode public runtime boundaries", () => {
+  it("keeps public /ask isolated from private user notes", () => {
+    const askAgent = functionBlock("askAgent");
+
+    expect(askAgent).not.toContain("userNotes");
+    expect(askAgent).not.toContain("getPrivate");
+    expect(askAgent).toContain("requireMember");
+    expect(askAgent).toContain("liveEventSources");
+    expect(askAgent).toContain("deterministic_synthesis");
+  });
+
+  it("keeps wiki publishing host-gated and sourced from public answers", () => {
+    const publishWiki = functionBlock("publishWiki");
+
+    expect(publishWiki).toContain("requireHost");
+    expect(publishWiki).toContain("liveEventAnswers");
+    expect(publishWiki).toContain("liveEventWikiVersions");
+    expect(publishWiki).not.toContain("userNotes");
+  });
+
+  it("keeps host claim idempotent for the same owner key before rejecting claimed rooms", () => {
+    const claimHost = functionBlock("claimHost");
+    const ownerLookup = claimHost.indexOf('withIndex("by_event_owner"');
+    const eventLookup = claimHost.indexOf('withIndex("by_event"');
+
+    expect(ownerLookup).toBeGreaterThanOrEqual(0);
+    expect(eventLookup).toBeGreaterThan(ownerLookup);
+    expect(claimHost).toContain("host_already_claimed");
+  });
+});

--- a/docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md
+++ b/docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md
@@ -1,0 +1,70 @@
+# Product Surface Runtime Ownership
+
+Last updated: 2026-05-26
+
+This note exists to prevent the exact confusion that happened around PRs #380 and #381: a PR title can say "proto chat" or "live context runtime" while the code only changes one of several chat-looking surfaces. Always identify the route and owning files before claiming product parity.
+
+## Route Ownership
+
+| Product surface | Public route | Primary files | Runtime responsibility |
+| --- | --- | --- | --- |
+| NodeBench current redesign | `/redesign`, `/redesign/reports`, `/redesign/chat`, `/redesign/inbox`, `/redesign/me` | `src/features/redesign/RedesignShell.tsx`, `src/features/redesign/surfaces/*`, `src/features/redesign/components/RightInspector.tsx` | Main product UI. Chat uses `useRedesignChatRun`; Reports uses live artifacts, graph neighborhoods, and a report runtime inspector. |
+| NodeBench cockpit / ExactKit | `/?surface=chat`, `/?surface=reports`, etc. | `src/layouts/ActiveSurfaceHost.tsx`, `src/features/designKit/exact/ExactKit.tsx` | Compatibility and visual-regression cockpit. Do not treat changes here as `/redesign` changes. |
+| ScratchNode public event room | `https://scratchnode.live/`, `/e/:slug`, `/docs` | `public/proto/home-v5.html`, `public/proto/docs.html`, `convex/events.ts`, `api/scratchnode-config.js`, `vercel.json` host rewrites | Anonymous event-room product with Convex chat, sourced `/ask`, private notes, FAQ, host claim, and wiki publish. It is not the NodeBench redesign app. |
+| NodeBench workspace | `/redesign/workspace?...` | `src/features/redesign/surfaces/WorkspaceSurface.tsx` | Separate workspace surface for a selected report identity. It is not a sixth main web tab. |
+
+## Current Runtime Contract
+
+The shared architecture sentence is:
+
+```text
+parallel context routing -> scored planning -> progressive execution -> layered verification -> report/notebook persistence
+```
+
+For the current redesign:
+
+- `/redesign/chat` owns the active chat runtime UI. It must expose context used, retrieval/tool decisions, verification, cost/latency, write proposals, and approval state through `RightInspector`.
+- `/redesign/reports` owns the report-library/runtime-inspector view. The right rail should describe the selected report's bounded graph/context packet, source coverage, claim verification, notebook patch state, and safe-write posture.
+- The Reports graph must stay a human-facing bounded graph. It can expose richer agent context packets, but it should not render the whole graph universe.
+
+For the ExactKit cockpit:
+
+- `/?surface=chat` is still real and should stay auth-honest.
+- It is not the route users are evaluating when they say the redesigned product page is wrong.
+- Any PR that only touches `src/features/designKit/exact/ExactKit.tsx` must say that it changed the cockpit, not `/redesign/chat`.
+
+For ScratchNode:
+
+- `home-v5.html` is the live event-room shell.
+- `convex/events.ts` is the public event backend.
+- Public `/ask` currently composes sourced answers deterministically from the public event corpus. If an LLM-backed agent is added later, name the boundary clearly so "agent" does not hide deterministic behavior.
+- Private notes stay in `userNotes` and must not be read by `askAgent` or public wiki publishing.
+
+## Required Start Checklist
+
+Before implementing UI or runtime work:
+
+1. Run `git fetch origin main --prune`.
+2. Work from a clean worktree based on `origin/main`.
+3. Name the target route first: `/redesign/chat`, `/redesign/reports`, `/?surface=chat`, or `scratchnode.live/e/:slug`.
+4. Inspect the owning files listed above before editing.
+5. Add or update tests that assert the target route's DOM markers.
+
+## DOM Markers To Keep Stable
+
+| Marker | Meaning |
+| --- | --- |
+| `[data-testid="right-inspector"][data-agent-runtime-surface="redesign-chat"]` | Current redesign Chat runtime inspector. |
+| `[data-testid="reports-runtime-inspector"][data-agent-runtime-surface="redesign-reports"]` | Current redesign Reports runtime inspector. |
+| `[data-testid="exact-web-chat-stream"]` | ExactKit cockpit chat surface at `/?surface=chat`. |
+| `document.body.dataset.snLive === "true"` | ScratchNode public room connected to Convex runtime. |
+
+## Review Rule
+
+If a PR says "live runtime", "proto parity", "home-v5", "redesign", or "scratchnode", the reviewer should ask:
+
+```text
+Which route changed, and which route was verified in the browser?
+```
+
+Do not merge vague runtime claims without a route-specific test or screenshot.

--- a/docs/runbooks/PROD_PARITY_UI_KIT_WORKFLOW.md
+++ b/docs/runbooks/PROD_PARITY_UI_KIT_WORKFLOW.md
@@ -66,6 +66,19 @@ Brief - Cards - Notebook - Sources - Chat - Map
 
 Workspace is a separate deployed surface, not a sixth tab in the main web app.
 
+## Route Ownership Guardrail
+
+Before claiming that a runtime or UI-kit change affects "NodeBench chat",
+"Reports", "the proto", or "ScratchNode", name the route and owning files:
+
+- Current NodeBench redesign: `/redesign/*` in `src/features/redesign/*`
+- ExactKit cockpit: `/?surface=*` in `src/features/designKit/exact/ExactKit.tsx`
+- ScratchNode public room: `scratchnode.live/e/:slug` in `public/proto/home-v5.html` plus `convex/events.ts`
+
+Use `docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md` as the canonical
+map. A change to `ExactKit.tsx` is not a `/redesign/chat` change. A change to
+`home-v5.html` is not a NodeBench redesign change.
+
 ## Runtime Safety Rules
 
 - Preserve live Convex-backed flows.

--- a/src/features/redesign/README.md
+++ b/src/features/redesign/README.md
@@ -1,8 +1,10 @@
 # `src/features/redesign/`
 
-> Standalone redesign showcase mounted at `/redesign`. Self-contained — does not touch the live cockpit.
+> Current NodeBench redesign surface mounted at `/redesign`. It is route-distinct from the ExactKit cockpit at `/?surface=...` and from ScratchNode's event room at `scratchnode.live`.
 >
 > Read [docs/architecture/REDESIGN_ROADMAP.md](../../../docs/architecture/REDESIGN_ROADMAP.md) for the full architecture and journey. This README is the developer-facing inventory + extension cookbook.
+>
+> Route ownership and runtime boundaries are documented in [docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md](../../../docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md). Read it before claiming a PR changed "the chat runtime" or "the proto" because several routes have chat-like UIs.
 
 ---
 
@@ -15,7 +17,7 @@ npm run dev
 # Toggle the "◐" FAB next to it to switch light/dark mode
 ```
 
-All redesign code is scoped to `[data-redesign]`. Nothing leaks into the existing cockpit.
+All redesign code is scoped to `[data-redesign]`. It shares live Convex runtime primitives with the product, but route ownership is explicit: `/redesign/*` is the current redesign, `/?surface=*` is the ExactKit cockpit, and `scratchnode.live/e/:slug` is the ScratchNode event room.
 
 ---
 
@@ -54,12 +56,20 @@ src/features/redesign/
 |---|---|
 | `/redesign` | HomeSurface |
 | `/redesign/reports` | ReportsSurface |
-| `/redesign/chat` | ChatSurface (with RightInspector on desktop) |
+| `/redesign/chat` | ChatSurface (with `RightInspector` Agent Runtime Inspector on desktop) |
 | `/redesign/inbox` | InboxSurface |
 | `/redesign/me` | MeSurface |
 | `/redesign/workspace` | WorkspaceSurface (6-tab — Brief default) |
 
 Wired in [src/App.tsx](../../App.tsx) as a standalone route check before `/memo` — bypasses the cockpit entirely.
+
+Important route split:
+
+| Route | Do not confuse with |
+|---|---|
+| `/redesign/chat` | `/?surface=chat` ExactKit cockpit |
+| `/redesign/reports` | `/?surface=reports` ExactKit cockpit |
+| `scratchnode.live/e/:slug` | NodeBench redesign or cockpit routes |
 
 ---
 

--- a/src/features/redesign/components/RightInspector.tsx
+++ b/src/features/redesign/components/RightInspector.tsx
@@ -70,7 +70,8 @@ export function RightInspector({ activeLiveArtifactDetail, agentSnapshot }: Righ
     <aside
       className="rd-pane rd-pane--right chat-context"
       data-testid="right-inspector"
-      aria-label="Session context"
+      aria-label="Agent runtime inspector"
+      data-agent-runtime-surface="redesign-chat"
       data-agent-context-ref={graphPacket?.contextRef ?? ""}
       data-agent-context-rank={graphPacket?.agentRank ?? ""}
     >

--- a/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
+++ b/src/features/redesign/surfaces/HomeV2PrototypeSurface.tsx
@@ -1680,7 +1680,9 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
   return (
     <aside
       className="rd-pane rd-pane--right right-rail"
-      aria-label="Agent chat"
+      aria-label="Report runtime inspector"
+      data-testid="reports-runtime-inspector"
+      data-agent-runtime-surface="redesign-reports"
       data-agent-context-ref={contextPacket.contextRef}
       data-agent-context-rank={contextPacket.agentRank}
       data-agent-context-attention-score={contextPacket.attentionScore}
@@ -1689,8 +1691,8 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
       <div className="ar-head">
         <span className="ar-dot" />
         <div className="ar-head-info">
-          <div className="ar-name">Coverage agent</div>
-          <div className="ar-meta">Reports · {contextEntityCount} entities · {entity.sources * 4} sources · {needsReview ? "3 active" : "12 active"}</div>
+          <div className="ar-name">Report Runtime Inspector</div>
+          <div className="ar-meta">Reports · ContextRuntimePacket · {contextEntityCount} entities · {entity.sources * 4} sources · {needsReview ? "3 active" : "12 active"}</div>
         </div>
         <div className="ar-head-actions">
           <button className="ar-head-btn" type="button" aria-label="Expand chat" title="Expand" onClick={() => ask(`Open Chat with ${entity.name} report context.`)}>↗</button>
@@ -1716,7 +1718,7 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
           <div className="ar-msg-system-line">
             <div className="ar-msg-system-body">
               <span className="ar-msg-system-icon">⚙</span>
-              Context loaded · {contextEntityCount} entities · {entity.sources * 4} sources
+              ContextRuntimePacket loaded · {contextEntityCount} entities · {entity.sources * 4} sources
               <time>3 min ago</time>
             </div>
           </div>
@@ -1731,7 +1733,7 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
           <div className="ar-msg-system-line">
             <div className="ar-msg-system-body">
               <span className="ar-msg-system-icon">↻</span>
-              Routed to deep-analysis model for multi-entity comparison
+              Parallel routing · memory · graph · source cache · verification lanes
             </div>
           </div>
         </div>
@@ -1742,7 +1744,7 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
             <div className="ar-msg-detail">
               <strong>{entity.name}</strong> — {needsReview ? "Evidence or freshness is below threshold. Verify stale claims before notebook patch or export." : "Current source rows are verified enough for the active coverage task."}<br />
               <strong>Notebook</strong> — {needsReview ? "Patch should stay proposed until review clears." : "Notebook can be opened, reused, or exported with the current source trail."}<br />
-              <strong>Graph</strong> — Related entities remain attached for comparison and follow-up routing.
+              <strong>Graph</strong> — Related entities stay bounded as a context packet, not a full graph dump.
             </div>
             <div className="ar-msg-tools">
               <span className="ar-tool-badge">Source scan</span>
@@ -1802,6 +1804,7 @@ function ReportsPrototypeRail({ onAsk, selectedEntity = "Anthropic", selectedRep
           <span className="ar-drawer-chevron">▾</span>
         </button>
         <div className="ar-drawer-body">
+          <div className="ar-ctx-row"><span className="ar-ctx-lbl">Runtime</span><span className="ar-ctx-val">parallel context routing → scored planning → layered verification</span></div>
           <div className="ar-drawer-entity">
             <span className="ar-drawer-icon">{entity.initial}</span>
             <span className="ar-drawer-name">{entity.name}</span>

--- a/tests/e2e/redesign-runtime-route-ownership.spec.ts
+++ b/tests/e2e/redesign-runtime-route-ownership.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL?.replace(/\/$/, "") ?? "http://127.0.0.1:5173";
+
+async function goto(page: import("@playwright/test").Page, path: string) {
+  await page.goto(`${BASE_URL}${path}`, { waitUntil: "networkidle", timeout: 30_000 });
+  await page.waitForTimeout(1_500);
+}
+
+test.describe("runtime route ownership", () => {
+  test("current redesign chat owns the Agent Runtime Inspector", async ({ page }) => {
+    await goto(page, "/redesign/chat?qa=runtime-ownership");
+
+    const inspector = page.getByTestId("right-inspector");
+    await expect(inspector).toBeVisible();
+    await expect(inspector).toHaveAttribute("data-agent-runtime-surface", "redesign-chat");
+    await expect(inspector).toContainText("Progress");
+    await expect(inspector).toContainText("Artifacts");
+
+    await page.getByRole("tab", { name: "Trace" }).click();
+    await expect(inspector).toContainText("Tool calls");
+    await expect(inspector).toContainText("Est. cost");
+    await expect(inspector).toContainText("Graph packet");
+  });
+
+  test("current redesign reports owns the Report Runtime Inspector", async ({ page }) => {
+    await goto(page, "/redesign/reports?qa=runtime-ownership");
+
+    const inspector = page.getByTestId("reports-runtime-inspector");
+    await expect(inspector).toBeVisible();
+    await expect(inspector).toHaveAttribute("data-agent-runtime-surface", "redesign-reports");
+    await expect(inspector).toContainText("Report Runtime Inspector");
+    await expect(inspector).toContainText("ContextRuntimePacket");
+    await expect(inspector).toContainText("Graph context packet");
+
+    const contextRef = await inspector.getAttribute("data-agent-context-ref");
+    expect(contextRef, "reports rail should expose a bounded graph context ref").toBeTruthy();
+  });
+
+  test("ExactKit cockpit chat remains separate from /redesign/chat", async ({ page }) => {
+    await goto(page, "/?surface=chat&qa=runtime-ownership");
+
+    const stream = page.getByTestId("exact-web-chat-stream");
+    await expect(stream).toBeVisible();
+    await expect(stream).toHaveAttribute("data-chat-live-status", /idle|thinking|ok|error/);
+    await expect(page.locator(".nb-stream-header h2")).toContainText("Live Context Runtime");
+    await expect(page.locator(".nb-stream-savebar strong")).toContainText("NodeBench live runtime");
+  });
+
+  test("ScratchNode event shell remains separate from NodeBench routes", async ({ page }) => {
+    await goto(page, "/proto/home-v5.html#demo");
+
+    await expect(page).toHaveTitle(/ScratchNode/);
+    await expect(page.locator("body")).toContainText("ScratchNode");
+    await expect(page.locator("body")).toContainText("/ask");
+  });
+});


### PR DESCRIPTION
## Summary
- documents the route ownership split between `/redesign/*`, ExactKit `/?surface=*`, and ScratchNode `home-v5.html`
- adds stable DOM markers for the `/redesign/chat` Agent Runtime Inspector and `/redesign/reports` Report Runtime Inspector
- adds route-specific e2e coverage and ScratchNode static runtime-boundary tests so future PRs cannot claim the wrong surface by title alone

## Verification
- `npx tsc --noEmit --pretty false`
- `npx tsc -p convex --noEmit --pretty false`
- `npx vitest run convex/events.runtime-boundary.test.ts src/features/redesign/hooks/useRedesignChatRun.test.ts src/features/redesign/lib/graphContextBridge.test.ts`
- `npm run build`
- `BASE_URL=http://127.0.0.1:5193 npx playwright test tests/e2e/redesign-runtime-route-ownership.spec.ts --project=chromium --reporter=line`
- `BASE_URL=http://127.0.0.1:5193 npx playwright test tests/e2e/exact-kit-parity-prod.spec.ts -g "Chat renders ExactChatSurface" --project=chromium --reporter=line`
- Browser screenshots saved under `.tmp/redesign-runtime-inspector-qa/`

## Notes
Supersedes #384, which had the same code but used a branch name rejected by the repo's branch-name gate.
