### PR TITLE
feat(scratchnode): anchor private notes to public chat

### DIFF
--- a/convex/events.runtime-boundary.test.ts
+++ b/convex/events.runtime-boundary.test.ts
@@ -5,8 +5,10 @@ import { dirname, join } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const eventsSource = readFileSync(join(here, "events.ts"), "utf8");
+const notesSource = readFileSync(join(here, "notes.ts"), "utf8");
+const eventsSchemaSource = readFileSync(join(here, "schema", "eventsSchema.ts"), "utf8");
 
-function functionBlock(name: string, kind: "mutation" | "action" | "internalQuery" | "internalMutation" = "mutation"): string {
+function functionBlock(name: string, kind: "query" | "mutation" | "action" | "internalQuery" | "internalMutation" = "mutation"): string {
   const start = eventsSource.indexOf(`export const ${name} = ${kind}({`);
   expect(start, `${name} ${kind} should exist`).toBeGreaterThanOrEqual(0);
   const next = eventsSource.indexOf("\nexport const ", start + 1);
@@ -38,6 +40,29 @@ describe("scratchnode public runtime boundaries", () => {
     expect(publishWiki).toContain("liveEventAnswers");
     expect(publishWiki).toContain("liveEventWikiVersions");
     expect(publishWiki).not.toContain("userNotes");
+  });
+
+  it("models private note anchors without making them public messages", () => {
+    expect(eventsSchemaSource).toContain("anchorType");
+    expect(eventsSchemaSource).toContain("by_owner_event_anchor");
+    expect(eventsSchemaSource).toContain("by_session_joined");
+    expect(eventsSchemaSource).toContain("by_owner");
+    expect(notesSource).toContain("sanitizeAnchor");
+    expect(notesSource).toContain("Private note anchors require anchorId");
+
+    const sendMessage = functionBlock("sendMessage");
+    expect(sendMessage).not.toContain("userNotes");
+    expect(sendMessage).not.toContain("anchorType");
+  });
+
+  it("keeps ScratchNode account event state as bounded joined and hosted lists", () => {
+    const getMyEvents = functionBlock("getMyEvents", "query");
+
+    expect(getMyEvents).toContain("MAX_MY_EVENTS_LIMIT");
+    expect(getMyEvents).toContain("by_session_joined");
+    expect(getMyEvents).toContain("by_owner");
+    expect(getMyEvents).toContain("joined");
+    expect(getMyEvents).toContain("hosted");
   });
 
   it("keeps host claim idempotent for the same owner key before rejecting claimed rooms", () => {

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -8,6 +8,7 @@
  *   - getEventBySlug({ slug })
  *   - getMessages({ eventId, limit? })            // realtime subscription
  *   - getMembers({ eventId })                     // realtime subscription
+ *   - getMyEvents({ sessionId, ownerKey, limit? }) // lightweight account/event state
  *   - joinEvent({ slug, sessionId, displayName }) // returns { eventId, ... }
  *   - sendMessage({ eventId, sessionId, displayName, text, kind, replyToMessageId? })
  *   - heartbeat({ eventId, sessionId })
@@ -57,6 +58,7 @@ const MAX_STALE_HOST_CLAIM_EVICT = 100;
 const MAX_SOURCE_BODY = 12_000;
 const MAX_ANSWER_BODY = 4_000;
 const MAX_ANSWER_LIMIT = 100;
+const MAX_MY_EVENTS_LIMIT = 50;
 const MAX_WIKI_ANSWERS = 20;
 // Phase 4 raised this from 80 -> 120 to fit HMAC-signed host tokens
 // (hk1:<eventIdShort>:<nonce>:<issuedAt>:<hmacShort> ~ 80-90 chars).
@@ -817,6 +819,67 @@ export const getHostStatus = query({
       .withIndex("by_event_owner", (q) => q.eq("eventId", eventId).eq("ownerKey", ownerKey))
       .first();
     return host ? { isHost: true, role: host.role, displayName: host.displayName } : { isHost: false };
+  },
+});
+
+export const getMyEvents = query({
+  args: {
+    sessionId: v.optional(v.string()),
+    ownerKey: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { sessionId, ownerKey, limit }) => {
+    const safeLimit = Math.min(Math.max(limit ?? 20, 1), MAX_MY_EVENTS_LIMIT);
+    const joined: any[] = [];
+    const hosted: any[] = [];
+
+    if (sessionId && sessionId.length >= 8 && sessionId.length <= 64) {
+      const memberRows = await ctx.db
+        .query("liveEventMembers")
+        .withIndex("by_session_joined", (q) => q.eq("sessionId", sessionId))
+        .order("desc")
+        .take(safeLimit);
+
+      for (const membership of memberRows) {
+        const event = await ctx.db.get(membership.eventId);
+        if (!event) continue;
+        joined.push({
+          eventId: event._id,
+          slug: event.slug,
+          name: event.name,
+          roomCode: event.roomCode,
+          status: event.status,
+          role: "attendee",
+          joinedAt: membership.joinedAt,
+          lastSeenAt: membership.lastSeenAt,
+        });
+      }
+    }
+
+    if (ownerKey && ownerKey.length >= 8 && ownerKey.length <= MAX_OWNER_KEY_LEN) {
+      const hostRows = await ctx.db
+        .query("liveEventHosts")
+        .withIndex("by_owner", (q) => q.eq("ownerKey", ownerKey))
+        .order("desc")
+        .take(safeLimit);
+
+      for (const host of hostRows) {
+        const event = await ctx.db.get(host.eventId);
+        if (!event) continue;
+        hosted.push({
+          eventId: event._id,
+          slug: event.slug,
+          name: event.name,
+          roomCode: event.roomCode,
+          status: event.status,
+          role: host.role,
+          authMethod: host.authMethod ?? "legacy_ownerkey",
+          createdAt: host.createdAt,
+        });
+      }
+    }
+
+    return { joined, hosted };
   },
 });
 

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -49,6 +49,61 @@ const MAX_TAG_LEN = 40;
 const MAX_NOTES_PER_QUERY = 500;
 const MIN_OWNER_KEY_LEN = 8;
 const MAX_OWNER_KEY_LEN = 80;             // accommodates "user:<convexId>" form
+const MAX_ANCHOR_ID = 200;
+const MAX_ANCHOR_LABEL = 160;
+const MAX_ANCHOR_PREVIEW = 240;
+
+const anchorTypeValidator = v.union(
+  v.literal("message"),
+  v.literal("thread"),
+  v.literal("time_range"),
+  v.literal("answer"),
+  v.literal("entity"),
+  v.literal("event"),
+);
+
+type PrivateNoteAnchorType = "message" | "thread" | "time_range" | "answer" | "entity" | "event";
+
+const sanitizeAnchor = (args: {
+  anchorType?: PrivateNoteAnchorType;
+  anchorId?: string;
+  anchorLabel?: string;
+  anchorPreview?: string;
+  startTs?: number;
+  endTs?: number;
+}) => {
+  if (!args.anchorType) return {};
+  const anchorId = typeof args.anchorId === "string" ? args.anchorId.trim().slice(0, MAX_ANCHOR_ID) : undefined;
+  if (args.anchorType !== "time_range" && !anchorId) {
+    throw new ConvexError({
+      code: "invalid_anchor",
+      message: "Private note anchors require anchorId unless anchorType is time_range.",
+    });
+  }
+  if (args.anchorType === "time_range") {
+    const startTs = Number(args.startTs);
+    const endTs = Number(args.endTs);
+    if (!Number.isFinite(startTs) || !Number.isFinite(endTs) || endTs < startTs) {
+      throw new ConvexError({
+        code: "invalid_anchor",
+        message: "time_range anchors require valid startTs and endTs.",
+      });
+    }
+  }
+  const anchor: Record<string, string | number> = {
+    anchorType: args.anchorType,
+  };
+  if (anchorId) anchor.anchorId = anchorId;
+  if (typeof args.anchorLabel === "string" && args.anchorLabel.trim()) {
+    anchor.anchorLabel = args.anchorLabel.trim().slice(0, MAX_ANCHOR_LABEL);
+  }
+  if (typeof args.anchorPreview === "string" && args.anchorPreview.trim()) {
+    anchor.anchorPreview = args.anchorPreview.trim().slice(0, MAX_ANCHOR_PREVIEW);
+  }
+  if (typeof args.startTs === "number") anchor.startTs = args.startTs;
+  if (typeof args.endTs === "number") anchor.endTs = args.endTs;
+  return anchor;
+};
 
 const validateOwnerKey = (ownerKey: string) => {
   if (!ownerKey || ownerKey.length < MIN_OWNER_KEY_LEN || ownerKey.length > MAX_OWNER_KEY_LEN) {
@@ -122,6 +177,12 @@ export const createNote = mutation({
     tags: v.optional(v.array(v.string())),
     isAsk: v.optional(v.boolean()),
     pinned: v.optional(v.boolean()),
+    anchorType: v.optional(anchorTypeValidator),
+    anchorId: v.optional(v.string()),
+    anchorLabel: v.optional(v.string()),
+    anchorPreview: v.optional(v.string()),
+    startTs: v.optional(v.number()),
+    endTs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     validateOwnerKey(args.ownerKey);
@@ -137,6 +198,7 @@ export const createNote = mutation({
       tags,
       pinned: !!args.pinned,
       isAsk: !!args.isAsk,
+      ...sanitizeAnchor(args),
       createdAt: now,
       updatedAt: now,
     });

--- a/convex/schema/eventsSchema.ts
+++ b/convex/schema/eventsSchema.ts
@@ -48,6 +48,7 @@ export const liveEventMembers = defineTable({
   lastSeenAt: v.number(),
 })
   .index("by_event_session", ["eventId", "sessionId"])
+  .index("by_session_joined", ["sessionId", "joinedAt"])
   .index("by_event_lastSeen", ["eventId", "lastSeenAt"]);
 
 // ------------------------------------------------------------------
@@ -170,11 +171,25 @@ export const userNotes = defineTable({
   tags: v.array(v.string()),
   pinned: v.boolean(),
   isAsk: v.boolean(),                                   // created via private /ask
+  anchorType: v.optional(v.union(
+    v.literal("message"),
+    v.literal("thread"),
+    v.literal("time_range"),
+    v.literal("answer"),
+    v.literal("entity"),
+    v.literal("event"),
+  )),
+  anchorId: v.optional(v.string()),                      // messageId, answerId, entityUri, event slug, etc.
+  anchorLabel: v.optional(v.string()),                   // human readable label: "Sarah Kim - 1:37p"
+  anchorPreview: v.optional(v.string()),                 // short public-context preview visible only to owner
+  startTs: v.optional(v.number()),                       // for time_range anchors
+  endTs: v.optional(v.number()),                         // for time_range anchors
   createdAt: v.number(),
   updatedAt: v.number(),
 })
   .index("by_owner_updated", ["ownerKey", "updatedAt"])
-  .index("by_owner_event", ["ownerKey", "eventId"]);
+  .index("by_owner_event", ["ownerKey", "eventId"])
+  .index("by_owner_event_anchor", ["ownerKey", "eventId", "anchorType", "anchorId"]);
 
 // ------------------------------------------------------------------
 // liveEventHosts - Phase 4 host ownership and moderation gate.
@@ -210,6 +225,7 @@ export const liveEventHosts = defineTable({
   createdAt: v.number(),
 })
   .index("by_event_owner", ["eventId", "ownerKey"])
+  .index("by_owner", ["ownerKey", "createdAt"])
   .index("by_event", ["eventId"]);
 
 // ------------------------------------------------------------------

--- a/docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
+++ b/docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
@@ -52,6 +52,10 @@ https://scratchnode.live/e/:eventSlug
 https://scratchnode.live/join/:roomCode
 https://scratchnode.live/e/:eventSlug/wiki
 https://scratchnode.live/e/:eventSlug/archive
+https://scratchnode.live/me/events
+https://scratchnode.live/me/notes
+https://scratchnode.live/host
+https://scratchnode.live/sign-in
 ```
 
 NodeBench private continuation URLs:
@@ -60,6 +64,9 @@ NodeBench private continuation URLs:
 https://nodebenchai.com/events/:eventSlug/private?source=scratchnode&room=:roomCode&return=:scratchnodeEventUrl
 https://nodebenchai.com/sign-in?return=:nodebenchPrivateEventUrl&intent=save-private-notes
 ```
+
+ScratchNode sign-in owns event participation state. NodeBench sign-in is only
+for the explicit "Open in NodeBench" private-workspace continuation.
 
 Current implementation in `public/proto/home-v5.html` exposes:
 
@@ -86,6 +93,88 @@ parseComposerIntent(raw)
 ```
 
 Private notes must return before public feed insertion. Normal chat must never invoke the agent.
+
+## Private Annotation Rule
+
+Lock this as the product and data rule:
+
+```text
+Private notes are never public messages.
+They may appear as private overlays anchored to public chat, visible only to the note owner.
+```
+
+Implementation shape:
+
+```text
+Public chat row
+  -> liveEventMessages row visible to everyone
+
+Private note
+  -> userNotes row owned by ownerKey
+  -> optional anchorType/anchorId/anchorLabel/anchorPreview
+  -> rendered as an owner-only marker beside the public row
+```
+
+Allowed:
+
+```text
+Private note marker visible only to owner
+Private note opens the owner notebook
+Private note can be exported by owner
+Private note can become a separate public FAQ suggestion only after explicit owner action
+```
+
+Never allowed:
+
+```text
+Private note inserted into liveEventMessages
+Private note compacted into liveEventWikiVersions
+Private note used by public /ask
+Private note cached in a public answer cache
+Private note visible to host by default
+```
+
+## ScratchNode Account Layer
+
+ScratchNode should support lightweight signed-in state without becoming the
+full NodeBench workspace.
+
+```text
+Anonymous visitor
+  -> view public room/wiki/archive
+
+Guest session
+  -> join event, chat, limited /ask, private notes owned by guest session
+
+Signed-in ScratchNode user
+  -> my joined events
+  -> my hosted events
+  -> my private notes
+  -> my saved /ask answers
+  -> my published event wikis
+```
+
+Host controls live on ScratchNode because they are event operations:
+
+```text
+create event
+set room code
+moderate chat
+review FAQ suggestions
+manage sources
+publish wiki
+export event analytics
+```
+
+NodeBench remains the deeper continuation surface:
+
+```text
+turn event notes into report notebooks
+run deep company/person research
+merge event deltas into Daily Brief
+export CRM/follow-up workflows
+inspect full trace DAG and graph context
+```
 
 ## Data Boundary
 

--- a/public/proto/docs.html
+++ b/public/proto/docs.html
@@ -379,7 +379,7 @@ kbd {
     <section class="invariants" aria-labelledby="invariants-label">
       <div class="invariants-label" id="invariants-label"><span class="icon">🛑</span>Release-blocker invariants — never violate these</div>
       <ol>
-        <li><strong>Private notes never enter the public feed.</strong> The composer says "only your notebook." The code path matches that string — <code>savePrivateNote()</code> returns before any feed insert.</li>
+        <li><strong>Private notes never enter the public feed.</strong> The composer says "only your notebook." The code path matches that string — <code>savePrivateNote()</code> returns before any feed insert. Private notes may render as owner-only markers anchored to public rows, but the note itself remains a private <code>userNotes</code> row.</li>
         <li><strong>Normal chat never invokes the agent.</strong> Only <code>/ask</code> or <code>@ScratchNode</code> dispatches to <code>postPublicAsk</code>.</li>
         <li><strong>Agent answers always show their parent ask.</strong> Every <code>.ans</code> card renders <em>"replying to &lt;name&gt;'s /ask"</em> in the head.</li>
         <li><strong>Public users suggest, hosts promote.</strong> Attendees see <em>"★ Suggest for FAQ"</em>; <code>data-role="host"</code> unlocks <em>"★ Promote to FAQ"</em>. Public users never directly mutate the durable wiki.</li>
@@ -388,7 +388,7 @@ kbd {
     </section>
 
     <h2 id="overview">Overview <a class="anchor" href="#overview">#</a></h2>
-    <p>ScratchNode is an event-knowledge product: a room code (e.g. <code>ORBITAL</code>) joins anyone — without an app or account — into a public live chat that compounds into a public wiki when the host wraps. Private notes live in a parallel notebook that never touches the public feed.</p>
+    <p>ScratchNode is an event-knowledge product: a room code (e.g. <code>ORBITAL</code>) joins anyone — without an app or account — into a public live chat that compounds into a public wiki when the host wraps. Private notes live in a parallel notebook that never touches the public feed. Signed-in ScratchNode state is lightweight: joined events, hosted events, private notes, saved answers, and published wikis. NodeBench is the deeper continuation workspace.</p>
     <div class="chips">
       <span class="chip v5">v5 = home-v5.html (viral SaaS, mobile-first)</span>
       <span class="chip v4">v4 = home-v4.html (spec proof, 4 view modes)</span>
@@ -406,6 +406,7 @@ kbd {
         <tr><td>Identity / display name</td><td><span class="badge proto">Prototype</span></td><td>localStorage <code>sn_v5_name</code></td><td>Guest session + optional account with magic link</td></tr>
         <tr><td>Sign-in / magic link</td><td><span class="badge proto">Prototype</span></td><td><code>sendMagicLink()</code> just toasts</td><td>Real OTP email + verified session token</td></tr>
         <tr><td>Private notes</td><td><span class="badge prod">Production floor</span></td><td>Convex <code>userNotes</code> scoped by owner key, with local fallback only when backend is unavailable</td><td>Per-user encrypted store, syncs across devices when signed in</td></tr>
+        <tr><td>Private note annotations</td><td><span class="badge prod">Production floor</span></td><td>Owner-only markers anchored to public messages via <code>anchorType</code> / <code>anchorId</code></td><td>Same privacy model plus time-range, answer, entity, and notebook-block anchors</td></tr>
         <tr><td>Notes editor</td><td><span class="badge proto">Prototype</span></td><td><code>document.execCommand</code> rich-text</td><td>TipTap / ProseMirror with mentions, backlinks, graph anchors</td></tr>
         <tr><td>QR code generation</td><td><span class="badge proto">Prototype</span></td><td>External <code>api.qrserver.com</code> image</td><td>Client-side SVG generator — privacy, offline, branding</td></tr>
         <tr><td><code>sim*</code> demo helpers</td><td><span class="badge proto">Prototype</span></td><td>Global functions on <code>window</code></td><td>Hidden behind <code>?debug=1</code> or removed entirely in prod build</td></tr>
@@ -585,11 +586,11 @@ scratchnode.<span class="fn">get_private_notes</span>({ userId, eventId }); <spa
     <table>
       <thead><tr><th>Domain</th><th>Surface</th><th>Audience</th><th>Auth</th></tr></thead>
       <tbody>
-        <tr><td><strong>scratchnode.live</strong></td><td>Public event rooms only (v5 surface). Root, <code>/e/:slug</code>, <code>/docs</code>.</td><td>Anonymous guests who joined via room code or share link</td><td>None — guests are anonymous by design</td></tr>
-        <tr><td><strong>nodebenchai.com</strong></td><td>Workspace, host console, billing, marketing site (v4 + existing surfaces).</td><td>Signed-in operators, founders, hosts creating events</td><td>Magic link / OAuth, session cookie</td></tr>
+        <tr><td><strong>scratchnode.live</strong></td><td>Public event rooms, lightweight account state, private notes, host console, and published event wikis (v5 surface).</td><td>Anonymous guests, signed-in attendees, and event hosts</td><td>Guest session by default; optional ScratchNode magic link / OAuth for sync and hosting</td></tr>
+        <tr><td><strong>nodebenchai.com</strong></td><td>Private workspace, notebooks, reports, artifacts, Daily Brief, graph context, billing, and deeper research flows (v4 + existing surfaces).</td><td>Signed-in operators, founders, and teams continuing work after events</td><td>Workspace auth, sessions, and permissioned private memory</td></tr>
       </tbody>
     </table>
-    <div class="callout"><span class="icon">🔀</span><div><strong>Anonymous-by-default on scratchnode.live.</strong> No cross-domain cookies, no shared session. Host actions ("Sign in", "Create event") redirect to <code>nodebenchai.com/sign-in?return=&lt;scratchnode-url&gt;</code> and bounce back after auth. Guests never need to sign in to chat, /ask, or save private notes (notes are localStorage-scoped to the device).</div></div>
+    <div class="callout"><span class="icon">🔀</span><div><strong>Anonymous-by-default on scratchnode.live.</strong> Guests never need to sign in to chat, /ask, or save device-scoped private notes. Signing in on ScratchNode unlocks My joined events, My hosted events, synced private notes, saved answers, and wiki publishing. <strong>Open in NodeBench</strong> is the explicit handoff for deeper report notebooks, artifacts, graph inspection, and private research.</div></div>
 
     <h3 id="vercel-setup">Vercel setup — single project, host-based routing</h3>
     <p>One Vercel project serves both domains. <code>vercel.json</code> has host-keyed rewrites + www→apex redirects:</p>
@@ -655,7 +656,7 @@ curl -sL https://nodebenchai.com/ | grep -E <span class="str">'(VITE|root|index)
 
     <div class="tldr">
       <div class="tldr-label">⚡ TL;DR — where we are vs where we're going</div>
-      <p><strong>Today (Phases 1-5 SHIPPED):</strong> <code>scratchnode.live/e/&lt;slug&gt;</code> is real Convex-backed multi-user chat with sourced <code>/ask</code>, FAQ suggestion, host claim, wiki publish, public source packets, answer cache, and private notes persisted through Convex. The current production floor is live enough to dogfood in a real small event room.</p>
+      <p><strong>Today (Phases 1-5 SHIPPED):</strong> <code>scratchnode.live/e/&lt;slug&gt;</code> is real Convex-backed multi-user chat with sourced <code>/ask</code>, FAQ suggestion, host claim, wiki publish, public source packets, answer cache, private notes persisted through Convex, and owner-only private annotations anchored to public messages. The current production floor is live enough to dogfood in a real small event room.</p>
       <p><strong>Goal:</strong> <em>"Two strangers on different devices open the same room URL and chat with each other in real time, with sourced agent answers and a private notebook each."</em> That core loop is now live through Convex; the remaining work is hardening quality, auth, rate limits, and provider-grade deep research.</p>
       <p><strong>Remaining work:</strong> Harden durable host authentication, add Redis/edge hot-room projection only after measuring Convex latency, and keep expanding browser QA. Provider-grade <code>/ask</code> now has a real action path with deterministic fallback; the next frontier is deeper research quality, not basic backend wiring.</p>
     </div>
@@ -667,10 +668,10 @@ curl -sL https://nodebenchai.com/ | grep -E <span class="str">'(VITE|root|index)
         <tr><td>Shared chat between visitors</td><td><span class="badge prod">Convex realtime query + presence</span></td><td>Rate limits, moderation, and account upgrade path</td></tr>
         <tr><td><code>/ask</code> agent answers</td><td><span class="badge prod">Convex action → Anthropic when configured, deterministic fallback otherwise</span></td><td>Add richer eval sets, rate limits, and provider budgets</td></tr>
         <tr><td>Sources / citation counts</td><td><span class="badge prod">Convex source records + answer source chips</span></td><td>Expand provider/source ingest coverage</td></tr>
-        <tr><td>Private notes</td><td><span class="badge prod">Convex per-session table with owner-key gating</span></td><td>Auth upgrade + encrypted per-user store</td></tr>
+        <tr><td>Private notes</td><td><span class="badge prod">Convex per-session table with owner-key gating + anchor metadata</span></td><td>ScratchNode account sync + encrypted per-user store</td></tr>
         <tr><td>Identity / display name</td><td><span class="badge proto">localStorage</span></td><td>Anon session UUID + optional auth upgrade</td></tr>
         <tr><td>FAQ promote / wiki publish</td><td><span class="badge prod">Convex mutations with host gate</span></td><td>Reviewer workflow, audit trail, and stronger policy UI</td></tr>
-        <tr><td>Sign-in</td><td><span class="badge proto">Guest/session + host-code auth</span></td><td>Redirect to <code>nodebenchai.com/sign-in?return=…</code></td></tr>
+        <tr><td>Sign-in</td><td><span class="badge proto">Guest/session + host-code auth</span></td><td>ScratchNode magic link for joined/hosted events and synced notes; NodeBench sign-in only for workspace continuation</td></tr>
         <tr><td>Event wiki</td><td><span class="badge prod">Convex-backed, version snapshotted</span></td><td>Scheduled compaction and richer source grouping</td></tr>
         <tr><td>Semantic answer cache</td><td><span class="badge prod">Exact normalized public-answer cache</span></td><td>Redis/LangCache semantic projection only after measuring need</td></tr>
       </tbody>
@@ -882,8 +883,8 @@ eventAnswers: <span class="fn">defineTable</span>({
   addedAt: v.number()
 }).<span class="fn">index</span>(<span class="str">"by_event_user"</span>, [<span class="str">"eventId"</span>, <span class="str">"userId"</span>])</pre>
         <ul class="checklist">
-          <li><input type="checkbox"> <span><code>nodebenchai.com/sign-in?return=&lt;url&gt;</code> route — magic link auth, on success redirect back to return URL with a signed short-lived JWT in URL hash</span></li>
-          <li><input type="checkbox"> <span><code>scratchnode.live</code> reads the JWT from hash, exchanges it for a Convex session via <code>auth/exchangeJWT</code> action, sets a same-site cookie scoped to <code>.scratchnode.live</code></span></li>
+          <li><input type="checkbox"> <span><code>scratchnode.live/sign-in?return=&lt;url&gt;</code> route — magic link auth, on success redirect back to return URL with a signed short-lived ScratchNode session in URL hash</span></li>
+          <li><input type="checkbox"> <span><code>scratchnode.live</code> reads the session token from hash, exchanges it for a Convex session via <code>auth/exchangeScratchNodeSession</code> action, sets a same-site cookie scoped to <code>.scratchnode.live</code></span></li>
           <li><input type="checkbox"> <span><code>convex/events/mutations.ts</code> — add server-side guard <code>requireHostRole(ctx, eventId)</code> that throws if <code>!eventHosts.exists({eventId, userId: ctx.userId})</code></span></li>
           <li><input type="checkbox"> <span>Apply guard to: <code>promoteToFAQ</code>, <code>publishWiki</code>, <code>hideMessage</code>, <code>kickMember</code>, <code>endEvent</code></span></li>
           <li><input type="checkbox"> <span>UI: real host console replaces the prototype host sheet — list of FAQ candidates, hidden messages, member list with kick action</span></li>

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -263,6 +263,16 @@ body[data-mode="private"] .c-hint::before { content: "🔒 Private — saves to 
 /* When reactions are visible below the text, lift the actions above them */
 .row:has(.row-reactions) .row-actions { bottom: 30px; }
 
+.private-note-marker {
+  display: inline-flex; align-items: center; gap: 5px;
+  margin-left: 8px; padding: 2px 7px;
+  border: 1px solid rgba(167,139,250,.28); border-radius: 999px;
+  background: rgba(167,139,250,.08); color: var(--purple);
+  font-family: var(--mono); font-size: 10px; line-height: 1.4;
+  cursor: pointer; vertical-align: baseline;
+}
+.private-note-marker:hover { border-color: rgba(167,139,250,.5); background: rgba(167,139,250,.14); }
+
 /* — Reply badge above a message that's a reply — */
 .row-replying { display: flex; align-items: center; gap: 4px; font-size: 10px; font-family: var(--mono); color: var(--ink-faint); margin-bottom: 2px; padding-left: 2px; }
 .row-replying::before { content: '↳'; color: var(--accent); }
@@ -1068,7 +1078,7 @@ body[data-new-user="true"] .h-menu::after {
   <button type="button" data-show-for="host" onclick="openHost()">Host console<span class="sub">Moderation · /ask queue · Publish wiki</span></button>
   <h4 style="margin-top:14px" data-show-for="all">Account</h4>
   <button type="button" data-hide-for="signed-in" onclick="openSignIn()">Sign in<span class="sub">Magic link — get your own events</span></button>
-  <button type="button" data-show-for="signed-in" onclick="openMyEvents()">My events<span class="sub">Joined and hosted rooms across devices</span></button>
+  <button type="button" onclick="openMyEvents()">My events<span class="sub" id="menu-events-sub">Joined and hosted rooms across devices</span></button>
   <button type="button" data-show-for="signed-in" onclick="snSignOut()">Sign out<span class="sub">Return to anonymous mode</span></button>
   <button type="button" data-show-for="named" onclick="setIdentity()">Change name<span class="sub" id="menu-name-sub">—</span></button>
   <button type="button" onclick="openShortcuts()">Keyboard shortcuts<span class="sub">Press ? anywhere</span></button>
@@ -1131,7 +1141,9 @@ var PUBLIC_BASE_URL = (function() {
 })();
 var EVENT_SLUG = 'ai-infra-summit-2026';
 var EVENT_URL = PUBLIC_BASE_URL + '/e/' + EVENT_SLUG;
-// On scratchnode.live, host-actions (sign-in, host console) live on the workspace domain.
+// NodeBench is the deeper private workspace. ScratchNode keeps lightweight
+// event account state, host controls, joined events, and private annotations
+// on the public room domain.
 var CANONICAL_WORKSPACE_HOST = 'nodebenchai.com';
 var WORKSPACE_BASE_URL = (function() {
   try {
@@ -1252,6 +1264,30 @@ function _clearComposer() {
 }
 function _isMobile() { return 'ontouchstart' in window || window.innerWidth <= 720; }
 
+function getMessageRowById(mid) {
+  var rows = document.querySelectorAll('.row[data-mid]');
+  for (var i = 0; i < rows.length; i++) {
+    if (rows[i].getAttribute('data-mid') === mid) return rows[i];
+  }
+  return null;
+}
+
+function buildPrivateNoteAnchor(room) {
+  var mid = room && room.replyingToMid;
+  if (!mid) return { type: 'event', id: EVENT_SLUG, label: 'AI Infra Summit', preview: 'Event-level private note' };
+  var row = getMessageRowById(mid);
+  if (!row) return { type: 'message', id: mid, label: 'Message', preview: '' };
+  var name = row.querySelector('.row-name') ? row.querySelector('.row-name').textContent : 'Message';
+  var time = row.querySelector('.row-time') ? row.querySelector('.row-time').textContent : '';
+  var text = row.querySelector('.row-text') ? row.querySelector('.row-text').textContent : '';
+  return {
+    type: 'message',
+    id: mid,
+    label: name + (time ? ' - ' + time : ''),
+    preview: text.length > 180 ? text.slice(0, 180) + '...' : text
+  };
+}
+
 // ── PRIVATE branch ──
 function savePrivateNote(intent) {
   var clean = intent.clean;
@@ -1269,6 +1305,10 @@ function savePrivateNote(intent) {
     body: (typeof escapeHtml === 'function' ? escapeHtml(clean) : clean).replace(/\n/g, '<br>'),
     tags: (typeof extractTags === 'function' ? extractTags(clean) : []),
     pinned: false, isAsk: intent.isAsk,
+    anchorType: intent.anchor && intent.anchor.type,
+    anchorId: intent.anchor && intent.anchor.id,
+    anchorLabel: intent.anchor && intent.anchor.label,
+    anchorPreview: intent.anchor && intent.anchor.preview,
     createdAt: intent.timestamp, updatedAt: intent.timestamp
   };
   (window._notes_v5 = window._notes_v5 || []).unshift(note);
@@ -1276,6 +1316,7 @@ function savePrivateNote(intent) {
     renderNotesListOnly();
   }
   if (typeof refreshNotesBadge === 'function') refreshNotesBadge();
+  if (typeof renderPrivateNoteMarkers === 'function') renderPrivateNoteMarkers();
   toast(
     'Private ' + (intent.isAsk ? '/ask' : 'note') + ' saved',
     '"' + (clean.length > 60 ? clean.slice(0, 60) + '…' : clean) + '" — only you see this.'
@@ -1363,7 +1404,9 @@ function sendComposerMessage() {
 
   // Branch 1: private — never touches the public feed (release-blocker invariant)
   if (intent.visibility === 'private') {
+    intent.anchor = buildPrivateNoteAnchor(room);
     savePrivateNote(intent);
+    if (room.replyingToMid) cancelReply();
     _clearComposer();
     return;
   }
@@ -1437,25 +1480,15 @@ function openWiki()    { closeMenu(); openSheet('wiki'); }
 function openPeople()  { closeMenu(); openSheet('people'); }
 function openShare()   { closeMenu(); openSheet('share'); }
 function openNotes()   { closeMenu(); openSheet('notes'); }
-// Host & sign-in are workspace-domain actions. On scratchnode.live they
-// redirect to nodebenchai.com with a return-URL hint; on the workspace
-// domain (or local preview) they open the in-page sheet.
+function openEvents()  { openMyEvents(); }
+// Host and sign-in stay on ScratchNode. "Open in NodeBench" is a separate
+// continuation action for deeper notebooks, reports, and artifacts.
 function openHost() {
   closeMenu();
-  if (ON_PUBLIC_DOMAIN) {
-    var returnUrl = encodeURIComponent(PUBLIC_BASE_URL + '/e/' + EVENT_SLUG);
-    window.location.assign(WORKSPACE_BASE_URL + '/host?return=' + returnUrl + '&intent=create-event');
-    return;
-  }
   openSheet('host');
 }
 function openSignIn() {
   closeMenu();
-  if (ON_PUBLIC_DOMAIN) {
-    var returnUrl = encodeURIComponent(location.href);
-    window.location.assign(WORKSPACE_BASE_URL + '/sign-in?return=' + returnUrl);
-    return;
-  }
   openSheet('signin');
 }
 
@@ -1846,6 +1879,29 @@ var SHEET_RENDERERS = {
       '<button type="button" class="sheet-button ghost" onclick="window.open(PUBLIC_BASE_URL,\'_blank\'); closeSheet();">Learn more &nearr;</button>';
   },
 
+  events: function() {
+    var state = window._sn_my_events || {
+      joined: [{ name: 'AI Infra Summit', slug: EVENT_SLUG, roomCode: 'ORBITAL', status: 'live', role: 'attendee' }],
+      hosted: []
+    };
+    var renderEvent = function(ev, kind) {
+      return '<div class="about-card"><h4>' + escapeHtml(ev.name || ev.slug || 'Untitled event') + '</h4>' +
+        '<p><strong>' + escapeHtml(kind) + '</strong> - ' + escapeHtml(ev.status || 'live') +
+        ' - code ' + escapeHtml(ev.roomCode || 'ORBITAL') + '</p>' +
+        '<button type="button" class="sheet-button ghost" onclick="window.location.href=\'' + PUBLIC_BASE_URL + '/e/' + escapeHtml(ev.slug || EVENT_SLUG) + '\'">Open room</button></div>';
+    };
+    var joined = (state.joined || []).map(function(ev) { return renderEvent(ev, 'Joined'); }).join('');
+    var hosted = (state.hosted || []).map(function(ev) { return renderEvent(ev, 'Hosted'); }).join('');
+    if (!joined) joined = '<p class="sheet-sub">No joined events yet. Join a room with its event link or room code.</p>';
+    if (!hosted) hosted = '<p class="sheet-sub">No hosted events yet. Use the Host console to claim or create one.</p>';
+    return '<div class="sheet-head"><h2 id="sheet-title">My events</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
+      '<p class="sheet-sub">ScratchNode account state lives here: joined events, hosted events, saved answers, and private notes. NodeBench is for deeper notebooks and artifacts.</p>' +
+      '<div class="sheet-section"><h3>Joined</h3>' + joined + '</div>' +
+      '<div class="sheet-section"><h3>Hosted</h3>' + hosted + '</div>' +
+      '<button type="button" class="sheet-button" onclick="openHost()">Host console</button>' +
+      '<button type="button" class="sheet-button ghost" onclick="openNodeBenchPrivateHandoff()">Open in NodeBench</button>';
+  },
+
   share: function() {
     var url = EVENT_URL;
     return '<div class="sheet-head"><h2 id="sheet-title">Share AI Infra Summit</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
@@ -2014,9 +2070,27 @@ var SHEET_RENDERERS = {
     // to navigate. Empty state explains how to populate it.
     var u = loadSignedInUser();
     if (!u) {
+      var state = window._sn_my_events || {
+        joined: [{ name: 'AI Infra Summit', slug: EVENT_SLUG, roomCode: 'ORBITAL', status: 'live', role: 'attendee' }],
+        hosted: []
+      };
+      var renderGuestEvent = function(ev, kind) {
+        var safeName = escapeHtml(ev.name || ev.slug || 'Untitled event');
+        var safeSlug = encodeURIComponent(ev.slug || EVENT_SLUG);
+        return '<div class="about-card"><h4>' + safeName + '</h4>' +
+          '<p><strong>' + escapeHtml(kind) + '</strong> - ' + escapeHtml(ev.status || 'live') +
+          ' - code ' + escapeHtml(ev.roomCode || 'ORBITAL') + '</p>' +
+          '<button type="button" class="sheet-button ghost" onclick="window.location.assign(\'/e/' + safeSlug + '\')">Open room</button></div>';
+      };
+      var joined = (state.joined || []).map(function(ev) { return renderGuestEvent(ev, 'Joined'); }).join('');
+      var hosted = (state.hosted || []).map(function(ev) { return renderGuestEvent(ev, 'Hosted'); }).join('');
+      if (!joined) joined = '<p class="sheet-sub">No joined events yet. Join a room with its event link or room code.</p>';
+      if (!hosted) hosted = '<p class="sheet-sub">No hosted events yet. Use the Host console to claim or create one.</p>';
       return '<div class="sheet-head"><h2 id="sheet-title">My events</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
-        '<p class="sheet-sub">Sign in to see the events you have joined or hosted across devices.</p>' +
-        '<button type="button" class="sheet-button" onclick="openSheet(\'signin\')">Sign in</button>';
+        '<p class="sheet-sub">This device can show the rooms you joined here. Sign in to sync joined events, hosted events, saved answers, and private notes across devices.</p>' +
+        '<div class="sheet-section"><h3>Joined on this device</h3>' + joined + '</div>' +
+        '<div class="sheet-section"><h3>Hosted on this device</h3>' + hosted + '</div>' +
+        '<button type="button" class="sheet-button" onclick="openSheet(\'signin\')">Sign in to sync</button>';
     }
     // Render the shell; content fetched async and injected.
     var shell =
@@ -2389,6 +2463,12 @@ function renderNotesEditor() {
   h.push('<div class="notes-edit-body">');
   h.push('<input type="text" class="notes-edit-title" id="notes-edit-title" placeholder="Untitled" value="' + escapeHtml(note.title || '') + '" oninput="updateActiveNote(\'title\', this.value)" />');
   if (tagsHtml) h.push('<div class="notes-edit-tags">' + tagsHtml + '</div>');
+  if (note.anchorType) {
+    h.push('<div class="notes-backlinks"><div class="notes-backlinks-label">Private anchor</div><div class="notes-backlink-row">' +
+      escapeHtml(note.anchorType) + (note.anchorLabel ? ' · ' + escapeHtml(note.anchorLabel) : '') +
+      (note.anchorPreview ? '<br><span style="color:var(--ink-faint)">' + escapeHtml(note.anchorPreview) + '</span>' : '') +
+      '</div></div>');
+  }
   h.push('<div class="notes-editor" id="notes-editor-body" contenteditable="true" data-placeholder="Start writing… use # for tags, @ for mentions" oninput="updateActiveNote(\'body\', this.innerHTML)" onblur="renderNotesListOnly()">' + (note.body || '') + '</div>');
   h.push(backlinksHtml);
   h.push('</div>');
@@ -2586,7 +2666,7 @@ function sendMagicLink() {
   }
   // Prototype fallback when Convex isn't live (proto-only previews).
   closeSheet();
-  toast('Magic link sent to ' + email, 'Check your inbox. Return target: NodeBench event notebook.');
+  toast('Magic link sent to ' + email, 'Check your inbox. This will save your ScratchNode events and private notes.');
   haptic(15);
 }
 
@@ -2989,13 +3069,14 @@ document.addEventListener('keydown', function(e) {
 // Apply mention rendering + add hover actions to all rows in feed
 function decorateRow(row, opts) {
   opts = opts || {};
-  var mid = opts.mid || 'm' + Date.now() + Math.floor(Math.random()*999);
+  var mid = opts.mid || row.getAttribute('data-mid') || 'm' + Date.now() + Math.floor(Math.random()*999);
   row.setAttribute('data-mid', mid);
   // Add hover-action bar
   if (!row.querySelector('.row-actions')) {
     var actions = document.createElement('div');
     actions.className = 'row-actions';
     actions.innerHTML =
+      '<button type="button" title="Save private note" aria-label="Save private note" onclick="noteOnMessage(\'' + mid + '\')">note</button>' +
       '<button type="button" title="Reply" aria-label="Reply" onclick="replyTo(\'' + mid + '\')">↳</button>' +
       '<button type="button" title="React" aria-label="React" onclick="toggleReactPicker(this, \'' + mid + '\')">😊</button>';
     row.appendChild(actions);
@@ -3007,6 +3088,7 @@ function decorateRow(row, opts) {
     textEl.innerHTML = renderMentions(raw);
     textEl.dataset.rendered = '1';
   }
+  if (typeof renderPrivateNoteMarkers === 'function') renderPrivateNoteMarkers();
 }
 
 // MutationObserver: auto-decorate any new rows added to the feed
@@ -3043,6 +3125,46 @@ function replyTo(mid) {
 function cancelReply() {
   _replyingToMid = null;
   document.getElementById('reply-ctx').setAttribute('data-open', 'false');
+}
+
+function noteOnMessage(mid) {
+  replyTo(mid);
+  if (document.body.getAttribute('data-mode') !== 'private') toggleLock();
+  toast('Private note anchor set', 'Your next private note will attach to this public message.');
+}
+
+function getPrivateNotesForAnchor(anchorId) {
+  return (window._notes_v5 || []).filter(function(n) {
+    return n.anchorType === 'message' && n.anchorId === anchorId;
+  });
+}
+
+function openPrivateAnchorNotes(anchorId) {
+  var notes = getPrivateNotesForAnchor(anchorId);
+  if (notes.length) window._activeNoteId = notes[0].id;
+  openNotes();
+}
+
+function renderPrivateNoteMarkers() {
+  document.querySelectorAll('.private-note-marker').forEach(function(el) { el.remove(); });
+  var rows = document.querySelectorAll('.row[data-mid]');
+  rows.forEach(function(row) {
+    var mid = row.getAttribute('data-mid');
+    var notes = getPrivateNotesForAnchor(mid);
+    if (!notes.length) return;
+    var body = row.querySelector('.row-body');
+    if (!body) return;
+    var marker = document.createElement('button');
+    marker.type = 'button';
+    marker.className = 'private-note-marker';
+    marker.setAttribute('aria-label', notes.length + ' private note' + (notes.length === 1 ? '' : 's') + ' anchored here');
+    marker.textContent = notes.length + ' private note' + (notes.length === 1 ? '' : 's');
+    marker.onclick = function(e) {
+      e.stopPropagation();
+      openPrivateAnchorNotes(mid);
+    };
+    body.appendChild(marker);
+  });
 }
 
 // (Wrapper #4 removed — reply context is now resolved inside _appendChatRow() via getRoomContext().replyingToMid)
@@ -3300,6 +3422,25 @@ setTimeout(refreshNotesCounter, 100);
   }
   const eventId = joined.eventId;
   window._sn_live = { client, eventId, sessionId, slug };
+  window._sn_my_events = {
+    joined: [{ eventId, slug: joined.slug, name: joined.name, roomCode: joined.roomCode, status: joined.status, role: 'attendee' }],
+    hosted: []
+  };
+  window.snRefreshMyEvents = function() {
+    const ownerKey = (typeof _snReadHostOwnerKey === 'function') ? _snReadHostOwnerKey() : sessionId;
+    return client.query('events:getMyEvents', { sessionId, ownerKey, limit: 20 })
+      .then((state) => {
+        window._sn_my_events = state || window._sn_my_events;
+        const joinedCount = ((state && state.joined) || []).length;
+        const hostedCount = ((state && state.hosted) || []).length;
+        const sub = document.getElementById('menu-events-sub');
+        if (sub) sub.textContent = joinedCount + ' joined - ' + hostedCount + ' hosted';
+        if (typeof _activeSheet !== 'undefined' && _activeSheet === 'events') openSheet('events');
+        return state;
+      })
+      .catch((e) => console.warn('[scratchnode] getMyEvents failed:', e.message || e));
+  };
+  window.snRefreshMyEvents();
 
   // Step 8 — auto-consume ?sign-in-token=XXX from URL once Convex is live.
   try {
@@ -3498,6 +3639,7 @@ setTimeout(refreshNotesCounter, 100);
           if (status && status.isHost) {
             document.body.setAttribute('data-role', 'host');
             window._sn_live.hostOwnerKey = existingV2;
+            if (window.snRefreshMyEvents) window.snRefreshMyEvents();
             toast('Host console re-enabled', 'Welcome back, ' + (status.displayName || hostName) + '.');
           } else {
             // Token didn't verify — clear it and re-prompt.
@@ -3558,6 +3700,7 @@ setTimeout(refreshNotesCounter, 100);
           localStorage.setItem('sn_host_owner_key_v2', newToken);
           document.body.setAttribute('data-role', 'host');
           window._sn_live.hostOwnerKey = newToken;
+          if (window.snRefreshMyEvents) window.snRefreshMyEvents();
           toast('Host console enabled', 'Real-auth host token issued and saved.');
         })
         .catch((e) => toast('Host claim blocked', (e && e.message) || String(e)));
@@ -3577,6 +3720,7 @@ setTimeout(refreshNotesCounter, 100);
         localStorage.setItem('sn_host_owner_key_v2', newToken);
         document.body.setAttribute('data-role', 'host');
         window._sn_live.hostOwnerKey = newToken;
+        if (window.snRefreshMyEvents) window.snRefreshMyEvents();
         toast('Host console enabled', 'Code verified — host token issued.');
       })
       .catch((e) => toast('Host claim blocked', (e && e.message) || String(e)));
@@ -3617,6 +3761,7 @@ setTimeout(refreshNotesCounter, 100);
         localStorage.setItem('sn_host_owner_key_v2', newToken);
         document.body.setAttribute('data-role', 'host');
         window._sn_live.hostOwnerKey = newToken;
+        if (window.snRefreshMyEvents) window.snRefreshMyEvents();
         if (input) input.value = '';
         toast('You are now host', 'Code verified — host token issued.');
         // Re-render the sheet so the rotation section becomes visible
@@ -3717,6 +3862,7 @@ setTimeout(refreshNotesCounter, 100);
     if (status && status.isHost) {
       document.body.setAttribute('data-role', 'host');
       window._sn_live.hostOwnerKey = _bootstrapKey;
+      if (window.snRefreshMyEvents) window.snRefreshMyEvents();
     }
   }).catch(() => {});
 
@@ -3752,6 +3898,12 @@ setTimeout(refreshNotesCounter, 100);
       tags: row.tags || [],
       pinned: !!row.pinned,
       isAsk: !!row.isAsk,
+      anchorType: row.anchorType,
+      anchorId: row.anchorId,
+      anchorLabel: row.anchorLabel,
+      anchorPreview: row.anchorPreview,
+      startTs: row.startTs,
+      endTs: row.endTs,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
       _convex: true,
@@ -3774,6 +3926,7 @@ setTimeout(refreshNotesCounter, 100);
       window._activeNoteId = (window._notes_v5[0] && window._notes_v5[0].id) || null;
     }
     if (typeof refreshNotesCounter === 'function') refreshNotesCounter();
+    if (typeof renderPrivateNoteMarkers === 'function') renderPrivateNoteMarkers();
     if (typeof _activeSheet !== 'undefined' && _activeSheet === 'notes') {
       if (typeof renderNotesListOnly === 'function') renderNotesListOnly();
     }
@@ -3915,6 +4068,10 @@ setTimeout(refreshNotesCounter, 100);
       tags: (typeof extractTags === 'function') ? extractTags(clean) : [],
       isAsk: !!intent.isAsk,
       pinned: false,
+      anchorType: intent.anchor && intent.anchor.type,
+      anchorId: intent.anchor && intent.anchor.id,
+      anchorLabel: intent.anchor && intent.anchor.label,
+      anchorPreview: intent.anchor && intent.anchor.preview,
     }).catch((e) => {
       console.warn('[scratchnode] private note Convex save failed (kept locally):', e.message || e);
     });

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -138,6 +138,23 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
     await waitForScratchNodeLive(pageA);
     await waitForScratchNodeLive(pageB);
 
+    const myEvents = await pageA.evaluate(async () => {
+      const live = (window as any)._sn_live;
+      return await live.client.query("events:getMyEvents", {
+        sessionId: live.sessionId,
+        ownerKey:
+          localStorage.getItem("sn_host_owner_key_v2") ||
+          localStorage.getItem("sn_host_owner_key") ||
+          live.sessionId,
+        limit: 10,
+      });
+    });
+    expect(myEvents.joined.some((event: any) => event.slug === "ai-infra-summit-2026")).toBe(true);
+    await pageA.evaluate(() => (window as any).openEvents());
+    await expect(pageA.locator("#sheet-title")).toContainText("My events");
+    await expect(pageA.locator("#sheet-content")).toContainText("AI Infra Summit");
+    await pageA.evaluate(() => (window as any).closeSheet());
+
     const chatText = `QA public chat sync ${qaId}`;
     await sendComposer(pageA, chatText);
     await expect
@@ -151,6 +168,13 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
         { timeout: 30_000 },
       )
       .toBe(true);
+    const publicMessageId = await pageA.evaluate((text) => {
+      const row = Array.from(document.querySelectorAll(".row[data-mid]")).find((node) =>
+        node.querySelector(".row-text")?.textContent?.includes(text),
+      );
+      return row?.getAttribute("data-mid") ?? null;
+    }, chatText);
+    expect(publicMessageId, "public message should have a stable row id for private anchors").toBeTruthy();
 
     const question = `what did attendees say about MCP auth ${qaId}`;
     await sendComposer(pageA, `/ask ${question}`);
@@ -219,11 +243,10 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
     }
 
     const privateNote = `QA private note ${qaId}`;
-    await pageA.evaluate(() => {
-      if (document.body.getAttribute("data-mode") !== "private") {
-        (window as any).toggleLock();
-      }
-    });
+    await pageA.evaluate((mid) => (window as any).noteOnMessage(mid), publicMessageId);
+    await expect
+      .poll(() => pageA.evaluate(() => document.body.getAttribute("data-mode")), { timeout: 5_000 })
+      .toBe("private");
     await sendComposer(pageA, privateNote);
 
     await expect
@@ -250,6 +273,35 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
       return note?.id ?? null;
     }, privateNote);
     expect(noteId, "private note should have a Convex id").toBeTruthy();
+    const anchoredNote = await pageA.evaluate((id) => {
+      return ((window as any)._notes_v5 || []).find((note: any) => note.id === id) ?? null;
+    }, noteId);
+    expect(anchoredNote.anchorType).toBe("message");
+    expect(anchoredNote.anchorId).toBe(publicMessageId);
+    await expect
+      .poll(
+        () =>
+          pageA.evaluate((mid) => {
+            const row = Array.from(document.querySelectorAll(".row[data-mid]")).find(
+              (node) => node.getAttribute("data-mid") === mid,
+            );
+            return row?.querySelector(".private-note-marker")?.textContent ?? "";
+          }, publicMessageId),
+        { timeout: 15_000 },
+      )
+      .toContain("private note");
+    await expect
+      .poll(
+        () =>
+          pageB.evaluate((mid) => {
+            const row = Array.from(document.querySelectorAll(".row[data-mid]")).find(
+              (node) => node.getAttribute("data-mid") === mid,
+            );
+            return !!row?.querySelector(".private-note-marker");
+          }, publicMessageId),
+        { timeout: 5_000 },
+      )
+      .toBe(false);
 
     await pageA.evaluate(() => (window as any).openNotes());
     await expect(pageA.locator("#sn-nodebench-private-handoff")).toBeVisible();
@@ -289,6 +341,18 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
         { timeout: 15_000 },
       )
       .toBe(true);
+    await expect
+      .poll(
+        () =>
+          pageA.evaluate((mid) => {
+            const row = Array.from(document.querySelectorAll(".row[data-mid]")).find(
+              (node) => node.getAttribute("data-mid") === mid,
+            );
+            return !!row?.querySelector(".private-note-marker");
+          }, publicMessageId),
+        { timeout: 15_000 },
+      )
+      .toBe(false);
 
     await pageA.screenshot({
       path: join(ARTIFACT_DIR, `${qaId}-event-final.png`),


### PR DESCRIPTION
## Summary
- Adds private-note anchor metadata to Convex userNotes without touching public liveEventMessages.
- Adds a bounded ScratchNode event-state query for joined and hosted events.
- Wires home-v5 private annotation markers, My events guest fallback, and docs for the ScratchNode vs NodeBench account boundary.
- Extends live backend dogfood coverage for getMyEvents and owner-only private-note markers.

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run convex/events.runtime-boundary.test.ts
- npm run build
- HTML script parse smoke for public/proto/home-v5.html
- Playwright visual smoke: private marker + My events sheet