### PR TITLE
feat(scratchnode): optional email channel for Phase 4 host claim codes (Resend)

### DIFF
--- a/convex/__tests__/scratchnode.events.test.ts
+++ b/convex/__tests__/scratchnode.events.test.ts
@@ -38,7 +38,7 @@ import { describe, expect, it } from "vitest";
 import { convexTest } from "convex-test";
 
 import * as eventsModule from "../events";
-import { publishWiki, claimHost } from "../events";
+import { publishWiki, claimHost, requestHostClaim } from "../events";
 import schema from "../schema";
 import { api } from "../_generated/api";
 
@@ -250,8 +250,19 @@ class MockDb {
   }
 }
 
+type SchedulerCall = { delayMs: number; ref: unknown; args: unknown };
+
+class MockScheduler {
+  public calls: SchedulerCall[] = [];
+
+  async runAfter(delayMs: number, ref: unknown, args: unknown) {
+    this.calls.push({ delayMs, ref, args });
+    return `scheduled:${this.calls.length}` as unknown;
+  }
+}
+
 function createCtx(tables: Tables) {
-  return { db: new MockDb(tables) };
+  return { db: new MockDb(tables), scheduler: new MockScheduler() };
 }
 
 const ANONYMOUS_SESSION_A = "session-anon-aaaaaaaa";
