### PR TITLE
feat(scratchnode): apex landing vs /demo_ver{N} routes (P0)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -33,8 +33,15 @@ import { next, rewrite } from '@vercel/edge';
 export const config = {
   // Keep middleware cost bounded: event/docs/random-path routing remains in
   // vercel.json because those rewrites already fire correctly.
-  matcher: ['/', '/index.html'],
+  //
+  // /demo_ver:n* is intentionally included so /demo_ver1, /demo_ver2, etc.
+  // all rewrite to /proto/home-v5.html while PRESERVING the URL bar so the
+  // page-side detector can read location.pathname.
+  matcher: ['/', '/index.html', '/demo_ver:n*'],
 };
+
+// /demo_ver{N} where N is one or more digits. Trailing slash optional.
+const DEMO_VER_RE = /^\/demo_ver\d+\/?$/;
 
 export default function middleware(request: Request): Response {
   const url = new URL(request.url);
@@ -47,17 +54,25 @@ export default function middleware(request: Request): Response {
   }
 
   // Path-specific routing for scratchnode.live:
-  //   /            → /proto/home-v5.html   (apex landing — the bug this fixes)
-  //   /index.html  → /proto/home-v5.html   (defensive)
-  //   /docs        → handled by vercel.json rewrite
-  //   /e/:slug*    → handled by vercel.json rewrite
-  //   /(any other) → handled by vercel.json catch-all
+  //   /                → /proto/home-v5.html   (apex landing — minimal page)
+  //   /index.html      → /proto/home-v5.html   (defensive)
+  //   /demo_ver{N}     → /proto/home-v5.html   (URL bar preserved by rewrite;
+  //                                            page-side reads location.pathname
+  //                                            to set data-page-mode="demo" and
+  //                                            auto-run runDemoFull)
+  //   /docs            → handled by vercel.json rewrite
+  //   /e/:slug*        → handled by vercel.json rewrite
+  //   /(any other)     → handled by vercel.json catch-all
   //
-  // We only need to handle the apex root here. For all other paths, return
-  // next() so Vercel's normal rewrite pipeline takes over.
+  // Per-file landing-vs-demo split inside home-v5.html itself —
+  // see public/proto/home-v5.html "page-mode detector" block.
   const pathname = url.pathname;
-  if (pathname === '/' || pathname === '/index.html') {
+  const isApex = pathname === '/' || pathname === '/index.html';
+  const isDemoVer = DEMO_VER_RE.test(pathname);
+  if (isApex || isDemoVer) {
     const destination = new URL('/proto/home-v5.html', request.url);
+    // Preserve search params (e.g. ?demoSpeed=fast) so they still reach the
+    // page-side runDemoFull options parser.
     destination.search = url.search;
     return rewrite(destination);
   }

--- a/public/proto/home-v4.html
+++ b/public/proto/home-v4.html
@@ -1721,9 +1721,168 @@ input { font-family: var(--ui); }
   .home-entity-card:hover { transform: none; }
   .home-details > summary::after { transition: none; }
 }
+
+/* ──────────────────────────────────────────────────────────────────
+   Landing-mode UI for home-v4 — shown when the URL lacks ?demo=1.
+   nodebenchai.com is NOT routed via Edge Middleware (only scratchnode.live
+   apex is), so query-param gating is the right tool here.
+   See block comment near body bootstrap script for full intent.
+   ────────────────────────────────────────────────────────────────── */
+.landing-v4 { display: none; }
+body[data-page-mode="landing"] .landing-v4 { display: flex; }
+
+/* Hide the full prototype shell when in landing mode. */
+body[data-page-mode="landing"] .shell { display: none !important; }
+
+/* Landing layout — minimal, centered hero matching NodeBench design DNA. */
+.landing-v4 {
+  min-height: 100vh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  gap: 24px;
+  background: var(--bg, #151413);
+  color: var(--ink, #e8e6e3);
+  font-family: "Manrope", system-ui, -apple-system, sans-serif;
+}
+.landing-v4 .landing-hero {
+  max-width: 560px;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+}
+.landing-v4 .landing-logo {
+  font-weight: 800;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  color: var(--ink, #e8e6e3);
+}
+.landing-v4 .landing-logo span { color: var(--accent, #d97757); }
+.landing-v4 h1 {
+  font-weight: 700;
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  margin: 8px 0 0;
+  color: var(--ink, #e8e6e3);
+}
+.landing-v4 p {
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink-muted, #a8a5a0);
+  margin: 0;
+  max-width: 460px;
+}
+.landing-v4 .landing-cta-row {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.landing-v4 .landing-primary,
+.landing-v4 .landing-secondary {
+  font-weight: 600;
+  font-size: 15px;
+  padding: 12px 20px;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: background .15s ease, color .15s ease, border-color .15s ease;
+}
+.landing-v4 .landing-primary {
+  border: 1px solid var(--accent, #d97757);
+  background: var(--accent, #d97757);
+  color: #fff;
+}
+.landing-v4 .landing-primary:hover { background: #c46a4e; }
+.landing-v4 .landing-primary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(217,119,87,.35);
+}
+.landing-v4 .landing-secondary {
+  border: 1px solid rgba(255,255,255,.12);
+  background: transparent;
+  color: var(--ink-muted, #a8a5a0);
+}
+.landing-v4 .landing-secondary:hover,
+.landing-v4 .landing-secondary:focus-visible {
+  color: var(--ink, #e8e6e3);
+  border-color: rgba(255,255,255,.24);
+  outline: none;
+}
+.landing-v4 .landing-trust {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-size: 12px;
+  color: var(--ink-faint, #6b6864);
+  margin-top: 24px;
+}
+.landing-v4 .landing-trust span:not(:last-child)::after {
+  content: '·';
+  margin-left: 14px;
+  color: var(--ink-faint, #6b6864);
+}
+@media (max-width: 600px) {
+  .landing-v4 h1 { font-size: 22px; }
+  .landing-v4 p { font-size: 14px; }
+  .landing-v4 .landing-primary,
+  .landing-v4 .landing-secondary { width: 100%; text-align: center; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .landing-v4 .landing-primary,
+  .landing-v4 .landing-secondary { transition: none; }
+}
 </style>
 </head>
 <body>
+
+<!--
+  ═══════════════════════════════════════════════════════════════════════════
+  page-mode detector — must run synchronously BEFORE any other JS / paint.
+
+  home-v4 has no Edge Middleware routing (only scratchnode.live apex does),
+  so we use a query-param gate:
+    - ?demo=1  -> "demo" mode (full NodeBench mockup as before)
+    - else     -> "landing" mode (minimal NodeBench hero)
+
+  Sets data-page-mode on body so CSS gates fire on first paint, preventing
+  a flash of the mockup on the bare URL.
+  ═══════════════════════════════════════════════════════════════════════════
+-->
+<script>
+(function () {
+  try {
+    var hasDemoQuery = new URLSearchParams(location.search || '').get('demo') === '1';
+    document.body.dataset.pageMode = hasDemoQuery ? 'demo' : 'landing';
+  } catch (e) {
+    try { document.body.dataset.pageMode = 'landing'; } catch (e2) {}
+  }
+})();
+</script>
+
+<!-- Landing-mode hero — visible only when data-page-mode === "landing" -->
+<section class="landing-v4" role="region" aria-label="NodeBench landing">
+  <div class="landing-hero">
+    <span class="landing-logo">Node<span>Bench</span></span>
+    <h1>Entity intelligence workspace.</h1>
+    <p>Notebook, Artifacts, Chat, Daily Brief. Private memory that compounds across events, companies, people, and topics.</p>
+    <div class="landing-cta-row">
+      <a href="https://www.nodebenchai.com/" class="landing-primary">Open NodeBench app &rarr;</a>
+      <a href="?demo=1" class="landing-secondary">See the prototype &rarr;</a>
+    </div>
+  </div>
+  <div class="landing-trust" aria-label="Privacy posture">
+    <span>Local-first.</span>
+    <span>Private by default.</span>
+    <span>Open source.</span>
+  </div>
+</section>
 
 <!-- ═══════════════════════════════════════════════════
      SHELL

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1531,9 +1531,248 @@ body[data-event-mode="sensitive"] .c-helpline::before {
   color: var(--accent); font-weight: 600;
 }
 
+/* ──────────────────────────────────────────────────────────────────
+   Landing-mode UI — shown when location.pathname === '/' (bare apex)
+   See block comment near body bootstrap script for full intent.
+   ────────────────────────────────────────────────────────────────── */
+.landing { display: none; }
+body[data-page-mode="landing"] .landing { display: flex; }
+
+/* When in landing mode, hide the event-room shell entirely so the
+   apex does NOT read as "the demo is running on the live site". */
+body[data-page-mode="landing"] .event-strip,
+body[data-page-mode="landing"] main.m,
+body[data-page-mode="landing"] .h-code,
+body[data-page-mode="landing"] .h-live,
+body[data-page-mode="landing"] #live-assist-rail,
+body[data-page-mode="landing"] .welcome {
+  display: none !important;
+}
+
+/* Landing layout — minimal, centered, glass-card hero. */
+.landing {
+  min-height: calc(100vh - 64px);
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  gap: 24px;
+}
+.landing-hero {
+  max-width: 560px;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+}
+.landing-logo {
+  font-family: var(--ui);
+  font-weight: 800;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+.landing-logo span { color: var(--accent); }
+.landing-hero h1 {
+  font-family: var(--ui);
+  font-weight: 700;
+  font-size: 28px;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin: 8px 0 0;
+}
+.landing-hero p {
+  font-family: var(--ui);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink-muted);
+  margin: 0;
+  max-width: 460px;
+}
+.landing-join {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+  max-width: 420px;
+  margin-top: 8px;
+}
+.landing-join input {
+  flex: 1;
+  font-family: var(--ui);
+  font-size: 15px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  outline: none;
+  transition: border-color .15s ease;
+}
+.landing-join input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(217,119,87,.18);
+}
+.landing-join input::placeholder { color: var(--ink-faint); }
+.landing-join button {
+  font-family: var(--ui);
+  font-weight: 600;
+  font-size: 15px;
+  padding: 12px 20px;
+  border-radius: 8px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  transition: background .15s ease;
+}
+.landing-join button:hover { background: #c46a4e; }
+.landing-join button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(217,119,87,.35);
+}
+.landing-cta-row {
+  display: flex;
+  gap: 18px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.landing-secondary {
+  font-family: var(--ui);
+  font-size: 14px;
+  color: var(--ink-muted);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color .15s ease, border-color .15s ease;
+}
+.landing-secondary:hover,
+.landing-secondary:focus-visible {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  outline: none;
+}
+.landing-trust {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-family: var(--ui);
+  font-size: 12px;
+  color: var(--ink-faint);
+  margin-top: 24px;
+}
+.landing-trust span:not(:last-child)::after {
+  content: '·';
+  margin-left: 14px;
+  color: var(--ink-faint);
+}
+@media (max-width: 600px) {
+  .landing-hero h1 { font-size: 22px; }
+  .landing-hero p { font-size: 14px; }
+  .landing-join { flex-direction: column; }
+  .landing-join button { width: 100%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .landing-join input,
+  .landing-join button,
+  .landing-secondary { transition: none; }
+}
+
 </style>
 </head>
 <body data-mode="public" data-role="attendee" data-event-mode="event" data-capture-level="0" data-la-open="false">
+
+<!--
+  ═══════════════════════════════════════════════════════════════════════════
+  page-mode detector — must run synchronously BEFORE any other JS / paint.
+
+  Three modes:
+    - "landing"  — bare apex `/` or `/index.html`. Show minimal landing only.
+                   No event auto-join, no demo auto-play, no event shell.
+    - "demo"     — `/demo_ver{N}` paths (rewritten by middleware.ts to this
+                   HTML but URL bar preserved). Full mockup + auto-play
+                   runDemoFull. Also triggered by legacy `?demo=1` query.
+    - "event"    — `/e/:slug` real event rooms. Convex bootstrap takes over.
+
+  Why inline + early: prevents a flash of demo content on the bare apex.
+  Sets data-page-mode on body so CSS gates fire on first paint.
+  ═══════════════════════════════════════════════════════════════════════════
+-->
+<script>
+(function () {
+  try {
+    var path = location.pathname || '/';
+    var search = location.search || '';
+    var demoVerMatch = path.match(/^\/demo_ver(\d+)\/?$/);
+    var isLandingPath = (path === '/' || path === '/index.html');
+    var isEventPath   = /^\/e\/[a-z0-9][a-z0-9-]{0,60}\/?$/i.test(path);
+    var hasDemoQuery  = new URLSearchParams(search).get('demo') === '1';
+    var pageMode;
+    if (demoVerMatch || hasDemoQuery) {
+      pageMode = 'demo';
+    } else if (isEventPath) {
+      pageMode = 'event';
+    } else if (isLandingPath) {
+      pageMode = 'landing';
+    } else {
+      // Unknown path that landed here via catch-all rewrite — default to
+      // landing so we don't leak the demo shell.
+      pageMode = 'landing';
+    }
+    document.body.dataset.pageMode = pageMode;
+    if (demoVerMatch) {
+      document.body.dataset.demoVer = demoVerMatch[1];
+    }
+  } catch (e) {
+    // If detection throws, default to landing — safer than leaking demo.
+    try { document.body.dataset.pageMode = 'landing'; } catch (e2) {}
+  }
+})();
+
+/**
+ * _landingJoin — handler for the landing-mode "Join" form.
+ * Encodes the room code, navigates to /e/<code>. Empty input → focus.
+ */
+function _landingJoin(ev) {
+  try { ev.preventDefault(); } catch (e) {}
+  var form = ev && ev.target;
+  if (!form) return false;
+  var input = form.querySelector('input[type="text"]');
+  if (!input) return false;
+  var code = String(input.value || '').trim().toLowerCase();
+  if (!code) { try { input.focus(); } catch (e) {} return false; }
+  // Allow only [a-z0-9-]; trim leading/trailing dashes; cap 60 chars.
+  code = code.replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60);
+  if (!code) { try { input.focus(); } catch (e) {} return false; }
+  location.href = '/e/' + encodeURIComponent(code);
+  return false;
+}
+</script>
+
+<!-- Landing-mode hero — visible only when data-page-mode === "landing" -->
+<section class="landing" role="region" aria-label="ScratchNode landing">
+  <div class="landing-hero">
+    <span class="landing-logo">Scratch<span>Node</span></span>
+    <h1>Live event Q&amp;A that compounds into a wiki.</h1>
+    <p>Anyone with a room code can join. Public chat, <code style="font-family:var(--mono);background:rgba(217,119,87,.12);color:var(--accent);padding:1px 6px;border-radius:3px">/ask</code> for sourced answers, private notes that stay yours. After the event, knowledge persists.</p>
+    <form class="landing-join" onsubmit="return _landingJoin(event)" aria-label="Join an event by room code">
+      <input type="text" placeholder="Enter room code (e.g. ORBITAL)" aria-label="Room code" maxlength="60" autocomplete="off" autocapitalize="off" spellcheck="false">
+      <button type="submit">Join &rarr;</button>
+    </form>
+    <div class="landing-cta-row">
+      <a href="/demo_ver1" class="landing-secondary">See the demo &rarr;</a>
+      <a href="/docs" class="landing-secondary">Read the docs &rarr;</a>
+    </div>
+  </div>
+  <div class="landing-trust" aria-label="Privacy posture">
+    <span>Consent-first.</span>
+    <span>Private by default.</span>
+    <span>No stealth overlays.</span>
+  </div>
+</section>
 
 <a class="skip-link" href="#feed">Skip to chat</a>
 
@@ -4817,12 +5056,16 @@ window._laCueAction       = _laCueAction;
 <script type="module">
 (async () => {
   // ─── Bail-early checks ─────────────────────────────────────────────
+  // Apex-landing refactor: bare `/` is now a marketing landing page, NOT
+  // an auto-join into the canonical event. Convex bootstrap only fires on
+  // explicit /e/:slug paths. The demo route /demo_ver{N} stays prototype-only
+  // (no live joinEvent call) so the demo never pollutes the canonical event's
+  // participant count.
   const slugMatch = location.pathname.match(/^\/e\/([a-z0-9][a-z0-9-]{0,60})\/?$/i);
-  const isCanonicalApex =
-    (location.pathname === '/' || location.pathname === '/index.html') &&
-    ON_PUBLIC_DOMAIN;
-  if (!slugMatch && !isCanonicalApex) return; // not an event URL — keep prototype-only behavior
-  const slug = slugMatch ? slugMatch[1] : EVENT_SLUG;
+  const pageMode = (document.body && document.body.dataset && document.body.dataset.pageMode) || '';
+  if (!slugMatch) return; // landing & demo modes stay prototype-only
+  if (pageMode === 'landing' || pageMode === 'demo') return; // belt-and-suspenders
+  const slug = slugMatch[1];
 
   // Stable anonymous session UUID — persists across reloads, per-device.
   let sessionId;
@@ -7596,10 +7839,18 @@ window._laCueAction       = _laCueAction;
   window.SN_AGENT_OUTPUT_REGISTRY = AGENT_OUTPUT_REGISTRY;
   window.evaluateAgentOutputEnvelope = evaluateAgentOutputEnvelope;
 
-  // ?demo=1 URL auto-run for one-click presentations.
+  // Auto-run runDemoFull for one-click presentations. Triggers:
+  //   - /demo_ver{N} routes (rewritten by middleware.ts → home-v5.html with
+  //     URL bar preserved; we detect via location.pathname)
+  //   - Legacy `?demo=1` query (preserved for shareable demo links and
+  //     backwards compatibility with prior PRs).
+  // Does NOT fire on bare apex `/` or `/index.html` — that's the landing
+  // mode and the whole point of this refactor is no demo content there.
   try {
     var params = new URLSearchParams(location.search);
-    if (params.get('demo') === '1') {
+    var demoVerMatch = location.pathname.match(/^\/demo_ver(\d+)\/?$/);
+    var isDemoRoute = !!demoVerMatch || params.get('demo') === '1';
+    if (isDemoRoute) {
       var speed = params.get('demoSpeed') || 'normal';
       // Defer until after DOMContentLoaded + small delay so live Convex bootstrap can settle.
       var kickoff = function() { setTimeout(function() { runDemoFull({ speed: speed }); }, 600); };


### PR DESCRIPTION
## Summary

P0 product behavior fix: bare `scratchnode.live/` and `nodebenchai.com/proto/home-v4.html` currently serve fully-rendered prototype/demo content (mocked "AI Infra Summit, 318 joined, 47 FAQ" event shell on home-v5; full TipTap/graph/presentation mockups on home-v4). To real users, this reads as "the demo is running on the live site."

After this PR:
- **scratchnode.live/** -> minimal landing (logo, headline, room-code input, "See the demo" link)
- **scratchnode.live/demo_ver1** (and `/demo_ver{N}`) -> current mocked event shell + auto-run runDemoFull
- **scratchnode.live/e/:slug** -> unchanged (real event room)
- **nodebenchai.com/proto/home-v4.html** -> minimal NodeBench landing
- **nodebenchai.com/proto/home-v4.html?demo=1** -> current full mockup

## Commits (commit-early discipline due to API socket-death risk)

- [x] 1/4 `feat(scratchnode): apex landing vs /demo_ver{N} split on home-v5`
- [ ] 2/4 home-v4 symmetric treatment
- [ ] 3/4 middleware.ts `/demo_ver:n` route handling
- [ ] 4/4 verification gates + live-DOM checks

## Test plan

- [x] `npx tsc --noEmit --pretty false` clean
- [x] `npm run build` clean
- [ ] jsdom smoke: bare apex has `data-page-mode="landing"` and `.event-strip` hidden
- [ ] jsdom smoke: `/demo_ver1` has `data-page-mode="demo"` and `.event-strip` visible
- [ ] `window.runDemoQA()` still returns 17/17 in demo mode
- [ ] `window.runLiveAssistQA()` still returns 8/8 in demo mode
- [ ] Post-merge live-DOM:
  - [ ] `https://scratchnode.live/` raw HTML contains `data-page-mode="landing"` and `class="landing"`
  - [ ] `https://scratchnode.live/demo_ver1` raw HTML contains `data-page-mode="demo"` and `.event-strip`
  - [ ] `https://www.nodebenchai.com/proto/home-v4.html` contains `class="landing-v4"`
  - [ ] `https://www.nodebenchai.com/proto/home-v4.html?demo=1` contains the existing TipTap blocks

## Diff budget

Target: ~600 LOC across home-v5.html, home-v4.html, middleware.ts. Constraint: do not touch `convex/*`, e2e specs, dogfood scripts, or `.claude/*`.

Will mark ready-for-review once all 4 checkpoints land and verification passes.

Generated with [Claude Code](https://claude.com/claude-code)
