### PR TITLE
test(proto): dogfood v4 and v5 backend surfaces

### DIFF
--- a/convex/events.runtime-boundary.test.ts
+++ b/convex/events.runtime-boundary.test.ts
@@ -15,13 +15,13 @@ function functionBlock(name: string): string {
 
 describe("scratchnode public runtime boundaries", () => {
   it("keeps public /ask isolated from private user notes", () => {
-    const askAgent = functionBlock("askAgent");
+    const composeAnswer = functionBlock("composeAnswer");
 
-    expect(askAgent).not.toContain("userNotes");
-    expect(askAgent).not.toContain("getPrivate");
-    expect(askAgent).toContain("requireMember");
-    expect(askAgent).toContain("liveEventSources");
-    expect(askAgent).toContain("deterministic_synthesis");
+    expect(composeAnswer).not.toContain("userNotes");
+    expect(composeAnswer).not.toContain("getPrivate");
+    expect(composeAnswer).toContain("requireMember");
+    expect(composeAnswer).toContain("liveEventSources");
+    expect(composeAnswer).toContain("deterministic_synthesis");
   });
 
   it("keeps wiki publishing host-gated and sourced from public answers", () => {

--- a/docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md
+++ b/docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md
@@ -38,7 +38,8 @@ For ScratchNode:
 - `home-v5.html` is the live event-room shell.
 - `convex/events.ts` is the public event backend.
 - Public `/ask` currently composes sourced answers deterministically from the public event corpus. If an LLM-backed agent is added later, name the boundary clearly so "agent" does not hide deterministic behavior.
-- Private notes stay in `userNotes` and must not be read by `askAgent` or public wiki publishing.
+- Private notes stay in `userNotes` and must not be read by `composeAnswer` or public wiki publishing.
+- Real backend dogfood for `home-v5` and interaction dogfood for `home-v4` are documented in `docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md`.
 
 ## Required Start Checklist
 

--- a/docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md
+++ b/docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md
@@ -1,0 +1,103 @@
+# Proto Surface Real Backend Dogfood
+
+Last updated: 2026-05-26
+
+This note removes the recurring confusion between the two prototype surfaces.
+
+## Route Ownership
+
+| Surface | Route | Backend status | Test expectation |
+| --- | --- | --- | --- |
+| ScratchNode v5 | `https://scratchnode.live/`, `/e/:slug` | Live Convex-backed event room. Phases 1-5 are wired. | Must prove data moves browser -> Convex -> second browser or rendered answer/wiki/note. |
+| NodeBench v4 | `https://www.nodebenchai.com/proto/home-v4.html` | Static spec proof for notebook, artifacts, chat, mentions, backlinks, wide mode. | Must prove every interaction works, and must explicitly assert no live Convex runtime marker exists. |
+
+## Live Dogfood Command
+
+Run the production dogfood only intentionally because it writes QA rows to the public demo event.
+
+```powershell
+npm run dogfood:proto-live-backend
+```
+
+Override targets when needed:
+
+```powershell
+$env:SCRATCHNODE_APEX_URL="https://scratchnode.live/"
+$env:SCRATCHNODE_EVENT_URL="https://scratchnode.live/e/ai-infra-summit-2026"
+$env:NODEBENCH_V4_URL="https://www.nodebenchai.com/proto/home-v4.html"
+npm run dogfood:proto-live-backend
+```
+
+The raw Playwright file is:
+
+```text
+tests/e2e/proto-live-backend-dogfood.spec.ts
+```
+
+## Covered v5 Backend Scenarios
+
+The dogfood covers these live boundaries:
+
+1. Apex `scratchnode.live/` serves the `home-v5` event shell and connects to Convex.
+2. Two anonymous browser contexts join the same event.
+3. Public chat from browser A appears in browser B through `events:sendMessage` and `events:getMessages`.
+4. `/ask` creates a sourced answer through `events:composeAnswer`.
+5. The rendered answer exposes:
+   - source reuse
+   - deterministic synthesis trace
+   - `no private notes`
+   - `data-answer-id`
+6. FAQ suggestion changes answer state through `events:suggestAnswerForFaq`.
+7. Host claim is attempted through `events:claimHost`.
+8. If the shared demo room is claimable, the run also promotes the answer and publishes the wiki through:
+   - `events:promoteAnswerToFaq`
+   - `events:publishWiki`
+   - `events:getPublishedWiki`
+9. If the room is already claimed, the run verifies the expected host gate instead of pretending publish happened.
+10. Private composer mode creates a Convex-backed note through `notes:createNote`.
+11. Pin and delete use `notes:togglePin` and `notes:deleteNote`.
+12. Private note text is asserted absent from:
+   - public event feed
+   - second anonymous browser
+
+## Covered v4 Prototype Scenarios
+
+The dogfood covers these static interactions:
+
+1. `switchMode("notebook")`
+2. `switchMode("artifacts")`
+3. artifact card rendering
+4. `switchMode("chat")`
+5. chat mock response pipeline
+6. mention context update through `openMentionById`
+7. backlink drawer through `openBacklinks`
+8. inline expansion through `toggleRefExpand`
+9. wide mode toggle
+
+It also asserts:
+
+```text
+document.body.dataset.snLive is absent
+window._sn_live is absent
+no Convex live runtime script is present
+```
+
+That is intentional. `home-v4` is the comprehensive design/spec surface. `home-v5` is the live backend product surface.
+
+## Artifacts
+
+Screenshots from the run are written to:
+
+```text
+.tmp/proto-live-backend-dogfood/
+```
+
+These files are not committed. They are operator evidence for the current dogfood loop.
+
+## Remaining Boundary
+
+The shared production demo event can only have one host owner. If a previous live dogfood or user has already claimed the room, a later run must verify the host gate and skip promote/publish writes. A future improvement is a host-authenticated seed route for isolated dogfood rooms, but that should not be added as an unauthenticated public mutation.
+
+## Apex Routing Note
+
+`home-v5.html` now treats `scratchnode.live/` and `scratchnode.live/index.html` as aliases for the canonical `ai-infra-summit-2026` event slug before bootstrapping Convex. Without that explicit alias, the HTML could serve correctly while the live runtime exited early because the URL was not `/e/:slug`.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "dogfood:qa:ledger": "node scripts/ui/buildDogfoodGenerationLedger.mjs",
     "dogfood:verify:first-class": "node scripts/ui/verifyDogfoodArtifacts.mjs --requireGemini true --requireGeneration true",
     "dogfood:qa:first-class": "npm run dogfood:verify:strict && npm run dogfood:qa:ledger && npm run dogfood:verify:first-class",
+    "dogfood:proto-live-backend": "cross-env PROTO_DOGFOOD_LIVE=1 playwright test tests/e2e/proto-live-backend-dogfood.spec.ts --project=chromium --workers=1 --reporter=list",
     "build:analyze": "cross-env ANALYZE=true npm run build",
     "perf:lighthouse": "lighthouse http://localhost:5173/#analytics/hitl --output=json --output-path=lighthouse-report.json --chrome-flags=\"--headless\" --only-categories=performance,accessibility && node analyze-lighthouse.cjs",
     "perf:bundle": "npm run build:analyze",

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -2874,8 +2874,11 @@ setTimeout(refreshNotesCounter, 100);
 (async () => {
   // ─── Bail-early checks ─────────────────────────────────────────────
   const slugMatch = location.pathname.match(/^\/e\/([a-z0-9][a-z0-9-]{0,60})\/?$/i);
-  if (!slugMatch) return; // not an event URL — keep prototype-only behavior
-  const slug = slugMatch[1];
+  const isCanonicalApex =
+    (location.pathname === '/' || location.pathname === '/index.html') &&
+    ON_PUBLIC_DOMAIN;
+  if (!slugMatch && !isCanonicalApex) return; // not an event URL — keep prototype-only behavior
+  const slug = slugMatch ? slugMatch[1] : EVENT_SLUG;
 
   // Stable anonymous session UUID — persists across reloads, per-device.
   let sessionId;
@@ -3121,19 +3124,24 @@ setTimeout(refreshNotesCounter, 100);
   const noteOwnerKey = sessionId;
   // Pending optimistic ops keyed by tempId so we can dedupe when Convex echoes back.
   const _pendingOps = new Map();
+  const _convexNoteIds = new Set();
+  const isLiveConvexNoteId = (id) => !!id && _convexNoteIds.has(id);
 
   // Map Convex rows → the shape the notes editor expects.
-  const mapConvexNote = (row) => ({
-    id: row._id,
-    title: row.title || 'Untitled',
-    body: row.bodyHtml || '',
-    tags: row.tags || [],
-    pinned: !!row.pinned,
-    isAsk: !!row.isAsk,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-    _convex: true,
-  });
+  const mapConvexNote = (row) => {
+    _convexNoteIds.add(row._id);
+    return {
+      id: row._id,
+      title: row.title || 'Untitled',
+      body: row.bodyHtml || '',
+      tags: row.tags || [],
+      pinned: !!row.pinned,
+      isAsk: !!row.isAsk,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      _convex: true,
+    };
+  };
 
   client.onUpdate('notes:listMyNotes', { ownerKey: noteOwnerKey, eventId }, (rows) => {
     if (!Array.isArray(rows)) return;
@@ -3169,6 +3177,7 @@ setTimeout(refreshNotesCounter, 100);
         isAsk: false,
         pinned: false,
       });
+      _convexNoteIds.add(res.noteId);
       window._activeNoteId = res.noteId;
       // Re-render with the new note focused (subscription will confirm within 1s).
       if (typeof renderNotesListOnly === 'function') renderNotesListOnly();
@@ -3196,7 +3205,7 @@ setTimeout(refreshNotesCounter, 100);
   const _origUpdateActive = window.updateActiveNote;
   window.updateActiveNote = function(field, value) {
     const id = window._activeNoteId;
-    if (!id || !id.match(/^[a-z0-9]{16,40}$/i)) {
+    if (!isLiveConvexNoteId(id)) {
       // Fallback for temp ids: just call original (in-memory)
       return _origUpdateActive && _origUpdateActive.call(this, field, value);
     }
@@ -3241,7 +3250,7 @@ setTimeout(refreshNotesCounter, 100);
   const _origTogglePin = window.togglePinNote;
   window.togglePinNote = async function() {
     const id = window._activeNoteId;
-    if (!id || !id.match(/^[a-z0-9]{16,40}$/i)) {
+    if (!isLiveConvexNoteId(id)) {
       return _origTogglePin && _origTogglePin.call(this);
     }
     try {
@@ -3256,7 +3265,7 @@ setTimeout(refreshNotesCounter, 100);
   const _origDelete = window.deleteActiveNote;
   window.deleteActiveNote = async function() {
     const id = window._activeNoteId;
-    if (!id || !id.match(/^[a-z0-9]{16,40}$/i)) {
+    if (!isLiveConvexNoteId(id)) {
       return _origDelete && _origDelete.call(this);
     }
     try {

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -1,0 +1,365 @@
+import { expect, test } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const RUN_LIVE = process.env.PROTO_DOGFOOD_LIVE === "1";
+const SCRATCHNODE_APEX_URL = process.env.SCRATCHNODE_APEX_URL ?? "https://scratchnode.live/";
+const SCRATCHNODE_EVENT_URL =
+  process.env.SCRATCHNODE_EVENT_URL ?? "https://scratchnode.live/e/ai-infra-summit-2026";
+const NODEBENCH_V4_URL =
+  process.env.NODEBENCH_V4_URL ?? "https://www.nodebenchai.com/proto/home-v4.html";
+const ARTIFACT_DIR = join(process.cwd(), ".tmp", "proto-live-backend-dogfood");
+
+test.skip(!RUN_LIVE, "Set PROTO_DOGFOOD_LIVE=1 to run real production backend dogfood.");
+test.describe.configure({ mode: "serial", timeout: 180_000 });
+
+function withQa(url: string, qaId: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("qa", qaId);
+  return parsed.toString();
+}
+
+async function waitForScratchNodeLive(page: import("@playwright/test").Page) {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => ({
+          live: document.body.getAttribute("data-sn-live"),
+          phases: document.body.getAttribute("data-sn-phases"),
+          eventId: (window as any)._sn_live?.eventId ?? null,
+        })),
+      { timeout: 45_000, intervals: [500, 1_000, 2_000] },
+    )
+    .toMatchObject({
+      live: "true",
+      phases: "1,2,3,4,5",
+      eventId: expect.any(String),
+    });
+}
+
+async function sendComposer(page: import("@playwright/test").Page, text: string) {
+  await page.evaluate((value) => {
+    const input = document.getElementById("ci") as HTMLInputElement | HTMLTextAreaElement | null;
+    if (!input) throw new Error("ScratchNode composer #ci not found");
+    input.value = value;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    (window as any).sendComposerMessage();
+  }, text);
+}
+
+async function findAnswerForQuestion(page: import("@playwright/test").Page, question: string) {
+  return await page.evaluate((q) => {
+    const answers = Array.from(document.querySelectorAll<HTMLElement>(".ans"));
+    const answer = answers.find((node) => node.textContent?.includes(q));
+    return answer
+      ? {
+          id: answer.getAttribute("data-answer-id"),
+          text: answer.textContent || "",
+        }
+      : null;
+  }, question);
+}
+
+async function queryAnswer(page: import("@playwright/test").Page, answerId: string) {
+  return await page.evaluate(async (id) => {
+    const live = (window as any)._sn_live;
+    if (!live?.client || !live?.eventId) throw new Error("ScratchNode live client missing");
+    const rows = await live.client.query("events:getAnswers", { eventId: live.eventId, limit: 100 });
+    return rows.find((row: any) => String(row._id) === id) ?? null;
+  }, answerId);
+}
+
+async function waitForHostRole(page: import("@playwright/test").Page, timeoutMs = 6_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const role = await page.evaluate(() => document.body.getAttribute("data-role"));
+    if (role === "host") return true;
+    await page.waitForTimeout(500);
+  }
+  return false;
+}
+
+test("home-v5 runs the live Convex event-room loop across shipped phases", async ({ browser }) => {
+  mkdirSync(ARTIFACT_DIR, { recursive: true });
+  const qaId = `proto-v5-${Date.now()}`;
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  try {
+    await pageA.goto(withQa(SCRATCHNODE_APEX_URL, `${qaId}-apex`), {
+      waitUntil: "domcontentloaded",
+      timeout: 45_000,
+    });
+    await waitForScratchNodeLive(pageA);
+    await expect(pageA).toHaveTitle(/ScratchNode/i);
+    await pageA.screenshot({
+      path: join(ARTIFACT_DIR, `${qaId}-apex-live.png`),
+      fullPage: true,
+    });
+
+    await pageA.goto(withQa(SCRATCHNODE_EVENT_URL, `${qaId}-a`), {
+      waitUntil: "domcontentloaded",
+      timeout: 45_000,
+    });
+    await pageB.goto(withQa(SCRATCHNODE_EVENT_URL, `${qaId}-b`), {
+      waitUntil: "domcontentloaded",
+      timeout: 45_000,
+    });
+    await waitForScratchNodeLive(pageA);
+    await waitForScratchNodeLive(pageB);
+
+    const chatText = `QA public chat sync ${qaId}`;
+    await sendComposer(pageA, chatText);
+    await expect
+      .poll(
+        () =>
+          pageB.evaluate((text) => {
+            return Array.from(document.querySelectorAll(".row-text")).some((node) =>
+              node.textContent?.includes(text),
+            );
+          }, chatText),
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+
+    const question = `what did attendees say about MCP auth ${qaId}`;
+    await sendComposer(pageA, `/ask ${question}`);
+    await expect
+      .poll(() => findAnswerForQuestion(pageA, question), { timeout: 60_000 })
+      .toMatchObject({ id: expect.any(String) });
+
+    const answer = await findAnswerForQuestion(pageA, question);
+    expect(answer?.id, "sourced answer should render with data-answer-id").toBeTruthy();
+    expect(answer?.text, "answer reuse line should state private notes were excluded").toContain(
+      "no private notes",
+    );
+
+    const answerRecord = await queryAnswer(pageA, answer!.id!);
+    expect(answerRecord.cacheHit).toBe(false);
+    expect(answerRecord.sources.length).toBeGreaterThan(0);
+    expect(answerRecord.trace.some((step: any) => step.step === "deterministic_synthesis")).toBe(
+      true,
+    );
+
+    await pageA.evaluate((answerId) => (window as any).snSuggestFaq(answerId), answer!.id);
+    await expect
+      .poll(async () => (await queryAnswer(pageA, answer!.id!))?.faqStatus, { timeout: 15_000 })
+      .toBe("suggested");
+
+    await pageA.evaluate(() => (window as any).snClaimHost());
+    const hostClaimed = await waitForHostRole(pageA);
+    if (hostClaimed) {
+      await pageA.evaluate((answerId) => (window as any).snPromoteFaq(answerId), answer!.id);
+      await expect
+        .poll(async () => (await queryAnswer(pageA, answer!.id!))?.faqStatus, { timeout: 15_000 })
+        .toBe("promoted");
+
+      await pageA.evaluate(() => (window as any).snPublishWiki());
+      await expect
+        .poll(
+          () =>
+            pageA.evaluate(() => {
+              const body = (window as any)._sn_published_wiki_body;
+              return typeof body === "string" && body.includes("AI Infra Summit Wiki");
+            }),
+          { timeout: 20_000 },
+        )
+        .toBe(true);
+    } else {
+      const hostStatus = await pageA.evaluate(async () => {
+        const live = (window as any)._sn_live;
+        return await live.client.query("events:getHostStatus", {
+          eventId: live.eventId,
+          ownerKey: localStorage.getItem("sn_host_owner_key") || live.sessionId,
+        });
+      });
+      expect(hostStatus.isHost).toBe(false);
+      await pageA.evaluate((answerId) => (window as any).snPromoteFaq(answerId), answer!.id);
+      await pageA.waitForTimeout(1_000);
+      expect((await queryAnswer(pageA, answer!.id!))?.faqStatus).not.toBe("promoted");
+    }
+
+    const privateNote = `QA private note ${qaId}`;
+    await pageA.evaluate(() => {
+      if (document.body.getAttribute("data-mode") !== "private") {
+        (window as any).toggleLock();
+      }
+    });
+    await sendComposer(pageA, privateNote);
+
+    await expect
+      .poll(
+        () =>
+          pageA.evaluate((text) => {
+            return ((window as any)._notes_v5 || []).some(
+              (note: any) =>
+                note._convex &&
+                (String(note.title || "").includes(text) ||
+                  String(note.body || "").includes(text)),
+            );
+          }, privateNote),
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+
+    const noteId = await pageA.evaluate((text) => {
+      const note = ((window as any)._notes_v5 || []).find(
+        (row: any) =>
+          row._convex &&
+          (String(row.title || "").includes(text) || String(row.body || "").includes(text)),
+      );
+      return note?.id ?? null;
+    }, privateNote);
+    expect(noteId, "private note should have a Convex id").toBeTruthy();
+
+    await pageA.evaluate((id) => {
+      (window as any)._activeNoteId = id;
+      return (window as any).togglePinNote();
+    }, noteId);
+    await expect
+      .poll(
+        () =>
+          pageA.evaluate((id) => {
+            return !!((window as any)._notes_v5 || []).find((note: any) => note.id === id)?.pinned;
+          }, noteId),
+        { timeout: 15_000 },
+      )
+      .toBe(true);
+
+    expect(await pageA.locator("#feed").textContent()).not.toContain(privateNote);
+    expect(await pageB.locator("body").textContent()).not.toContain(privateNote);
+
+    await pageA.evaluate((id) => {
+      (window as any)._activeNoteId = id;
+      return (window as any).deleteActiveNote();
+    }, noteId);
+    await expect
+      .poll(
+        () =>
+          pageA.evaluate((id) => {
+            return !((window as any)._notes_v5 || []).some((note: any) => note.id === id);
+          }, noteId),
+        { timeout: 15_000 },
+      )
+      .toBe(true);
+
+    await pageA.screenshot({
+      path: join(ARTIFACT_DIR, `${qaId}-event-final.png`),
+      fullPage: true,
+    });
+    await pageB.screenshot({
+      path: join(ARTIFACT_DIR, `${qaId}-second-browser-sync.png`),
+      fullPage: true,
+    });
+  } finally {
+    await contextA.close();
+    await contextB.close();
+  }
+});
+
+test("home-v4 dogfoods every prototype interaction without claiming live backend", async ({ page }) => {
+  mkdirSync(ARTIFACT_DIR, { recursive: true });
+  const qaId = `proto-v4-${Date.now()}`;
+  await page.goto(withQa(NODEBENCH_V4_URL, qaId), {
+    waitUntil: "domcontentloaded",
+    timeout: 45_000,
+  });
+
+  await expect(page).toHaveTitle(/NodeBench v4/i);
+  const initialProbe = await page.evaluate(() => ({
+    snLive: document.body.getAttribute("data-sn-live"),
+    hasScratchLiveClient: !!(window as any)._sn_live,
+    hasConvexRuntimeScript: Array.from(document.scripts).some((script) =>
+      script.textContent?.includes("ConvexReactClient"),
+    ),
+    functions: {
+      switchMode: typeof (window as any).switchMode,
+      openMentionById: typeof (window as any).openMentionById,
+      openBacklinks: typeof (window as any).openBacklinks,
+      toggleRefExpand: typeof (window as any).toggleRefExpand,
+      sendChat: typeof (window as any).sendChat,
+      toggleWideMode: typeof (window as any).toggleWideMode,
+    },
+  }));
+  expect(initialProbe.snLive).toBe(null);
+  expect(initialProbe.hasScratchLiveClient).toBe(false);
+  expect(initialProbe.hasConvexRuntimeScript).toBe(false);
+  expect(Object.values(initialProbe.functions)).toEqual([
+    "function",
+    "function",
+    "function",
+    "function",
+    "function",
+    "function",
+  ]);
+
+  const modeProbe = async (mode: string) => {
+    await page.evaluate((m) => (window as any).switchMode(m), mode);
+    return await page.evaluate(() => ({
+      shellMode: document.querySelector(".shell")?.getAttribute("data-mode"),
+      leftMode: document.querySelector(".left-index")?.getAttribute("data-mode"),
+      activeSurface: document.querySelector(".center-surface.active")?.getAttribute("data-mode"),
+      rightRailChat: document.getElementById("right-context")?.classList.contains("chat-active"),
+      artifactCards: document.querySelectorAll(".art-card").length,
+    }));
+  };
+
+  expect(await modeProbe("notebook")).toMatchObject({
+    shellMode: "notebook",
+    leftMode: "notebook",
+    activeSurface: "notebook",
+    rightRailChat: false,
+  });
+  expect(await modeProbe("artifacts")).toMatchObject({
+    shellMode: "artifacts",
+    leftMode: "artifacts",
+    activeSurface: "artifacts",
+    rightRailChat: false,
+  });
+  expect((await modeProbe("artifacts")).artifactCards).toBeGreaterThan(0);
+  expect(await modeProbe("chat")).toMatchObject({
+    shellMode: "chat",
+    leftMode: "chat",
+    activeSurface: "chat",
+    rightRailChat: true,
+  });
+
+  const chatText = `Compare Orbital Labs and Anthropic ${qaId}`;
+  await page.evaluate((text) => {
+    const input = document.getElementById("chat-input") as HTMLInputElement | null;
+    if (!input) throw new Error("home-v4 chat input missing");
+    input.value = text;
+    (window as any).sendChat();
+  }, chatText);
+  await expect(page.locator("#chat-messages")).toContainText(chatText);
+  await expect(page.locator("#chat-messages")).toContainText("Processing query", { timeout: 5_000 });
+  await expect(page.locator("#chat-messages")).toContainText("I found relevant context", {
+    timeout: 5_000,
+  });
+
+  await page.evaluate(() => (window as any).openMentionById("ent_orbital"));
+  await expect(page.locator("#ctx-entity-name")).toContainText("Orbital Labs");
+
+  await page.evaluate(() => (window as any).openBacklinks("topic_mcp"));
+  await expect(page.locator("#bl-drawer")).toHaveClass(/open/);
+  await expect(page.locator("#bl-drawer-title")).toContainText("MCP Protocol");
+  await expect(page.locator("#bl-drawer-content")).toContainText("Notebooks");
+
+  await page.evaluate(() => {
+    const mention = document.querySelector(".mention[data-id='ent_anthropic']");
+    (window as any).toggleRefExpand(mention);
+  });
+  await expect(page.locator(".nb-ref-expand[data-kind='company']")).toContainText("Anthropic");
+
+  await page.evaluate(() => (window as any).toggleWideMode());
+  await expect(page.locator(".shell")).toHaveAttribute("data-wide", "");
+  await page.evaluate(() => (window as any).toggleWideMode());
+  await expect(page.locator(".shell")).not.toHaveAttribute("data-wide", "");
+
+  await page.screenshot({
+    path: join(ARTIFACT_DIR, `${qaId}-home-v4-interactions.png`),
+    fullPage: true,
+  });
+});


### PR DESCRIPTION
## Summary
- add a deliberate live dogfood harness for ScratchNode home-v5 and NodeBench home-v4
- fix home-v5 apex runtime bootstrap so scratchnode.live/ joins the canonical event instead of serving a non-live shell
- fix home-v5 live note detection so Convex note pin/delete/update flows do not fall back to the old prototype DOM path
- update the stale runtime boundary test from askAgent to composeAnswer and document route ownership/dogfood boundaries

## Verification
- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
- npx vitest run convex/events.runtime-boundary.test.ts convex/__tests__/scratchnode.events.test.ts
- npm run build
- PROTO_DOGFOOD_LIVE=1 with patched home-v5 served locally against production Convex + production home-v4: 2 passed
- Production home-v4-only dogfood: passed

## Notes
The default production dogfood currently exposes the pre-deploy apex/non-live and live-note fallback bugs. This branch fixes both; rerun npm run dogfood:proto-live-backend after deploy to verify scratchnode.live/ directly.