### PR TITLE
feat(scratchnode): add agent output L123 contract

### DIFF
--- a/docs/architecture/AGENT_OUTPUT_L123_CONTRACT.md
+++ b/docs/architecture/AGENT_OUTPUT_L123_CONTRACT.md
@@ -1,0 +1,249 @@
+# Agent Output L1/L2/L3 Contract
+
+Last updated: 2026-05-27
+
+## Locked Rule
+
+Every agent output must be classified, validated, stored, retrieved, rendered,
+traced, and evaluated through the same three-level contract:
+
+```text
+L1 = broad output family
+L2 = object category
+L3 = exact contract, renderer, and validator
+```
+
+No output is accepted unless it has:
+
+```text
+valid l1/l2/l3
+visibility boundary
+target id
+source/citation policy
+traceRef
+producer metadata
+storage policy
+renderer mapping
+evaluator mapping
+```
+
+The implementation lives in:
+
+```text
+src/shared/agentOutputContract.ts
+src/shared/agentOutputContract.test.ts
+public/proto/home-v5.html
+```
+
+## Why This Exists
+
+ScratchNode and NodeBench already have the right runtime primitives:
+
+```text
+public event wiki
+private notes
+traces
+semantic cache
+context retriever
+Convex truth
+Redis hot layer
+Typesense search
+Linkup search
+pi-ai orchestration
+```
+
+The missing shared spine was a typed way to say what an agent produced and what
+rules apply to it. L1/L2/L3 gives one gate for public wiki generation, private
+LightRAG memory, search retrieval tools, semantic cache entries, trace nodes,
+artifacts, and UI renderers.
+
+## L1 Families
+
+```text
+public_knowledge
+private_memory
+retrieval_context
+graph_memory
+agent_trace
+generated_artifact
+operational_cache
+ui_renderable
+```
+
+## Core Envelope
+
+```ts
+type AgentOutputEnvelope = {
+  id: string;
+  l1: OutputL1;
+  l2: string;
+  l3: string;
+  target: {
+    eventId?: string;
+    notebookId?: string;
+    artifactId?: string;
+    entityId?: string;
+    messageId?: string;
+    traceId?: string;
+  };
+  visibility: "event_public" | "private" | "workspace" | "host_draft";
+  sourceRefs: string[];
+  citationRefs: string[];
+  traceRef: string;
+  producedBy: {
+    runId: string;
+    skill: string;
+    model?: string;
+    toolChain: string[];
+  };
+  version: {
+    wikiVersion?: number;
+    sourceBundleVersion?: number;
+    memorySnapshotVersion?: number;
+  };
+  output: Record<string, unknown>;
+};
+```
+
+## Validator Stack
+
+The shared evaluator checks:
+
+```text
+taxonomy validity
+policy mapping
+visibility mapping
+target presence
+trace completeness
+producer metadata
+source/citation array shape
+public/private leakage
+FAQ answer contract
+wiki version contract
+semantic cache key contract
+retrieval visibility contract
+private note contract
+```
+
+The public/private rule is strict:
+
+```text
+event_public output cannot reference private notes, private sources, or
+privateNotesUsed=true.
+```
+
+Private notes remain:
+
+```text
+l1 = private_memory
+l2 = private_note
+visibility = private
+```
+
+If a private note is shared, the system should create a separate public
+suggestion or FAQ candidate. It must not mutate the original private object into
+public content.
+
+## ScratchNode Demo Wiring
+
+`home-v5.html` now records typed envelopes while `runDemoFull()` plays:
+
+```text
+public /ask answer
+semantic answer cache entry
+retrieval context packet
+public trace output node
+semantic cache trace tool call
+agent answer UI card
+private anchored note
+private note patch trace
+private note marker UI card
+event wiki section items
+published event wiki artifact
+LightRAG atomic claim
+NodeBench presentation artifact
+workspace artifact-created trace
+```
+
+`runDemoQA()` still returns the 17 user-facing release-blocker checks, and now
+also returns:
+
+```ts
+summary.contract = {
+  passed: boolean,
+  total: number,
+  invalid: string[],
+  missingFamilies: string[],
+  byL1: Record<string, number>,
+  rendererMapped: boolean,
+  evaluatorMapped: boolean
+}
+```
+
+This means the demo now proves both layers:
+
+```text
+human-visible product invariants
+machine-readable agent output contract invariants
+```
+
+## Golden Contract Examples
+
+Public cached FAQ answer:
+
+```text
+l1 = public_knowledge
+l2 = event_faq
+l3 = faq.cached_reuse_answer
+visibility = event_public
+privateNotesUsed = false
+sourceRefs present
+traceRef present
+```
+
+Private anchored note:
+
+```text
+l1 = private_memory
+l2 = private_note
+l3 = note.anchored_to_chat
+visibility = private
+anchor = message id
+never creates eventMessages row
+```
+
+Public retrieval packet:
+
+```text
+l1 = retrieval_context
+l2 = index_search
+l3 = retrieval.context_packet
+visibility = event_public
+includePrivate = false
+no private results
+```
+
+Public semantic cache:
+
+```text
+l1 = operational_cache
+l2 = semantic_answer_cache
+l3 = cache.public_faq_answer
+visibility = event_public
+eventId + wikiVersion + sourceBundleVersion in key
+privateContextAllowed = false
+```
+
+## Release Impact
+
+This does not replace Convex, Redis, Typesense, Linkup, or pi-ai. It makes their
+outputs auditable before storage and rendering.
+
+Runtime rule:
+
+```text
+Classify -> Validate -> Persist -> Render -> Trace -> Evaluate
+```
+
+Any new agent skill must declare the L3 contracts it can emit before it writes to
+Convex, cache, artifact storage, or UI.

