### PR TITLE
feat(scratchnode): provider-ready live ask agent

### DIFF
--- a/convex/__tests__/scratchnode.events.test.ts
+++ b/convex/__tests__/scratchnode.events.test.ts
@@ -409,6 +409,9 @@ describe("composeAnswer — cache reuse across attendees", () => {
     expect(Array.isArray(callA.sourceIds)).toBe(true);
     expect(callA.sourceIds.length).toBeGreaterThanOrEqual(1);
     expect(callA.body.length).toBeGreaterThan(20);
+    expect(callA.agentMode).toBe("deterministic");
+    expect(callA.evaluation?.passed).toBe(true);
+    expect(callA.evaluation?.score).toBeGreaterThanOrEqual(80);
     expect(callA.trace.some((step: any) => step.step === "deterministic_synthesis")).toBe(true);
     expect(callA.trace.find((step: any) => step.step === "deterministic_synthesis").status).toBe("ok");
 
@@ -422,6 +425,8 @@ describe("composeAnswer — cache reuse across attendees", () => {
 
     expect(callB).toBeTruthy();
     expect(callB.cacheHit).toBe(true);
+    expect(callB.agentMode).toBe("cache");
+    expect(callB.evaluation?.passed).toBe(true);
     expect(callB.body).toBe(callA.body);
     expect(callB.sourceIds).toEqual(callA.sourceIds);
     const cacheStep = callB.trace.find((step: any) => step.step === "semantic_cache_lookup");

--- a/convex/events.runtime-boundary.test.ts
+++ b/convex/events.runtime-boundary.test.ts
@@ -6,9 +6,9 @@ import { dirname, join } from "node:path";
 const here = dirname(fileURLToPath(import.meta.url));
 const eventsSource = readFileSync(join(here, "events.ts"), "utf8");
 
-function functionBlock(name: string): string {
-  const start = eventsSource.indexOf(`export const ${name} = mutation({`);
-  expect(start, `${name} mutation should exist`).toBeGreaterThanOrEqual(0);
+function functionBlock(name: string, kind: "mutation" | "action" | "internalQuery" | "internalMutation" = "mutation"): string {
+  const start = eventsSource.indexOf(`export const ${name} = ${kind}({`);
+  expect(start, `${name} ${kind} should exist`).toBeGreaterThanOrEqual(0);
   const next = eventsSource.indexOf("\nexport const ", start + 1);
   return eventsSource.slice(start, next > start ? next : undefined);
 }
@@ -16,12 +16,19 @@ function functionBlock(name: string): string {
 describe("scratchnode public runtime boundaries", () => {
   it("keeps public /ask isolated from private user notes", () => {
     const composeAnswer = functionBlock("composeAnswer");
+    const askAgent = functionBlock("askAgent", "action");
 
     expect(composeAnswer).not.toContain("userNotes");
     expect(composeAnswer).not.toContain("getPrivate");
     expect(composeAnswer).toContain("requireMember");
     expect(composeAnswer).toContain("liveEventSources");
     expect(composeAnswer).toContain("deterministic_synthesis");
+    expect(askAgent).not.toContain("userNotes");
+    expect(askAgent).not.toContain("getPrivate");
+    expect(askAgent).toContain("_prepareAskAgentContext");
+    expect(askAgent).toContain("generateProviderAnswer");
+    expect(askAgent).toContain("quality_gate");
+    expect(askAgent).toContain("private notes excluded");
   });
 
   it("keeps wiki publishing host-gated and sourced from public answers", () => {

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -25,8 +25,8 @@
  */
 
 import { v } from "convex/values";
-import { query, mutation, internalMutation } from "./_generated/server";
-import { internal } from "./_generated/api";
+import { api, internal } from "./_generated/api";
+import { action, query, mutation, internalMutation, internalQuery } from "./_generated/server";
 
 class ConvexError<T extends Record<string, unknown>> extends Error {
   data: T;
@@ -62,6 +62,10 @@ const MAX_WIKI_ANSWERS = 20;
 // (hk1:<eventIdShort>:<nonce>:<issuedAt>:<hmacShort> ~ 80-90 chars).
 // 120 is still tight enough to reject obvious junk.
 const MAX_OWNER_KEY_LEN = 120;
+const MAX_AGENT_CONTEXT_SOURCES = 6;
+const MAX_AGENT_CONTEXT_CHARS = 9_000;
+const MAX_LINKUP_SOURCES = 4;
+const SCRATCHNODE_DEFAULT_ASK_MODEL = "claude-haiku-4-5-20251001";
 
 // Phase 4 follow-up Item 1: optional email channel for claim codes.
 // Validation kept basic on purpose — Resend re-validates server-side, and
@@ -445,6 +449,218 @@ function synthesizeAnswer(
   ].join("\n");
 }
 
+function shouldProbeLiveSearch(question: string, ranked: Array<{ score: number }>) {
+  const q = question.toLowerCase();
+  const freshnessIntent = /\b(today|latest|recent|this week|this month|2026|now|new|announced|raised|launched)\b/.test(q);
+  const weakCorpusMatch = ranked.length === 0 || (ranked[0]?.score ?? 0) <= 1;
+  return freshnessIntent || weakCorpusMatch;
+}
+
+function boundedContextText(sources: Array<{ title: string; excerpt: string; body: string; uri?: string }>) {
+  let remaining = MAX_AGENT_CONTEXT_CHARS;
+  return sources.slice(0, MAX_AGENT_CONTEXT_SOURCES).map((source, index) => {
+    const raw = `${source.excerpt || ""}\n${source.body || ""}`.trim();
+    const body = raw.slice(0, Math.max(0, remaining));
+    remaining -= body.length;
+    return [
+      `[${index + 1}] ${source.title}`,
+      `URI: ${source.uri || "event-source"}`,
+      body,
+    ].join("\n");
+  }).join("\n\n---\n\n");
+}
+
+function estimateTokens(input: string) {
+  return Math.ceil((input || "").length / 4);
+}
+
+function estimateAnthropicCostCents(inputTokens: number, outputTokens: number, modelId: string) {
+  // Conservative planning rates per 1M tokens. Actual billing is provider-side.
+  const fast = modelId.includes("haiku");
+  const inputPer1M = fast ? 1 : 3;
+  const outputPer1M = fast ? 5 : 15;
+  return Number((((inputTokens / 1_000_000) * inputPer1M + (outputTokens / 1_000_000) * outputPer1M) * 100).toFixed(4));
+}
+
+function evaluateAnswerQuality(args: {
+  question: string;
+  body: string;
+  sourceCount: number;
+  traceSteps: string[];
+}) {
+  const checks: Array<{ name: string; status: "pass" | "warn" | "fail"; detail?: string }> = [];
+  const body = args.body || "";
+  const hasBody = body.trim().length >= 80;
+  checks.push({
+    name: "substantive_answer",
+    status: hasBody ? "pass" : "fail",
+    detail: hasBody ? "Answer has enough body to be useful." : "Answer is too short.",
+  });
+  const hasSources = args.sourceCount > 0;
+  checks.push({
+    name: "source_backed",
+    status: hasSources ? "pass" : "fail",
+    detail: `${args.sourceCount} public sources attached.`,
+  });
+  const privateLeak = /\bprivate note|userNotes|only your notebook\b/i.test(body);
+  checks.push({
+    name: "public_private_boundary",
+    status: privateLeak ? "fail" : "pass",
+    detail: privateLeak ? "Answer body references private-note implementation details." : "No private-note content in answer body.",
+  });
+  const hasRuntimeTrace = args.traceSteps.length >= 3;
+  checks.push({
+    name: "runtime_trace",
+    status: hasRuntimeTrace ? "pass" : "warn",
+    detail: `${args.traceSteps.length} trace steps persisted.`,
+  });
+  const failed = checks.filter((check) => check.status === "fail").length;
+  const warned = checks.filter((check) => check.status === "warn").length;
+  const score = Math.max(0, 100 - failed * 35 - warned * 10);
+  return { passed: failed === 0, score, checks };
+}
+
+async function searchLinkup(question: string) {
+  const apiKey = process.env.LINKUP_API_KEY;
+  if (!apiKey || process.env.SCRATCHNODE_ALLOW_LINKUP !== "1") {
+    return { status: "skipped" as const, sources: [], detail: "Linkup disabled or key not configured." };
+  }
+  const startedAt = Date.now();
+  try {
+    const response = await fetch("https://api.linkup.so/v1/search", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        q: question,
+        depth: "standard",
+        outputType: "searchResults",
+        includeSources: true,
+        maxResults: MAX_LINKUP_SOURCES,
+      }),
+    });
+    if (!response.ok) {
+      return {
+        status: "error" as const,
+        sources: [],
+        detail: `Linkup returned HTTP ${response.status} in ${Date.now() - startedAt}ms.`,
+      };
+    }
+    const data: any = await response.json();
+    const rawSources = Array.isArray(data.sources) ? data.sources : Array.isArray(data.results) ? data.results : [];
+    const sources = rawSources.slice(0, MAX_LINKUP_SOURCES).map((source: any, index: number) => ({
+      uri: String(source.url || source.uri || `linkup://${stableHash(`${question}:${index}`)}`).slice(0, 500),
+      kind: "url" as const,
+      title: String(source.name || source.title || "External source").slice(0, 200),
+      excerpt: String(source.snippet || source.content || "").slice(0, 500),
+      body: String(source.content || source.snippet || source.name || "").slice(0, MAX_SOURCE_BODY),
+    }));
+    return {
+      status: "ok" as const,
+      sources,
+      detail: `Linkup returned ${sources.length} sources in ${Date.now() - startedAt}ms.`,
+    };
+  } catch (err: any) {
+    return {
+      status: "error" as const,
+      sources: [],
+      detail: `Linkup failed: ${err?.message || String(err)}`,
+    };
+  }
+}
+
+async function generateProviderAnswer(args: {
+  eventName: string;
+  question: string;
+  sources: Array<{ title: string; excerpt: string; body: string; uri?: string }>;
+}) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return { ok: false as const, detail: "ANTHROPIC_API_KEY not configured." };
+  }
+  const model = process.env.SCRATCHNODE_ASK_MODEL || SCRATCHNODE_DEFAULT_ASK_MODEL;
+  const system = [
+    "You are ScratchNode's event answer agent.",
+    "Answer only from the provided public event sources.",
+    "Do not use or mention private notes.",
+    "If evidence is thin, say what is known and what remains unclear.",
+    "Write concise, useful prose for an event attendee.",
+    "End with a short 'Next move:' sentence.",
+  ].join(" ");
+  const context = boundedContextText(args.sources);
+  const user = [
+    `Event: ${args.eventName}`,
+    `Question: ${args.question}`,
+    "",
+    "Public event sources:",
+    context,
+  ].join("\n");
+  const inputTokens = estimateTokens(system + "\n" + user);
+  const startedAt = Date.now();
+  try {
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 700,
+        temperature: 0.2,
+        system,
+        messages: [{ role: "user", content: user }],
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      return {
+        ok: false as const,
+        detail: `Anthropic HTTP ${response.status}: ${body.slice(0, 240)}`,
+        model,
+        inputTokens,
+        elapsedMs: Date.now() - startedAt,
+      };
+    }
+    const data: any = await response.json();
+    const text = Array.isArray(data.content)
+      ? data.content.map((part: any) => part?.type === "text" ? part.text : "").join("").trim()
+      : "";
+    const outputTokens = Number(data.usage?.output_tokens ?? estimateTokens(text));
+    const usageInput = Number(data.usage?.input_tokens ?? inputTokens);
+    if (!text) {
+      return {
+        ok: false as const,
+        detail: "Anthropic returned an empty text response.",
+        model,
+        inputTokens: usageInput,
+        outputTokens,
+        elapsedMs: Date.now() - startedAt,
+      };
+    }
+    return {
+      ok: true as const,
+      body: text.slice(0, MAX_ANSWER_BODY),
+      model,
+      inputTokens: usageInput,
+      outputTokens,
+      estimatedCostCents: estimateAnthropicCostCents(usageInput, outputTokens, model),
+      elapsedMs: Date.now() - startedAt,
+    };
+  } catch (err: any) {
+    return {
+      ok: false as const,
+      detail: `Anthropic request failed: ${err?.message || String(err)}`,
+      model,
+      inputTokens,
+      elapsedMs: Date.now() - startedAt,
+    };
+  }
+}
+
 async function buildAnswerPayload(ctx: any, answerId: any) {
   const answer = await ctx.db.get(answerId);
   if (!answer) return null;
@@ -616,6 +832,162 @@ export const getPublishedWiki = query({
   },
 });
 
+export const _prepareAskAgentContext = internalQuery({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    question: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const question = (args.question || "").trim().slice(0, 1000);
+    if (!question) {
+      throw new ConvexError({ code: "empty_question", message: "/ask question required." });
+    }
+    const event = await ctx.db.get(args.eventId);
+    if (!event) {
+      throw new ConvexError({ code: "event_not_found", message: "Event no longer exists." });
+    }
+    if (event.status === "ended") {
+      throw new ConvexError({ code: "event_ended", message: "This event has ended." });
+    }
+    await requireMember(ctx, args.eventId, args.sessionId);
+    const normalizedQuestion = normalizeQuestion(question);
+    const cached = await ctx.db
+      .query("liveEventAnswers")
+      .withIndex("by_event_normalized", (q) =>
+        q.eq("eventId", args.eventId).eq("normalizedQuestion", normalizedQuestion),
+      )
+      .order("desc")
+      .first();
+    const sources = await ctx.db
+      .query("liveEventSources")
+      .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+      .take(100);
+    return {
+      event: {
+        _id: event._id,
+        slug: event.slug,
+        name: event.name,
+        status: event.status,
+      },
+      normalizedQuestion,
+      cached,
+      sources,
+    };
+  },
+});
+
+export const _upsertAgentSources = internalMutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sources: v.array(v.object({
+      uri: v.string(),
+      kind: v.union(
+        v.literal("transcript"),
+        v.literal("doc"),
+        v.literal("url"),
+        v.literal("slide"),
+      ),
+      title: v.string(),
+      excerpt: v.string(),
+      body: v.string(),
+    })),
+  },
+  handler: async (ctx, { eventId, sources }) => {
+    const rows: any[] = [];
+    for (const source of sources.slice(0, MAX_LINKUP_SOURCES)) {
+      const uri = source.uri.slice(0, 500);
+      const body = (source.body || source.excerpt || source.title).slice(0, MAX_SOURCE_BODY);
+      const existing = await ctx.db
+        .query("liveEventSources")
+        .withIndex("by_event_uri", (q) => q.eq("eventId", eventId).eq("uri", uri))
+        .first();
+      if (existing) {
+        rows.push(existing);
+        continue;
+      }
+      const id = await ctx.db.insert("liveEventSources", {
+        eventId,
+        uri,
+        kind: source.kind,
+        title: source.title.slice(0, 200),
+        excerpt: source.excerpt.slice(0, 500),
+        body,
+        sourceHash: stableHash(`${uri}|${body}`),
+        isSeeded: false,
+        uploadedAt: Date.now(),
+      });
+      const inserted = await ctx.db.get(id);
+      if (inserted) rows.push(inserted);
+    }
+    return rows;
+  },
+});
+
+export const _persistAgentAnswer = internalMutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    questionMessageId: v.id("liveEventMessages"),
+    question: v.string(),
+    normalizedQuestion: v.string(),
+    body: v.string(),
+    sourceIds: v.array(v.id("liveEventSources")),
+    trace: v.array(v.object({
+      step: v.string(),
+      status: v.union(v.literal("ok"), v.literal("miss"), v.literal("error")),
+      detail: v.optional(v.string()),
+      durationMs: v.number(),
+    })),
+    cacheHit: v.boolean(),
+    agentMode: v.union(
+      v.literal("deterministic"),
+      v.literal("provider"),
+      v.literal("provider_fallback"),
+      v.literal("cache"),
+    ),
+    provider: v.optional(v.string()),
+    modelId: v.optional(v.string()),
+    inputTokens: v.optional(v.number()),
+    outputTokens: v.optional(v.number()),
+    estimatedCostCents: v.optional(v.number()),
+    externalSearches: v.optional(v.number()),
+    evaluation: v.object({
+      passed: v.boolean(),
+      score: v.number(),
+      checks: v.array(v.object({
+        name: v.string(),
+        status: v.union(v.literal("pass"), v.literal("warn"), v.literal("fail")),
+        detail: v.optional(v.string()),
+      })),
+    }),
+  },
+  handler: async (ctx, args) => {
+    const answerId = await ctx.db.insert("liveEventAnswers", {
+      eventId: args.eventId,
+      questionMessageId: args.questionMessageId,
+      askedBySessionId: args.sessionId,
+      question: args.question,
+      normalizedQuestion: args.normalizedQuestion,
+      body: args.body.slice(0, MAX_ANSWER_BODY),
+      sourceIds: args.sourceIds,
+      trace: args.trace,
+      cacheHit: args.cacheHit,
+      agentMode: args.agentMode,
+      provider: args.provider,
+      modelId: args.modelId,
+      inputTokens: args.inputTokens,
+      outputTokens: args.outputTokens,
+      estimatedCostCents: args.estimatedCostCents,
+      externalSearches: args.externalSearches,
+      evaluation: args.evaluation,
+      faqStatus: "none",
+      createdAt: Date.now(),
+    });
+    return await buildAnswerPayload(ctx, answerId);
+  },
+});
+
 // ─── MUTATIONS ────────────────────────────────────────────────────────────
 
 /**
@@ -780,18 +1152,201 @@ export const sendMessage = mutation({
 });
 
 /**
- * composeAnswer — Phase 2 deterministic synthesis for /ask in live events.
+ * askAgent - provider-ready /ask path for live events.
  *
- * Ranks event sources by source-token-overlap against the question, then
- * stitches a citation-grounded answer together with NO LLM call. This is the
- * Phase 2 wiring that runs today.
- *
- * The future LLM-backed action (vector search + Anthropic) will ship as a
- * separate function named `askAgent` when the Anthropic integration lands —
- * see public/proto/docs.html "Live prod plan / Phase 2". Renaming this
- * function frees the `askAgent` name for that real-LLM caller and prevents
- * future readers from assuming LLM behavior that isn't here.
+ * This action is the production path. It reads only public event sources,
+ * optionally probes Linkup when freshness is justified, calls Anthropic when the
+ * key is configured, and falls back to deterministic synthesis with the same
+ * source and quality metadata. `composeAnswer` remains the deterministic
+ * mutation fallback for older clients or environments where Convex actions are
+ * unavailable.
  */
