### PR TITLE
chore(scratchnode): _adminForceReleaseHost + contract-path rule extension

### DIFF
--- a/.claude/rules/backend_contract_migration.md
+++ b/.claude/rules/backend_contract_migration.md
@@ -99,6 +99,51 @@ After each deploy step:
 
 If verification fails at any step, do not proceed to the next step.
 
+## Contract path discipline (added 2026-05-27)
+
+**Every Convex contract MUST specify the deployed path as `<filename>:<exportName>`, not just the export name.** Convex resolves paths by filename — putting `requestSignInLink` in `convex/users.ts` deploys it at `users:requestSignInLink`, not `events:requestSignInLink`, regardless of what the contract doc says.
+
+Case study — PR #407/#409 hotfix (2026-05-27): the Step 8 contract specified mutations as `events:requestSignInLink` / `events:verifySignInToken` / `events:listMyEvents` to match the existing scratchnode namespace. The implementing agent put them in `convex/users.ts` (sensible — `events.ts` was overloaded). Deployed paths became `users:*`. Frontend and dogfood script kept calling `events:*` — silent function-not-found at runtime. Convex's HTTP API masks this as a generic "Server Error" message, hiding the mismatch from CI.
+
+### Required contract format
+
+```ts
+// ❌ BAD — ambiguous, doesn't capture deployed path
+events:requestSignInLink({ email }) → { ok }
+
+// ✅ GOOD — deployed path is explicit
+users:requestSignInLink({ email }) → { ok }
+// implemented in convex/users.ts as `export const requestSignInLink = mutation({...})`
+```
+
+If the contract author wants the path to be `events:*` despite the implementation living in another file, the implementing PR must add an explicit re-export:
+
+```ts
+// convex/events.ts
+export { requestSignInLink, verifySignInToken, listMyEvents } from "./users";
+```
+
+This is one valid mitigation (preserves contract path stability), but it should be a deliberate choice documented in the PR description, not an accident.
+
+## Happy-path-success verification (added 2026-05-27)
+
+**Dogfood scenarios that only test sad-path validation can pass coincidentally even when the deployed path is wrong** — because validation throws *before* dispatching to the mistargeted function. The PR #407 case study: scenarios 23/24/25 (sad paths — bogus token, malformed email, nonexistent userId) all passed live; only scenario 22 (the happy path that ACTUALLY dispatched) failed.
+
+Required pattern: for every new mutation/query, the dogfood suite MUST include at least ONE scenario that exercises the **happy-path-success branch** (returns ok=true with expected payload shape), not just rejection scenarios.
+
+### Verification floor extension
+
+After the existing `tsc / convex tsc / vitest / build / dogfood` gates, add:
+
+5. **Happy-path probe via `npx convex run`** for any new mutation. Example:
+   ```bash
+   npx convex run --prod <fullPath>:<funcName> '{...validArgs}'
+   # Must return success (not throw, not Server Error)
+   ```
+   This bypasses the HTTP API's "Server Error" masking — `npx convex run` surfaces the typed ConvexError code, making path mismatches immediately diagnosable.
+
+6. **Inventory check**: `npx convex run` with a deliberately-wrong path lists ALL deployed function names. Use this to confirm `<file>:<export>` matches what you expect after every schema/function-add PR.
+
 ## Anti-patterns
 
 - Renaming + frontend flip + old-name removal in one PR
@@ -107,6 +152,10 @@ If verification fails at any step, do not proceed to the next step.
 - Removing the legacy alias before confirming zero callers remain
 - Manually triggering Convex deploy before Vercel finishes — flips
   the race direction but doesn't close the window
+- **Specifying contract paths by export name only** (e.g. `requestSignInLink`)
+  without the deployed `<file>:<export>` form
+- **Shipping a feature with only sad-path scenarios** — happy-path-success
+  must be exercised at least once to catch path mismatches that throw post-validation
 
 ## Detection
 

--- a/convex/__tests__/scratchnode.events.test.ts
+++ b/convex/__tests__/scratchnode.events.test.ts
@@ -37,7 +37,7 @@
 import { describe, expect, it } from "vitest";
 
 import * as eventsModule from "../events";
