### PR TITLE
feat(scratchnode): lock NodeBench private handoff

### DIFF
--- a/docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
+++ b/docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
@@ -1,0 +1,154 @@
+# ScratchNode Live <-> NodeBench AI Boundary
+
+Last updated: 2026-05-27
+
+## Locked Product Sentence
+
+ScratchNode Live is the public event room. NodeBench AI is the private intelligence workspace behind it.
+
+## Public vs Private Surfaces
+
+```text
+scratchnode.live
+= public event room
+= guest-first, no-account
+= one room, one feed, one notebook
+= public chat, public /ask, public wiki
+
+nodebenchai.com
+= private/user workspace
+= notebooks, artifacts, reports, daily brief, private memory
+= event continuation after ScratchNode proves value
+
+NodeBench Runtime
+= shared backend, Convex truth, agent orchestration, search, graph, traces, cost control
+```
+
+Keep ScratchNode v5 simple. Put v4 depth in NodeBench.
+
+## Current Prototype Roles
+
+```text
+public/proto/home-v5.html
+= ScratchNode Live product target
+= live Convex-backed event-room dogfood surface
+= public room, public feed, public /ask, public wiki, private-note entrypoint
+
+public/proto/home-v4.html
+= NodeBench AI workspace design target
+= authenticated workspace depth reference
+= notebooks, artifacts, private memory, graphs, daily brief, trace-rich agent work
+```
+
+Do not wire `home-v4.html` as the public ScratchNode event room. Use it as the UI kit packet for porting NodeBench workspace depth into production React surfaces. Until that port is complete, `home-v4.html` should remain honest about being a prototype and should not claim live backend parity.
+
+## URL Contract
+
+ScratchNode public event URLs:
+
+```text
+https://scratchnode.live/
+https://scratchnode.live/e/:eventSlug
+https://scratchnode.live/join/:roomCode
+https://scratchnode.live/e/:eventSlug/wiki
+https://scratchnode.live/e/:eventSlug/archive
+```
+
+NodeBench private continuation URLs:
+
+```text
+https://nodebenchai.com/events/:eventSlug/private?source=scratchnode&room=:roomCode&return=:scratchnodeEventUrl
+https://nodebenchai.com/sign-in?return=:nodebenchPrivateEventUrl&intent=save-private-notes
+```
+
+Current implementation in `public/proto/home-v5.html` exposes:
+
+```text
+EVENT_URL
+buildNodeBenchEventPrivateUrl()
+buildNodeBenchSignInUrl()
+openNodeBenchPrivateHandoff()
+```
+
+The release test must fail if any active share or handoff URL regresses to `scratchnode.com`.
+
+## Composer Contract
+
+The ScratchNode composer has exactly three branches:
+
+```text
+parseComposerIntent(raw)
+  -> getRoomContext()
+  -> getIdentity()
+  -> if private: save private note only
+  -> if public /ask: send public ask and agent answer
+  -> else: send public chat
+```
+
+Private notes must return before public feed insertion. Normal chat must never invoke the agent.
+
+## Data Boundary
+
+Public data may become FAQ/wiki:
+
+```text
+liveEventMessages
+liveEventAnswers
+liveEventSources
+liveEventWikiVersions
+```
+
+Private data may become the user's NodeBench notebook:
+
+```text
+userNotes
+future authenticated notebooks/notebookBlocks
+```
+
+Never allow `userNotes` into public `/ask`, FAQ promotion, wiki compaction, public cache, or public trace.
+
+## Runtime Rule
+
+Convex remains durable source of truth. Redis and Typesense are projections only after measured need:
+
+```text
+Convex: truth, permissions, event records, notes, sources, wiki, traces
+Redis: hot room state, active run state, semantic answer cache
+Typesense: search-as-you-type, @mention autocomplete, human-facing search
+Linkup: external discovery only when event corpus misses or freshness requires it
+pi-ai / NodeBench runtime: orchestration and governed tools, not raw database access
+```
+
+## Trace Contract
+
+ScratchNode shows a compact public trace:
+
+```text
+context selected
+cache hit or miss
+sources reused
+Linkup skipped or used
+private notes excluded
+```
+
+NodeBench may show the full trace DAG with tool calls, artifacts, graph updates, and notebook patches.
+
+## Minimum QA Gates
+
+```text
+SN-LIVE-001 scratchnode.live/e/:slug loads without login
+SN-LIVE-002 guest joins with room code
+SN-LIVE-003 normal chat does not invoke agent
+SN-LIVE-004 /ask invokes agent
+SN-LIVE-005 agent answer is nested under parent ask
+SN-LIVE-006 answer trace shows no private notes used
+SN-LIVE-007 private note does not appear in public feed
+SN-LIVE-008 private note appears in private notebook
+SN-LIVE-009 attendee sees Suggest for FAQ
+SN-LIVE-010 host sees Promote to FAQ
+SN-LIVE-011 host can publish wiki
+SN-LIVE-012 published wiki excludes private notes
+SN-LIVE-013 share URL uses scratchnode.live
+SN-LIVE-014 guest can sign in and preserve notes
+SN-LIVE-015 NodeBench workspace handoff URL carries event + private-note continuation context
+```

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1059,6 +1059,7 @@ body[data-new-user="true"] .h-menu::after {
   <!-- Notes appear once user has set a name (matches the privacy/identity contract) -->
   <h4 style="margin-top:14px" data-show-for="named">Your notes</h4>
   <button type="button" data-show-for="named" onclick="openNotes()">My private notes<span class="sub">🔒 only you can see</span></button>
+  <button type="button" onclick="openNodeBenchPrivateHandoff()">Continue in NodeBench<span class="sub">Private notes + event artifact</span></button>
   <!-- Host console hidden until data-role="host" on body -->
   <h4 style="margin-top:14px" data-show-for="host">For hosts</h4>
   <button type="button" data-show-for="host" onclick="openHost()">Host console<span class="sub">Moderation · /ask queue · Publish wiki</span></button>
@@ -1126,11 +1127,44 @@ var PUBLIC_BASE_URL = (function() {
 var EVENT_SLUG = 'ai-infra-summit-2026';
 var EVENT_URL = PUBLIC_BASE_URL + '/e/' + EVENT_SLUG;
 // On scratchnode.live, host-actions (sign-in, host console) live on the workspace domain.
-var WORKSPACE_BASE_URL = 'https://nodebenchai.com';
+var CANONICAL_WORKSPACE_HOST = 'nodebenchai.com';
+var WORKSPACE_BASE_URL = (function() {
+  try {
+    var h = location.hostname || '';
+    var proto = (location.protocol === 'http:' || location.protocol === 'https:') ? location.protocol : 'https:';
+    if (h === CANONICAL_WORKSPACE_HOST || h === 'www.' + CANONICAL_WORKSPACE_HOST) {
+      return proto + '//' + h + (location.port && location.port !== '80' && location.port !== '443' ? (':' + location.port) : '');
+    }
+  } catch (e) {}
+  return 'https://' + CANONICAL_WORKSPACE_HOST;
+})();
 var ON_PUBLIC_DOMAIN = (function() {
   try { return location.hostname === CANONICAL_PUBLIC_HOST || location.hostname.endsWith('.' + CANONICAL_PUBLIC_HOST); }
   catch (e) { return false; }
 })();
+
+function buildNodeBenchEventPrivateUrl() {
+  var roomCode = 'ORBITAL';
+  try {
+    var room = getRoomContext();
+    roomCode = (room && room.roomCode) || roomCode;
+  } catch (e) {}
+  return WORKSPACE_BASE_URL +
+    '/events/' + encodeURIComponent(EVENT_SLUG) +
+    '/private?source=scratchnode&room=' + encodeURIComponent(roomCode) +
+    '&return=' + encodeURIComponent(EVENT_URL);
+}
+
+function buildNodeBenchSignInUrl(targetUrl) {
+  var target = targetUrl || buildNodeBenchEventPrivateUrl();
+  return WORKSPACE_BASE_URL + '/sign-in?return=' + encodeURIComponent(target) + '&intent=save-private-notes';
+}
+
+function openNodeBenchPrivateHandoff() {
+  closeMenu();
+  closeSheet();
+  window.location.assign(buildNodeBenchSignInUrl(buildNodeBenchEventPrivateUrl()));
+}
 
 // ── Debug-gate flag for prototype helpers ──
 // Production builds should keep this false. ?debug=1 in URL enables sim* helpers on window.
@@ -1716,7 +1750,11 @@ var SHEET_RENDERERS = {
       '<div class="notes-list-scroll" id="notes-list-scroll">' + renderNotesList() + '</div>' +
       '</div>' +
       '<div class="notes-pane-edit" id="notes-pane-edit">' + renderNotesEditor() + '</div>' +
-      '</div>';
+      '</div>' +
+      '<div class="sheet-section" style="margin-top:14px"><h3>Continue privately</h3>' +
+      '<p class="sheet-sub">Open this event in NodeBench with the public wiki, your private notes, saved asks, and follow-up workspace attached.</p>' +
+      '<button type="button" class="sheet-button" id="sn-nodebench-private-handoff" onclick="openNodeBenchPrivateHandoff()">Open NodeBench event notebook</button>' +
+      '<div style="margin-top:8px;font-size:11px;color:var(--ink-faint);font-family:var(--mono);word-break:break-all">' + buildNodeBenchEventPrivateUrl() + '</div></div>';
   },
 
   wiki: function() {
@@ -1845,10 +1883,11 @@ var SHEET_RENDERERS = {
 
   signin: function() {
     return '<div class="sheet-head"><h2 id="sheet-title">Sign in to ScratchNode</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
-      '<p class="sheet-sub">No password. We&rsquo;ll email you a magic link. Sign in to create your own events, persist notes across devices, and host with full controls.</p>' +
+      '<p class="sheet-sub">No password. We&rsquo;ll email you a magic link. Sign in to create your own events, persist notes across devices, and continue this room privately in NodeBench.</p>' +
       '<div class="sheet-field"><label class="sheet-label" for="sheet-signin-email">Email address</label>' +
       '<input id="sheet-signin-email" class="sheet-input" type="email" placeholder="you@company.com" autocomplete="email" inputmode="email" /></div>' +
       '<button type="button" class="sheet-button" onclick="sendMagicLink()">Send me a magic link</button>' +
+      '<button type="button" class="sheet-button ghost" onclick="openNodeBenchPrivateHandoff()">Continue this event in NodeBench</button>' +
       '<div style="display:flex;gap:8px;margin:12px 0;align-items:center;color:var(--ink-faint);font-size:10px;font-family:var(--mono);letter-spacing:.1em"><span style="flex:1;height:1px;background:var(--line)"></span>OR<span style="flex:1;height:1px;background:var(--line)"></span></div>' +
       '<button type="button" class="sheet-button ghost" onclick="toast(\'Google sign-in\',\'OAuth handoff (demo).\'); closeSheet();">Continue with Google</button>' +
       '<button type="button" class="sheet-button ghost" onclick="toast(\'GitHub sign-in\',\'OAuth handoff (demo).\'); closeSheet();">Continue with GitHub</button>' +
@@ -2371,7 +2410,7 @@ function sendMagicLink() {
     return;
   }
   closeSheet();
-  toast('Magic link sent to ' + email, 'Check your inbox.');
+  toast('Magic link sent to ' + email, 'Check your inbox. Return target: NodeBench event notebook.');
   haptic(15);
 }
 

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -94,6 +94,34 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
     });
     await waitForScratchNodeLive(pageA);
     await expect(pageA).toHaveTitle(/ScratchNode/i);
+    const boundary = await pageA.evaluate(() => {
+      const win = window as any;
+      return {
+        publicBaseUrl: win.PUBLIC_BASE_URL,
+        eventUrl: win.EVENT_URL,
+        workspaceBaseUrl: win.WORKSPACE_BASE_URL,
+        privateHandoffUrl: win.buildNodeBenchEventPrivateUrl?.(),
+        signInHandoffUrl: win.buildNodeBenchSignInUrl?.(),
+        hasOpenHandoff: typeof win.openNodeBenchPrivateHandoff,
+      };
+    });
+    const expectedPublicOrigin = new URL(SCRATCHNODE_APEX_URL).origin;
+    expect(boundary.publicBaseUrl).toBe(expectedPublicOrigin);
+    expect(boundary.eventUrl).toBe(`${expectedPublicOrigin}/e/ai-infra-summit-2026`);
+    expect(boundary.eventUrl).not.toContain("scratchnode.com");
+    expect(boundary.workspaceBaseUrl).toBe("https://nodebenchai.com");
+    expect(boundary.privateHandoffUrl).toContain(
+      "https://nodebenchai.com/events/ai-infra-summit-2026/private",
+    );
+    expect(boundary.privateHandoffUrl).toContain("source=scratchnode");
+    expect(boundary.privateHandoffUrl).toContain("room=ORBITAL");
+    expect(decodeURIComponent(boundary.privateHandoffUrl)).toContain(
+      `return=${expectedPublicOrigin}/e/ai-infra-summit-2026`,
+    );
+    expect(decodeURIComponent(boundary.signInHandoffUrl)).toContain(
+      "/events/ai-infra-summit-2026/private",
+    );
+    expect(boundary.hasOpenHandoff).toBe("function");
     await pageA.screenshot({
       path: join(ARTIFACT_DIR, `${qaId}-apex-live.png`),
       fullPage: true,
@@ -136,6 +164,9 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
       "no private notes",
     );
 
+    await expect
+      .poll(() => queryAnswer(pageA, answer!.id!), { timeout: 15_000 })
+      .not.toBeNull();
     const answerRecord = await queryAnswer(pageA, answer!.id!);
     expect(answerRecord.cacheHit).toBe(false);
     expect(answerRecord.sources.length).toBeGreaterThan(0);
@@ -219,6 +250,14 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
       return note?.id ?? null;
     }, privateNote);
     expect(noteId, "private note should have a Convex id").toBeTruthy();
+
+    await pageA.evaluate(() => (window as any).openNotes());
+    await expect(pageA.locator("#sn-nodebench-private-handoff")).toBeVisible();
+    await expect(pageA.locator("#sheet-content")).toContainText("Open NodeBench event notebook");
+    await expect(pageA.locator("#sheet-content")).toContainText(
+      "https://nodebenchai.com/events/ai-infra-summit-2026/private",
+    );
+    await pageA.evaluate(() => (window as any).closeSheet());
 
     await pageA.evaluate((id) => {
       (window as any)._activeNoteId = id;


### PR DESCRIPTION
## Summary
- lock the ScratchNode Live ↔ NodeBench AI product boundary in docs
- add deterministic ScratchNode v5 → NodeBench private event notebook handoff URLs
- extend live backend dogfood to enforce scratchnode.live/public and nodebenchai.com/private URL boundaries

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run convex/events.runtime-boundary.test.ts
- npm run build
- local patched home-v5 + real Convex config: npm run dogfood:proto-live-backend (3 passed)

## Known existing harness gap
- npx vitest run convex/__tests__/scratchnode.events.test.ts is blocked by unresolved convex-test in the current install, despite package.json declaring it. This branch does not touch that harness.