@@ -991,5 +1002,213 @@ describe("_evictStaleHostClaimCodes — Phase 4 defense-in-depth janitor", () =>
     // Exactly 1 patch was issued (only the stale row).
     expect((ctx.db as MockDb).patches.length).toBe(1);
     expect((ctx.db as MockDb).patches[0].id).toBe("liveEvents:stale-with-hash");
+  });
+});
+
+/* ========================================================================== */
+/* Test 4 — requestHostClaim email channel (Phase 4 follow-up Item 1)          */
+/* ========================================================================== */
+
+describe("requestHostClaim — optional Resend email delivery", () => {
+  /**
+   * Background: PR #396 returns the plaintext claim code synchronously from
+   * requestHostClaim. The Phase 4 follow-up adds an OPTIONAL email channel:
+   * when the caller supplies deliverToEmail, the mutation schedules a
+   * fire-and-forget action (convex/email.ts:sendHostClaimCodeEmail) to
+   * email the code. The mutation MUST still return the code synchronously
+   * — email is convenience, not source of truth.
+   *
+   * Failure semantics under test:
+   *   - deliverToEmail omitted → no scheduler call, code returned as before
+   *   - deliverToEmail malformed → no scheduler call, no throw, code returned
+   *   - deliverToEmail valid → scheduler called exactly once with the right
+   *     args (email + code + eventName + expiresHintAt), code returned
+   */
+
+  it("deliverToEmail omitted: no scheduler call, code returned (back-compat)", async () => {
+    /**
+     * Scenario:    Legacy caller (the existing scratchnode UI) does not
+     *              pass deliverToEmail at all. Behavior must be identical
+     *              to PR #396 — code returned, no email channel touched.
+     * User:        Anonymous member self-claiming their own room
+     * Goal:        Get a one-time claim code, no email needed
+     * Prior state: event live; 0 liveEventHosts; member joined
+     * Actions:     requestHostClaim without deliverToEmail
+     * Scale:       1 caller
+     * Duration:    Single mutation
+     * Expected:    ok=true, hostClaimCode present, scheduler.calls empty,
+     *              event.hostClaimCodeHash persisted.
+     * Edge:        Must not silently call scheduler with undefined email.
+     */
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventMembers: [baseMember(ANONYMOUS_SESSION_A)],
+      liveEventHosts: [],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await (requestHostClaim as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+      requesterSessionId: ANONYMOUS_SESSION_A,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(typeof result.hostClaimCode).toBe("string");
+    expect(result.hostClaimCode.length).toBeGreaterThanOrEqual(16);
+    expect(typeof result.expiresHintAt).toBe("number");
+    // Critical: no email channel touched when deliverToEmail omitted.
+    expect(ctx.scheduler.calls.length).toBe(0);
+    // Hash persisted (back-compat invariant).
+    expect(tables.liveEvents[0].hostClaimCodeHash).toBeTruthy();
+  });
+
+  it("deliverToEmail malformed: no scheduler call, no throw, code still returned", async () => {
+    /**
+     * Scenario:    Caller passes a string that is NOT a valid email
+     *              (missing @, missing dot, or oversized). The mutation
+     *              must NOT throw — the plaintext code is still useful to
+     *              the caller, the bad email is a UX issue not a security
+     *              issue. The scheduler MUST NOT be called (so Resend
+     *              never sees the garbage payload).
+     * User:        Misconfigured client or fat-fingered input
+     * Goal:        Get a code; email channel silently skipped
+     * Prior state: event live; member joined
+     * Actions:     requestHostClaim with deliverToEmail set to several
+     *              shapes of garbage — empty string, missing @, missing
+     *              dot, too long
+     * Scale:       1 caller, 4 garbage shapes in sequence
+     * Duration:    Sub-second
+     * Expected:    Each call returns ok=true with code; scheduler.calls
+     *              stays empty across all four; no throw.
+     * Edge:        Email > 254 chars must be rejected (RFC 5321 SMTP path
+     *              cap — protects against pathological inputs).
+     */
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventMembers: [baseMember(ANONYMOUS_SESSION_A)],
+      liveEventHosts: [],
+    };
+    const ctx = createCtx(tables);
+
+    const malformed = [
+      "",
+      "not-an-email",
+      "missing-dot@example",
+      "missing-at-example.com",
+      // 261-char string with @ + dot — passes regex but exceeds 254-char
+      // RFC 5321 SMTP path length cap, so the validator must reject.
+      `${"a".repeat(254)}@x.co`,
+    ];
+    for (const bad of malformed) {
+      const result = await (requestHostClaim as any)._handler(ctx, {
+        eventId: "liveEvents:1",
+        requesterSessionId: ANONYMOUS_SESSION_A,
+        deliverToEmail: bad,
+      });
+      expect(result.ok).toBe(true);
+      expect(typeof result.hostClaimCode).toBe("string");
+    }
+    // ZERO scheduler calls across all malformed inputs.
+    expect(ctx.scheduler.calls.length).toBe(0);
+  });
+
+  it("deliverToEmail valid: scheduler called once with right args (code, email, eventName, expiresHintAt)", async () => {
+    /**
+     * Scenario:    Co-host onboarding — primary host requests a claim code
+     *              and wants it emailed to a colleague in another building.
+     *              The mutation returns the code synchronously AND schedules
+     *              a fire-and-forget action to deliver the code by email.
+     * User:        Host or pre-host member (the gate is requireMember, not
+     *              requireHost, since pre-claim is allowed)
+     * Goal:        Get the code AND have it emailed
+     * Prior state: event live; member joined; no existing host
+     * Actions:     requestHostClaim with valid deliverToEmail
+     * Scale:       1 caller
+     * Duration:    Single mutation; the action is scheduled, not awaited.
+     * Expected:    ok=true; code returned; scheduler.calls.length === 1;
+     *              args.email matches input; args.code === result.hostClaimCode;
+     *              args.eventName === event.name; args.expiresHintAt is a
+     *              future timestamp (~30 min ahead).
+     * Edge:        The action ref must be internal.email.sendHostClaimCodeEmail
+     *              (not internal.events.* or any other path) so this test
+     *              also catches accidental wiring drift.
+     */
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventMembers: [baseMember(ANONYMOUS_SESSION_A)],
+      liveEventHosts: [],
+    };
+    const ctx = createCtx(tables);
+
+    const startTime = Date.now();
+    const validEmail = "cohost@example.com";
+
+    const result = await (requestHostClaim as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+      requesterSessionId: ANONYMOUS_SESSION_A,
+      deliverToEmail: validEmail,
+    });
+
+    // Mutation result invariants.
+    expect(result.ok).toBe(true);
+    expect(typeof result.hostClaimCode).toBe("string");
+    expect(result.hostClaimCode.length).toBeGreaterThanOrEqual(16);
+    expect(typeof result.expiresHintAt).toBe("number");
+    expect(result.expiresHintAt).toBeGreaterThan(startTime);
+
+    // Scheduler called EXACTLY once.
+    expect(ctx.scheduler.calls.length).toBe(1);
+    const [scheduled] = ctx.scheduler.calls;
+    expect(scheduled.delayMs).toBe(0);
+
+    // Args carry the right code + email + event name + expiresHintAt.
+    const args = scheduled.args as {
+      email: string;
+      code: string;
+      eventName: string;
+      expiresHintAt: number;
+    };
+    expect(args.email).toBe(validEmail);
+    expect(args.code).toBe(result.hostClaimCode);
+    expect(args.eventName).toBe("AI Infra Summit");
+    expect(args.expiresHintAt).toBe(result.expiresHintAt);
+
+    // ref must be a truthy FunctionReference — Convex's anyApi proxies
+    // are opaque objects that resist primitive conversion, so we don't
+    // stringify them. The args check above is the real correctness gate
+    // (eventName + code + email + expiresHintAt prove the wiring is right).
+    expect(scheduled.ref).toBeTruthy();
+  });
+
+  it("deliverToEmail with whitespace: trimmed before scheduling (defense in depth)", async () => {
+    /**
+     * Scenario:    Caller pastes an email with leading/trailing whitespace
+     *              (common copy-paste failure mode). The mutation must
+     *              trim before scheduling so Resend never sees stray
+     *              whitespace.
+     * User:        Anyone pasting an email from a chat client
+     * Goal:        Robust handling of cosmetic input bugs
+     * Prior state: event live; member joined
+     * Actions:     requestHostClaim with deliverToEmail="  good@ex.com  "
+     * Scale:       1 caller
+     * Expected:    Scheduler called once with args.email === "good@ex.com"
+     *              (trimmed).
+     */
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventMembers: [baseMember(ANONYMOUS_SESSION_A)],
+      liveEventHosts: [],
+    };
+    const ctx = createCtx(tables);
+
+    await (requestHostClaim as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+      requesterSessionId: ANONYMOUS_SESSION_A,
+      deliverToEmail: "  good@ex.com  ",
+    });
+
+    expect(ctx.scheduler.calls.length).toBe(1);
+    const args = ctx.scheduler.calls[0].args as { email: string };
+    expect(args.email).toBe("good@ex.com");
   });
 });

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1330,6 +1330,7 @@ import type * as domains_verification_validation_selfQuestionAgent from "../doma
 import type * as domains_verification_verificationAuditTrail from "../domains/verification/verificationAuditTrail.js";
 import type * as domains_verification_verificationWorkflow from "../domains/verification/verificationWorkflow.js";
 import type * as domains_world_operations from "../domains/world/operations.js";
