### PR TITLE
fix(scratchnode): P0 — sign-in calls targeting wrong Convex namespace

### DIFF
--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1466,7 +1466,7 @@ function openMyEvents() {
 }
 
 // Step 8 — render the list of joined/hosted events into #sn-my-events-list.
-// Live mode only: calls events:listMyEvents via the Convex client. In
+// Live mode only: calls users:listMyEvents via the Convex client. In
 // prototype mode (no Convex), shows a "live backend required" hint.
 function renderMyEventsList(userId) {
   var el = document.getElementById('sn-my-events-list');
@@ -1479,7 +1479,7 @@ function renderMyEventsList(userId) {
       '</div>';
     return;
   }
-  live.client.query('events:listMyEvents', { userId: userId })
+  live.client.query('users:listMyEvents', { userId: userId })
     .then(function(res) {
       var rows = (res && Array.isArray(res.joined)) ? res.joined : [];
       if (rows.length === 0) {
@@ -1525,7 +1525,7 @@ function renderMyEventsList(userId) {
 }
 
 // Step 8 — magic-link landing. If the page URL carries ?sign-in-token=XXX,
-// auto-call events:verifySignInToken, persist the resulting user to
+// auto-call users:verifySignInToken, persist the resulting user to
 // localStorage, clean the URL, and toast the result.
 function consumeSignInTokenFromUrl() {
   var params;
@@ -1555,7 +1555,7 @@ window.consumeSignInTokenFromUrl = consumeSignInTokenFromUrl;
 function consumeSignInTokenInner(live, token) {
   var sid = null;
   try { sid = localStorage.getItem('sn_session_id'); } catch (e) {}
-  live.client.mutation('events:verifySignInToken', {
+  live.client.mutation('users:verifySignInToken', {
     token: token,
     sessionId: sid || undefined,
   })
@@ -2009,7 +2009,7 @@ var SHEET_RENDERERS = {
   },
 
   myevents: function() {
-    // Step 8 — "My events" surface. Calls events:listMyEvents with the
+    // Step 8 — "My events" surface. Calls users:listMyEvents with the
     // stored userId. Renders a list of joined/hosted events; tap a row
     // to navigate. Empty state explains how to populate it.
     var u = loadSignedInUser();
@@ -2550,7 +2550,7 @@ function shareTo(p) {
   if (dest) { window.open(dest, '_blank', 'noopener'); closeSheet(); haptic(); }
 }
 
-// ── Magic-link sign-in (Step 8 — calls events:requestSignInLink) ──
+// ── Magic-link sign-in (Step 8 — calls users:requestSignInLink) ──
 // Wires the email input on the 'signin' sheet to the Convex backend. If
 // Convex isn't live yet (prototype mode), falls back to the demo toast.
 // On success: closes sheet, shows "check your inbox" toast.
@@ -2570,7 +2570,7 @@ function sendMagicLink() {
     // brings the user back to the same event with ?sign-in-token=XXX
     // in the URL.
     var returnUrl = location.origin + location.pathname;
-    live.client.mutation('events:requestSignInLink', {
+    live.client.mutation('users:requestSignInLink', {
       email: email,
       returnUrl: returnUrl,
     })

--- a/scripts/scratchnode-multi-user-dogfood.mjs
+++ b/scripts/scratchnode-multi-user-dogfood.mjs
@@ -710,7 +710,7 @@ async function main() {
   header('SCENARIO 22: Step 8 — requestSignInLink schedules email (Resend wiring)');
   // ───────────────────────────────────────────────────────────────
   try {
-    const r = await convexMutation('events:requestSignInLink', { email: step8Email });
+    const r = await convexMutation('users:requestSignInLink', { email: step8Email });
     record('Phase8 requestSignInLink ok', !!r.value?.ok,
       `mutation returned ok=${r.value?.ok}; email scheduled fire-and-forget`,
       r.latency);
@@ -726,7 +726,7 @@ async function main() {
   // bogus token must throw token_invalid (NOT silently succeed, NOT
   // crash the server).
   try {
-    await convexMutation('events:verifySignInToken', {
+    await convexMutation('users:verifySignInToken', {
       token: 'BOGUSTOKENBOGUSTOKEN',
       sessionId: `dogfood-step8-${RUN_ID}-`.padEnd(40, 'x'),
     });
@@ -741,7 +741,7 @@ async function main() {
   header('SCENARIO 24: Step 8 — malformed email rejected by requestSignInLink');
   // ───────────────────────────────────────────────────────────────
   try {
-    await convexMutation('events:requestSignInLink', { email: 'not-an-email' });
+    await convexMutation('users:requestSignInLink', { email: 'not-an-email' });
     record('Phase8 malformed email rejected', false,
       'CRITICAL: requestSignInLink accepted malformed email (no @ + dot check)');
   } catch (e) {
@@ -768,7 +768,7 @@ async function main() {
     // is HONEST_STATUS. Test passes if we get either:
     //   (a) the call returns { joined: [], _truncated: false }, or
     //   (b) the call throws on schema validation.
-    const r = await convexQuery('events:listMyEvents', { userId: eventId });
+    const r = await convexQuery('users:listMyEvents', { userId: eventId });
     const ok = Array.isArray(r.value?.joined) && r.value.joined.length === 0
       && r.value._truncated === false;
     record('Phase8 listMyEvents empty for unknown user', ok,


### PR DESCRIPTION
P0 hotfix. PR #407 deployed Step 8 mutations at `users:*` paths but the frontend + dogfood script call `events:*`. Real users hitting Sign In on scratchnode.live get nothing (Convex HTTP API masks function-not-found as generic Server Error). Fix: 7 callsites updated. Verified 33/33 dogfood pass against live prod after fix.