### PR TITLE
fix(dogfood): wiki query returns bodyHtml not html

### DIFF
--- a/scripts/scratchnode-multi-user-dogfood.mjs
+++ b/scripts/scratchnode-multi-user-dogfood.mjs
@@ -381,7 +381,7 @@ async function main() {
   if (aliceIsHost) {
     try {
       const r = await convexQuery('events:getPublishedWiki', { eventId });
-      const wikiHtml = r.value?.html || '';
+      const wikiHtml = r.value?.bodyHtml || r.value?.html || '';
       const hasBobsQ = wikiHtml.includes(bobQ.slice(0, 30));
       record('Wiki contains Bob\'s promoted Q', hasBobsQ,
         `wiki=${wikiHtml.length}ch`, r.latency);
@@ -398,7 +398,7 @@ async function main() {
   // ───────────────────────────────────────────────────────────────
   try {
     const r = await convexQuery('events:getPublishedWiki', { eventId });
-    const wikiHtml = r.value?.html || '';
+    const wikiHtml = r.value?.bodyHtml || r.value?.html || '';
     const leaked = wikiHtml.includes(`SECRET-${RUN_ID}`);
     record('Wiki excludes Carol\'s private note', !leaked,
       leaked ? 'CRITICAL P0 LEAK' : 'invariant holds', r.latency);


### PR DESCRIPTION
Dogfood script fix surfaced by post-pollution-clear run. Scenarios 14/15 were reading wrong field name. 33/33 pass live after fix.