+import type * as email from "../email.js";
 import type * as events from "../events.js";
 import type * as feed from "../feed.js";
 import type * as globalResearch_artifacts from "../globalResearch/artifacts.js";
@@ -2842,6 +2843,7 @@ declare const fullApi: ApiFromModules<{
   "domains/verification/verificationAuditTrail": typeof domains_verification_verificationAuditTrail;
   "domains/verification/verificationWorkflow": typeof domains_verification_verificationWorkflow;
   "domains/world/operations": typeof domains_world_operations;
+  email: typeof email;
   events: typeof events;
   feed: typeof feed;
   "globalResearch/artifacts": typeof globalResearch_artifacts;

--- a/convex/email.ts
+++ b/convex/email.ts
@@ -1,0 +1,264 @@
+/**
+ * convex/email.ts — Phase 4 follow-up Item 1: Resend integration for host
+ * claim codes.
+ *
+ * SCOPE
+ *   This module exposes ONE internal action: sendHostClaimCodeEmail. It is
+ *   scheduled (fire-and-forget) by events.ts:requestHostClaim when the caller
+ *   provides an optional `deliverToEmail`. The mutation still returns the
+ *   plaintext code synchronously — email is a CONVENIENCE channel, not a
+ *   source of truth.
+ *
+ * WHY ACTION (not mutation):
+ *   Convex mutations must be deterministic and side-effect free wrt external
+ *   services. The Resend API is a non-deterministic HTTP call, so it goes
+ *   in an action and is scheduled via ctx.scheduler.runAfter(0, ...). The
+ *   mutation returns immediately; the email is sent in the background.
+ *
+ * GRACEFUL DEGRADATION
+ *   - Missing RESEND_API_KEY: logs warning, returns void. Does NOT throw.
+ *     (The plaintext code already returned to the caller is the source of
+ *     truth; a missing email key must not break the claim flow.)
+ *   - Resend API error (4xx/5xx): logs error with status + body snippet,
+ *     returns void. Does NOT throw. Same rationale.
+ *   - Network/abort error: logs error, returns void.
+ *
+ * AGENTIC RELIABILITY (per .claude/rules/agentic_reliability.md)
+ *   - HONEST_STATUS: the calling mutation does NOT pretend email succeeded.
+ *     It returns the code synchronously; email status is fire-and-forget.
+ *   - TIMEOUT: AbortController with 10s budget on the Resend HTTP call.
+ *   - BOUND_READ: response body read with 4KB cap (Resend responses are
+ *     small JSON; anything bigger indicates an upstream incident — we log
+ *     a truncated snippet and move on).
+ *   - SSRF: not applicable — destination URL is the hardcoded Resend API
+ *     endpoint, not user-controlled.
+ *   - ERROR_BOUNDARY: try/catch around all fetch + JSON parsing.
+ *
+ * PRIOR ART
+ *   Mirrors the existing convex/domains/integrations/resend.ts sendEmail
+ *   action shape (same fetch-to-api.resend.com, same Bearer auth) but
+ *   adds: AbortController, bounded response read, fail-closed-on-no-key
+ *   semantics (existing action throws — this one logs+returns to preserve
+ *   the claim flow).
+ */
+
+import { v } from "convex/values";
+import { internalAction } from "./_generated/server";
+
+// 10s budget — Resend's documented p99 is <1s, so 10s is a generous ceiling
+// before we abort and surface the gap.
+const RESEND_TIMEOUT_MS = 10_000;
+// Bound the response body we read on error (BOUND_READ). Resend error JSON
+// is typically <500 bytes; capping at 4KB catches misconfigured proxies
+// returning HTML error pages.
+const MAX_ERROR_BODY_BYTES = 4096;
+
+// Validate email at the call site too — this is a defense-in-depth check
+// so a misconfigured caller can't sneak garbage into the Resend API.
+// Aligned with the regex used in events.ts:requestHostClaim.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LEN = 254; // RFC 5321 SMTP path limit.
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+/**
+ * Build the claim-code email HTML. Keep it short and scannable — the
+ * recipient may be on mobile in a noisy hallway at the start of the event.
+ */
+function buildClaimCodeHtml(
+  code: string,
+  eventName: string,
+  expiresHintAt: number,
+): string {
+  const safeCode = escapeHtml(code);
+  const safeEventName = escapeHtml(eventName);
+  // Localized "minutes from now" hint — Resend renders the HTML, but we
+  // compute this server-side so the recipient's clock skew can't make the
+  // expiry sound stale.
+  const minutesFromNow = Math.max(
+    1,
+    Math.round((expiresHintAt - Date.now()) / 60_000),
+  );
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your host claim code for ${safeEventName}</title>
+</head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f8fafc;">
+    <tr>
+      <td align="center" style="padding:32px 16px;">
+        <table width="560" cellpadding="0" cellspacing="0" border="0" style="background:#ffffff;border-radius:12px;border:1px solid #e2e8f0;">
+          <tr>
+            <td style="padding:28px 32px;border-bottom:1px solid #e2e8f0;">
+              <h1 style="margin:0;font-size:18px;font-weight:600;color:#0f172a;">Your host claim code</h1>
+              <p style="margin:6px 0 0;font-size:13px;color:#64748b;">For event: <strong>${safeEventName}</strong></p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 32px;">
+              <p style="margin:0 0 16px;font-size:14px;color:#334155;line-height:1.5;">
+                Enter this code on the scratchnode.live page to claim host access for this event. The code is one-time and valid for about ${minutesFromNow} minute${minutesFromNow === 1 ? "" : "s"}.
+              </p>
+              <div style="margin:0 0 16px;padding:16px 20px;background:#f1f5f9;border:1px solid #cbd5e1;border-radius:8px;text-align:center;">
+                <code style="font-family:'JetBrains Mono','SF Mono',Consolas,monospace;font-size:20px;font-weight:600;letter-spacing:0.08em;color:#0f172a;word-break:break-all;">${safeCode}</code>
+              </div>
+              <p style="margin:0;font-size:12px;color:#94a3b8;line-height:1.5;">
+                If you did not request this, you can safely ignore this email. The code expires automatically and can be re-issued from the room.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 12px 12px;">
+              <p style="margin:0;font-size:11px;color:#94a3b8;text-align:center;">
+                Sent by scratchnode.live - one-time host claim code
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+/**
+ * sendHostClaimCodeEmail — internal action, fire-and-forget from
+ * events.ts:requestHostClaim.
+ *
+ * Failure semantics: NEVER throws. All errors are logged and swallowed so
+ * the upstream claim flow (which already returned the code to the caller)
+ * is not affected by email-channel issues.
+ */
+export const sendHostClaimCodeEmail = internalAction({
+  args: {
+    email: v.string(),
+    code: v.string(),
+    eventName: v.string(),
+    expiresHintAt: v.number(),
+  },
+  handler: async (_ctx, args) => {
+    // Defense in depth — re-validate the email at the action boundary even
+    // though events.ts:requestHostClaim already did. If a future caller
+    // forgets, we still fail closed quietly.
+    const trimmedEmail = (args.email || "").trim();
+    if (
+      !trimmedEmail ||
+      trimmedEmail.length > MAX_EMAIL_LEN ||
+      !EMAIL_REGEX.test(trimmedEmail)
+    ) {
+      console.warn(
+        "[sendHostClaimCodeEmail] Rejected malformed email; skipping send.",
+      );
+      return;
+    }
+
+    const apiKey = (globalThis as any)?.process?.env?.RESEND_API_KEY;
+    if (typeof apiKey !== "string" || apiKey.length === 0) {
+      // Fail closed but quietly — the plaintext code is already in the
+      // caller's hands. Missing key must not break the claim flow.
+      console.warn(
+        "[sendHostClaimCodeEmail] RESEND_API_KEY not configured; skipping email delivery. " +
+          "To enable: npx convex env set RESEND_API_KEY <key>",
+      );
+      return;
+    }
+
+    const fromAddress =
+      (globalThis as any)?.process?.env?.EMAIL_FROM_HOST_CLAIM ||
+      (globalThis as any)?.process?.env?.EMAIL_FROM ||
+      "scratchnode.live <onboarding@resend.dev>";
+
+    // Subject is short, recognizable, and does NOT include the code (codes
+    // appear in many email previews — putting it in the subject would leak
+    // it in notification banners).
+    const safeEventName = args.eventName.slice(0, 80) || "scratchnode.live event";
+    const subject = `Your host claim code for ${safeEventName}`;
+    const html = buildClaimCodeHtml(args.code, safeEventName, args.expiresHintAt);
+
+    // TIMEOUT — abort the request if Resend hangs.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), RESEND_TIMEOUT_MS);
+
+    try {
+      const response = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: fromAddress,
+          to: [trimmedEmail],
+          subject,
+          html,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        // BOUND_READ — cap the body we ingest on error. Resend errors are
+        // small JSON; oversized responses indicate a misconfigured proxy
+        // returning HTML, which we don't need verbatim.
+        let snippet = "";
+        try {
+          const reader = response.body?.getReader();
+          if (reader) {
+            let total = 0;
+            const chunks: Uint8Array[] = [];
+            while (total < MAX_ERROR_BODY_BYTES) {
+              const { done, value } = await reader.read();
+              if (done || !value) break;
+              chunks.push(value);
+              total += value.byteLength;
+              if (total >= MAX_ERROR_BODY_BYTES) {
+                await reader.cancel();
+                break;
+              }
+            }
+            const merged = new Uint8Array(Math.min(total, MAX_ERROR_BODY_BYTES));
+            let offset = 0;
+            for (const chunk of chunks) {
+              const take = Math.min(chunk.byteLength, merged.byteLength - offset);
+              merged.set(chunk.subarray(0, take), offset);
+              offset += take;
+              if (offset >= merged.byteLength) break;
+            }
+            snippet = new TextDecoder().decode(merged);
+          }
+        } catch {
+          // If we can't even read the error body, log what we have.
+          snippet = "<unreadable response body>";
+        }
+        console.error(
+          "[sendHostClaimCodeEmail] Resend API error:",
+          response.status,
+          snippet.slice(0, 500),
+        );
+        return;
+      }
+      // Success — log a minimal record (no PII beyond a short event-name
+      // marker). The Convex dashboard will surface this on demand.
+      console.log(
+        "[sendHostClaimCodeEmail] Sent claim code email for event:",
+        safeEventName,
+      );
+    } catch (err: any) {
+      // Aborts and network failures land here. Never re-throw — this is a
+      // fire-and-forget side channel.
+      const reason = err?.name === "AbortError" ? "timeout" : err?.message ?? String(err);
+      console.error("[sendHostClaimCodeEmail] Send failed:", reason);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  },
+});

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -26,6 +26,7 @@
 
 import { v } from "convex/values";
 import { query, mutation, internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 
 class ConvexError<T extends Record<string, unknown>> extends Error {
   data: T;
@@ -61,6 +62,22 @@ const MAX_WIKI_ANSWERS = 20;
 // (hk1:<eventIdShort>:<nonce>:<issuedAt>:<hmacShort> ~ 80-90 chars).
 // 120 is still tight enough to reject obvious junk.
 const MAX_OWNER_KEY_LEN = 120;
+
+// Phase 4 follow-up Item 1: optional email channel for claim codes.
+// Validation kept basic on purpose — Resend re-validates server-side, and
+// the regex is meant to catch *obviously* malformed input (missing @,
+// missing dot, oversized strings) before we even schedule the action.
+// MAX_EMAIL_LEN matches RFC 5321 (SMTP path length).
+const MAX_EMAIL_LEN = 254;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const isLikelyValidEmail = (value: string | undefined): value is string => {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed.length > MAX_EMAIL_LEN) return false;
+  return EMAIL_REGEX.test(trimmed);
+};
 
 const DEMO_SOURCES = [
   {
@@ -1009,8 +1026,15 @@ export const requestHostClaim = mutation({
     // host can rotate by providing their current ownerKey (HMAC token).
     // Required only when an existing claim_code host exists.
     existingOwnerKey: v.optional(v.string()),
+    // Phase 4 follow-up Item 1: optional out-of-band email channel. When
+    // present and well-formed, the mutation schedules a fire-and-forget
+    // action (convex/email.ts:sendHostClaimCodeEmail) to deliver the
+    // plaintext code by email. The mutation STILL returns the code
+    // synchronously — email is a convenience channel, not a source of
+    // truth. Failed delivery does NOT break the claim flow.
+    deliverToEmail: v.optional(v.string()),
   },
-  handler: async (ctx, { eventId, requesterSessionId, existingOwnerKey }) => {
+  handler: async (ctx, { eventId, requesterSessionId, existingOwnerKey, deliverToEmail }) => {
     // Membership gate — same shape as composeAnswer / suggestAnswerForFaq.
     await requireMember(ctx, eventId, requesterSessionId);
     const event = await ctx.db.get(eventId);
@@ -1051,6 +1075,32 @@ export const requestHostClaim = mutation({
       hostClaimCodeHash: codeHash,
       hostClaimCodeCreatedAt: Date.now(),
     });
+    const expiresHintAt = Date.now() + 30 * 60 * 1000;
+
+    // Phase 4 follow-up Item 1 — optional email channel.
+    // Fire-and-forget: schedule the action so the mutation can return
+    // synchronously. Validation here is cheap (regex + length) — the
+    // action re-validates as defense in depth. Failures inside the
+    // action are logged but do NOT break the claim flow.
+    if (deliverToEmail !== undefined) {
+      if (isLikelyValidEmail(deliverToEmail)) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.email.sendHostClaimCodeEmail,
+          {
+            email: deliverToEmail.trim(),
+            code,
+            eventName: event.name,
+            expiresHintAt,
+          },
+        );
+      }
+      // Malformed email: silently skip scheduling. We don't throw because
+      // the plaintext code is still being returned to the caller, and a
+      // bad email is a UX issue, not a security issue. (Future: surface
+      // a soft warning field in the response if UX needs it.)
+    }
+
     // Return the plaintext code EXACTLY ONCE. Caller must persist it
     // immediately — it is never recoverable from the database.
     return {
@@ -1060,7 +1110,7 @@ export const requestHostClaim = mutation({
       // stale. Not enforced server-side (the hash is the source of
       // truth) — purely for UX. requestHostClaim can be re-called any
       // time to mint a new code.
-      expiresHintAt: Date.now() + 30 * 60 * 1000,
+      expiresHintAt,
     };
   },
 });


### PR DESCRIPTION
## Summary

Phase 4 follow-up Item 1: optional email channel for host claim codes.

- `events:requestHostClaim` now accepts an optional `deliverToEmail` arg. When present and well-formed, it schedules a fire-and-forget internal action that emails the plaintext code via Resend.
- The mutation **still returns the code synchronously** — email is convenience, not source of truth. Failed delivery does not break the claim flow.
- Why action (not mutation): Convex mutations must be deterministic + side-effect-free wrt external services. The Resend HTTP call goes in an `internalAction` scheduled via `ctx.scheduler.runAfter(0, ...)`, so the mutation returns immediately and the email is sent in the background.

## Files

- `convex/email.ts` (new) — `internalAction sendHostClaimCodeEmail` with Resend integration, AbortController timeout (10s), bounded error-body read (4KB), and fail-closed logging (never throws).
- `convex/events.ts` — `requestHostClaim` accepts optional `deliverToEmail`; validates via length + regex; schedules action on match.
- `convex/__tests__/scratchnode.events.test.ts` — 4 new scenario-based tests.
- `convex/_generated/api.d.ts` — codegen entry for the new `email` module. Will be regenerated idempotently on next `npx convex codegen`.

## Reliability (per .claude/rules/agentic_reliability.md)

- **HONEST_STATUS**: mutation returns code synchronously regardless of email outcome. Action logs but does not throw on error.
- **TIMEOUT**: 10s AbortController budget on the Resend HTTP call.
- **BOUND_READ**: error response body capped at 4KB.
- **ERROR_BOUNDARY**: try/catch around the entire send path with a `finally` to clear the timeout.
- **SSRF**: not applicable — destination URL is the hardcoded Resend API endpoint.

## Frontend impact

Zero. Existing callers without `deliverToEmail` see no behavior change. The home-v5.html UI for entering an email comes in a separate follow-up.

## USER ACTION REQUIRED post-merge

To activate the email channel in production:

1. **Get a Resend API key**: signup at https://resend.com (free tier supports `onboarding@resend.dev` testing without domain verification).
2. **Set the env var**: `npx convex env set RESEND_API_KEY re_xxxxxxxxxxxxxxxx`
3. **Optional: verify a custom domain** in Resend (DNS TXT records) so the From: address is `noreply@scratchnode.live` instead of the default `onboarding@resend.dev`. To override the From: address, also set `EMAIL_FROM_HOST_CLAIM` (or use the existing `EMAIL_FROM`).
4. **Verify**: the flow gracefully degrades if `RESEND_API_KEY` is missing — the mutation still returns the code, and the action logs a `[sendHostClaimCodeEmail] RESEND_API_KEY not configured; skipping email delivery` warning.

## Test plan

- [x] `npx tsc --noEmit --pretty false` — clean
- [x] `npx tsc -p convex --noEmit --pretty false` — clean
- [x] `npx vitest run convex/__tests__/scratchnode.events.test.ts` — 11/11 pass (4 new tests + 7 existing)
- [x] `npx vitest run convex/events.runtime-boundary.test.ts` — 8/8 pass
- [x] `npm run build` — clean
- [ ] Post-merge: set `RESEND_API_KEY` and verify a real email lands in test inbox
- [ ] Post-merge: re-run the 24-scenario dogfood script (`scripts/scratchnode-multi-user-dogfood.mjs`) to confirm zero regression on existing callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
