### PR TITLE
feat(scratchnode): releaseHost mutation — unblock stuck legacy-host events

### DIFF
--- a/convex/__tests__/scratchnode.events.test.ts
+++ b/convex/__tests__/scratchnode.events.test.ts
@@ -38,7 +38,7 @@ import { describe, expect, it } from "vitest";
 import { convexTest } from "convex-test";
 
 import * as eventsModule from "../events";
-import { publishWiki, claimHost, requestHostClaim } from "../events";
+import { publishWiki, claimHost, requestHostClaim, releaseHost } from "../events";
 import schema from "../schema";
 import { api } from "../_generated/api";
 
@@ -1215,5 +1215,204 @@ describe("requestHostClaim — optional Resend email delivery", () => {
     expect(ctx.scheduler.calls.length).toBe(1);
     const args = ctx.scheduler.calls[0].args as { email: string };
     expect(args.email).toBe("good@ex.com");
+  });
+});
+
+/* ========================================================================== */
+/* Test 7 — releaseHost                                                        */
+/* ========================================================================== */
+
+describe("releaseHost — host can relinquish ownership", () => {
+  /**
+   * Scenario:    The current host needs to step down (lost access, rotating
+   *              away from a test event, etc.). They call releaseHost with
+   *              their ownerKey. The contract: their host row is deleted,
+   *              any dangling claim code is cleared, and the event is now
+   *              freshly claimable by anyone.
+   * User:        Current host with legacy plain-string ownerKey
+   * Goal:        Step down so the event can be re-claimed by someone else
+   * Prior state: event live; one liveEventHosts row owned by HOST_OWNER_KEY
+   * Actions:     releaseHost({ eventId, ownerKey: HOST_OWNER_KEY })
+   * Scale:       1 user
+   * Duration:    Sub-second
+   * Expected:    ok=true, released=true, hostsDeleted=1. liveEventHosts is
+   *              now empty. claimHost with a NEW ownerKey now succeeds.
+   */
+  it("host can release with valid legacy ownerKey", async () => {
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventHosts: [
+        {
+          _id: "liveEventHosts:1",
+          eventId: "liveEvents:1",
+          ownerKey: HOST_OWNER_KEY,
+          displayName: "Host",
+          role: "owner",
+          createdAt: 1_700_000_000_000,
+        },
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await (releaseHost as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+      ownerKey: HOST_OWNER_KEY,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.released).toBe(true);
+    expect(result.hostsDeleted).toBe(1);
+    expect(tables.liveEventHosts.length).toBe(0);
+
+    // A new ownerKey can now claim cleanly.
+    const newOwnerKey = "different-owner-key-67890";
+    const newClaim = await (claimHost as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+      ownerKey: newOwnerKey,
+      displayName: "Fresh Host",
+    });
+    expect(newClaim.ok).toBe(true);
+    expect(newClaim.created).toBe(true);
+    expect(tables.liveEventHosts.length).toBe(1);
+    expect(tables.liveEventHosts[0].ownerKey).toBe(newOwnerKey);
+  });
+
+  /**
+   * Scenario:    An attendee tries to release a host they don't own.
+   *              requireHost must reject them with code=not_host. The host
+   *              row stays intact. This protects against the most obvious
+   *              attack: anyone who knows the eventId calling releaseHost
+   *              to steal control.
+   * User:        Attacker / attendee
+   * Goal:        Steal host by force-releasing
+   * Prior state: event live; HOST_OWNER_KEY holds host row
+   * Actions:     releaseHost with ATTENDEE_OWNER_KEY
+   * Scale:       1 attacker
+   * Expected:    Throws code=not_host. liveEventHosts unchanged (still 1 row,
+   *              still owned by HOST_OWNER_KEY).
+   */
+  it("non-host cannot release another host's event", async () => {
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventHosts: [
+        {
+          _id: "liveEventHosts:1",
+          eventId: "liveEvents:1",
+          ownerKey: HOST_OWNER_KEY,
+          displayName: "Host",
+          role: "owner",
+          createdAt: 1_700_000_000_000,
+        },
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    await expect(
+      (releaseHost as any)._handler(ctx, {
+        eventId: "liveEvents:1",
+        ownerKey: ATTENDEE_OWNER_KEY,
+      }),
+    ).rejects.toThrow(/not_host|Host ownership/i);
+
+    expect(tables.liveEventHosts.length).toBe(1);
+    expect(tables.liveEventHosts[0].ownerKey).toBe(HOST_OWNER_KEY);
+  });
+
+  /**
+   * Scenario:    Defense-in-depth — when a host releases, any dangling
+   *              hostClaimCodeHash + hostClaimCodeCreatedAt on the event
+   *              row MUST be cleared, so a mid-rotation code can't be
+   *              exploited by the next person to call claimHostWithCode
+   *              without going through requestHostClaim.
+   * User:        Host who minted a claim code (for rotation) and then
+   *              changed their mind and released directly
+   * Goal:        Leave the event in a clean state with no exploitable
+   *              dangling state
+   * Prior state: event has hostClaimCodeHash + hostClaimCodeCreatedAt;
+   *              host row exists
+   * Actions:     releaseHost
+   * Scale:       1 host
+   * Expected:    Both hostClaimCodeHash and hostClaimCodeCreatedAt are
+   *              cleared from the event row.
+   */
+  it("clears dangling claim code on release (defense-in-depth)", async () => {
+    const event = baseEvent({
+      hostClaimCodeHash: "sha256:fake-hash-from-prior-requestHostClaim",
+      hostClaimCodeCreatedAt: 1_700_000_000_000,
+    });
+    const tables: Tables = {
+      liveEvents: [event],
+      liveEventHosts: [
+        {
+          _id: "liveEventHosts:1",
+          eventId: "liveEvents:1",
+          ownerKey: HOST_OWNER_KEY,
+          displayName: "Host",
+          role: "owner",
+          createdAt: 1_700_000_000_000,
+        },
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await (releaseHost as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+      ownerKey: HOST_OWNER_KEY,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(tables.liveEvents[0].hostClaimCodeHash).toBeUndefined();
+    expect(tables.liveEvents[0].hostClaimCodeCreatedAt).toBeUndefined();
+  });
+
+  /**
+   * Scenario:    A host who's been rotated (e.g. via claimHostWithCode
+   *              after a prior release) calls releaseHost. The releaseHost
+   *              implementation must clean up EVERY host row for the event,
+   *              not just the one matching the calling ownerKey. This
+   *              protects against rotation history leaving stale rows that
+   *              would block future claims.
+   * User:        Host with rotation history
+   * Goal:        Fully release so the next claim starts clean
+   * Prior state: event live; 2 liveEventHosts rows (current + stale legacy)
+   * Actions:     releaseHost with the CURRENT host's ownerKey
+   * Scale:       1 user
+   * Expected:    Both host rows deleted. hostsDeleted=2.
+   */
+  it("deletes all host rows for the event, not just the calling row", async () => {
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventHosts: [
+        {
+          _id: "liveEventHosts:1",
+          eventId: "liveEvents:1",
+          ownerKey: HOST_OWNER_KEY,
+          displayName: "Current Host",
+          role: "owner",
+          authMethod: "claim_code",
+          createdAt: 1_700_000_000_100,
+        },
+        {
+          _id: "liveEventHosts:2",
+          eventId: "liveEvents:1",
+          ownerKey: "stale-legacy-key-from-old-rotation",
+          displayName: "Stale Host",
+          role: "owner",
+          authMethod: "legacy_ownerkey",
+          createdAt: 1_700_000_000_000,
+        },
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await (releaseHost as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+      ownerKey: HOST_OWNER_KEY,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.released).toBe(true);
+    expect(result.hostsDeleted).toBe(2);
+    expect(tables.liveEventHosts.length).toBe(0);
   });
 });

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1854,6 +1854,67 @@ export const publishWiki = mutation({
 });
 
 /**
+ * releaseHost — relinquish host ownership of an event.
+ *
+ * Why this exists: once a `liveEventHosts` row exists, both `claimHost` and
+ * `requestHostClaim` refuse to proceed (a different ownerKey gets either
+ * `host_already_claimed` or `legacy_host_must_rotate_first`). Without a
+ * release path, an event whose host loses access OR a test event that needs
+ * to be reset is permanently stuck. This is the canonical release.
+ *
+ * Auth: the caller must prove possession of the CURRENT host's ownerKey —
+ * either the legacy plain-string format OR the `hk1:` HMAC token. Same
+ * `requireHost` gate that `promoteAnswerToFaq` / `publishWiki` use.
+ *
+ * Side effects:
+ *   - Deletes ALL `liveEventHosts` rows for this eventId (rotation history
+ *     can leave more than one row from prior `claimHostWithCode` migrations;
+ *     this clears them all so the next host starts from a clean state).
+ *   - Clears `liveEvents.hostClaimCodeHash` + `hostClaimCodeCreatedAt` so a
+ *     dangling code mid-rotation doesn't become exploitable.
+ *
+ * HONEST_STATUS: emits `console.warn` for audit visibility — host release
+ * is a destructive operation and operators should see it in logs.
+ *
+ * Idempotency: a second call from a now-non-host caller throws `not_host`
+ * (because the host row was just deleted). This is correct — the operation
+ * was applied, the contract is "you must be the current host to call this."
+ */
+export const releaseHost = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    ownerKey: v.string(),
+  },
+  handler: async (ctx, { eventId, ownerKey }) => {
+    const callingHost = await requireHost(ctx, eventId, ownerKey);
+    // Pull every host row for the event — rotation may have left more than
+    // one. Use the by_event index so we don't scan the full table.
+    const allHosts = await ctx.db
+      .query("liveEventHosts")
+      .withIndex("by_event", (q: any) => q.eq("eventId", eventId))
+      .collect();
+    let hostsDeleted = 0;
+    for (const row of allHosts) {
+      await ctx.db.delete(row._id);
+      hostsDeleted += 1;
+    }
+    // Defensive: clear any dangling claim code so the event is fully reset.
+    const event = await ctx.db.get(eventId);
+    if (event && (event.hostClaimCodeHash || event.hostClaimCodeCreatedAt)) {
+      await ctx.db.patch(eventId, {
+        hostClaimCodeHash: undefined,
+        hostClaimCodeCreatedAt: undefined,
+      });
+    }
+    console.warn(
+      `[releaseHost] eventId=${eventId} hostsDeleted=${hostsDeleted} ` +
+        `by=${callingHost.role} authMethod=${callingHost.authMethod ?? "legacy_ownerkey"}`,
+    );
+    return { ok: true, released: hostsDeleted > 0, hostsDeleted };
+  },
+});
+
+/**
  * Cheap presence heartbeat. UI calls this every 30s. Idempotent — early-returns
  * if lastSeenAt was bumped within the last 15s (rate-limits accidental spam).
  */


### PR DESCRIPTION
## Summary

Adds `events:releaseHost` mutation so a current host can relinquish ownership of an event. The Phase 4 follow-up Item #4 (originally bundled with the frontend flip and dogfood unstuck — the frontend flip already shipped via PR #401's predecessors, this PR closes the loop with the backend release path + tests).

## Why

Once a `liveEventHosts` row exists, both `claimHost` (legacy) and `requestHostClaim` (Phase 4) refuse a different `ownerKey` (`host_already_claimed` / `legacy_host_must_rotate_first`). Without a release path, an event held by a lost-access host OR a test event needing reset is permanently stuck.

The demo event `ai-infra-summit-2026` has been in exactly this state since dogfood runs landed a static `dogfood-alice-static-host-key-2026-aaaaaaaaaaaa` host row. This blocks real users from claiming host on the demo, and blocks Phase 4 scenarios from running cleanly.

## API

```ts
events:releaseHost({ eventId, ownerKey })
  → { ok: true, released: boolean, hostsDeleted: number }
```

Auth: caller must prove possession of the **current** host's `ownerKey` (legacy plain string OR `hk1:` HMAC token). Same `requireHost` gate that `promoteAnswerToFaq` and `publishWiki` use.

Side effects (atomic):
- Deletes ALL `liveEventHosts` rows for the event (handles rotation history)
- Clears `liveEvents.hostClaimCodeHash` + `hostClaimCodeCreatedAt` (defense-in-depth — dangling code can't be exploited after release)
- Emits `console.warn` for audit visibility (per `HONEST_STATUS`)

## Tests (4 new, 18/18 total)

| # | Scenario | Verifies |
|---|---|---|
| 1 | Happy path | host releases → row deleted → new ownerKey can claim |
| 2 | Auth gate | non-host gets `not_host` error; host row intact |
| 3 | Defense-in-depth | dangling `hostClaimCodeHash` cleared on release |
| 4 | Rotation history | all 2 rows deleted when event has stale + current host |

All use the existing MockDb pattern (scope discipline — `convex-test` is only used for the race test per PR #400).

## Verification

- ✅ `npx tsc --noEmit --pretty false` — clean
- ✅ `npx tsc -p convex --noEmit --pretty false` — clean
- ✅ `npx vitest run convex/__tests__/scratchnode.events.test.ts` — **18/18 pass** (14 prior + 4 new)
- ✅ `npm run build` — clean

## Post-merge action

After deploy, unstick the demo event:

```bash
npx convex run --prod events:releaseHost '{
  "eventId":"k19t4ejhxaj5vz87r6hmaar7r987ett4",
  "ownerKey":"dogfood-alice-static-host-key-2026-aaaaaaaaaaaa"
}'
```

Then `node scripts/scratchnode-multi-user-dogfood.mjs` — Scenarios 8/9/13/14 should drop their "SKIPPED — host blocked by previous run pollution" branch and execute the real flow (true 24/24 with no skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