+export const askAgent = action({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    questionMessageId: v.id("liveEventMessages"),
+    question: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const startedAt = Date.now();
+    const question = (args.question || "").trim().slice(0, 1000);
+    let prepared: any = await ctx.runQuery((internal as any).events._prepareAskAgentContext, {
+      eventId: args.eventId,
+      sessionId: args.sessionId,
+      question,
+    });
+
+    if (prepared.cached) {
+      const evaluation = evaluateAnswerQuality({
+        question,
+        body: prepared.cached.body,
+        sourceCount: prepared.cached.sourceIds?.length ?? 0,
+        traceSteps: ["semantic_cache_lookup"],
+      });
+      return await ctx.runMutation((internal as any).events._persistAgentAnswer, {
+        eventId: args.eventId,
+        sessionId: args.sessionId,
+        questionMessageId: args.questionMessageId,
+        question,
+        normalizedQuestion: prepared.normalizedQuestion,
+        body: prepared.cached.body,
+        sourceIds: prepared.cached.sourceIds,
+        trace: [{
+          step: "semantic_cache_lookup",
+          status: "ok",
+          detail: `Reused public answer ${prepared.cached._id}; private notes excluded.`,
+          durationMs: Date.now() - startedAt,
+        }],
+        cacheHit: true,
+        agentMode: "cache",
+        provider: prepared.cached.provider || "cache",
+        modelId: prepared.cached.modelId || "cached-answer",
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostCents: 0,
+        externalSearches: 0,
+        evaluation,
+      });
+    }
+
+    let sources: any[] = prepared.sources || [];
+    if (sources.length === 0 && prepared.event?.slug === "ai-infra-summit-2026") {
+      await ctx.runMutation((api as any).events.ensureDemoEvent, {});
+      prepared = await ctx.runQuery((internal as any).events._prepareAskAgentContext, {
+        eventId: args.eventId,
+        sessionId: args.sessionId,
+        question,
+      });
+      sources = prepared.sources || [];
+    }
+
+    const retrievalStarted = Date.now();
+    let ranked = sources
+      .map((source: any) => ({ source, score: scoreSource(question, source) }))
+      .sort((a: any, b: any) => b.score - a.score || b.source.uploadedAt - a.source.uploadedAt);
+    const trace: Array<{ step: string; status: "ok" | "miss" | "error"; detail?: string; durationMs: number }> = [
+      {
+        step: "semantic_cache_lookup",
+        status: "miss",
+        detail: "No same-question public answer found for this event.",
+        durationMs: retrievalStarted - startedAt,
+      },
+    ];
+
+    let externalSearches = 0;
+    if (shouldProbeLiveSearch(question, ranked)) {
+      const externalStarted = Date.now();
+      const linkup = await searchLinkup(question);
+      trace.push({
+        step: "external_search",
+        status: linkup.status === "ok" ? "ok" : linkup.status === "skipped" ? "miss" : "error",
+        detail: linkup.detail,
+        durationMs: Date.now() - externalStarted,
+      });
+      if (linkup.status === "ok" && linkup.sources.length > 0) {
+        externalSearches = 1;
+        const rows = await ctx.runMutation((internal as any).events._upsertAgentSources, {
+          eventId: args.eventId,
+          sources: linkup.sources,
+        });
+        sources = [...sources, ...rows];
+        ranked = sources
+          .map((source: any) => ({ source, score: scoreSource(question, source) }))
+          .sort((a: any, b: any) => b.score - a.score || b.source.uploadedAt - a.source.uploadedAt);
+      }
+    } else {
+      trace.push({
+        step: "external_search",
+        status: "miss",
+        detail: "Skipped because event corpus had enough matching public sources.",
+        durationMs: 0,
+      });
+    }
+
+    const selected = ranked.filter((row: any) => row.score > 0).slice(0, MAX_AGENT_CONTEXT_SOURCES);
+    const topSources = (selected.length ? selected : ranked.slice(0, 3)).map((row: any) => row.source);
+    trace.push({
+      step: "bounded_source_retrieval",
+      status: topSources.length > 0 ? "ok" : "error",
+      detail: `Scored ${sources.length} sources; selected ${topSources.length}.`,
+      durationMs: Date.now() - retrievalStarted,
+    });
+    if (!topSources.length) {
+      throw new ConvexError({
+        code: "no_sources",
+        message: "No event sources are available for sourced /ask yet.",
+      });
+    }
+
+    const provider = await generateProviderAnswer({
+      eventName: prepared.event.name,
+      question,
+      sources: topSources,
+    });
+    let body: string;
+    let agentMode: "provider" | "provider_fallback";
+    if (provider.ok) {
+      body = provider.body;
+      agentMode = "provider";
+      trace.push({
+        step: "provider_llm",
+        status: "ok",
+        detail: `Anthropic ${provider.model}; estimated ${provider.estimatedCostCents} cents.`,
+        durationMs: provider.elapsedMs,
+      });
+    } else {
+      body = synthesizeAnswer(question, prepared.event.name, topSources).slice(0, MAX_ANSWER_BODY);
+      agentMode = "provider_fallback";
+      trace.push({
+        step: "provider_llm",
+        status: "error",
+        detail: provider.detail,
+        durationMs: provider.elapsedMs ?? 0,
+      });
+      trace.push({
+        step: "deterministic_fallback",
+        status: "ok",
+        detail: "Generated from public event corpus only; private notes excluded.",
+        durationMs: Date.now() - startedAt,
+      });
+    }
+
+    const evaluation = evaluateAnswerQuality({
+      question,
+      body,
+      sourceCount: topSources.length,
+      traceSteps: trace.map((step) => step.step),
+    });
+    trace.push({
+      step: "quality_gate",
+      status: evaluation.passed ? "ok" : "error",
+      detail: `Deterministic answer quality score ${evaluation.score}.`,
+      durationMs: Date.now() - startedAt,
+    });
+
+    return await ctx.runMutation((internal as any).events._persistAgentAnswer, {
+      eventId: args.eventId,
+      sessionId: args.sessionId,
+      questionMessageId: args.questionMessageId,
+      question,
+      normalizedQuestion: prepared.normalizedQuestion,
+      body,
+      sourceIds: topSources.map((source: any) => source._id),
+      trace,
+      cacheHit: false,
+      agentMode,
+      provider: provider.ok ? "anthropic" : "deterministic",
+      modelId: provider.model || "bounded-source-synthesizer",
+      inputTokens: provider.inputTokens ?? 0,
+      outputTokens: provider.outputTokens ?? estimateTokens(body),
+      estimatedCostCents: provider.estimatedCostCents ?? 0,
+      externalSearches,
+      evaluation,
+    });
+  },
+});
+
 export const composeAnswer = mutation({
   args: {
     eventId: v.id("liveEvents"),
@@ -830,6 +1385,7 @@ export const composeAnswer = mutation({
       const answerId = await ctx.db.insert("liveEventAnswers", {
         eventId: args.eventId,
         questionMessageId: args.questionMessageId,
+        askedBySessionId: args.sessionId,
         question,
         normalizedQuestion,
         body: cached.body,
@@ -843,6 +1399,19 @@ export const composeAnswer = mutation({
           },
         ],
         cacheHit: true,
+        agentMode: "cache",
+        provider: cached.provider,
+        modelId: cached.modelId,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostCents: 0,
+        externalSearches: 0,
+        evaluation: evaluateAnswerQuality({
+          question,
+          body: cached.body,
+          sourceCount: cached.sourceIds.length,
+          traceSteps: ["semantic_cache_lookup"],
+        }),
         faqStatus: "none",
         createdAt: Date.now(),
       });
@@ -870,6 +1439,7 @@ export const composeAnswer = mutation({
     const answerId = await ctx.db.insert("liveEventAnswers", {
       eventId: args.eventId,
       questionMessageId: args.questionMessageId,
+      askedBySessionId: args.sessionId,
       question,
       normalizedQuestion,
       body: answerBody,
@@ -895,6 +1465,19 @@ export const composeAnswer = mutation({
         },
       ],
       cacheHit: false,
+      agentMode: "deterministic",
+      provider: "deterministic",
+      modelId: "bounded-source-synthesizer",
+      inputTokens: estimateTokens(`${question}\n${topSources.map((source) => source.body).join("\n")}`),
+      outputTokens: estimateTokens(answerBody),
+      estimatedCostCents: 0,
+      externalSearches: 0,
+      evaluation: evaluateAnswerQuality({
+        question,
+        body: answerBody,
+        sourceCount: topSources.length,
+        traceSteps: ["semantic_cache_lookup", "bounded_source_retrieval", "deterministic_synthesis"],
+      }),
       faqStatus: "none",
       createdAt: Date.now(),
     });

--- a/convex/schema/eventsSchema.ts
+++ b/convex/schema/eventsSchema.ts
@@ -108,6 +108,7 @@ export const liveEventSources = defineTable({
 export const liveEventAnswers = defineTable({
   eventId: v.id("liveEvents"),
   questionMessageId: v.id("liveEventMessages"),
+  askedBySessionId: v.optional(v.string()),
   question: v.string(),
   normalizedQuestion: v.string(),
   body: v.string(),
@@ -123,6 +124,27 @@ export const liveEventAnswers = defineTable({
     durationMs: v.number(),
   })),
   cacheHit: v.boolean(),
+  agentMode: v.optional(v.union(
+    v.literal("deterministic"),
+    v.literal("provider"),
+    v.literal("provider_fallback"),
+    v.literal("cache"),
+  )),
+  provider: v.optional(v.string()),
+  modelId: v.optional(v.string()),
+  inputTokens: v.optional(v.number()),
+  outputTokens: v.optional(v.number()),
+  estimatedCostCents: v.optional(v.number()),
+  externalSearches: v.optional(v.number()),
+  evaluation: v.optional(v.object({
+    passed: v.boolean(),
+    score: v.number(),
+    checks: v.array(v.object({
+      name: v.string(),
+      status: v.union(v.literal("pass"), v.literal("warn"), v.literal("fail")),
+      detail: v.optional(v.string()),
+    })),
+  })),
   faqStatus: v.union(
     v.literal("none"),
     v.literal("suggested"),                             // attendee proposed it

--- a/docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md
+++ b/docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md
@@ -8,7 +8,7 @@ This note removes the recurring confusion between the two prototype surfaces.
 
 | Surface | Route | Backend status | Test expectation |
 | --- | --- | --- | --- |
-| ScratchNode v5 | `https://scratchnode.live/`, `/e/:slug` | Live Convex-backed event room. Phases 1-5 are wired. | Must prove data moves browser -> Convex -> second browser or rendered answer/wiki/note. |
+| ScratchNode v5 | `https://scratchnode.live/`, `/e/:slug` | Live Convex-backed event room. Phases 1-5 are wired, and `/ask` now uses the provider-ready `events:askAgent` action with deterministic fallback. | Must prove data moves browser -> Convex -> second browser or rendered answer/wiki/note. |
 | NodeBench v4 | `https://www.nodebenchai.com/proto/home-v4.html` | Static spec proof for notebook, artifacts, chat, mentions, backlinks, wide mode. | Must prove every interaction works, and must explicitly assert no live Convex runtime marker exists. |
 
 ## Live Dogfood Command
@@ -41,10 +41,12 @@ The dogfood covers these live boundaries:
 1. Apex `scratchnode.live/` serves the `home-v5` event shell and connects to Convex.
 2. Two anonymous browser contexts join the same event.
 3. Public chat from browser A appears in browser B through `events:sendMessage` and `events:getMessages`.
-4. `/ask` creates a sourced answer through `events:composeAnswer`.
+4. `/ask` creates a sourced answer through `events:askAgent`, falling back to `events:composeAnswer` only when Convex actions are unavailable.
 5. The rendered answer exposes:
    - source reuse
-   - deterministic synthesis trace
+   - provider or deterministic-fallback trace
+   - answer quality gate score
+   - model/cost metadata when the provider path runs
    - `no private notes`
    - `data-answer-id`
 6. FAQ suggestion changes answer state through `events:suggestAnswerForFaq`.

--- a/public/proto/docs.html
+++ b/public/proto/docs.html
@@ -405,7 +405,7 @@ kbd {
       <tbody>
         <tr><td>Identity / display name</td><td><span class="badge proto">Prototype</span></td><td>localStorage <code>sn_v5_name</code></td><td>Guest session + optional account with magic link</td></tr>
         <tr><td>Sign-in / magic link</td><td><span class="badge proto">Prototype</span></td><td><code>sendMagicLink()</code> just toasts</td><td>Real OTP email + verified session token</td></tr>
-        <tr><td>Private notes</td><td><span class="badge proto">Prototype</span></td><td><code>window._notes_v5</code> + localStorage</td><td>Per-user encrypted store, syncs across devices when signed in</td></tr>
+        <tr><td>Private notes</td><td><span class="badge prod">Production floor</span></td><td>Convex <code>userNotes</code> scoped by owner key, with local fallback only when backend is unavailable</td><td>Per-user encrypted store, syncs across devices when signed in</td></tr>
         <tr><td>Notes editor</td><td><span class="badge proto">Prototype</span></td><td><code>document.execCommand</code> rich-text</td><td>TipTap / ProseMirror with mentions, backlinks, graph anchors</td></tr>
         <tr><td>QR code generation</td><td><span class="badge proto">Prototype</span></td><td>External <code>api.qrserver.com</code> image</td><td>Client-side SVG generator — privacy, offline, branding</td></tr>
         <tr><td><code>sim*</code> demo helpers</td><td><span class="badge proto">Prototype</span></td><td>Global functions on <code>window</code></td><td>Hidden behind <code>?debug=1</code> or removed entirely in prod build</td></tr>
@@ -419,7 +419,7 @@ kbd {
     </table>
 
     <h2 id="production-arch">Production architecture <a class="anchor" href="#production-arch">#</a></h2>
-    <p>The prototype keeps everything in <code>window._notes_v5</code> and DOM. Production splits responsibilities across four layers so the runtime is fast, cheap, and the durable layer stays trustworthy. The product message stays simple: <strong>"Ask once, answer many. Live context while the event is happening. Durable wiki after it ends. Private notes stay private."</strong></p>
+    <p>The static file still has local fallback state, but <code>scratchnode.live</code> now boots a Convex-backed live runtime for chat, sourced answers, FAQ, wiki publishing, and private notes. Production splits responsibilities across four layers so the runtime is fast, cheap, and the durable layer stays trustworthy. The product message stays simple: <strong>"Ask once, answer many. Live context while the event is happening. Durable wiki after it ends. Private notes stay private."</strong></p>
 
     <h3 id="prod-stack">The stack</h3>
     <pre><span class="lang">arch</span>                         ┌──────────────────────────┐
@@ -657,22 +657,22 @@ curl -sL https://nodebenchai.com/ | grep -E <span class="str">'(VITE|root|index)
       <div class="tldr-label">⚡ TL;DR — where we are vs where we're going</div>
       <p><strong>Today (Phases 1-5 SHIPPED):</strong> <code>scratchnode.live/e/&lt;slug&gt;</code> is real Convex-backed multi-user chat with sourced <code>/ask</code>, FAQ suggestion, host claim, wiki publish, public source packets, answer cache, and private notes persisted through Convex. The current production floor is live enough to dogfood in a real small event room.</p>
       <p><strong>Goal:</strong> <em>"Two strangers on different devices open the same room URL and chat with each other in real time, with sourced agent answers and a private notebook each."</em> That core loop is now live through Convex; the remaining work is hardening quality, auth, rate limits, and provider-grade deep research.</p>
-      <p><strong>Remaining work:</strong> Replace the deterministic sourced-answer fallback with provider-grade research when keys/budget are enabled, add durable host authentication, add Redis/edge hot-room projection only after measuring Convex latency, and continue UX polish with browser QA. These are hardening layers, not blockers for the current live Convex product loop.</p>
+      <p><strong>Remaining work:</strong> Harden durable host authentication, add Redis/edge hot-room projection only after measuring Convex latency, and keep expanding browser QA. Provider-grade <code>/ask</code> now has a real action path with deterministic fallback; the next frontier is deeper research quality, not basic backend wiring.</p>
     </div>
 
     <h3 id="plan-where-we-are">Where we are today (honest baseline)</h3>
     <table class="status-table">
       <thead><tr><th>Capability</th><th>Today</th><th>Production target</th></tr></thead>
       <tbody>
-        <tr><td>Shared chat between visitors</td><td><span class="badge proto">DOM-only</span></td><td>Convex realtime query</td></tr>
-        <tr><td><code>/ask</code> agent answers</td><td><span class="badge proto">setTimeout(1100ms) → hardcoded card</span></td><td>Convex action → Anthropic + Linkup</td></tr>
-        <tr><td>Sources / citation counts</td><td><span class="badge proto">Hardcoded strings</span></td><td>Real source-bundle records w/ provenance</td></tr>
-        <tr><td>Private notes</td><td><span class="badge proto">window._notes_v5 + localStorage</span></td><td>Convex per-session table</td></tr>
+        <tr><td>Shared chat between visitors</td><td><span class="badge prod">Convex realtime query + presence</span></td><td>Rate limits, moderation, and account upgrade path</td></tr>
+        <tr><td><code>/ask</code> agent answers</td><td><span class="badge prod">Convex action → Anthropic when configured, deterministic fallback otherwise</span></td><td>Add richer eval sets, rate limits, and provider budgets</td></tr>
+        <tr><td>Sources / citation counts</td><td><span class="badge prod">Convex source records + answer source chips</span></td><td>Expand provider/source ingest coverage</td></tr>
+        <tr><td>Private notes</td><td><span class="badge prod">Convex per-session table with owner-key gating</span></td><td>Auth upgrade + encrypted per-user store</td></tr>
         <tr><td>Identity / display name</td><td><span class="badge proto">localStorage</span></td><td>Anon session UUID + optional auth upgrade</td></tr>
-        <tr><td>FAQ promote / wiki publish</td><td><span class="badge proto">Toast only</span></td><td>Server-gated mutation w/ role check</td></tr>
-        <tr><td>Sign-in</td><td><span class="badge proto">Toast only</span></td><td>Redirect to <code>nodebenchai.com/sign-in?return=…</code></td></tr>
-        <tr><td>Event wiki</td><td><span class="badge proto">Hardcoded HTML in sheet</span></td><td>Convex-backed, version-snapshotted, compacted on event end</td></tr>
-        <tr><td>Semantic answer cache</td><td><span class="badge proto">None</span></td><td>Redis LangCache pattern (Phase 6)</td></tr>
+        <tr><td>FAQ promote / wiki publish</td><td><span class="badge prod">Convex mutations with host gate</span></td><td>Reviewer workflow, audit trail, and stronger policy UI</td></tr>
+        <tr><td>Sign-in</td><td><span class="badge proto">Guest/session + host-code auth</span></td><td>Redirect to <code>nodebenchai.com/sign-in?return=…</code></td></tr>
+        <tr><td>Event wiki</td><td><span class="badge prod">Convex-backed, version snapshotted</span></td><td>Scheduled compaction and richer source grouping</td></tr>
+        <tr><td>Semantic answer cache</td><td><span class="badge prod">Exact normalized public-answer cache</span></td><td>Redis/LangCache semantic projection only after measuring need</td></tr>
       </tbody>
     </table>
 
@@ -806,10 +806,10 @@ eventAnswers: <span class="fn">defineTable</span>({
 
         <h4>Convex action + UI wiring</h4>
         <ul class="checklist">
-          <li><input type="checkbox"> <span><code>convex/events/actions.ts</code> — <code>askAgent({eventId, question, sessionId})</code>: vector-search <code>eventSources</code> (top-k=8), prior <code>eventAnswers</code> (cache lookup), call Anthropic with retrieved context, return <code>{answerId, body, sourceIds, trace}</code></span></li>
-          <li><input type="checkbox"> <span>Replace <code>streamAgentAnswer</code>'s <code>setTimeout</code> with: <code>const result = await client.action(api.events.askAgent, {eventId, question, sessionId})</code></span></li>
-          <li><input type="checkbox"> <span>Render <code>result.sources</code> as the source chips (with real URLs from <code>eventSources</code>)</span></li>
-          <li><input type="checkbox"> <span>Render <code>result.trace</code> as the 5-step canonical trace (real durations from action steps)</span></li>
+          <li><input type="checkbox" checked> <span><code>convex/events.ts</code> — <code>askAgent({eventId, question, sessionId})</code>: bounded public-source retrieval, prior <code>eventAnswers</code> cache lookup, optional Linkup freshness probe, Anthropic provider call when configured, deterministic fallback, quality gate, and persisted <code>{answerId, body, sourceIds, trace}</code></span></li>
+          <li><input type="checkbox" checked> <span>Replace <code>streamAgentAnswer</code>'s <code>setTimeout</code> with: <code>client.action('events:askAgent', {eventId, question, sessionId})</code>, falling back to <code>events:composeAnswer</code> only if actions are unavailable</span></li>
+          <li><input type="checkbox" checked> <span>Render <code>result.sources</code> as the source chips (with real URLs from <code>eventSources</code>)</span></li>
+          <li><input type="checkbox" checked> <span>Render <code>result.trace</code>, model/cost metadata, live-search count, and deterministic QA score as the canonical agent trace</span></li>
           <li><input type="checkbox"> <span>Replace the hardcoded reuse chip (<em>"Answered from event wiki · 12 similar"</em>) with counts from <code>result</code></span></li>
           <li><input type="checkbox"> <span>Wire "Suggest for FAQ" / "Promote to FAQ" buttons to a server mutation that updates <code>eventAnswers.faqStatus</code> (gated by role in Phase 4)</span></li>
         </ul>
@@ -821,7 +821,7 @@ eventAnswers: <span class="fn">defineTable</span>({
         </ul>
 
         <p class="accept">/ask "What is the MCP auth timeline?" — answer comes back in &lt;5s, body is non-canned text grounded in the seeded sources, source chips link to real URLs, trace shows real durations. Same question 30s later: cache hit, &lt;500ms, trace says "Matched 1 similar in semantic cache".</p>
-        <p class="risk">Anthropic API key in Convex env (<code>ANTHROPIC_API_KEY</code>) — already set for the workspace. Cost: ~$0.01–0.05 per /ask depending on model and context size. Mitigation: per-event spending caps + the cache hit path.</p>
+        <p class="risk">Anthropic API key in Convex env (<code>ANTHROPIC_API_KEY</code>) - required for provider generation. If it is missing or the provider fails, the same public-source action falls back to deterministic synthesis. Cost: track per answer and cap by event budget.</p>
       </div>
     </div>
 
@@ -1354,7 +1354,7 @@ eventAnswers: <span class="fn">defineTable</span>({
       <li><strong>Private notes never feed the public wiki.</strong> The wiki compaction reads only public messages, /ask answers, and host-uploaded sources.</li>
       <li><strong>UI promise matches data path.</strong> The composer reads "only your notebook" while purple — the code path matches that string.</li>
       <li><strong>Mentions ≠ notifications.</strong> Inserting <code>@Alex</code> renders a pill but does not call a notification endpoint in v5.</li>
-      <li><strong>localStorage is per-device.</strong> No data leaves the browser in either prototype.</li>
+      <li><strong>v4 stays local; v5 is live.</strong> <code>home-v4.html</code> stores only browser-local prototype data. <code>home-v5.html</code> writes public room data and private owner-key-scoped notes to Convex when loaded through <code>scratchnode.live</code>.</li>
     </ol>
 
     <h2 id="closing">What's next <a class="anchor" href="#closing">#</a></h2>

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -3093,6 +3093,20 @@ setTimeout(refreshNotesCounter, 100);
     const sourceChips = (answer.sources || []).slice(0, 5).map((source) =>
       '<span title="' + snEscape(source.excerpt || source.uri) + '">' + snEscape(source.title || source.uri) + '</span>'
     ).join('');
+    const liveSearches = Number(answer.externalSearches || 0);
+    const agentLabel = answer.agentMode === 'provider'
+      ? ('AI agent' + (answer.modelId ? ' · ' + answer.modelId : ''))
+      : answer.agentMode === 'provider_fallback'
+        ? 'AI fallback · deterministic'
+        : answer.cacheHit
+          ? 'cache hit'
+          : 'sourced answer';
+    const costLabel = typeof answer.estimatedCostCents === 'number'
+      ? answer.estimatedCostCents.toFixed(4) + '¢'
+      : 'cost tracked';
+    const qualityLabel = answer.evaluation && typeof answer.evaluation.score === 'number'
+      ? 'QA ' + answer.evaluation.score
+      : 'QA pending';
     const trace = (answer.trace || []).map((step) =>
       '<div class="step"><span class="c">' + (step.status === 'ok' ? '&check;' : step.status === 'miss' ? '&middot;' : '!') + '</span><span>' +
       snEscape(String(step.step || '').replace(/_/g, ' ')) + (step.detail ? ' · ' + snEscape(step.detail) : '') +
@@ -3104,7 +3118,7 @@ setTimeout(refreshNotesCounter, 100);
       '<div class="ans-q"></div>' +
       '<div class="ans-body"></div>' +
       '<div class="ans-sources">' + (sourceChips || '<span>public event corpus</span>') + '<span>' + sourceCount + ' sources</span></div>' +
-      '<div class="ans-reuse" aria-label="Reuse summary"><span class="pin">' + (answer.cacheHit ? 'Answered from cache' : 'Answered from event corpus') + '</span><span class="sep">·</span><span><b>' + sourceCount + '</b> reused</span><span class="sep">·</span><span class="pulled"><b>0</b> live searches</span><span class="sep">·</span><span class="priv">no private notes</span></div>' +
+      '<div class="ans-reuse" aria-label="Reuse summary"><span class="pin">' + agentLabel + '</span><span class="sep">·</span><span><b>' + sourceCount + '</b> reused</span><span class="sep">·</span><span class="pulled"><b>' + liveSearches + '</b> live searches</span><span class="sep">·</span><span>' + costLabel + '</span><span class="sep">·</span><span>' + qualityLabel + '</span><span class="sep">·</span><span class="priv">no private notes</span></div>' +
       '<button class="ans-show" type="button" aria-expanded="false" onclick="toggleHow(this)">Show trace &rarr;</button>' +
       '<div class="ans-how">' + trace + '</div>' +
       '<div class="ans-actions"><button type="button" class="primary attendee-only" onclick="window.snSuggestFaq && window.snSuggestFaq(\'' + answer._id + '\')">Suggest for FAQ</button><button type="button" class="primary host-only" onclick="window.snPromoteFaq && window.snPromoteFaq(\'' + answer._id + '\')">Promote to FAQ</button> <button type="button" onclick="openWiki()">View in wiki &rarr;</button> <button type="button" onclick="document.getElementById(\'ci\').focus()">Follow-up</button></div>';
@@ -3147,12 +3161,19 @@ setTimeout(refreshNotesCounter, 100);
       kind: intent.kind === 'agent_ask' ? 'ask' : 'chat',
     }).then((res) => {
       if (intent.kind !== 'agent_ask') return null;
-      return client.mutation('events:composeAnswer', {
+      const payload = {
         eventId,
         sessionId,
         questionMessageId: res.messageId,
         question: intent.clean,
-      }).then((answer) => {
+      };
+      const runAsk = typeof client.action === 'function'
+        ? client.action('events:askAgent', payload).catch((actionError) => {
+            console.warn('[scratchnode] askAgent action failed, falling back to composeAnswer:', actionError.message || actionError);
+            return client.mutation('events:composeAnswer', payload);
+          })
+        : client.mutation('events:composeAnswer', payload);
+      return runAsk.then((answer) => {
         if (answer) renderAnswer(answer);
       });
     }).catch((e) => {

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -139,9 +139,15 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
     const answerRecord = await queryAnswer(pageA, answer!.id!);
     expect(answerRecord.cacheHit).toBe(false);
     expect(answerRecord.sources.length).toBeGreaterThan(0);
-    expect(answerRecord.trace.some((step: any) => step.step === "deterministic_synthesis")).toBe(
-      true,
-    );
+    expect(["provider", "provider_fallback", "deterministic"]).toContain(answerRecord.agentMode);
+    expect(answerRecord.evaluation?.passed).toBe(true);
+    expect(answerRecord.evaluation?.score).toBeGreaterThanOrEqual(80);
+    expect(
+      answerRecord.trace.some((step: any) =>
+        ["provider_llm", "deterministic_synthesis", "deterministic_fallback"].includes(step.step),
+      ),
+    ).toBe(true);
+    expect(answerRecord.trace.some((step: any) => step.step === "quality_gate")).toBe(true);
 
     await pageA.evaluate((answerId) => (window as any).snSuggestFaq(answerId), answer!.id);
     await expect


### PR DESCRIPTION
﻿## Summary

This makes ScratchNode v5's `/ask` path provider-ready without replacing the existing Convex-backed event-room product loop.

- Adds `events:askAgent` as the production action for public event questions.
- Keeps Convex as source of truth and reads only `liveEventSources` / `liveEventAnswers`, never private notes.
- Uses bounded source retrieval, exact public-answer cache reuse, optional Linkup freshness probe, Anthropic provider generation when `ANTHROPIC_API_KEY` is configured, and deterministic fallback when the provider/search path is unavailable.
- Persists agent mode, provider/model, token/cost estimate, external-search count, deterministic quality-gate result, and trace steps on `liveEventAnswers`.
- Updates `home-v5.html` to call `events:askAgent` first and fall back to `events:composeAnswer` only when actions are unavailable.
- Updates docs so future sessions know: `home-v4.html` is still the static NodeBench spec proof; `home-v5.html` is the live ScratchNode event-room surface.

## Why

The product had live Convex chat, sources, FAQ, host auth, wiki, and notes, but `/ask` was still deterministic-only and docs still created confusion between prototype/spec surfaces and live surfaces. This closes that backend boundary while preserving safe fallback behavior.

## Verification

- `npx tsc -p convex --noEmit --pretty false`
- `npx vitest run convex/events.runtime-boundary.test.ts convex/__tests__/scratchnode.events.test.ts` (22 tests)
- `npx tsc --noEmit --pretty false`
- `npm run build`

## Post-merge live dogfood required

Run after Convex deploys this branch to production:

```powershell
npm run dogfood:proto-live-backend
```

That is intentionally post-merge because production currently does not have `events:askAgent`; running the updated dogfood suite before deploy would exercise the old backend.

## Runtime notes

- Provider generation requires `ANTHROPIC_API_KEY`; otherwise the same action falls back to deterministic source synthesis and records `agentMode: "provider_fallback"`.
- Linkup is gated by `SCRATCHNODE_ALLOW_LINKUP=1` plus `LINKUP_API_KEY`.
- Private notes remain structurally isolated from public `/ask` and wiki paths.