-import { publishWiki, claimHost, requestHostClaim, releaseHost } from "../events";
+import { publishWiki, claimHost, requestHostClaim, releaseHost, _adminForceReleaseHost } from "../events";
 import {
   deleteNote,
   createNoteAnchor,
@@ -2269,5 +2269,134 @@ describe("listMyEvents — surfaces joined events for signed-in user", () => {
     });
     expect(result.joined).toEqual([]);
     expect(result._truncated).toBe(false);
+  });
+});
+
+/* ========================================================================== */
+/* Test — _adminForceReleaseHost (one-time pollution recovery tool)           */
+/* ========================================================================== */
+
+describe("_adminForceReleaseHost — internal admin tool", () => {
+  /**
+   * Scenario:    The demo event ai-infra-summit-2026 was claimed by a
+   *              now-unknown ownerKey from an earlier dogfood run before
+   *              the static-key migration. Real users + Phase 4
+   *              requestHostClaim are blocked because legitimate
+   *              releaseHost requires the original ownerKey. Ops calls
+   *              this internal mutation via `npx convex run --prod` to
+   *              force-clear.
+   * User:        Operator (CLI via npx convex run), NOT end users
+   * Goal:        Clear stuck legacy host so the event can be re-claimed
+   * Prior state: event live; 1 liveEventHosts row with unknown ownerKey
+   * Actions:     _adminForceReleaseHost({ eventId }) — NO ownerKey arg
+   * Scale:       1 ops call
+   * Duration:    Sub-second
+   * Expected:    ok=true, released=true, hostsDeleted=1.
+   *              liveEventHosts table empty. New ownerKey can immediately claim.
+   */
+  it("force-clears a stuck legacy host (no ownerKey required)", async () => {
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventHosts: [
+        {
+          _id: "liveEventHosts:1",
+          eventId: "liveEvents:1",
+          ownerKey: "unknown-legacy-key-from-old-dogfood-run-aaaaaaa",
+          displayName: "Stuck Legacy",
+          role: "owner",
+          authMethod: "legacy_ownerkey",
+          createdAt: 1_700_000_000_000,
+        },
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await (_adminForceReleaseHost as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.released).toBe(true);
+    expect(result.hostsDeleted).toBe(1);
+    expect(tables.liveEventHosts.length).toBe(0);
+
+    // Verify the event is now claimable by anyone
+    const newClaim = await (claimHost as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+      ownerKey: "fresh-owner-key-12345",
+      displayName: "Fresh Host",
+    });
+    expect(newClaim.ok).toBe(true);
+    expect(newClaim.created).toBe(true);
+    expect(tables.liveEventHosts.length).toBe(1);
+  });
+
+  /**
+   * Scenario:    Defense-in-depth — force-release also clears any
+   *              dangling claim code on the event row. Without this,
+   *              a Phase 4 code that was minted mid-pollution could be
+   *              redeemed after force-release to claim host (the legacy
+   *              host gate is what normally protects against this).
+   * User:        Operator (CLI)
+   * Goal:        Leave the event in a fully clean state
+   * Prior state: event has hostClaimCodeHash set; 1 stuck host row
+   * Actions:     _adminForceReleaseHost
+   * Expected:    Both hostClaimCodeHash and hostClaimCodeCreatedAt are
+   *              undefined on the event row after the call.
+   */
+  it("clears dangling claim code on force-release (defense-in-depth)", async () => {
+    const event = baseEvent({
+      hostClaimCodeHash: "sha256:dangling-from-mid-pollution",
+      hostClaimCodeCreatedAt: 1_700_000_000_000,
+    });
+    const tables: Tables = {
+      liveEvents: [event],
+      liveEventHosts: [
+        {
+          _id: "liveEventHosts:1",
+          eventId: "liveEvents:1",
+          ownerKey: "stuck-key",
+          displayName: "Stuck",
+          role: "owner",
+          createdAt: 1_700_000_000_000,
+        },
+      ],
+    };
+    const ctx = createCtx(tables);
+
+    await (_adminForceReleaseHost as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+    });
+
+    expect(tables.liveEvents[0].hostClaimCodeHash).toBeUndefined();
+    expect(tables.liveEvents[0].hostClaimCodeCreatedAt).toBeUndefined();
+  });
+
+  /**
+   * Scenario:    Idempotency — calling force-release on an event with no
+   *              host record (already released, never claimed) returns
+   *              ok=true with released=false, hostsDeleted=0. Does not
+   *              throw. This matters for ops re-running the command after
+   *              a successful release to confirm the state.
+   * User:        Operator (CLI)
+   * Goal:        Confirm post-release state is stable
+   * Prior state: event with 0 liveEventHosts rows
+   * Actions:     _adminForceReleaseHost
+   * Expected:    Returns ok=true, released=false, hostsDeleted=0.
+   */
+  it("is idempotent on an already-released event", async () => {
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventHosts: [],
+    };
+    const ctx = createCtx(tables);
+
+    const result = await (_adminForceReleaseHost as any)._handler(ctx, {
+      eventId: "liveEvents:1",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.released).toBe(false);
+    expect(result.hostsDeleted).toBe(0);
   });
 });

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1880,6 +1880,65 @@ export const publishWiki = mutation({
  * (because the host row was just deleted). This is correct — the operation
  * was applied, the contract is "you must be the current host to call this."
  */
+/**
+ * _adminForceReleaseHost — internal admin tool for one-time pollution
+ * recovery. NEVER call from user-facing code. Callable ONLY via:
+ *
+ *   npx convex run --prod events:_adminForceReleaseHost '{"eventId":"..."}'
+ *
+ * Use case: an event was claimed by a now-unknown ownerKey (e.g., an
+ * earlier dogfood run with a RUN_ID-randomized key). The legitimate
+ * `releaseHost` mutation requires the current host's ownerKey, so the
+ * event is stuck — neither legacy `claimHost` nor Phase 4
+ * `requestHostClaim` can proceed. This internal mutation force-deletes
+ * all liveEventHosts rows + clears any dangling claim code WITHOUT
+ * proving host ownership.
+ *
+ * Security:
+ *   - `internalMutation` is NOT exposed via api.* — only via
+ *     `internal.events._adminForceReleaseHost`, which Convex restricts
+ *     to server-side callers (CLI via `npx convex run`, scheduler,
+ *     crons, other actions).
+ *   - The HTTP /api/mutation endpoint refuses internal paths — a
+ *     curl POST to "events:_adminForceReleaseHost" returns
+ *     function_not_found.
+ *   - Audit log emitted via console.warn for forensic visibility.
+ *
+ * Naming convention:
+ *   - Leading underscore signals "internal, do not call from frontend"
+ *     (same convention as `_evictStalePresence`, `_evictStaleHostClaimCodes`).
+ *   - `Unsafe` not in the name to keep the CLI command paste-friendly,
+ *     but the JSDoc above is the canonical "do not use lightly" warning.
+ */
+export const _adminForceReleaseHost = internalMutation({
+  args: {
+    eventId: v.id("liveEvents"),
+  },
+  handler: async (ctx, { eventId }) => {
+    const allHosts = await ctx.db
+      .query("liveEventHosts")
+      .withIndex("by_event", (q: any) => q.eq("eventId", eventId))
+      .collect();
+    let hostsDeleted = 0;
+    for (const row of allHosts) {
+      await ctx.db.delete(row._id);
+      hostsDeleted += 1;
+    }
+    const event = await ctx.db.get(eventId);
+    if (event && (event.hostClaimCodeHash || event.hostClaimCodeCreatedAt)) {
+      await ctx.db.patch(eventId, {
+        hostClaimCodeHash: undefined,
+        hostClaimCodeCreatedAt: undefined,
+      });
+    }
+    console.warn(
+      `[_adminForceReleaseHost] eventId=${eventId} hostsDeleted=${hostsDeleted} ` +
+        `(force release — no auth check; called via internal admin path)`,
+    );
+    return { ok: true, released: hostsDeleted > 0, hostsDeleted };
+  },
+});
+
 export const releaseHost = mutation({
   args: {
     eventId: v.id("liveEvents"),


### PR DESCRIPTION
Closes the last two open follow-ups: Task #72 (demo event pollution recovery tool) + Task #78 (rule extension capturing PR #382 + #407/#409 lessons). 37/37 vitest pass.