### PR TITLE
chore(scratchnode): janitor cron for stale Phase 4 claim code hashes

### DIFF
--- a/convex/__tests__/scratchnode.events.test.ts
+++ b/convex/__tests__/scratchnode.events.test.ts
@@ -797,3 +797,142 @@ describe("claimHost — concurrent race invariant", () => {
     expect(hostRows).toBeGreaterThanOrEqual(1);
   });
 });
+
+/* -------------------------------------------------------------------------- */
+/* Phase 4 follow-up Item 5 — host-claim-code janitor                          */
+/* -------------------------------------------------------------------------- */
+//
+// Scenario: a host clicks "Generate claim code", copies the code, then closes
+// their tab and never redeems it. `requestHostClaim` already wrote
+// `hostClaimCodeHash` + `hostClaimCodeCreatedAt` to the liveEvents row. The
+// hash sits there forever unless somebody force-clears it. Codes are 24-char
+// A-Z2-9 (~120 bits of entropy), so brute-force is already infeasible — but
+// keeping a stale hash around indefinitely widens the attack surface for no
+// reason. The 10-min janitor cron sweeps any row whose
+// `hostClaimCodeCreatedAt` is older than 30 min and clears both fields.
+//
+// Coverage matrix:
+//   1. Empty result — no liveEvents rows are stale → evicted: 0.
+//   2. Clears stale rows — row with createdAt > 30 min ago AND hash set →
+//      both fields are unset after the janitor runs.
+//   3. Skips rows without a hash — row with hash undefined is NEVER patched
+//      (even if some other timestamp says it's old).
+
+const _evictStaleHostClaimCodes = (eventsModule as any)._evictStaleHostClaimCodes;
+
+describe("_evictStaleHostClaimCodes — Phase 4 defense-in-depth janitor", () => {
+  it("empty result when no rows are stale (fresh event, recent code)", async () => {
+    // Persona: a host who just minted a code 30 seconds ago. The janitor must
+    // NOT touch this row — the user is still mid-flow toward redemption.
+    // Goal: verify the janitor's TTL respects in-flight claims.
+    // Scale: 1 event, 1 row.
+    // Duration: single tick.
+    const now = Date.now();
+    const tables: Tables = {
+      liveEvents: [
+        baseEvent({
+          hostClaimCodeHash: "fresh-hash-aaaaa",
+          hostClaimCodeCreatedAt: now - 30 * 1000, // 30s ago, well inside TTL
+        }),
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await _evictStaleHostClaimCodes._handler(ctx);
+
+    expect(result).toEqual({ evicted: 0 });
+    // Row untouched — the hash and timestamp must still be there for the
+    // upcoming claimHostWithCode call to succeed.
+    expect(tables.liveEvents[0].hostClaimCodeHash).toBe("fresh-hash-aaaaa");
+    expect(tables.liveEvents[0].hostClaimCodeCreatedAt).toBe(now - 30 * 1000);
+    expect((ctx.db as MockDb).patches.length).toBe(0);
+  });
+
+  it("clears fields when hostClaimCodeCreatedAt is older than 30 min", async () => {
+    // Persona: a host abandoned their claim flow 31 min ago — closed the tab,
+    // never came back. The hash sat on the event row that whole time. The
+    // janitor must clear both fields so the hash stops widening the
+    // brute-force window.
+    // Goal: verify the eviction is correct and HONEST_STATUS reports the
+    // count truthfully.
+    // Scale: 1 event.
+    // Duration: single tick.
+    const now = Date.now();
+    const tables: Tables = {
+      liveEvents: [
+        baseEvent({
+          hostClaimCodeHash: "stale-hash-zzzzz",
+          hostClaimCodeCreatedAt: now - 31 * 60 * 1000, // 31 min ago — past TTL
+        }),
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await _evictStaleHostClaimCodes._handler(ctx);
+
+    expect(result).toEqual({ evicted: 1 });
+    // Both fields cleared. (MockDb patches set them to undefined directly;
+    // Convex translates undefined → field-removal at the row level.)
+    expect(tables.liveEvents[0].hostClaimCodeHash).toBeUndefined();
+    expect(tables.liveEvents[0].hostClaimCodeCreatedAt).toBeUndefined();
+    expect((ctx.db as MockDb).patches.length).toBe(1);
+  });
+
+  it("does NOT touch rows where hostClaimCodeHash is undefined", async () => {
+    // Persona: an event that NEVER minted a claim code. The row has no hash
+    // field at all (or it's explicitly undefined). The janitor must skip it
+    // — patching `undefined` onto a row that already has undefined is a
+    // wasted write, and more importantly, this proves the filter doesn't
+    // catch ghost rows.
+    // Goal: surface false positives — if the janitor patches events with no
+    // hash, it has a bug that wastes DB ops on every cron tick.
+    // Scale: mix of 3 rows in one run — one stale-with-hash, one no-hash, one
+    // recent-with-hash. Verify exactly one eviction happens.
+    // Duration: single tick.
+    const now = Date.now();
+    const tables: Tables = {
+      liveEvents: [
+        baseEvent({
+          _id: "liveEvents:no-hash",
+          // No hostClaimCodeHash, no hostClaimCodeCreatedAt — pristine event.
+        }),
+        baseEvent({
+          _id: "liveEvents:stale-with-hash",
+          hostClaimCodeHash: "stale-hash-yyyyy",
+          hostClaimCodeCreatedAt: now - 45 * 60 * 1000, // 45 min ago
+        }),
+        baseEvent({
+          _id: "liveEvents:fresh-with-hash",
+          hostClaimCodeHash: "fresh-hash-bbbbb",
+          hostClaimCodeCreatedAt: now - 5 * 60 * 1000, // 5 min ago
+        }),
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await _evictStaleHostClaimCodes._handler(ctx);
+
+    // Exactly one row evicted — the stale one.
+    expect(result).toEqual({ evicted: 1 });
+
+    // Pristine row (no hash) — never patched.
+    const pristine = tables.liveEvents.find((r) => r._id === "liveEvents:no-hash")!;
+    expect(pristine.hostClaimCodeHash).toBeUndefined();
+    expect(pristine.hostClaimCodeCreatedAt).toBeUndefined();
+
+    // Stale row — cleared.
+    const stale = tables.liveEvents.find((r) => r._id === "liveEvents:stale-with-hash")!;
+    expect(stale.hostClaimCodeHash).toBeUndefined();
+    expect(stale.hostClaimCodeCreatedAt).toBeUndefined();
+
+    // Fresh row (recent code) — UNTOUCHED. This is the load-bearing
+    // assertion: the janitor must never race a legitimate redemption.
+    const fresh = tables.liveEvents.find((r) => r._id === "liveEvents:fresh-with-hash")!;
+    expect(fresh.hostClaimCodeHash).toBe("fresh-hash-bbbbb");
+    expect(fresh.hostClaimCodeCreatedAt).toBe(now - 5 * 60 * 1000);
+
+    // Exactly 1 patch was issued (only the stale row).
+    expect((ctx.db as MockDb).patches.length).toBe(1);
+    expect((ctx.db as MockDb).patches[0].id).toBe("liveEvents:stale-with-hash");
+  });
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1062,4 +1062,15 @@ crons.interval(
   {},
 );
 
+// Phase 4 defense-in-depth: soft-prune host-claim-code hashes that were
+// minted but never redeemed within 30 min. Codes already carry ~120 bits of
+// entropy, but a stale hash widens the brute-force window for no reason.
+// BOUND: 100 evictions per run. HONEST_STATUS: returns { evicted: N }.
+crons.interval(
+  "scratchnode host-claim-code janitor",
+  { minutes: 10 },
+  internal.events._evictStaleHostClaimCodes,
+  {},
+);
+
 export default crons;

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -44,6 +44,15 @@ const MAX_MESSAGE_TEXT = 4000;
 const DEFAULT_MESSAGE_LIMIT = 200;
 const MAX_MESSAGE_LIMIT = 500;
 const PRESENCE_TTL_MS = 5 * 60 * 1000; // 5 min
+// Phase 4 defense-in-depth: after this window, an unredeemed host-claim-code
+// hash is force-cleared by the janitor cron. Codes are ~120 bits of entropy
+// already; this just narrows the brute-force window further. Cutoff is
+// deliberately wider than the UI expiresHintAt (also 30 min) so that a slow
+// human still completes their claim — the janitor only sweeps abandoned
+// codes, never racing the redemption path.
+const HOST_CLAIM_CODE_TTL_MS = 30 * 60 * 1000; // 30 min
+// BOUND: cap per-run evictions so the janitor never thunders the DB.
+const MAX_STALE_HOST_CLAIM_EVICT = 100;
 const MAX_SOURCE_BODY = 12_000;
 const MAX_ANSWER_BODY = 4_000;
 const MAX_ANSWER_LIMIT = 100;
@@ -1291,5 +1300,57 @@ export const _evictStalePresence = internalMutation({
       await ctx.db.delete(row._id);
     }
     return { evicted: stale.length };
+  },
+});
+
+/**
+ * Phase 4 follow-up Item 5 — soft-prune stale host-claim-code hashes.
+ *
+ * Defense-in-depth janitor. `requestHostClaim` writes a code hash + minted-at
+ * timestamp on the event row; `claimHostWithCode` clears both atomically on
+ * a successful redemption. If a user mints a code and never redeems, the hash
+ * lingers — codes already have ~120 bits of entropy (24 chars A-Z2-9), but
+ * letting the hash sit forever widens the brute-force attack window for no
+ * reason. This cron narrows that window to ~30 min.
+ *
+ * Contract:
+ *   - Runs every 10 min from convex/crons.ts.
+ *   - Clears `hostClaimCodeHash` and `hostClaimCodeCreatedAt` on rows where
+ *     `hostClaimCodeCreatedAt < Date.now() - HOST_CLAIM_CODE_TTL_MS`.
+ *   - Rows without a hash (no claim ever requested, or already-redeemed) are
+ *     filtered out by the `hostClaimCodeCreatedAt` lt-check (undefined fails
+ *     lt comparison) — they are never patched.
+ *   - BOUND: at most MAX_STALE_HOST_CLAIM_EVICT rows per run. If more accrue
+ *     than that in a 10-min window, the next tick catches them.
+ *   - HONEST_STATUS: returns { evicted: N } so the operator surface (and
+ *     tests) can verify behavior.
+ *
+ * Idempotent — patching `undefined` onto an already-cleared row is a no-op
+ * (Convex treats `undefined` as field-removal).
+ */
+export const _evictStaleHostClaimCodes = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = Date.now() - HOST_CLAIM_CODE_TTL_MS;
+    // Filter on hostClaimCodeCreatedAt (the timestamp). Convex `q.lt` against
+    // an undefined field yields false, so rows that never minted a code are
+    // skipped — exactly the behavior we want.
+    const stale = await ctx.db
+      .query("liveEvents")
+      .filter((q) => q.lt(q.field("hostClaimCodeCreatedAt"), cutoff))
+      .take(MAX_STALE_HOST_CLAIM_EVICT);
+    let evicted = 0;
+    for (const row of stale) {
+      // Belt-and-suspenders: only patch when the hash is actually set. The
+      // filter above should already guarantee this, but checking the hash
+      // explicitly keeps the eviction safe if the filter ever loosens.
+      if (!row.hostClaimCodeHash) continue;
+      await ctx.db.patch(row._id, {
+        hostClaimCodeHash: undefined,
+        hostClaimCodeCreatedAt: undefined,
+      });
+      evicted += 1;
+    }
+    return { evicted };
   },
 });


### PR DESCRIPTION
## Summary

Phase 4 follow-up Item 5. Adds a defense-in-depth janitor cron that soft-prunes `liveEvents.hostClaimCodeHash` entries older than 30 min.

`requestHostClaim` writes `hostClaimCodeHash` + `hostClaimCodeCreatedAt` to the event row; `claimHostWithCode` clears both on a successful redemption. If a user mints a code and never redeems, the hash sits there forever. Codes are already ~120 bits of entropy (24-char A-Z2-9), so brute-force was already infeasible, but a stale hash widens the attack window for no reason. This narrows the window to ~30 min.

## Design

- `convex/events.ts` -- new internal mutation `_evictStaleHostClaimCodes`
  - BOUND: max 100 rows per run
  - HONEST_STATUS: returns `{ evicted: N }`
  - Filters on `hostClaimCodeCreatedAt < Date.now() - HOST_CLAIM_CODE_TTL_MS`
  - Belt-and-suspenders: also skip rows whose hash is already undefined
  - Idempotent (patching `undefined` onto an already-cleared row is a no-op)
- `convex/crons.ts` -- registered at 10-min interval
- `convex/__tests__/scratchnode.events.test.ts` -- 3 scenario tests

## Test plan

- [x] `npx tsc --noEmit --pretty false` clean
- [x] `npx tsc -p convex --noEmit --pretty false` clean
- [x] `npx vitest run convex/__tests__/scratchnode.events.test.ts` -- 10/10 passing
- [x] `npm run build` clean
- [x] Diff under 100 LOC of code (72 across events.ts + crons.ts, 139 tests)

Scenario coverage:
1. **Empty result** - fresh code (30s old) is NEVER touched. The janitor must not race the redemption flow.
2. **Clears stale fields** - 31-min-old hash is cleared, `{ evicted: 1 }` returned.
3. **Mixed batch** - 3 rows (no-hash, stale-with-hash, fresh-with-hash). Only the stale row patched. Verifies the filter doesn't waste DB ops on pristine rows and doesn't race recent codes.

Generated with [Claude Code](https://claude.com/claude-code)