### PR TITLE
ci(tier-b): URL-encode branch ref so polling actually matches the deployment

### DIFF
--- a/.github/workflows/tier-b-preview.yml
+++ b/.github/workflows/tier-b-preview.yml
@@ -154,11 +154,18 @@ jobs:
           # we treat it as "Vercel never built anything for this branch" → skip
           # green (matches Vercel's own ignore-build decision).
           deadline=$(( $(date +%s) + 600 ))
+          # URL-encode the branch ref. Branches with "/" in the name (refactor/X,
+          # fix/Y, test/Z) require encoding — without it, Vercel's API treats
+          # the query as an empty match, returns no deployments, and the loop
+          # below burns the full 10-min deadline to skip-green. With encoding,
+          # the API returns the actual deployment within seconds.
+          # (jq is preinstalled on ubuntu-latest GitHub runners.)
+          encoded_ref=$(printf '%s' "$GITHUB_REF" | jq -sRr @uri)
           while [ "$(date +%s)" -lt "$deadline" ]; do
             # Query by branch name (stable) AND limit=20 to catch the latest few
             # deployments on this branch even if Vercel created multiple builds.
             payload=$(curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
-              "https://api.vercel.com/v6/deployments?teamId=$VERCEL_TEAM_ID&projectId=$VERCEL_PROJECT_ID&meta-githubCommitRef=$GITHUB_REF&limit=20&target=preview")
+              "https://api.vercel.com/v6/deployments?teamId=$VERCEL_TEAM_ID&projectId=$VERCEL_PROJECT_ID&meta-githubCommitRef=$encoded_ref&limit=20&target=preview")
             result=$(GITHUB_SHA="$GITHUB_SHA" node -e "
               let s=''; process.stdin.on('data',c=>s+=c).on('end',()=>{
                 try {


### PR DESCRIPTION
## Summary
- URL-encode `$GITHUB_REF` before injecting into Vercel's deployments API query
- One-line change in `.github/workflows/tier-b-preview.yml` + jq encoding step

## Why this is needed

Branches with `/` in the name (per the repo's own `<type>/<short-slug>` branch-name gate, **basically every PR branch**) fail the Vercel polling silently:

```
meta-githubCommitRef=$GITHUB_REF
                     ↑
                     unencoded "refactor/X" → API empty-match → 10-min skip-green
```

### Evidence — Tier B runs from 2026-05-26 that hit the 10-min skip-green path

| PR | Branch | Tier B duration |
|---|---|---|
| #382 | `refactor/rename-ask-to-compose` | 12m2s → skip-green |
| #383 | `test/scratchnode-p1-coverage` | 10m+ → skip-green |
| #386 | `docs/backend-contract-migration-rule` | 10m+ → skip-green |
| #387 | `fix/scratchnode-apex-routing` | 10m+ → skip-green |

In every case, Tier B's Playwright tests **never ran**. The 10-min wait was pure cost — no verification delivered.

## Fix

```diff
+ encoded_ref=$(printf '%s' "$GITHUB_REF" | jq -sRr @uri)
  while [ "$(date +%s)" -lt "$deadline" ]; do
    payload=$(curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" \
-     "...&meta-githubCommitRef=$GITHUB_REF&...")
+     "...&meta-githubCommitRef=$encoded_ref&...")
```

`jq -sRr @uri` is the canonical Bash-friendly URL-encoder. jq is preinstalled on `ubuntu-latest` GitHub runners — no new dependency.

## Expected impact

**Per-PR pace gain**: ~10 minutes saved on Tier B for every PR with `/` in the branch name (i.e. nearly all of them).
**Coverage gain**: Tier B Playwright tests (`exact-kit-parity-prod.spec.ts`, `one-flow-regression.spec.ts`) **actually run again** instead of timing out at the polling step.

## Test plan
- [x] yaml syntax valid (no lint issues)
- [ ] On merge, watch the next PR with a `/` branch name → Tier B should reach the Playwright run step (vs. previously timing out at "Resolve Vercel preview URL")
- [ ] If a real Tier B failure is surfaced post-fix, that's a *true positive* — fix the underlying issue rather than reverting this PR

## Related rules
- `.claude/rules/live_dom_verification.md` — Tier B is one of the canonical pre-merge verification layers
- `.claude/rules/pre_release_review.md` — layer 8 (Live Browser Verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