--- a/docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
+++ b/docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
@@ -208,6 +208,35 @@ Linkup: external discovery only when event corpus misses or freshness requires i
 pi-ai / NodeBench runtime: orchestration and governed tools, not raw database access
 ```
 
+## Agent Output Contract
+
+All agent outputs must pass the shared L1/L2/L3 contract before they are stored,
+rendered, cached, or promoted:
+
+```text
+L1 = broad output family
+L2 = object category
+L3 = exact contract / renderer / validator
+```
+
+Examples:
+
+```text
+public_knowledge / event_faq / faq.cached_reuse_answer
+private_memory / private_note / note.anchored_to_chat
+retrieval_context / index_search / retrieval.context_packet
+operational_cache / semantic_answer_cache / cache.public_faq_answer
+agent_trace / output_node / trace.output.public_answer
+generated_artifact / event_archive / artifact.published_event_wiki
+```
+
+The executable registry and evaluator live in
+`src/shared/agentOutputContract.ts`. The ScratchNode demo records evaluated
+envelopes during `runDemoFull()` and exposes the contract result through
+`runDemoQA().contract`.
+
+Reference: `docs/architecture/AGENT_OUTPUT_L123_CONTRACT.md`.
+
 ## Trace Contract
 
 ScratchNode shows a compact public trace:

--- a/public/proto/docs.html
+++ b/public/proto/docs.html
@@ -308,6 +308,7 @@ kbd {
     <a class="toc-link" href="#production-arch" data-toc="production-arch">Production architecture</a>
     <a class="toc-link sub" href="#prod-stack" data-toc="prod-stack">The stack</a>
     <a class="toc-link sub" href="#prod-responsibilities" data-toc="prod-responsibilities">Layer responsibilities</a>
+    <a class="toc-link sub" href="#prod-output-contract" data-toc="prod-output-contract">Output contract</a>
     <a class="toc-link sub" href="#prod-ask-runtime" data-toc="prod-ask-runtime">/ask runtime pipeline</a>
     <a class="toc-link sub" href="#prod-cache-key" data-toc="prod-cache-key">Cache key shape</a>
     <a class="toc-link sub" href="#prod-mcp-tools" data-toc="prod-mcp-tools">MCP tool design</a>
@@ -463,6 +464,16 @@ sources/traces              context retrieval packets         autocomplete
         <tr><td><strong>pi-ai runtime</strong></td><td>Orchestration, streaming, skill/tool dispatch</td><td>Owning data directly</td></tr>
       </tbody>
     </table>
+
+    <h3 id="prod-output-contract">Agent output L1/L2/L3 contract</h3>
+    <p>Every agent output must now be classified, validated, stored, rendered, traced, and evaluated through one shared contract: <code>L1</code> broad family, <code>L2</code> object category, and <code>L3</code> exact contract / renderer / validator. The executable registry lives in <code>src/shared/agentOutputContract.ts</code>; <code>home-v5.html</code> records evaluated envelopes during <code>runDemoFull()</code>.</p>
+    <pre><span class="lang">text</span>public_knowledge / event_faq / faq.cached_reuse_answer
+private_memory / private_note / note.anchored_to_chat
+retrieval_context / index_search / retrieval.context_packet
+operational_cache / semantic_answer_cache / cache.public_faq_answer
+agent_trace / output_node / trace.output.public_answer
+generated_artifact / event_archive / artifact.published_event_wiki</pre>
+    <div class="callout"><span class="icon">âœ…</span><div><strong>Acceptance gate:</strong> no output is accepted unless it has a valid <code>l1/l2/l3</code>, visibility boundary, target id, <code>traceRef</code>, source/citation arrays, producer metadata, storage policy, renderer mapping, and evaluator mapping. <code>runDemoQA().contract</code> shows the demo envelope pass/fail summary by L1 family.</div></div>
 
     <h3 id="prod-ask-runtime">The <code>/ask</code> runtime pipeline</h3>
     <p>The agent answer trace shown in the UI is a flattened view of this pipeline. Every step in the trace corresponds to a real cache/retrieval decision.</p>

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -4606,6 +4606,134 @@ setTimeout(refreshNotesCounter, 100);
       .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
+  var AGENT_OUTPUT_REGISTRY = {
+    public_knowledge: {
+      event_wiki: ['wiki.need_to_know_item','wiki.what_changed_item','wiki.followup_item','wiki.people_item','wiki.company_item','wiki.source_item','wiki.trace_summary'],
+      event_faq: ['faq.answer_candidate','faq.host_promoted_answer','faq.cached_reuse_answer','faq.delta_refreshed_answer'],
+      public_agent_answer: ['answer.public_event_card','answer.cached_event_answer','answer.delta_refreshed_answer']
+    },
+    private_memory: {
+      private_note: ['note.raw_shorthand','note.agent_enhanced','note.voice_transcript','note.anchored_to_chat','note.followup_task'],
+      private_notebook_patch: ['notebook.append_block','notebook.update_block','notebook.followup_task']
+    },
+    retrieval_context: {
+      index_search: ['retrieval.typesense_hit','retrieval.convex_exact','retrieval.redis_semantic_cache_hit','retrieval.linkup_result','retrieval.source_bundle','retrieval.context_packet']
+    },
+    graph_memory: {
+      lightrag_memory: ['memory.entity','memory.atomic_claim','memory.semantic_edge','memory.citation','memory.compacted_summary','memory.famous_branch','memory.versioned_snapshot']
+    },
+    agent_trace: {
+      output_node: ['trace.output.public_answer','trace.output.private_note_patch','trace.output.wiki_update','trace.output.artifact_created'],
+      phase: ['trace.phase.context_resolved','trace.phase.cache_lookup','trace.phase.context_retrieval','trace.phase.verification','trace.phase.persistence'],
+      tool_call: ['trace.tool.semantic_cache_lookup','trace.tool.retrieve_context','trace.tool.linkup_search','trace.tool.save_private_note_patch']
+    },
+    generated_artifact: {
+      presentation: ['artifact.presentation_html'],
+      source_bundle: ['artifact.source_bundle'],
+      export: ['artifact.csv_export','artifact.crm_export'],
+      event_archive: ['artifact.published_event_wiki']
+    },
+    operational_cache: {
+      semantic_answer_cache: ['cache.public_faq_answer','cache.private_answer_forbidden','cache.stale_public_answer','cache.delta_refresh_required']
+    },
+    ui_renderable: {
+      ui_card: ['ui.agent_answer_card','ui.trace_drawer','ui.private_note_marker','ui.mention_chip']
+    }
+  };
+  var AGENT_OUTPUT_POLICIES = {
+    'faq.cached_reuse_answer': { l1:'public_knowledge', l2:'event_faq', storage:'convex', renderer:'AgentAnswerCard', evaluator:'faq_validator', allowedVisibility:['event_public'] },
+    'note.anchored_to_chat': { l1:'private_memory', l2:'private_note', storage:'convex', renderer:'PrivateNoteMarker', evaluator:'note_validator', allowedVisibility:['private'] },
+    'note.agent_enhanced': { l1:'private_memory', l2:'private_note', storage:'convex', renderer:'PrivateNoteSheet', evaluator:'note_validator', allowedVisibility:['private'] },
+    'note.voice_transcript': { l1:'private_memory', l2:'private_note', storage:'convex', renderer:'PrivateNoteSheet', evaluator:'note_validator', allowedVisibility:['private'] },
+    'note.raw_shorthand': { l1:'private_memory', l2:'private_note', storage:'convex', renderer:'PrivateNoteSheet', evaluator:'note_validator', allowedVisibility:['private'] },
+    'retrieval.context_packet': { l1:'retrieval_context', l2:'index_search', storage:'convex', renderer:'ContextPacket', evaluator:'context_resolver_evaluator', allowedVisibility:['event_public','private','workspace'] },
+    'memory.atomic_claim': { l1:'graph_memory', l2:'lightrag_memory', storage:'convex', renderer:'ClaimCard', evaluator:'memory_compaction_evaluator', allowedVisibility:['event_public','private','workspace'] },
+    'cache.public_faq_answer': { l1:'operational_cache', l2:'semantic_answer_cache', storage:'redis', renderer:'CacheTraceRow', evaluator:'cache_safety_evaluator', allowedVisibility:['event_public'] },
+    'trace.output.public_answer': { l1:'agent_trace', l2:'output_node', storage:'convex', renderer:'TraceNode', evaluator:'trace_evaluator', allowedVisibility:['event_public'] },
+    'trace.output.private_note_patch': { l1:'agent_trace', l2:'output_node', storage:'convex', renderer:'TraceNode', evaluator:'trace_evaluator', allowedVisibility:['private','workspace'] },
+    'trace.output.wiki_update': { l1:'agent_trace', l2:'output_node', storage:'convex', renderer:'TraceNode', evaluator:'trace_evaluator', allowedVisibility:['event_public','host_draft'] },
+    'trace.output.artifact_created': { l1:'agent_trace', l2:'output_node', storage:'convex', renderer:'TraceNode', evaluator:'trace_evaluator', allowedVisibility:['event_public','workspace'] },
+    'trace.tool.semantic_cache_lookup': { l1:'agent_trace', l2:'tool_call', storage:'convex', renderer:'TraceToolCall', evaluator:'tool_call_evaluator', allowedVisibility:['event_public','private','workspace'] },
+    'trace.tool.retrieve_context': { l1:'agent_trace', l2:'tool_call', storage:'convex', renderer:'TraceToolCall', evaluator:'tool_call_evaluator', allowedVisibility:['event_public','private','workspace'] },
+    'trace.tool.save_private_note_patch': { l1:'agent_trace', l2:'tool_call', storage:'convex', renderer:'TraceToolCall', evaluator:'tool_call_evaluator', allowedVisibility:['private','workspace'] },
+    'wiki.need_to_know_item': { l1:'public_knowledge', l2:'event_wiki', storage:'convex', renderer:'WikiSectionItem', evaluator:'wiki_validator', allowedVisibility:['event_public','host_draft'] },
+    'wiki.what_changed_item': { l1:'public_knowledge', l2:'event_wiki', storage:'convex', renderer:'WikiSectionItem', evaluator:'wiki_validator', allowedVisibility:['event_public','host_draft'] },
+    'artifact.published_event_wiki': { l1:'generated_artifact', l2:'event_archive', storage:'artifact_lake', renderer:'EventArchiveArtifact', evaluator:'artifact_validator', allowedVisibility:['event_public'] },
+    'artifact.presentation_html': { l1:'generated_artifact', l2:'presentation', storage:'artifact_lake', renderer:'PresentationArtifact', evaluator:'artifact_validator', allowedVisibility:['event_public','workspace'] },
+    'ui.agent_answer_card': { l1:'ui_renderable', l2:'ui_card', storage:'ui_only', renderer:'AgentAnswerCard', evaluator:'ui_snapshot_evaluator', allowedVisibility:['event_public'] },
+    'ui.private_note_marker': { l1:'ui_renderable', l2:'ui_card', storage:'ui_only', renderer:'PrivateNoteMarker', evaluator:'ui_snapshot_evaluator', allowedVisibility:['private'] }
+  };
+  function _isValidOutputTaxonomy(l1, l2, l3) {
+    return !!(AGENT_OUTPUT_REGISTRY[l1] && AGENT_OUTPUT_REGISTRY[l1][l2] && AGENT_OUTPUT_REGISTRY[l1][l2].indexOf(l3) !== -1);
+  }
+  function _hasOutputTarget(target) {
+    if (!target) return false;
+    return Object.keys(target).some(function(k) { return typeof target[k] === 'string' && target[k].length > 0; });
+  }
+  function _readOutputPath(obj, path) {
+    var cur = obj;
+    for (var i = 0; i < path.length; i++) {
+      if (!cur || typeof cur !== 'object') return undefined;
+      cur = cur[path[i]];
+    }
+    return cur;
+  }
+  function _hasPrivateOutputRef(envelope) {
+    var refs = [].concat(envelope.sourceRefs || [], envelope.citationRefs || []);
+    if (refs.some(function(r) { return /^private[:/_-]|private_note|userNotes|note_private/i.test(String(r)); })) return true;
+    return /"(?:privateNoteIds?|private_source_refs?|privateNotesUsed)"\s*:\s*true/i.test(JSON.stringify(envelope.output || {}));
+  }
+  function evaluateAgentOutputEnvelope(envelope) {
+    var issues = [];
+    function err(code, message) { issues.push({ code: code, message: message, severity: 'error' }); }
+    var policy = AGENT_OUTPUT_POLICIES[envelope && envelope.l3];
+    if (!envelope || !envelope.id) err('EVAL-SCHEMA-000', 'Envelope id is required.');
+    if (!envelope || !_isValidOutputTaxonomy(envelope.l1, envelope.l2, envelope.l3)) err('EVAL-SCHEMA-001', 'l1/l2/l3 must match registry.');
+    if (!policy) err('EVAL-SCHEMA-005', 'l3 must map to storage, renderer, and evaluator.');
+    if (policy && (policy.l1 !== envelope.l1 || policy.l2 !== envelope.l2)) err('EVAL-SCHEMA-003', 'l3 belongs to a different l1/l2 pair.');
+    if (policy && policy.allowedVisibility.indexOf(envelope.visibility) === -1) err('EVAL-POLICY-006', 'visibility not allowed for l3.');
+    if (!_hasOutputTarget(envelope && envelope.target)) err('EVAL-SCHEMA-006', 'At least one target id is required.');
+    if (!envelope.traceRef) err('EVAL-TRACE-001', 'traceRef is required.');
+    if (!envelope.producedBy || !envelope.producedBy.runId || !envelope.producedBy.skill || !Array.isArray(envelope.producedBy.toolChain)) err('EVAL-TRACE-002', 'producedBy.runId, skill, and toolChain are required.');
+    if (!Array.isArray(envelope.sourceRefs) || !Array.isArray(envelope.citationRefs)) err('EVAL-CITE-000', 'sourceRefs and citationRefs must be arrays.');
+    if (envelope.visibility === 'event_public' && _hasPrivateOutputRef(envelope)) err('EVAL-POLICY-001', 'event_public output cannot reference private notes.');
+    if (envelope.l1 === 'private_memory' && envelope.visibility !== 'private') err('NOTE-001', 'private_memory outputs must be private.');
+    if (envelope.l2 === 'event_faq' || envelope.l2 === 'public_agent_answer') {
+      if (!_readOutputPath(envelope.output, ['parentAskMessageId'])) err('FAQ-001', 'Public answer requires parentAskMessageId.');
+      if (_readOutputPath(envelope.output, ['reuseSummary','privateNotesUsed']) !== false) err('FAQ-003', 'Public answer privateNotesUsed must be false.');
+      if ((envelope.sourceRefs || []).length === 0) err('FAQ-009', 'Public answer requires sourceRefs.');
+    }
+    if (envelope.l2 === 'semantic_answer_cache') {
+      if (!envelope.target || !envelope.target.eventId) err('CACHE-002', 'Cache entry requires eventId.');
+      if (!envelope.version || typeof envelope.version.wikiVersion !== 'number') err('CACHE-003', 'Cache entry requires wikiVersion.');
+      if (!envelope.version || typeof envelope.version.sourceBundleVersion !== 'number') err('CACHE-004', 'Cache entry requires sourceBundleVersion.');
+      if (envelope.visibility === 'event_public' && _readOutputPath(envelope.output, ['privateContextAllowed']) !== false) err('CACHE-005', 'Public cache privateContextAllowed must be false.');
+    }
+    if (envelope.l2 === 'index_search') {
+      if (envelope.visibility === 'event_public' && _readOutputPath(envelope.output, ['scope','includePrivate']) !== false) err('RET-003', 'Public retrieval must set includePrivate=false.');
+      var results = _readOutputPath(envelope.output, ['results']);
+      if (envelope.visibility === 'event_public' && Array.isArray(results) && results.some(function(r) { return r && r.visibility === 'private'; })) err('RET-003', 'Public retrieval cannot include private results.');
+    }
+    if (envelope.l2 === 'event_wiki') {
+      if (!envelope.target || !envelope.target.eventId) err('WIKI-STRUCT-001', 'Wiki output requires eventId.');
+      if (!envelope.version || typeof envelope.version.wikiVersion !== 'number') err('WIKI-STRUCT-007', 'Wiki output requires wikiVersion.');
+    }
+    if (envelope.l2 === 'private_note') {
+      if (!_readOutputPath(envelope.output, ['body'])) err('NOTE-002', 'Private note requires body.');
+    }
+    return { passed: issues.length === 0, issues: issues, policy: policy };
+  }
+  function recordAgentOutputEnvelope(envelope) {
+    var result = evaluateAgentOutputEnvelope(envelope);
+    envelope.evaluation = result;
+    if (!window._demo_state) _initDemoState();
+    window._demo_state.agentOutputs.push(envelope);
+    if (!result.passed) console.warn('[scratchnode][contract] invalid envelope', envelope.id, result.issues);
+    return envelope;
+  }
+  function _refSlug(value) {
+    return String(value || 'ref').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 48) || 'ref';
+  }
   function _nextId(prefix) {
     var s = window._demo_state;
     s._idSeq = (s._idSeq || 0) + 1;
@@ -4653,6 +4781,7 @@ setTimeout(refreshNotesCounter, 100);
       publicMessages: [],   // [{id, actorId, text, isAsk, time}]
       privateNotes: [],     // [{id, ownerId, anchorMessageId, text, source, time}]
       agentAnswers: [],     // [{id, replyingToActorId, question, body, sources, reuse, trace}]
+      agentOutputs: [],     // AgentOutputEnvelope[] classified by L1/L2/L3 contract.
       hostQueue: [],        // [{id, question, suggestedByActorId, promoted}]
       wikiPublished: false,
       activeActorId: null,
@@ -4777,6 +4906,110 @@ setTimeout(refreshNotesCounter, 100);
         id: ansId, replyingToActorId: askActor.id, question: args.question, body: args.body,
         sources: sources, reuse: reuse, trace: trace
       });
+      var parentAskMessageId = args.parentAskMessageId || args.askMessageId || ansId;
+      var runId = 'run_' + ansId;
+      var traceRef = 'trace_' + ansId;
+      var sourceRefs = sources.map(function(s, i) { return 'source:event:' + _refSlug(s) + ':' + i; });
+      var citationRefs = sources.map(function(s, i) { return 'citation:' + ansId + ':' + i; });
+      var commonProducedBy = { runId: runId, skill: 'event-room-qa', toolChain: ['semantic_cache_lookup','retrieve_event_context'] };
+      recordAgentOutputEnvelope({
+        id: 'out_' + ansId,
+        l1: 'public_knowledge',
+        l2: 'event_faq',
+        l3: 'faq.cached_reuse_answer',
+        target: { eventId: 'evt_ai_infra_summit', messageId: parentAskMessageId, traceId: traceRef },
+        visibility: 'event_public',
+        sourceRefs: sourceRefs,
+        citationRefs: citationRefs,
+        traceRef: traceRef,
+        producedBy: commonProducedBy,
+        version: { wikiVersion: 3, sourceBundleVersion: 7 },
+        output: {
+          parentAskMessageId: parentAskMessageId,
+          canonicalQuestion: args.question || '',
+          answerMarkdown: args.body || '',
+          answerMode: reuse.newSearches === 0 ? 'cache_hit' : 'delta_refresh',
+          reuseSummary: { similarQuestions: reuse.similar || 0, reusedSources: reuse.reused || sources.length, newSearches: reuse.newSearches || 0, privateNotesUsed: false },
+          promotionState: 'suggested'
+        }
+      });
+      recordAgentOutputEnvelope({
+        id: 'cache_' + ansId,
+        l1: 'operational_cache',
+        l2: 'semantic_answer_cache',
+        l3: 'cache.public_faq_answer',
+        target: { eventId: 'evt_ai_infra_summit', messageId: parentAskMessageId, traceId: traceRef },
+        visibility: 'event_public',
+        sourceRefs: sourceRefs,
+        citationRefs: citationRefs,
+        traceRef: traceRef,
+        producedBy: commonProducedBy,
+        version: { wikiVersion: 3, sourceBundleVersion: 7 },
+        output: { normalizedQuestion: _refSlug(args.question || ''), privateContextAllowed: false, reuseCount: reuse.similar || 0 }
+      });
+      recordAgentOutputEnvelope({
+        id: 'ctx_' + ansId,
+        l1: 'retrieval_context',
+        l2: 'index_search',
+        l3: 'retrieval.context_packet',
+        target: { eventId: 'evt_ai_infra_summit', messageId: parentAskMessageId, traceId: traceRef },
+        visibility: 'event_public',
+        sourceRefs: sourceRefs,
+        citationRefs: citationRefs,
+        traceRef: traceRef,
+        producedBy: commonProducedBy,
+        version: { wikiVersion: 3, sourceBundleVersion: 7 },
+        output: {
+          query: args.question || '',
+          normalizedQuery: _refSlug(args.question || ''),
+          scope: { eventId: 'evt_ai_infra_summit', includePrivate: false, visibility: 'event_public' },
+          results: sources.map(function(s, i) {
+            return { uri: sourceRefs[i], type: 'source', title: s, snippet: 'Event corpus source reused for public answer', reasonSelected: 'semantic cache + event wiki match', visibility: 'event_public' };
+          })
+        }
+      });
+      recordAgentOutputEnvelope({
+        id: 'trace_out_' + ansId,
+        l1: 'agent_trace',
+        l2: 'output_node',
+        l3: 'trace.output.public_answer',
+        target: { eventId: 'evt_ai_infra_summit', messageId: parentAskMessageId, traceId: traceRef },
+        visibility: 'event_public',
+        sourceRefs: sourceRefs,
+        citationRefs: citationRefs,
+        traceRef: traceRef,
+        producedBy: commonProducedBy,
+        version: { wikiVersion: 3, sourceBundleVersion: 7 },
+        output: { summary: 'Public answer card produced from event wiki cache', trace: trace, noPrivateNotesUsed: true }
+      });
+      recordAgentOutputEnvelope({
+        id: 'trace_cache_' + ansId,
+        l1: 'agent_trace',
+        l2: 'tool_call',
+        l3: 'trace.tool.semantic_cache_lookup',
+        target: { eventId: 'evt_ai_infra_summit', messageId: parentAskMessageId, traceId: traceRef },
+        visibility: 'event_public',
+        sourceRefs: sourceRefs,
+        citationRefs: [],
+        traceRef: traceRef,
+        producedBy: commonProducedBy,
+        version: { wikiVersion: 3, sourceBundleVersion: 7 },
+        output: { cacheHit: true, privateContextAllowed: false, newSearches: reuse.newSearches || 0 }
+      });
+      recordAgentOutputEnvelope({
+        id: 'ui_' + ansId,
+        l1: 'ui_renderable',
+        l2: 'ui_card',
+        l3: 'ui.agent_answer_card',
+        target: { eventId: 'evt_ai_infra_summit', messageId: parentAskMessageId, traceId: traceRef },
+        visibility: 'event_public',
+        sourceRefs: sourceRefs,
+        citationRefs: citationRefs,
+        traceRef: traceRef,
+        producedBy: commonProducedBy,
+        version: { wikiVersion: 3, sourceBundleVersion: 7 },
+        output: { renderer: 'AgentAnswerCard', parentAskMessageId: parentAskMessageId, privateNotesUsed: false }
+      });
       return ansId;
     });
   }
@@ -4827,6 +5060,78 @@ setTimeout(refreshNotesCounter, 100);
     // If anchor provided, show the private marker
     if (args.anchor) {
       showPrivateMarker({ anchorMessageId: args.anchor, ownerId: ownerActor.id, label: args.label || 'note' });
+    }
+    var traceRef = 'trace_' + noteId;
+    var noteL3 = args.source === 'voice'
+      ? 'note.voice_transcript'
+      : (args.source === 'shorthand-enhance' ? 'note.agent_enhanced' : (args.anchor ? 'note.anchored_to_chat' : 'note.raw_shorthand'));
+    var producedBy = {
+      runId: 'run_' + noteId,
+      skill: args.source === 'voice' ? 'voice-capture-note-builder' : 'private-note-builder',
+      toolChain: ['save_private_note_patch']
+    };
+    recordAgentOutputEnvelope({
+      id: 'out_' + noteId,
+      l1: 'private_memory',
+      l2: 'private_note',
+      l3: noteL3,
+      target: { eventId: 'evt_ai_infra_summit', messageId: args.anchor || undefined, traceId: traceRef },
+      visibility: 'private',
+      sourceRefs: args.anchor ? ['message:' + args.anchor] : ['event:evt_ai_infra_summit'],
+      citationRefs: [],
+      traceRef: traceRef,
+      producedBy: producedBy,
+      version: { memorySnapshotVersion: 1 },
+      output: {
+        body: args.text,
+        anchor: args.anchor ? { type: 'message', id: args.anchor } : { type: 'event', id: 'evt_ai_infra_summit' },
+        extractedEntities: args.text.indexOf('Orbital') !== -1 ? ['@Orbital Labs'] : [],
+        followUps: /follow|ask|schedule/i.test(args.text) ? [args.text] : []
+      }
+    });
+    recordAgentOutputEnvelope({
+      id: 'trace_' + noteId + '_out',
+      l1: 'agent_trace',
+      l2: 'output_node',
+      l3: 'trace.output.private_note_patch',
+      target: { eventId: 'evt_ai_infra_summit', messageId: args.anchor || undefined, traceId: traceRef },
+      visibility: 'private',
+      sourceRefs: args.anchor ? ['message:' + args.anchor] : ['event:evt_ai_infra_summit'],
+      citationRefs: [],
+      traceRef: traceRef,
+      producedBy: producedBy,
+      version: { memorySnapshotVersion: 1 },
+      output: { summary: 'Private note stored owner-only; not written to public feed.', storageTarget: 'userNotes' }
+    });
+    recordAgentOutputEnvelope({
+      id: 'trace_' + noteId + '_tool',
+      l1: 'agent_trace',
+      l2: 'tool_call',
+      l3: 'trace.tool.save_private_note_patch',
+      target: { eventId: 'evt_ai_infra_summit', messageId: args.anchor || undefined, traceId: traceRef },
+      visibility: 'private',
+      sourceRefs: args.anchor ? ['message:' + args.anchor] : ['event:evt_ai_infra_summit'],
+      citationRefs: [],
+      traceRef: traceRef,
+      producedBy: producedBy,
+      version: { memorySnapshotVersion: 1 },
+      output: { table: 'userNotes', publicFeedWrite: false }
+    });
+    if (args.anchor) {
+      recordAgentOutputEnvelope({
+        id: 'ui_' + noteId,
+        l1: 'ui_renderable',
+        l2: 'ui_card',
+        l3: 'ui.private_note_marker',
+        target: { eventId: 'evt_ai_infra_summit', messageId: args.anchor, traceId: traceRef },
+        visibility: 'private',
+        sourceRefs: ['message:' + args.anchor],
+        citationRefs: [],
+        traceRef: traceRef,
+        producedBy: producedBy,
+        version: { memorySnapshotVersion: 1 },
+        output: { renderer: 'PrivateNoteMarker', ownerId: ownerActor.id, publicContentVisible: false }
+      });
     }
     // Toast for visual feedback (only when in normal/fast speed)
     if (_currentSpeed.mult > 0 && typeof toast === 'function') {
@@ -4970,6 +5275,51 @@ setTimeout(refreshNotesCounter, 100);
       '<div class="privacy-notice">' + _esc(args.privacyNotice || 'Wiki uses only public messages + suggested FAQs. Private notes were not included.') + '</div>';
     feed.appendChild(card);
     _scroll(card);
+    var traceRef = 'trace_wiki_v1';
+    ['Need to know', 'What changed'].forEach(function(section, i) {
+      recordAgentOutputEnvelope({
+        id: 'wiki_v1_' + i,
+        l1: 'public_knowledge',
+        l2: 'event_wiki',
+        l3: i === 0 ? 'wiki.need_to_know_item' : 'wiki.what_changed_item',
+        target: { eventId: 'evt_ai_infra_summit', traceId: traceRef },
+        visibility: 'event_public',
+        sourceRefs: ['source:event-wiki:v1', 'source:event-corpus'],
+        citationRefs: ['citation:wiki:v1:' + i],
+        traceRef: traceRef,
+        producedBy: { runId: 'run_wiki_v1', skill: 'faq-promoter', toolChain: ['retrieve_event_context'] },
+        version: { wikiVersion: 1, sourceBundleVersion: 7 },
+        output: { title: section, body: section + ' section generated from public chat, public answers, and host-promoted FAQ only.' }
+      });
+    });
+    recordAgentOutputEnvelope({
+      id: 'trace_wiki_v1_out',
+      l1: 'agent_trace',
+      l2: 'output_node',
+      l3: 'trace.output.wiki_update',
+      target: { eventId: 'evt_ai_infra_summit', traceId: traceRef },
+      visibility: 'event_public',
+      sourceRefs: ['source:event-wiki:v1', 'source:event-corpus'],
+      citationRefs: [],
+      traceRef: traceRef,
+      producedBy: { runId: 'run_wiki_v1', skill: 'faq-promoter', toolChain: ['retrieve_event_context'] },
+      version: { wikiVersion: 1, sourceBundleVersion: 7 },
+      output: { privateNotesExcluded: true, hostPromotedOnly: true }
+    });
+    recordAgentOutputEnvelope({
+      id: 'artifact_wiki_v1',
+      l1: 'generated_artifact',
+      l2: 'event_archive',
+      l3: 'artifact.published_event_wiki',
+      target: { eventId: 'evt_ai_infra_summit', artifactId: 'artifact_ai_infra_summit_wiki_v1', traceId: traceRef },
+      visibility: 'event_public',
+      sourceRefs: ['source:event-wiki:v1', 'source:event-corpus'],
+      citationRefs: [],
+      traceRef: traceRef,
+      producedBy: { runId: 'run_wiki_v1', skill: 'faq-promoter', toolChain: ['retrieve_event_context'] },
+      version: { wikiVersion: 1, sourceBundleVersion: 7 },
+      output: { renderer: 'EventArchiveArtifact', privateNotesExcluded: true }
+    });
     return card;
   }
 
@@ -5139,7 +5489,36 @@ setTimeout(refreshNotesCounter, 100);
   }
 
   function createNodeBenchArtifact() {
-    return Promise.resolve({ id: 'art_' + Date.now(), kind: 'event-artifact', label: 'AI Infra Summit' });
+    var artifact = { id: 'art_' + Date.now(), kind: 'event-artifact', label: 'AI Infra Summit' };
+    recordAgentOutputEnvelope({
+      id: 'artifact_recap_deck',
+      l1: 'generated_artifact',
+      l2: 'presentation',
+      l3: 'artifact.presentation_html',
+      target: { eventId: 'evt_ai_infra_summit', artifactId: artifact.id, traceId: 'trace_nodebench_handoff' },
+      visibility: 'workspace',
+      sourceRefs: ['source:event-wiki:v1', 'source:private-notebook-summary'],
+      citationRefs: [],
+      traceRef: 'trace_nodebench_handoff',
+      producedBy: { runId: 'run_nodebench_handoff', skill: 'nodebench-event-handoff', toolChain: ['retrieve_event_context'] },
+      version: { wikiVersion: 1, sourceBundleVersion: 7, memorySnapshotVersion: 1 },
+      output: { renderer: 'PresentationArtifact', title: 'AI Infra Summit Recap', slideCount: 6 }
+    });
+    recordAgentOutputEnvelope({
+      id: 'trace_nodebench_handoff_out',
+      l1: 'agent_trace',
+      l2: 'output_node',
+      l3: 'trace.output.artifact_created',
+      target: { eventId: 'evt_ai_infra_summit', artifactId: artifact.id, traceId: 'trace_nodebench_handoff' },
+      visibility: 'workspace',
+      sourceRefs: ['source:event-wiki:v1', 'source:private-notebook-summary'],
+      citationRefs: [],
+      traceRef: 'trace_nodebench_handoff',
+      producedBy: { runId: 'run_nodebench_handoff', skill: 'nodebench-event-handoff', toolChain: ['retrieve_event_context'] },
+      version: { wikiVersion: 1, sourceBundleVersion: 7, memorySnapshotVersion: 1 },
+      output: { publicWikiUsed: true, privateNotesUsed: true, workspaceOnly: true }
+    });
+    return Promise.resolve(artifact);
   }
   function createDailyBriefDelta() {
     // The brief is rendered by the Reports tab in the overlay.
@@ -5260,6 +5639,7 @@ setTimeout(refreshNotesCounter, 100);
       text: 'what is the realistic p95 latency budget for voice agents in clinical triage?'
     });
     return streamAgentAnswer({
+      parentAskMessageId: ask.askMessageId,
       replyingTo: ask.askActor,
       question: ask.question,
       body: 'Clinical-grade voice agents converge on a sub-350ms round-trip budget per turn. 800ms end-to-end is workable for non-acute triage but clinicians disengage past that. Orbital Labs panel data isolates contributors: ASR ~80ms, LLM TTFT ~120ms, TTS ~80ms, network ~60-100ms.',
@@ -5272,6 +5652,27 @@ setTimeout(refreshNotesCounter, 100);
         '0 new searches · Linkup skipped',
         'No private notes used · public layer only'
       ]
+    }).then(function(ansId) {
+      recordAgentOutputEnvelope({
+        id: 'memory_orbital_claim_' + ansId,
+        l1: 'graph_memory',
+        l2: 'lightrag_memory',
+        l3: 'memory.atomic_claim',
+        target: { eventId: 'evt_ai_infra_summit', entityId: 'entity_orbital_labs', traceId: 'trace_' + ansId },
+        visibility: 'event_public',
+        sourceRefs: ['source:event:orbital-eval-infra-docs:0', 'source:event:lambda-labs-pricing:1'],
+        citationRefs: ['citation:' + ansId + ':orbital-claim'],
+        traceRef: 'trace_' + ansId,
+        producedBy: { runId: 'run_' + ansId, skill: 'event-room-qa', toolChain: ['semantic_cache_lookup','retrieve_event_context'] },
+        version: { wikiVersion: 3, sourceBundleVersion: 7, memorySnapshotVersion: 1 },
+        output: {
+          claim: 'Orbital Labs benchmarks voice agents at scale and is repeatedly referenced in the event corpus.',
+          atomic: true,
+          relation: 'mentioned_in',
+          anchors: [{ sourceType: 'chat_message', sourceId: ask.askMessageId }]
+        }
+      });
+      return ansId;
     });
   }
 
@@ -5332,6 +5733,7 @@ setTimeout(refreshNotesCounter, 100);
       text: 'how does Orbital Labs benchmark voice agents at scale? GPU stack + concurrency numbers?'
     });
     return streamAgentAnswer({
+      parentAskMessageId: ask.askMessageId,
       replyingTo: ask.askActor,
       question: ask.question,
       body: 'Orbital Labs runs 50 concurrent voice eval sessions on a 4x A100 40GB SXM rig with NVLink ($6.40/hr) for production parity. For dev: 2x L40S on Lambda ($2.80/hr) handles Whisper-large-v3 + Llama-3.1-70B quantized. RunPod H100 80GB single ($3.20/hr) wins tail-latency for clinical use.',
@@ -5597,9 +5999,27 @@ setTimeout(refreshNotesCounter, 100);
     var allClean = anyPubAns.length > 0 && Array.from(anyPubAns).every(function(h) { return /No private notes used/i.test(h.textContent); });
     check('DEMO-017', 'Public agent answer trace says no private notes', allClean, 'clean ans=' + anyPubAns.length);
 
+    var outputs = state.agentOutputs || [];
+    var requiredFamilies = ['public_knowledge','private_memory','retrieval_context','graph_memory','agent_trace','generated_artifact','operational_cache','ui_renderable'];
+    var byL1 = {};
+    outputs.forEach(function(out) { byL1[out.l1] = (byL1[out.l1] || 0) + 1; });
+    var missingFamilies = requiredFamilies.filter(function(l1) { return !byL1[l1]; });
+    var invalidOutputs = outputs.filter(function(out) { return !out.evaluation || !out.evaluation.passed; });
+    var rendererMapped = outputs.every(function(out) { return out.evaluation && out.evaluation.policy && out.evaluation.policy.renderer; });
+    var evaluatorMapped = outputs.every(function(out) { return out.evaluation && out.evaluation.policy && out.evaluation.policy.evaluator; });
+    var contractSummary = {
+      passed: outputs.length > 0 && invalidOutputs.length === 0 && missingFamilies.length === 0 && rendererMapped && evaluatorMapped,
+      total: outputs.length,
+      invalid: invalidOutputs.map(function(out) { return out.id; }),
+      missingFamilies: missingFamilies,
+      byL1: byL1,
+      rendererMapped: rendererMapped,
+      evaluatorMapped: evaluatorMapped
+    };
+
     var passed = results.filter(function(r) { return r.pass; }).length;
     var failed = results.length - passed;
-    var summary = { passed: passed, failed: failed, total: results.length, results: results };
+    var summary = { passed: passed, failed: failed, total: results.length, results: results, contract: contractSummary };
     // Pretty-print failures for the console
     if (failed > 0) {
       console.group('[scratchnode][demoQA] ' + passed + '/' + results.length + ' passed (' + failed + ' failed)');
@@ -5607,6 +6027,11 @@ setTimeout(refreshNotesCounter, 100);
       console.groupEnd();
     } else {
       console.log('[scratchnode][demoQA] ' + passed + '/' + results.length + ' passed ✅');
+    }
+    if (contractSummary.passed) {
+      console.log('[scratchnode][outputContract] ' + contractSummary.total + ' envelopes passed L1/L2/L3 evaluation', contractSummary.byL1);
+    } else {
+      console.warn('[scratchnode][outputContract] failed', contractSummary);
     }
     return summary;
   }
@@ -5651,6 +6076,8 @@ setTimeout(refreshNotesCounter, 100);
   window.runDemoQA   = runDemoQA;
   window.demoReset   = demoReset;
   window.demoStep    = demoStep;
+  window.SN_AGENT_OUTPUT_REGISTRY = AGENT_OUTPUT_REGISTRY;
+  window.evaluateAgentOutputEnvelope = evaluateAgentOutputEnvelope;
 
   // ?demo=1 URL auto-run for one-click presentations.
   try {

--- a/src/shared/agentOutputContract.test.ts
+++ b/src/shared/agentOutputContract.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertValidAgentOutput,
+  evaluateAgentOutput,
+  getOutputPolicy,
+  isValidTaxonomy,
+  type AgentOutputEnvelope,
+} from "./agentOutputContract";
+
+const baseEnvelope = {
+  id: "out_1",
+  target: { eventId: "evt_ai_infra_summit", messageId: "msg_sarah_latency" },
+  visibility: "event_public",
+  sourceRefs: ["source:event-wiki:v3", "source:orbital-panel"],
+  citationRefs: ["citation:latency-budget"],
+  traceRef: "trace_public_ask_1",
+  producedBy: {
+    runId: "run_public_ask_1",
+    skill: "event-room-qa",
+    toolChain: ["semantic_cache_lookup", "retrieve_event_context"],
+  },
+  version: { wikiVersion: 3, sourceBundleVersion: 7 },
+} satisfies Partial<AgentOutputEnvelope>;
+
+describe("agent output L1/L2/L3 contract", () => {
+  it("accepts a cached public FAQ answer with source refs and a public trace", () => {
+    const envelope: AgentOutputEnvelope = {
+      ...baseEnvelope,
+      l1: "public_knowledge",
+      l2: "event_faq",
+      l3: "faq.cached_reuse_answer",
+      output: {
+        parentAskMessageId: "msg_sarah_latency",
+        canonicalQuestion: "What is the p95 latency budget for clinical triage voice agents?",
+        answerMarkdown: "Clinical-grade voice agents converge on a sub-350ms round-trip budget.",
+        answerMode: "cache_hit",
+        reuseSummary: {
+          similarQuestions: 15,
+          reusedSources: 4,
+          newSearches: 0,
+          privateNotesUsed: false,
+        },
+        promotionState: "suggested",
+        noPrivateNotesUsed: true,
+      },
+    };
+
+    const result = evaluateAgentOutput(envelope);
+
+    expect(result.passed).toBe(true);
+    expect(result.policy?.renderer).toBe("AgentAnswerCard");
+    expect(result.policy?.evaluator).toBe("faq_validator");
+    expect(() => assertValidAgentOutput(envelope)).not.toThrow();
+  });
+
+  it("accepts a private anchored note and maps it to the private-note marker renderer", () => {
+    const envelope: AgentOutputEnvelope = {
+      ...baseEnvelope,
+      id: "note_out_1",
+      l1: "private_memory",
+      l2: "private_note",
+      l3: "note.anchored_to_chat",
+      visibility: "private",
+      sourceRefs: ["message:msg_sarah_latency"],
+      citationRefs: [],
+      traceRef: "trace_private_note_1",
+      producedBy: {
+        runId: "run_private_note_1",
+        skill: "private-note-builder",
+        toolChain: ["save_private_note_patch"],
+      },
+      output: {
+        body: "Latency framing useful for JPM healthcare AI coverage.",
+        anchor: { type: "message", id: "msg_sarah_latency" },
+        extractedEntities: ["@Orbital Labs"],
+        followUps: ["Ask Alex about p95 latency."],
+      },
+    };
+
+    const result = evaluateAgentOutput(envelope);
+
+    expect(result.passed).toBe(true);
+    expect(result.policy?.renderer).toBe("PrivateNoteMarker");
+  });
+
+  it("rejects public answers that use private notes", () => {
+    const envelope: AgentOutputEnvelope = {
+      ...baseEnvelope,
+      l1: "public_knowledge",
+      l2: "event_faq",
+      l3: "faq.cached_reuse_answer",
+      sourceRefs: ["source:event-wiki:v3", "private_note:note_123"],
+      output: {
+        parentAskMessageId: "msg_sarah_latency",
+        canonicalQuestion: "What changed?",
+        answerMarkdown: "This incorrectly uses a private note.",
+        answerMode: "cache_hit",
+        reuseSummary: {
+          similarQuestions: 4,
+          reusedSources: 2,
+          newSearches: 0,
+          privateNotesUsed: true,
+        },
+      },
+    };
+
+    const result = evaluateAgentOutput(envelope);
+
+    expect(result.passed).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(["EVAL-POLICY-001", "FAQ-003"]),
+    );
+  });
+
+  it("rejects taxonomy mismatches and missing policy mappings", () => {
+    expect(isValidTaxonomy("public_knowledge", "event_faq", "note.anchored_to_chat")).toBe(false);
+    expect(getOutputPolicy("note.anchored_to_chat")?.l1).toBe("private_memory");
+
+    const envelope: AgentOutputEnvelope = {
+      ...baseEnvelope,
+      l1: "public_knowledge",
+      l2: "event_faq",
+      l3: "note.anchored_to_chat",
+      output: {
+        parentAskMessageId: "msg_sarah_latency",
+        reuseSummary: { privateNotesUsed: false },
+      },
+    };
+
+    const result = evaluateAgentOutput(envelope);
+
+    expect(result.passed).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(["EVAL-SCHEMA-001", "EVAL-SCHEMA-003", "EVAL-POLICY-006"]),
+    );
+  });
+
+  it("requires public semantic cache entries to include event/wiki/source versions and forbid private context", () => {
+    const validCache: AgentOutputEnvelope = {
+      ...baseEnvelope,
+      id: "cache_1",
+      l1: "operational_cache",
+      l2: "semantic_answer_cache",
+      l3: "cache.public_faq_answer",
+      output: {
+        normalizedQuestion: "p95 latency budget clinical triage",
+        privateContextAllowed: false,
+        reuseCount: 4,
+      },
+    };
+
+    expect(evaluateAgentOutput(validCache).passed).toBe(true);
+
+    const missingVersion: AgentOutputEnvelope = {
+      ...validCache,
+      id: "cache_2",
+      version: { wikiVersion: 3 },
+      output: {
+        normalizedQuestion: "p95 latency budget clinical triage",
+        privateContextAllowed: true,
+      },
+    };
+
+    const result = evaluateAgentOutput(missingVersion);
+
+    expect(result.passed).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(["CACHE-004", "CACHE-005"]),
+    );
+  });
+
+  it("rejects public retrieval packets that include private results", () => {
+    const envelope: AgentOutputEnvelope = {
+      ...baseEnvelope,
+      id: "retrieval_1",
+      l1: "retrieval_context",
+      l2: "index_search",
+      l3: "retrieval.context_packet",
+      output: {
+        scope: { eventId: "evt_ai_infra_summit", includePrivate: false, visibility: "event_public" },
+        results: [
+          {
+            uri: "event_wiki:evt_ai_infra_summit:v3",
+            type: "event_wiki",
+            title: "AI Infra Summit wiki",
+            snippet: "Clinical triage latency",
+            visibility: "event_public",
+          },
+          {
+            uri: "private_note:note_1",
+            type: "private_note",
+            title: "Private note",
+            snippet: "Owner-only note",
+            visibility: "private",
+          },
+        ],
+      },
+    };
+
+    const result = evaluateAgentOutput(envelope);
+
+    expect(result.passed).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toContain("RET-003");
+  });
+});

--- a/src/shared/agentOutputContract.ts
+++ b/src/shared/agentOutputContract.ts
@@ -1,0 +1,409 @@
+export const OUTPUT_REGISTRY = {
+  public_knowledge: {
+    event_wiki: [
+      "wiki.need_to_know_item",
+      "wiki.what_changed_item",
+      "wiki.followup_item",
+      "wiki.people_item",
+      "wiki.company_item",
+      "wiki.source_item",
+      "wiki.trace_summary",
+    ],
+    event_faq: [
+      "faq.canonical_question",
+      "faq.answer_candidate",
+      "faq.host_promoted_answer",
+      "faq.cached_reuse_answer",
+      "faq.delta_refreshed_answer",
+    ],
+    public_agent_answer: [
+      "answer.public_event_card",
+      "answer.cached_event_answer",
+      "answer.delta_refreshed_answer",
+    ],
+  },
+  private_memory: {
+    private_note: [
+      "note.raw_shorthand",
+      "note.agent_enhanced",
+      "note.voice_transcript",
+      "note.anchored_to_chat",
+      "note.followup_task",
+    ],
+    private_notebook_patch: [
+      "notebook.append_block",
+      "notebook.update_block",
+      "notebook.followup_task",
+    ],
+  },
+  retrieval_context: {
+    index_search: [
+      "retrieval.typesense_hit",
+      "retrieval.convex_exact",
+      "retrieval.redis_semantic_cache_hit",
+      "retrieval.linkup_result",
+      "retrieval.source_bundle",
+      "retrieval.context_packet",
+    ],
+  },
+  graph_memory: {
+    lightrag_memory: [
+      "memory.entity",
+      "memory.atomic_claim",
+      "memory.semantic_edge",
+      "memory.citation",
+      "memory.compacted_summary",
+      "memory.famous_branch",
+      "memory.versioned_snapshot",
+    ],
+  },
+  agent_trace: {
+    output_node: [
+      "trace.output.public_answer",
+      "trace.output.private_note_patch",
+      "trace.output.wiki_update",
+      "trace.output.artifact_created",
+    ],
+    phase: [
+      "trace.phase.context_resolved",
+      "trace.phase.cache_lookup",
+      "trace.phase.context_retrieval",
+      "trace.phase.verification",
+      "trace.phase.persistence",
+    ],
+    tool_call: [
+      "trace.tool.semantic_cache_lookup",
+      "trace.tool.retrieve_context",
+      "trace.tool.linkup_search",
+      "trace.tool.save_private_note_patch",
+    ],
+  },
+  generated_artifact: {
+    presentation: ["artifact.presentation_html"],
+    source_bundle: ["artifact.source_bundle"],
+    export: ["artifact.csv_export", "artifact.crm_export"],
+    event_archive: ["artifact.published_event_wiki"],
+  },
+  operational_cache: {
+    semantic_answer_cache: [
+      "cache.public_faq_answer",
+      "cache.private_answer_forbidden",
+      "cache.stale_public_answer",
+      "cache.delta_refresh_required",
+    ],
+  },
+  ui_renderable: {
+    ui_card: [
+      "ui.agent_answer_card",
+      "ui.trace_drawer",
+      "ui.private_note_marker",
+      "ui.mention_chip",
+    ],
+  },
+} as const;
+
+export type OutputL1 = keyof typeof OUTPUT_REGISTRY;
+
+export type OutputL2<L1 extends OutputL1 = OutputL1> = {
+  [K in OutputL1]: keyof (typeof OUTPUT_REGISTRY)[K];
+}[L1] &
+  string;
+
+export type OutputL3 = {
+  [K in OutputL1]: {
+    [L in keyof (typeof OUTPUT_REGISTRY)[K]]: (typeof OUTPUT_REGISTRY)[K][L][number];
+  }[keyof (typeof OUTPUT_REGISTRY)[K]];
+}[OutputL1];
+
+export type OutputVisibility = "event_public" | "private" | "workspace" | "host_draft";
+
+export type AgentOutputTarget = {
+  eventId?: string;
+  notebookId?: string;
+  artifactId?: string;
+  entityId?: string;
+  messageId?: string;
+  traceId?: string;
+};
+
+export type AgentOutputEnvelope = {
+  id: string;
+  l1: OutputL1;
+  l2: string;
+  l3: string;
+  target: AgentOutputTarget;
+  visibility: OutputVisibility;
+  sourceRefs: string[];
+  citationRefs: string[];
+  traceRef: string;
+  producedBy: {
+    runId: string;
+    skill: string;
+    model?: string;
+    toolChain: string[];
+  };
+  version: {
+    wikiVersion?: number;
+    sourceBundleVersion?: number;
+    memorySnapshotVersion?: number;
+  };
+  output: Record<string, unknown>;
+};
+
+export type AgentOutputPolicy = {
+  l1: OutputL1;
+  l2: string;
+  l3: OutputL3;
+  storage: "convex" | "redis" | "typesense" | "artifact_lake" | "ui_only";
+  renderer: string;
+  evaluator: string;
+  allowedVisibility: OutputVisibility[];
+};
+
+export type EvalIssue = {
+  code: string;
+  message: string;
+  severity: "error" | "warning";
+};
+
+export type EvalResult = {
+  passed: boolean;
+  issues: EvalIssue[];
+  policy?: AgentOutputPolicy;
+};
+
+const VISIBILITIES: OutputVisibility[] = ["event_public", "private", "workspace", "host_draft"];
+
+export const AGENT_OUTPUT_POLICIES: AgentOutputPolicy[] = [
+  policy("public_knowledge", "event_wiki", "wiki.need_to_know_item", "convex", "WikiSectionItem", "wiki_validator", ["event_public", "host_draft"]),
+  policy("public_knowledge", "event_wiki", "wiki.what_changed_item", "convex", "WikiSectionItem", "wiki_validator", ["event_public", "host_draft"]),
+  policy("public_knowledge", "event_wiki", "wiki.followup_item", "convex", "WikiSectionItem", "wiki_validator", ["event_public", "host_draft"]),
+  policy("public_knowledge", "event_wiki", "wiki.people_item", "convex", "WikiSectionItem", "wiki_validator", ["event_public", "host_draft"]),
+  policy("public_knowledge", "event_wiki", "wiki.company_item", "convex", "WikiSectionItem", "wiki_validator", ["event_public", "host_draft"]),
+  policy("public_knowledge", "event_wiki", "wiki.source_item", "convex", "WikiSectionItem", "wiki_validator", ["event_public", "host_draft"]),
+  policy("public_knowledge", "event_wiki", "wiki.trace_summary", "convex", "WikiSectionItem", "wiki_validator", ["event_public", "host_draft"]),
+  policy("public_knowledge", "event_faq", "faq.answer_candidate", "convex", "AgentAnswerCard", "faq_validator", ["event_public"]),
+  policy("public_knowledge", "event_faq", "faq.host_promoted_answer", "convex", "AgentAnswerCard", "faq_validator", ["event_public"]),
+  policy("public_knowledge", "event_faq", "faq.cached_reuse_answer", "convex", "AgentAnswerCard", "faq_validator", ["event_public"]),
+  policy("public_knowledge", "event_faq", "faq.delta_refreshed_answer", "convex", "AgentAnswerCard", "faq_validator", ["event_public"]),
+  policy("public_knowledge", "public_agent_answer", "answer.public_event_card", "convex", "AgentAnswerCard", "answer_validator", ["event_public"]),
+  policy("public_knowledge", "public_agent_answer", "answer.cached_event_answer", "convex", "AgentAnswerCard", "answer_validator", ["event_public"]),
+  policy("public_knowledge", "public_agent_answer", "answer.delta_refreshed_answer", "convex", "AgentAnswerCard", "answer_validator", ["event_public"]),
+  policy("private_memory", "private_note", "note.raw_shorthand", "convex", "PrivateNoteSheet", "note_validator", ["private"]),
+  policy("private_memory", "private_note", "note.agent_enhanced", "convex", "PrivateNoteSheet", "note_validator", ["private"]),
+  policy("private_memory", "private_note", "note.voice_transcript", "convex", "PrivateNoteSheet", "note_validator", ["private"]),
+  policy("private_memory", "private_note", "note.anchored_to_chat", "convex", "PrivateNoteMarker", "note_validator", ["private"]),
+  policy("private_memory", "private_note", "note.followup_task", "convex", "PrivateNoteSheet", "note_validator", ["private"]),
+  policy("private_memory", "private_notebook_patch", "notebook.append_block", "convex", "NotebookPatchCard", "notebook_patch_validator", ["private", "workspace"]),
+  policy("private_memory", "private_notebook_patch", "notebook.update_block", "convex", "NotebookPatchCard", "notebook_patch_validator", ["private", "workspace"]),
+  policy("private_memory", "private_notebook_patch", "notebook.followup_task", "convex", "NotebookPatchCard", "notebook_patch_validator", ["private", "workspace"]),
+  policy("retrieval_context", "index_search", "retrieval.typesense_hit", "typesense", "RetrievalHit", "retrieval_evaluator", ["event_public", "private", "workspace"]),
+  policy("retrieval_context", "index_search", "retrieval.convex_exact", "convex", "RetrievalHit", "retrieval_evaluator", ["event_public", "private", "workspace"]),
+  policy("retrieval_context", "index_search", "retrieval.redis_semantic_cache_hit", "redis", "RetrievalHit", "retrieval_evaluator", ["event_public", "private", "workspace"]),
+  policy("retrieval_context", "index_search", "retrieval.linkup_result", "convex", "RetrievalHit", "retrieval_evaluator", ["event_public", "private", "workspace"]),
+  policy("retrieval_context", "index_search", "retrieval.source_bundle", "convex", "RetrievalHit", "retrieval_evaluator", ["event_public", "private", "workspace"]),
+  policy("retrieval_context", "index_search", "retrieval.context_packet", "convex", "ContextPacket", "context_resolver_evaluator", ["event_public", "private", "workspace"]),
+  policy("graph_memory", "lightrag_memory", "memory.entity", "convex", "GraphNode", "graph_integrity_validator", ["event_public", "private", "workspace"]),
+  policy("graph_memory", "lightrag_memory", "memory.atomic_claim", "convex", "ClaimCard", "memory_compaction_evaluator", ["event_public", "private", "workspace"]),
+  policy("graph_memory", "lightrag_memory", "memory.semantic_edge", "convex", "GraphEdge", "graph_integrity_validator", ["event_public", "private", "workspace"]),
+  policy("graph_memory", "lightrag_memory", "memory.citation", "convex", "CitationChip", "graph_integrity_validator", ["event_public", "private", "workspace"]),
+  policy("graph_memory", "lightrag_memory", "memory.compacted_summary", "convex", "MemorySummary", "memory_compaction_evaluator", ["event_public", "private", "workspace"]),
+  policy("graph_memory", "lightrag_memory", "memory.famous_branch", "convex", "FamousBranch", "memory_compaction_evaluator", ["event_public", "private", "workspace"]),
+  policy("graph_memory", "lightrag_memory", "memory.versioned_snapshot", "convex", "MemorySnapshot", "memory_compaction_evaluator", ["event_public", "private", "workspace"]),
+  policy("agent_trace", "output_node", "trace.output.public_answer", "convex", "TraceNode", "trace_evaluator", ["event_public"]),
+  policy("agent_trace", "output_node", "trace.output.private_note_patch", "convex", "TraceNode", "trace_evaluator", ["private", "workspace"]),
+  policy("agent_trace", "output_node", "trace.output.wiki_update", "convex", "TraceNode", "trace_evaluator", ["event_public", "host_draft"]),
+  policy("agent_trace", "output_node", "trace.output.artifact_created", "convex", "TraceNode", "trace_evaluator", ["event_public", "workspace"]),
+  policy("agent_trace", "phase", "trace.phase.context_resolved", "convex", "TracePhase", "trace_evaluator", ["event_public", "private", "workspace", "host_draft"]),
+  policy("agent_trace", "phase", "trace.phase.cache_lookup", "convex", "TracePhase", "trace_evaluator", ["event_public", "private", "workspace", "host_draft"]),
+  policy("agent_trace", "phase", "trace.phase.context_retrieval", "convex", "TracePhase", "trace_evaluator", ["event_public", "private", "workspace", "host_draft"]),
+  policy("agent_trace", "phase", "trace.phase.verification", "convex", "TracePhase", "trace_evaluator", ["event_public", "private", "workspace", "host_draft"]),
+  policy("agent_trace", "phase", "trace.phase.persistence", "convex", "TracePhase", "trace_evaluator", ["event_public", "private", "workspace", "host_draft"]),
+  policy("agent_trace", "tool_call", "trace.tool.semantic_cache_lookup", "convex", "TraceToolCall", "tool_call_evaluator", ["event_public", "private", "workspace"]),
+  policy("agent_trace", "tool_call", "trace.tool.retrieve_context", "convex", "TraceToolCall", "tool_call_evaluator", ["event_public", "private", "workspace"]),
+  policy("agent_trace", "tool_call", "trace.tool.linkup_search", "convex", "TraceToolCall", "tool_call_evaluator", ["event_public", "private", "workspace"]),
+  policy("agent_trace", "tool_call", "trace.tool.save_private_note_patch", "convex", "TraceToolCall", "tool_call_evaluator", ["private", "workspace"]),
+  policy("generated_artifact", "presentation", "artifact.presentation_html", "artifact_lake", "PresentationArtifact", "artifact_validator", ["event_public", "workspace"]),
+  policy("generated_artifact", "source_bundle", "artifact.source_bundle", "artifact_lake", "SourceBundleArtifact", "artifact_validator", ["event_public", "workspace"]),
+  policy("generated_artifact", "export", "artifact.csv_export", "artifact_lake", "ExportArtifact", "artifact_validator", ["private", "workspace"]),
+  policy("generated_artifact", "export", "artifact.crm_export", "artifact_lake", "ExportArtifact", "artifact_validator", ["private", "workspace"]),
+  policy("generated_artifact", "event_archive", "artifact.published_event_wiki", "artifact_lake", "EventArchiveArtifact", "artifact_validator", ["event_public"]),
+  policy("operational_cache", "semantic_answer_cache", "cache.public_faq_answer", "redis", "CacheTraceRow", "cache_safety_evaluator", ["event_public"]),
+  policy("operational_cache", "semantic_answer_cache", "cache.private_answer_forbidden", "redis", "CacheTraceRow", "cache_safety_evaluator", ["private"]),
+  policy("operational_cache", "semantic_answer_cache", "cache.stale_public_answer", "redis", "CacheTraceRow", "cache_safety_evaluator", ["event_public"]),
+  policy("operational_cache", "semantic_answer_cache", "cache.delta_refresh_required", "redis", "CacheTraceRow", "cache_safety_evaluator", ["event_public"]),
+  policy("ui_renderable", "ui_card", "ui.agent_answer_card", "ui_only", "AgentAnswerCard", "ui_snapshot_evaluator", ["event_public"]),
+  policy("ui_renderable", "ui_card", "ui.trace_drawer", "ui_only", "TraceDrawer", "ui_snapshot_evaluator", ["event_public", "private", "workspace"]),
+  policy("ui_renderable", "ui_card", "ui.private_note_marker", "ui_only", "PrivateNoteMarker", "ui_snapshot_evaluator", ["private"]),
+  policy("ui_renderable", "ui_card", "ui.mention_chip", "ui_only", "MentionChip", "ui_snapshot_evaluator", ["event_public", "private", "workspace"]),
+];
+
+const POLICY_BY_L3 = new Map<string, AgentOutputPolicy>(
+  AGENT_OUTPUT_POLICIES.map((entry) => [entry.l3, entry]),
+);
+
+function policy(
+  l1: OutputL1,
+  l2: string,
+  l3: OutputL3,
+  storage: AgentOutputPolicy["storage"],
+  renderer: string,
+  evaluator: string,
+  allowedVisibility: OutputVisibility[],
+): AgentOutputPolicy {
+  return { l1, l2, l3, storage, renderer, evaluator, allowedVisibility };
+}
+
+export function isValidTaxonomy(l1: string, l2: string, l3: string): boolean {
+  const l2Registry = OUTPUT_REGISTRY[l1 as OutputL1] as Record<string, readonly string[]> | undefined;
+  return !!l2Registry?.[l2]?.includes(l3);
+}
+
+export function getOutputPolicy(l3: string): AgentOutputPolicy | undefined {
+  return POLICY_BY_L3.get(l3);
+}
+
+export function evaluateAgentOutput(envelope: AgentOutputEnvelope): EvalResult {
+  const issues: EvalIssue[] = [];
+  const addError = (code: string, message: string) => issues.push({ code, message, severity: "error" });
+
+  if (!envelope.id) addError("EVAL-SCHEMA-000", "Envelope id is required.");
+  if (!isValidTaxonomy(envelope.l1, envelope.l2, envelope.l3)) {
+    addError("EVAL-SCHEMA-001", "l1/l2/l3 must be present and match the output registry.");
+  }
+  if (!VISIBILITIES.includes(envelope.visibility)) {
+    addError("EVAL-POLICY-000", "visibility must be one of the supported output visibilities.");
+  }
+  if (!hasTarget(envelope.target)) addError("EVAL-SCHEMA-006", "At least one target id is required.");
+  if (!envelope.traceRef) addError("EVAL-TRACE-001", "traceRef is required.");
+  if (!envelope.producedBy?.runId) addError("EVAL-TRACE-002", "producedBy.runId is required.");
+  if (!envelope.producedBy?.skill) addError("EVAL-TRACE-003", "producedBy.skill is required.");
+  if (!Array.isArray(envelope.producedBy?.toolChain)) addError("EVAL-TRACE-004", "producedBy.toolChain must be an array.");
+  if (!Array.isArray(envelope.sourceRefs)) addError("EVAL-CITE-000", "sourceRefs must be an array.");
+  if (!Array.isArray(envelope.citationRefs)) addError("EVAL-CITE-001", "citationRefs must be an array.");
+
+  const policyEntry = getOutputPolicy(envelope.l3);
+  if (!policyEntry) {
+    addError("EVAL-SCHEMA-005", "l3 must have a storage, renderer, and evaluator policy.");
+  } else {
+    if (policyEntry.l1 !== envelope.l1 || policyEntry.l2 !== envelope.l2) {
+      addError("EVAL-SCHEMA-003", "l3 belongs to a different l1/l2 pair than the envelope declares.");
+    }
+    if (!policyEntry.allowedVisibility.includes(envelope.visibility)) {
+      addError("EVAL-POLICY-006", `${envelope.l3} cannot be stored with visibility=${envelope.visibility}.`);
+    }
+    if (!policyEntry.renderer) addError("EVAL-UI-001", "l3 must map to a renderer.");
+    if (!policyEntry.evaluator) addError("EVAL-SCHEMA-007", "l3 must map to an evaluator.");
+  }
+
+  validatePublicPrivateBoundary(envelope, addError);
+  validateSpecificContract(envelope, addError);
+
+  return {
+    passed: issues.every((issue) => issue.severity !== "error"),
+    issues,
+    policy: policyEntry,
+  };
+}
+
+export function assertValidAgentOutput(envelope: AgentOutputEnvelope): AgentOutputEnvelope {
+  const result = evaluateAgentOutput(envelope);
+  if (!result.passed) {
+    const details = result.issues.map((issue) => `${issue.code}: ${issue.message}`).join("; ");
+    throw new Error(`Invalid agent output envelope: ${details}`);
+  }
+  return envelope;
+}
+
+function hasTarget(target: AgentOutputTarget | undefined): boolean {
+  return !!target && Object.values(target).some((value) => typeof value === "string" && value.length > 0);
+}
+
+function validatePublicPrivateBoundary(
+  envelope: AgentOutputEnvelope,
+  addError: (code: string, message: string) => void,
+) {
+  const hasPrivateRef = [...(envelope.sourceRefs ?? []), ...(envelope.citationRefs ?? [])].some(isPrivateRef);
+  const serializedOutput = JSON.stringify(envelope.output ?? {});
+  const outputMentionsPrivateNote =
+    /"(?:privateNoteIds?|private_source_refs?|privateNotesUsed)"\s*:\s*true/i.test(serializedOutput);
+
+  if (envelope.visibility === "event_public") {
+    if (hasPrivateRef || outputMentionsPrivateNote) {
+      addError("EVAL-POLICY-001", "event_public output cannot reference private notes or private sources.");
+    }
+  }
+
+  if (envelope.l1 === "private_memory" && envelope.visibility !== "private") {
+    addError("NOTE-001", "private_memory outputs must use visibility=private.");
+  }
+}
+
+function validateSpecificContract(
+  envelope: AgentOutputEnvelope,
+  addError: (code: string, message: string) => void,
+) {
+  if (envelope.l2 === "event_faq" || envelope.l2 === "public_agent_answer") {
+    const out = envelope.output;
+    if (!stringField(out, "parentAskMessageId")) addError("FAQ-001", "Public answer output requires parentAskMessageId.");
+    if (readPath(out, ["reuseSummary", "privateNotesUsed"]) !== false) {
+      addError("FAQ-003", "Public answer reuseSummary.privateNotesUsed must be false.");
+    }
+    if ((envelope.sourceRefs ?? []).length === 0 && readPath(out, ["answerMode"]) !== "room_signal_only") {
+      addError("FAQ-009", "Public answer requires sourceRefs unless explicitly room-signal only.");
+    }
+  }
+
+  if (envelope.l2 === "event_wiki") {
+    if (!envelope.target?.eventId) addError("WIKI-STRUCT-001", "Wiki output requires target.eventId.");
+    if (typeof envelope.version?.wikiVersion !== "number") addError("WIKI-STRUCT-007", "Wiki output requires wikiVersion.");
+    if (envelope.visibility === "event_public" && envelope.sourceRefs.some(isPrivateRef)) {
+      addError("WIKI-STRUCT-006", "Public wiki output cannot include private note refs.");
+    }
+  }
+
+  if (envelope.l2 === "semantic_answer_cache") {
+    if (!envelope.target?.eventId) addError("CACHE-002", "Event cache entries require target.eventId.");
+    if (typeof envelope.version?.wikiVersion !== "number") addError("CACHE-003", "Event cache entries require wikiVersion.");
+    if (typeof envelope.version?.sourceBundleVersion !== "number") {
+      addError("CACHE-004", "Event cache entries require sourceBundleVersion.");
+    }
+    if (envelope.visibility === "event_public" && readPath(envelope.output, ["privateContextAllowed"]) !== false) {
+      addError("CACHE-005", "Public cache entries must set privateContextAllowed=false.");
+    }
+  }
+
+  if (envelope.l2 === "index_search") {
+    const includePrivate = readPath(envelope.output, ["scope", "includePrivate"]);
+    const results = readPath(envelope.output, ["results"]);
+    if (envelope.visibility === "event_public" && includePrivate !== false) {
+      addError("RET-003", "Public retrieval context must set includePrivate=false.");
+    }
+    if (Array.isArray(results) && envelope.visibility === "event_public") {
+      const hasPrivateResult = results.some((result) => result?.visibility === "private");
+      if (hasPrivateResult) addError("RET-003", "Public retrieval context cannot return private results.");
+    }
+  }
+
+  if (envelope.l2 === "private_note") {
+    if (envelope.visibility !== "private") addError("NOTE-001", "Private notes require visibility=private.");
+    if (!stringField(envelope.output, "body")) addError("NOTE-002", "Private notes require a body.");
+  }
+}
+
+function isPrivateRef(ref: string): boolean {
+  return /^private[:/_-]|private_note|userNotes|note_private/i.test(ref);
+}
+
+function stringField(value: Record<string, unknown> | undefined, key: string): boolean {
+  return typeof value?.[key] === "string" && String(value[key]).length > 0;
+}
+
+function readPath(value: unknown, path: string[]): unknown {
+  let current = value;
+  for (const key of path) {
+    if (!current || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}

--- a/tests/e2e/home-v5-output-contract.spec.ts
+++ b/tests/e2e/home-v5-output-contract.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+test("home-v5 runDemoFull keeps visible invariants and L1/L2/L3 output contracts aligned", async ({
+  page,
+}) => {
+  const fileUrl = pathToFileURL(resolve("public/proto/home-v5.html")).toString();
+
+  await page.goto(fileUrl, { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () => typeof (window as any).runDemoFull === "function" && typeof (window as any).runDemoQA === "function",
+  );
+
+  const qa = await page.evaluate(async () => {
+    await (window as any).runDemoFull({ speed: "instant" });
+    return (window as any).runDemoQA();
+  });
+
+  expect(qa.failed).toBe(0);
+  expect(qa.total).toBe(17);
+  expect(qa.contract.passed).toBe(true);
+  expect(qa.contract.total).toBeGreaterThanOrEqual(20);
+  expect(qa.contract.invalid).toEqual([]);
+  expect(qa.contract.missingFamilies).toEqual([]);
+  expect(qa.contract.rendererMapped).toBe(true);
+  expect(qa.contract.evaluatorMapped).toBe(true);
+  expect(Object.keys(qa.contract.byL1).sort()).toEqual([
+    "agent_trace",
+    "generated_artifact",
+    "graph_memory",
+    "operational_cache",
+    "private_memory",
+    "public_knowledge",
+    "retrieval_context",
+    "ui_renderable",
+  ]);
+});

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -368,6 +368,48 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
   }
 });
 
+test("home-v5 runDemoFull emits evaluated L1/L2/L3 output envelopes", async ({ page }) => {
+  mkdirSync(ARTIFACT_DIR, { recursive: true });
+  const qaId = `proto-v5-contract-${Date.now()}`;
+  const parsed = new URL(SCRATCHNODE_EVENT_URL);
+  parsed.searchParams.set("demo", "1");
+  parsed.searchParams.set("demoSpeed", "instant");
+  parsed.searchParams.set("qa", qaId);
+
+  await page.goto(parsed.toString(), { waitUntil: "domcontentloaded", timeout: 45_000 });
+  await page.waitForFunction(() => typeof (window as any).runDemoQA === "function", null, {
+    timeout: 45_000,
+  });
+  await page.waitForTimeout(2_500);
+
+  const qa = await page.evaluate(async () => {
+    await (window as any).runDemoFull({ speed: "instant" });
+    return (window as any).runDemoQA();
+  });
+
+  expect(qa.failed).toBe(0);
+  expect(qa.total).toBe(17);
+  expect(qa.contract.passed).toBe(true);
+  expect(qa.contract.missingFamilies).toEqual([]);
+  expect(qa.contract.rendererMapped).toBe(true);
+  expect(qa.contract.evaluatorMapped).toBe(true);
+  expect(Object.keys(qa.contract.byL1).sort()).toEqual([
+    "agent_trace",
+    "generated_artifact",
+    "graph_memory",
+    "operational_cache",
+    "private_memory",
+    "public_knowledge",
+    "retrieval_context",
+    "ui_renderable",
+  ]);
+
+  await page.screenshot({
+    path: join(ARTIFACT_DIR, `${qaId}-output-contract.png`),
+    fullPage: true,
+  });
+});
+
 // ─── Phase 4 host auth — code flow against the live backend ─────────
 //
 // Verifies the new requestHostClaim + claimHostWithCode + HMAC token


### PR DESCRIPTION
## Summary
- Add a shared L1/L2/L3 agent output registry, policy map, and evaluator in src/shared/agentOutputContract.ts.
- Wire home-v5 runDemoFull to emit evaluated envelopes for public answers, semantic cache, retrieval packets, graph memory, private notes, traces, artifacts, and UI renderables.
- Add docs so future sessions know the rule: Classify -> Validate -> Persist -> Render -> Trace -> Evaluate.
- Extend dogfood coverage with a local home-v5 output-contract e2e and a live-gated prod parity assertion.

## Verification
- npx vitest run src/shared/agentOutputContract.test.ts
- npx playwright test tests/e2e/home-v5-output-contract.spec.ts --project=chromium --workers=1 --reporter=list
- npx tsc --noEmit --pretty false
- npm run build
- Local browser dogfood: runDemoFull({ speed: 'instant' }) then runDemoQA() returned 17/17 visible checks and contract.passed=true across all 8 L1 families.

## Notes
- The live prod e2e remains gated behind PROTO_DOGFOOD_LIVE=1 because production will only include these envelopes after this PR deploys.
- Public outputs require trace/policy/visibility validation and reject private-note leakage; private-note outputs map to owner-only renderers and evaluators.