### PR TITLE
feat(scratchnode): classify live assist outputs

### DIFF
--- a/docs/architecture/AGENT_OUTPUT_L123_CONTRACT.md
+++ b/docs/architecture/AGENT_OUTPUT_L123_CONTRACT.md
@@ -59,6 +59,44 @@ rules apply to it. L1/L2/L3 gives one gate for public wiki generation, private
 LightRAG memory, search retrieval tools, semantic cache entries, trace nodes,
 artifacts, and UI renderers.
 
+## Live Assist Additions
+
+```text
+private_memory
+  live_cue
+    cue.question_suggestion
+    cue.context_card
+    cue.contradiction_warning
+    cue.followup_prompt
+    cue.decision_hint
+  private_note
+    note.raw_shorthand
+    note.agent_enhanced
+    note.voice_transcript
+    note.anchored_to_chat
+
+generated_artifact
+  meeting_brief
+    artifact.private_meeting_summary
+    artifact.team_meeting_summary
+```
+
+Live Assist cues are private by default and must never auto-post:
+
+```text
+visibility = private | workspace
+cueText required
+trigger required
+autoPost = false
+```
+
+Meeting summaries that use owner notes must remain private:
+
+```text
+artifact.private_meeting_summary may use privateNotesUsed=true
+artifact.team_meeting_summary cannot include private-note payloads
+```
+
 ## L1 Families
 
 ```text

--- a/docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
+++ b/docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
@@ -223,10 +223,12 @@ Examples:
 
 ```text
 public_knowledge / event_faq / faq.cached_reuse_answer
+private_memory / live_cue / cue.question_suggestion
 private_memory / private_note / note.anchored_to_chat
 retrieval_context / index_search / retrieval.context_packet
 operational_cache / semantic_answer_cache / cache.public_faq_answer
 agent_trace / output_node / trace.output.public_answer
+generated_artifact / meeting_brief / artifact.private_meeting_summary
 generated_artifact / event_archive / artifact.published_event_wiki
 ```
 

--- a/public/proto/docs.html
+++ b/public/proto/docs.html
@@ -509,6 +509,7 @@ kbd {
     <a class="toc-link" href="#positioning" data-toc="positioning">Consent-first positioning</a>
     <a class="toc-link" href="#capture-levels" data-toc="capture-levels">3 capture levels</a>
     <a class="toc-link" href="#assist-rail" data-toc="assist-rail">Live Assist rail</a>
+    <a class="toc-link" href="#global-assist-cost" data-toc="global-assist-cost">Global assist cost</a>
     <a class="toc-link" href="#safety-rules" data-toc="safety-rules">Anti-Cluely rules</a>
     <a class="toc-link" href="#feature-map" data-toc="feature-map">Master feature map</a>
     <a class="toc-link" href="#mvp-order" data-toc="mvp-order">MVP build order</a>
@@ -712,6 +713,18 @@ kbd {
       </ul>
     </section>
 
+    <h2 id="global-assist-cost">Global event chat assist cost model <a class="anchor" href="#global-assist-cost">#</a></h2>
+    <p>Global event chat assist is the default because it amortizes agent work across the room. Normal public chat stays human-to-human. <code>/ask</code> or <code>@ScratchNode</code> creates one shared answer card, one trace, one FAQ candidate, and one cacheable public knowledge object.</p>
+    <table>
+      <thead><tr><th>Path</th><th>Runtime behavior</th><th>Cost posture</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Normal chat</strong></td><td>Public row only; no agent call; no Linkup search.</td><td>Near-zero marginal cost.</td></tr>
+        <tr><td><strong>Public /ask</strong></td><td>One room-visible sourced answer; eligible for FAQ/wiki/cache.</td><td>Shared once, reused by everyone.</td></tr>
+        <tr><td><strong>Private Live Assist</strong></td><td>Owner-only cue cards, micronotes, follow-ups, private meeting summary.</td><td>Opt-in and budgeted by trigger.</td></tr>
+      </tbody>
+    </table>
+    <p>Track: cache hit rate, new searches avoided, cost per <code>/ask</code>, cost per attendee, FAQ reuse count, private vs public agent calls, semantic-cache miss rate, and stale-cache refresh count.</p>
+
     <!-- ─── Section D: Anti-Cluely safety rules ─── -->
     <h2 id="safety-rules">Anti-Cluely safety rules (10) <a class="anchor" href="#safety-rules">#</a></h2>
     <p>Hard product invariants. Each rule is paired with a code-level enforcement point. Violating any of these is a release blocker.</p>
@@ -867,10 +880,12 @@ sources/traces              context retrieval packets         autocomplete
     <h3 id="prod-output-contract">Agent output L1/L2/L3 contract</h3>
     <p>Every agent output must now be classified, validated, stored, rendered, traced, and evaluated through one shared contract: <code>L1</code> broad family, <code>L2</code> object category, and <code>L3</code> exact contract / renderer / validator. The executable registry lives in <code>src/shared/agentOutputContract.ts</code>; <code>home-v5.html</code> records evaluated envelopes during <code>runDemoFull()</code>.</p>
     <pre><span class="lang">text</span>public_knowledge / event_faq / faq.cached_reuse_answer
+private_memory / live_cue / cue.question_suggestion
 private_memory / private_note / note.anchored_to_chat
 retrieval_context / index_search / retrieval.context_packet
 operational_cache / semantic_answer_cache / cache.public_faq_answer
 agent_trace / output_node / trace.output.public_answer
+generated_artifact / meeting_brief / artifact.private_meeting_summary
 generated_artifact / event_archive / artifact.published_event_wiki</pre>
     <div class="callout"><span class="icon">âœ…</span><div><strong>Acceptance gate:</strong> no output is accepted unless it has a valid <code>l1/l2/l3</code>, visibility boundary, target id, <code>traceRef</code>, source/citation arrays, producer metadata, storage policy, renderer mapping, and evaluator mapping. <code>runDemoQA().contract</code> shows the demo envelope pass/fail summary by L1 family.</div></div>
 

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -4305,7 +4305,51 @@ function pushLiveAssistCue(text, opts) {
   // (Ive principle: every element earns its place; oldest cues age out).
   if (window._live_assist.cues.length > 3) window._live_assist.cues.length = 3;
   _renderLiveAssist();
+  if (typeof window.recordAgentOutputEnvelope === 'function') {
+    var trigger = opts.trigger || _inferLiveCueTrigger(text);
+    var l3 = opts.l3 || _inferLiveCueL3(text);
+    var traceRef = 'trace_' + cue.id;
+    window.recordAgentOutputEnvelope({
+      id: 'out_' + cue.id,
+      l1: 'private_memory',
+      l2: 'live_cue',
+      l3: l3,
+      target: { eventId: 'evt_ai_infra_summit', messageId: opts.messageId || undefined, traceId: traceRef },
+      visibility: opts.visibility || 'private',
+      sourceRefs: opts.sourceRefs || ['event:evt_ai_infra_summit'],
+      citationRefs: opts.citationRefs || [],
+      traceRef: traceRef,
+      producedBy: {
+        runId: 'run_' + cue.id,
+        skill: opts.skill || 'meeting-live-cue',
+        toolChain: opts.toolChain || ['retrieve_event_context']
+      },
+      version: { memorySnapshotVersion: 1 },
+      output: {
+        cueText: text,
+        trigger: trigger,
+        autoPost: false,
+        actions: ['save_note','ask_private','make_followup'],
+        ownerOnly: true,
+        source: cue.source
+      }
+    });
+  }
   return cue.id;
+}
+function _inferLiveCueL3(text) {
+  if (/contradict|earlier|now said/i.test(text || '')) return 'cue.contradiction_warning';
+  if (/follow.?up|owner|deadline|next step/i.test(text || '')) return 'cue.followup_prompt';
+  if (/decision|decide|approved|agreed/i.test(text || '')) return 'cue.decision_hint';
+  if (/@|context|source/i.test(text || '')) return 'cue.context_card';
+  return 'cue.question_suggestion';
+}
+function _inferLiveCueTrigger(text) {
+  if (/contradict|earlier|now said/i.test(text || '')) return 'contradiction_detected';
+  if (/follow.?up|owner|deadline|next step/i.test(text || '')) return 'action_item_detected';
+  if (/decision|decide|approved|agreed/i.test(text || '')) return 'decision_detected';
+  if (/@|context|source/i.test(text || '')) return 'entity_topic_changed';
+  return 'question_detected';
 }
 
 // Set context chips (entity mentions, current focus).
@@ -5837,6 +5881,7 @@ window._laCueAction       = _laCueAction;
       public_agent_answer: ['answer.public_event_card','answer.cached_event_answer','answer.delta_refreshed_answer']
     },
     private_memory: {
+      live_cue: ['cue.question_suggestion','cue.context_card','cue.contradiction_warning','cue.followup_prompt','cue.decision_hint'],
       private_note: ['note.raw_shorthand','note.agent_enhanced','note.voice_transcript','note.anchored_to_chat','note.followup_task'],
       private_notebook_patch: ['notebook.append_block','notebook.update_block','notebook.followup_task']
     },
@@ -5853,6 +5898,7 @@ window._laCueAction       = _laCueAction;
     },
     generated_artifact: {
       presentation: ['artifact.presentation_html'],
+      meeting_brief: ['artifact.private_meeting_summary','artifact.team_meeting_summary'],
       source_bundle: ['artifact.source_bundle'],
       export: ['artifact.csv_export','artifact.crm_export'],
       event_archive: ['artifact.published_event_wiki']
@@ -5866,6 +5912,11 @@ window._laCueAction       = _laCueAction;
   };
   var AGENT_OUTPUT_POLICIES = {
     'faq.cached_reuse_answer': { l1:'public_knowledge', l2:'event_faq', storage:'convex', renderer:'AgentAnswerCard', evaluator:'faq_validator', allowedVisibility:['event_public'] },
+    'cue.question_suggestion': { l1:'private_memory', l2:'live_cue', storage:'convex', renderer:'LiveAssistCueCard', evaluator:'live_cue_validator', allowedVisibility:['private','workspace'] },
+    'cue.context_card': { l1:'private_memory', l2:'live_cue', storage:'convex', renderer:'LiveAssistContextCard', evaluator:'live_cue_validator', allowedVisibility:['private','workspace'] },
+    'cue.contradiction_warning': { l1:'private_memory', l2:'live_cue', storage:'convex', renderer:'LiveAssistCueCard', evaluator:'live_cue_validator', allowedVisibility:['private','workspace'] },
+    'cue.followup_prompt': { l1:'private_memory', l2:'live_cue', storage:'convex', renderer:'LiveAssistCueCard', evaluator:'live_cue_validator', allowedVisibility:['private','workspace'] },
+    'cue.decision_hint': { l1:'private_memory', l2:'live_cue', storage:'convex', renderer:'LiveAssistCueCard', evaluator:'live_cue_validator', allowedVisibility:['private','workspace'] },
     'note.anchored_to_chat': { l1:'private_memory', l2:'private_note', storage:'convex', renderer:'PrivateNoteMarker', evaluator:'note_validator', allowedVisibility:['private'] },
     'note.agent_enhanced': { l1:'private_memory', l2:'private_note', storage:'convex', renderer:'PrivateNoteSheet', evaluator:'note_validator', allowedVisibility:['private'] },
     'note.voice_transcript': { l1:'private_memory', l2:'private_note', storage:'convex', renderer:'PrivateNoteSheet', evaluator:'note_validator', allowedVisibility:['private'] },
@@ -5884,6 +5935,8 @@ window._laCueAction       = _laCueAction;
     'wiki.what_changed_item': { l1:'public_knowledge', l2:'event_wiki', storage:'convex', renderer:'WikiSectionItem', evaluator:'wiki_validator', allowedVisibility:['event_public','host_draft'] },
     'artifact.published_event_wiki': { l1:'generated_artifact', l2:'event_archive', storage:'artifact_lake', renderer:'EventArchiveArtifact', evaluator:'artifact_validator', allowedVisibility:['event_public'] },
     'artifact.presentation_html': { l1:'generated_artifact', l2:'presentation', storage:'artifact_lake', renderer:'PresentationArtifact', evaluator:'artifact_validator', allowedVisibility:['event_public','workspace'] },
+    'artifact.private_meeting_summary': { l1:'generated_artifact', l2:'meeting_brief', storage:'artifact_lake', renderer:'MeetingBriefArtifact', evaluator:'artifact_validator', allowedVisibility:['private','workspace'] },
+    'artifact.team_meeting_summary': { l1:'generated_artifact', l2:'meeting_brief', storage:'artifact_lake', renderer:'MeetingBriefArtifact', evaluator:'artifact_validator', allowedVisibility:['workspace'] },
     'ui.agent_answer_card': { l1:'ui_renderable', l2:'ui_card', storage:'ui_only', renderer:'AgentAnswerCard', evaluator:'ui_snapshot_evaluator', allowedVisibility:['event_public'] },
     'ui.private_note_marker': { l1:'ui_renderable', l2:'ui_card', storage:'ui_only', renderer:'PrivateNoteMarker', evaluator:'ui_snapshot_evaluator', allowedVisibility:['private'] }
   };
@@ -5944,6 +5997,18 @@ window._laCueAction       = _laCueAction;
     }
     if (envelope.l2 === 'private_note') {
       if (!_readOutputPath(envelope.output, ['body'])) err('NOTE-002', 'Private note requires body.');
+    }
+    if (envelope.l2 === 'live_cue') {
+      if (['private','workspace'].indexOf(envelope.visibility) === -1) err('CUE-001', 'Live Assist cues must be private or workspace-scoped.');
+      if (!_readOutputPath(envelope.output, ['cueText'])) err('CUE-002', 'Live Assist cues require cueText.');
+      if (_readOutputPath(envelope.output, ['autoPost']) !== false) err('CUE-003', 'Live Assist cues must set autoPost=false.');
+      if (!_readOutputPath(envelope.output, ['trigger'])) err('CUE-004', 'Live Assist cues require trigger.');
+    }
+    if (envelope.l2 === 'meeting_brief') {
+      if (envelope.visibility === 'event_public') err('ART-007', 'Meeting brief artifacts cannot be event_public.');
+      if (!_readOutputPath(envelope.output, ['summary'])) err('ART-001', 'Meeting brief artifacts require summary.');
+      if (!Array.isArray(_readOutputPath(envelope.output, ['actionItems']))) err('ART-002', 'Meeting brief artifacts require actionItems.');
+      if (_readOutputPath(envelope.output, ['privateNotesUsed']) === true && envelope.visibility !== 'private') err('ART-005', 'Meeting briefs with private notes must remain private.');
     }
     return { passed: issues.length === 0, issues: issues, policy: policy };
   }
@@ -6992,8 +7057,28 @@ window._laCueAction       = _laCueAction;
     return Promise.resolve(artifact);
   }
   function createDailyBriefDelta() {
-    // The brief is rendered by the Reports tab in the overlay.
-    return Promise.resolve({ entitiesAdded: 3, signalsAdded: 5 });
+    // The brief is rendered by the Reports tab in the overlay. The private
+    // meeting summary is a first-class artifact because it may use owner notes.
+    recordAgentOutputEnvelope({
+      id: 'artifact_private_meeting_summary',
+      l1: 'generated_artifact',
+      l2: 'meeting_brief',
+      l3: 'artifact.private_meeting_summary',
+      target: { eventId: 'evt_ai_infra_summit', artifactId: 'artifact_private_meeting_summary', traceId: 'trace_nodebench_handoff' },
+      visibility: 'private',
+      sourceRefs: ['source:event-wiki:v1', 'private-notebook-summary'],
+      citationRefs: [],
+      traceRef: 'trace_nodebench_handoff',
+      producedBy: { runId: 'run_post_meeting_brief', skill: 'post-meeting-brief', toolChain: ['retrieve_event_context','save_private_note_patch'] },
+      version: { wikiVersion: 1, sourceBundleVersion: 7, memorySnapshotVersion: 1 },
+      output: {
+        summary: 'Orbital Labs and clinical triage latency became the private follow-through theme.',
+        actionItems: ['Ask Alex about p95 latency targets.', 'Confirm whether Epic integration is planned.'],
+        privateNotesUsed: true,
+        workspaceOnly: true
+      }
+    });
+    return Promise.resolve({ entitiesAdded: 3, signalsAdded: 5, privateMeetingSummary: true });
   }
 
   // ── Actor switch (toggles body[data-actor-id] + identity strip) ──
@@ -7516,12 +7601,15 @@ window._laCueAction       = _laCueAction;
     var invalidOutputs = outputs.filter(function(out) { return !out.evaluation || !out.evaluation.passed; });
     var rendererMapped = outputs.every(function(out) { return out.evaluation && out.evaluation.policy && out.evaluation.policy.renderer; });
     var evaluatorMapped = outputs.every(function(out) { return out.evaluation && out.evaluation.policy && out.evaluation.policy.evaluator; });
+    var liveCueCount = outputs.filter(function(out) { return out.l2 === 'live_cue'; }).length;
+    var meetingBriefCount = outputs.filter(function(out) { return out.l2 === 'meeting_brief'; }).length;
     var contractSummary = {
       passed: outputs.length > 0 && invalidOutputs.length === 0 && missingFamilies.length === 0 && rendererMapped && evaluatorMapped,
       total: outputs.length,
       invalid: invalidOutputs.map(function(out) { return out.id; }),
       missingFamilies: missingFamilies,
       byL1: byL1,
+      liveAssist: { liveCueCount: liveCueCount, meetingBriefCount: meetingBriefCount },
       rendererMapped: rendererMapped,
       evaluatorMapped: evaluatorMapped
     };
@@ -7595,6 +7683,7 @@ window._laCueAction       = _laCueAction;
   window.demoStep    = demoStep;
   window.SN_AGENT_OUTPUT_REGISTRY = AGENT_OUTPUT_REGISTRY;
   window.evaluateAgentOutputEnvelope = evaluateAgentOutputEnvelope;
+  window.recordAgentOutputEnvelope = recordAgentOutputEnvelope;
 
   // ?demo=1 URL auto-run for one-click presentations.
   try {

--- a/src/shared/agentOutputContract.test.ts
+++ b/src/shared/agentOutputContract.test.ts
@@ -83,6 +83,81 @@ describe("agent output L1/L2/L3 contract", () => {
     expect(result.policy?.renderer).toBe("PrivateNoteMarker");
   });
 
+  it("accepts a private Live Assist cue and rejects auto-posting cues", () => {
+    const envelope: AgentOutputEnvelope = {
+      ...baseEnvelope,
+      id: "cue_1",
+      l1: "private_memory",
+      l2: "live_cue",
+      l3: "cue.question_suggestion",
+      visibility: "private",
+      sourceRefs: ["message:msg_sarah_latency"],
+      citationRefs: [],
+      traceRef: "trace_cue_1",
+      producedBy: {
+        runId: "run_cue_1",
+        skill: "meeting-live-cue",
+        toolChain: ["retrieve_event_context"],
+      },
+      output: {
+        cueText: "Clarify whether this is p95 or average latency.",
+        trigger: "question_detected",
+        autoPost: false,
+        actions: ["save_note", "ask_private", "make_followup"],
+      },
+    };
+
+    const result = evaluateAgentOutput(envelope);
+
+    expect(result.passed).toBe(true);
+    expect(result.policy?.renderer).toBe("LiveAssistCueCard");
+
+    const unsafe = {
+      ...envelope,
+      id: "cue_unsafe",
+      output: { ...envelope.output, autoPost: true },
+    };
+
+    expect(evaluateAgentOutput(unsafe).issues.map((issue) => issue.code)).toContain("CUE-003");
+  });
+
+  it("accepts private meeting brief artifacts and blocks private content from workspace summaries", () => {
+    const envelope: AgentOutputEnvelope = {
+      ...baseEnvelope,
+      id: "brief_1",
+      l1: "generated_artifact",
+      l2: "meeting_brief",
+      l3: "artifact.private_meeting_summary",
+      visibility: "private",
+      traceRef: "trace_meeting_brief_1",
+      producedBy: {
+        runId: "run_meeting_brief_1",
+        skill: "post-meeting-brief",
+        toolChain: ["retrieve_event_context", "save_private_note_patch"],
+      },
+      output: {
+        summary: "Orbital Labs and clinical triage latency dominated the meeting.",
+        actionItems: ["Ask Alex about p95 latency targets."],
+        sourceTranscriptAnchors: ["msg_sarah_latency"],
+        privateNotesUsed: true,
+      },
+    };
+
+    expect(evaluateAgentOutput(envelope).passed).toBe(true);
+
+    const unsafeWorkspaceSummary: AgentOutputEnvelope = {
+      ...envelope,
+      id: "brief_workspace_unsafe",
+      l3: "artifact.team_meeting_summary",
+      visibility: "workspace",
+    };
+
+    const result = evaluateAgentOutput(unsafeWorkspaceSummary);
+
+    expect(result.passed).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toContain("ART-005");
+  });
+
   it("rejects public answers that use private notes", () => {
     const envelope: AgentOutputEnvelope = {
       ...baseEnvelope,

--- a/src/shared/agentOutputContract.ts
+++ b/src/shared/agentOutputContract.ts
@@ -23,6 +23,13 @@ export const OUTPUT_REGISTRY = {
     ],
   },
   private_memory: {
+    live_cue: [
+      "cue.question_suggestion",
+      "cue.context_card",
+      "cue.contradiction_warning",
+      "cue.followup_prompt",
+      "cue.decision_hint",
+    ],
     private_note: [
       "note.raw_shorthand",
       "note.agent_enhanced",
@@ -80,6 +87,7 @@ export const OUTPUT_REGISTRY = {
   },
   generated_artifact: {
     presentation: ["artifact.presentation_html"],
+    meeting_brief: ["artifact.private_meeting_summary", "artifact.team_meeting_summary"],
     source_bundle: ["artifact.source_bundle"],
     export: ["artifact.csv_export", "artifact.crm_export"],
     event_archive: ["artifact.published_event_wiki"],
@@ -189,6 +197,11 @@ export const AGENT_OUTPUT_POLICIES: AgentOutputPolicy[] = [
   policy("public_knowledge", "public_agent_answer", "answer.public_event_card", "convex", "AgentAnswerCard", "answer_validator", ["event_public"]),
   policy("public_knowledge", "public_agent_answer", "answer.cached_event_answer", "convex", "AgentAnswerCard", "answer_validator", ["event_public"]),
   policy("public_knowledge", "public_agent_answer", "answer.delta_refreshed_answer", "convex", "AgentAnswerCard", "answer_validator", ["event_public"]),
+  policy("private_memory", "live_cue", "cue.question_suggestion", "convex", "LiveAssistCueCard", "live_cue_validator", ["private", "workspace"]),
+  policy("private_memory", "live_cue", "cue.context_card", "convex", "LiveAssistContextCard", "live_cue_validator", ["private", "workspace"]),
+  policy("private_memory", "live_cue", "cue.contradiction_warning", "convex", "LiveAssistCueCard", "live_cue_validator", ["private", "workspace"]),
+  policy("private_memory", "live_cue", "cue.followup_prompt", "convex", "LiveAssistCueCard", "live_cue_validator", ["private", "workspace"]),
+  policy("private_memory", "live_cue", "cue.decision_hint", "convex", "LiveAssistCueCard", "live_cue_validator", ["private", "workspace"]),
   policy("private_memory", "private_note", "note.raw_shorthand", "convex", "PrivateNoteSheet", "note_validator", ["private"]),
   policy("private_memory", "private_note", "note.agent_enhanced", "convex", "PrivateNoteSheet", "note_validator", ["private"]),
   policy("private_memory", "private_note", "note.voice_transcript", "convex", "PrivateNoteSheet", "note_validator", ["private"]),
@@ -224,6 +237,8 @@ export const AGENT_OUTPUT_POLICIES: AgentOutputPolicy[] = [
   policy("agent_trace", "tool_call", "trace.tool.linkup_search", "convex", "TraceToolCall", "tool_call_evaluator", ["event_public", "private", "workspace"]),
   policy("agent_trace", "tool_call", "trace.tool.save_private_note_patch", "convex", "TraceToolCall", "tool_call_evaluator", ["private", "workspace"]),
   policy("generated_artifact", "presentation", "artifact.presentation_html", "artifact_lake", "PresentationArtifact", "artifact_validator", ["event_public", "workspace"]),
+  policy("generated_artifact", "meeting_brief", "artifact.private_meeting_summary", "artifact_lake", "MeetingBriefArtifact", "artifact_validator", ["private", "workspace"]),
+  policy("generated_artifact", "meeting_brief", "artifact.team_meeting_summary", "artifact_lake", "MeetingBriefArtifact", "artifact_validator", ["workspace"]),
   policy("generated_artifact", "source_bundle", "artifact.source_bundle", "artifact_lake", "SourceBundleArtifact", "artifact_validator", ["event_public", "workspace"]),
   policy("generated_artifact", "export", "artifact.csv_export", "artifact_lake", "ExportArtifact", "artifact_validator", ["private", "workspace"]),
   policy("generated_artifact", "export", "artifact.crm_export", "artifact_lake", "ExportArtifact", "artifact_validator", ["private", "workspace"]),
@@ -389,10 +404,39 @@ function validateSpecificContract(
     if (envelope.visibility !== "private") addError("NOTE-001", "Private notes require visibility=private.");
     if (!stringField(envelope.output, "body")) addError("NOTE-002", "Private notes require a body.");
   }
+
+  if (envelope.l2 === "live_cue") {
+    if (!["private", "workspace"].includes(envelope.visibility)) {
+      addError("CUE-001", "Live Assist cues must be private or workspace-scoped.");
+    }
+    if (!stringField(envelope.output, "cueText")) addError("CUE-002", "Live Assist cues require cueText.");
+    if (readPath(envelope.output, ["autoPost"]) !== false) {
+      addError("CUE-003", "Live Assist cues must set autoPost=false.");
+    }
+    if (!stringField(envelope.output, "trigger")) addError("CUE-004", "Live Assist cues require the event trigger.");
+  }
+
+  if (envelope.l2 === "meeting_brief") {
+    if (envelope.visibility === "event_public") {
+      addError("ART-007", "Meeting brief artifacts cannot be event_public.");
+    }
+    if (!stringField(envelope.output, "summary")) addError("ART-001", "Meeting brief artifacts require a summary.");
+    if (!Array.isArray(readPath(envelope.output, ["actionItems"]))) {
+      addError("ART-002", "Meeting brief artifacts require actionItems.");
+    }
+    if (containsPrivatePayload(envelope.output) && envelope.visibility !== "private") {
+      addError("ART-005", "Meeting briefs with private note content must remain private.");
+    }
+  }
 }
 
 function isPrivateRef(ref: string): boolean {
   return /^private[:/_-]|private_note|userNotes|note_private/i.test(ref);
+}
+
+function containsPrivatePayload(value: unknown): boolean {
+  if (!value) return false;
+  return /"(?:privateNoteIds?|private_source_refs?|privateNotesUsed)"\s*:\s*true/i.test(JSON.stringify(value));
 }
 
 function stringField(value: Record<string, unknown> | undefined, key: string): boolean {

--- a/tests/e2e/home-v5-output-contract.spec.ts
+++ b/tests/e2e/home-v5-output-contract.spec.ts
@@ -25,6 +25,8 @@ test("home-v5 runDemoFull keeps visible invariants and L1/L2/L3 output contracts
   expect(qa.contract.missingFamilies).toEqual([]);
   expect(qa.contract.rendererMapped).toBe(true);
   expect(qa.contract.evaluatorMapped).toBe(true);
+  expect(qa.contract.liveAssist.liveCueCount).toBeGreaterThanOrEqual(1);
+  expect(qa.contract.liveAssist.meetingBriefCount).toBe(1);
   expect(qa.riskAttack.passed).toBe(7);
   expect(qa.riskAttack.failed).toBe(0);
   expect(qa.riskAttack.total).toBe(7);

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -393,6 +393,8 @@ test("home-v5 runDemoFull emits evaluated L1/L2/L3 output envelopes", async ({ p
   expect(qa.contract.missingFamilies).toEqual([]);
   expect(qa.contract.rendererMapped).toBe(true);
   expect(qa.contract.evaluatorMapped).toBe(true);
+  expect(qa.contract.liveAssist.liveCueCount).toBeGreaterThanOrEqual(1);
+  expect(qa.contract.liveAssist.meetingBriefCount).toBe(1);
   expect(qa.riskAttack.passed).toBe(7);
   expect(qa.riskAttack.failed).toBe(0);
   expect(qa.riskAttack.total).toBe(7);


### PR DESCRIPTION
## Summary

- Adds first-class L1/L2/L3 contracts for ScratchNode Live Assist cues and post-meeting brief artifacts.
- Wires `home-v5.html` demo/runtime recording so private cue cards and private meeting summaries produce validated agent-output envelopes.
- Updates prototype docs with the global event chat assist cost model: normal chat stays human-only, public `/ask` is shared/cacheable, and private Live Assist remains opt-in and owner-scoped.
- Extends Playwright dogfood assertions so the demo proves at least one Live Assist cue and exactly one private meeting brief are emitted.

## Verification

- `npx vitest run src/shared/agentOutputContract.test.ts src/shared/riskAttackEvaluator.test.ts`
- `npx playwright test tests/e2e/home-v5-output-contract.spec.ts --project=chromium --workers=1 --reporter=list`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`

## Notes

`gh auth status` currently reports an invalid local CLI token, so this PR was opened through the GitHub connector after pushing the branch with git.