### PR TITLE
fix(scratchnode): gate demo autoplay route

### DIFF
--- a/public/proto/docs.html
+++ b/public/proto/docs.html
@@ -1462,8 +1462,8 @@ eventAnswers: <span class="fn">defineTable</span>({
     </ul>
 
     <h2 id="quick-start">Quick start <a class="anchor" href="#quick-start">#</a></h2>
-    <p>Open <a href="home-v5.html">home-v5.html</a> directly in a browser. No build, no npm. To skip onboarding and land mid-conversation:</p>
-    <pre><span class="lang">url</span>home-v5.html<span class="kw">#demo</span></pre>
+    <p>Open <a href="home-v5.html">home-v5.html</a> directly in a browser. No build, no npm. Demo autoplay is production-route gated; use the dedicated public route:</p>
+    <pre><span class="lang">url</span>/demo_ver1</pre>
     <p>To replay onboarding from a specific step:</p>
     <pre><span class="lang">url</span>home-v5.html<span class="kw">#wiz=</span><span class="num">2</span></pre>
     <div class="callout note"><span class="icon">⚡</span><div><strong>Tip:</strong> All demo controls are also exposed as functions on <code>window</code> — see <a href="#js-api">JS API</a>.</div></div>
@@ -1703,13 +1703,15 @@ eventAnswers: <span class="fn">defineTable</span>({
     </ul>
 
     <h2 id="demo-controls">Demo controls <a class="anchor" href="#demo-controls">#</a></h2>
-    <p>Every demoable state is reachable from either a URL hash or a window-scoped function. Use URL hashes when driving headless screenshots (Chromium can't always exec JS); use functions when you're hand-driving a live demo.</p>
+    <p>Demo autoplay only belongs on <code>/demo_ver...</code> routes. Root, event, docs, and live production routes ignore stale <code>?demo=1</code> or <code>#demo</code> values.</p>
 
-    <h3 id="hash-routes">URL hashes</h3>
+    <h3 id="hash-routes">Demo routes</h3>
     <table>
-      <thead><tr><th>Hash</th><th>Effect</th></tr></thead>
+      <thead><tr><th>Route</th><th>Effect</th></tr></thead>
       <tbody>
-        <tr><td><code>#demo</code></td><td>Triggers <code>runDemo()</code> — full live timeline of incoming messages, /ask answers, mentions, reactions.</td></tr>
+        <tr><td><code>/demo_ver1</code></td><td>Triggers <code>runDemoFull()</code> - full end-to-end ScratchNode + NodeBench handoff demo.</td></tr>
+        <tr><td><code>/demo_ver1?demo=legacy</code></td><td>Triggers legacy <code>runDemo()</code> for the short conversation simulator.</td></tr>
+        <tr><td><code>/demo_ver1?demo=0</code></td><td>Loads the demo surface without autoplay for manual console driving.</td></tr>
         <tr><td><code>#wiz=1</code> / <code>2</code> / <code>3</code></td><td>Jump directly to onboarding step N.</td></tr>
         <tr><td><code>#empty</code></td><td>Clears the feed and shows the empty-state CTA.</td></tr>
         <tr><td><code>#viewmode=workspace</code></td><td>(v4) sets view mode without going through landing.</td></tr>
@@ -1792,7 +1794,7 @@ eventAnswers: <span class="fn">defineTable</span>({
 
     <h2 id="closing">What's next <a class="anchor" href="#closing">#</a></h2>
     <p>The two prototypes are deliberately parallel: v4 proves the full feature surface; v5 proves you can ship 10% of it and still earn the room. The docs page you're reading is the canonical reference between them.</p>
-    <p>Open v5 with <code>#demo</code> to see all of it animated end-to-end. Open v4 to see the spec proof at full fidelity.</p>
+    <p>Open v5 through <code>/demo_ver1</code> to see all of it animated end-to-end. Open v4 to see the spec proof at full fidelity.</p>
   </article>
 
   <!-- ─── Right rail: on-page nav ─── -->

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1852,6 +1852,33 @@ var ON_PUBLIC_DOMAIN = (function() {
   catch (e) { return false; }
 })();
 
+function isScratchNodeDemoRoute(pathname) {
+  var p = String(pathname || '/').toLowerCase();
+  // Owned demo routes: /demo_ver, /demo_ver1, /demo_ver_v5, /demo_ver-v5, /demo_ver/1.
+  // Deliberately does not match /, /e/:slug, /proto/home-v5.html, or /demo_version.
+  return /^\/demo_ver(?:$|[0-9][a-z0-9_-]*$|[_-][a-z0-9_-]+$|\/)/.test(p);
+}
+
+function shouldRunScratchNodeFullDemo() {
+  if (!isScratchNodeDemoRoute(location.pathname)) return false;
+  if (location.hash === '#legacy-demo') return false;
+  try {
+    var params = new URLSearchParams(location.search);
+    return params.get('demo') !== '0' && params.get('autorun') !== '0' && params.get('demo') !== 'legacy';
+  } catch (e) {
+    return true;
+  }
+}
+
+function shouldRunScratchNodeLegacyDemo() {
+  if (!isScratchNodeDemoRoute(location.pathname)) return false;
+  try {
+    var params = new URLSearchParams(location.search);
+    if (params.get('demo') === 'legacy') return true;
+  } catch (e) {}
+  return location.hash === '#legacy-demo';
+}
+
 function buildNodeBenchEventPrivateUrl() {
   var roomCode = 'ORBITAL';
   try {
@@ -3598,7 +3625,7 @@ setTimeout(refreshEmptyState, 100);
 //   • Dario Amodei (Anthropic CEO)
 //   • Sarah Kim (Google DeepMind VP Eng)
 //   • Alex Chen (Orbital Labs founder)
-// Run with #demo in URL hash, or call runDemo() from console.
+// Run on /demo_ver...?demo=legacy, or call runDemo() from console.
 // ═══════════════════════════════════════════════════════
 
 var CHAR_COLORS = {
@@ -3617,16 +3644,16 @@ function _time() {
 
 // ─── Debug-gated prototype simulators ───────────────────────────────────────
 // All sim* helpers are scaffolding for live demos and screenshots. They are
-// NOT shipped to production unless the user opts in via ?debug=1 or #demo in
-// the URL. Production builds should keep DEBUG_MODE false and remove this
+// NOT shipped to production unless the user opts in via ?debug=1 or /demo_ver...
+// in the URL. Production builds should keep DEBUG_MODE false and remove this
 // block entirely (it is marked Prototype in docs.html).
 var _DEBUG_HELPERS_ON = (function() {
   if (DEBUG_MODE) return true;
-  try { return location.hash.indexOf('demo') !== -1; } catch (e) { return false; }
+  try { return isScratchNodeDemoRoute(location.pathname); } catch (e) { return false; }
 })();
 if (!_DEBUG_HELPERS_ON) {
   // Production / non-debug: leave window.sim* undefined and skip the rest of this block.
-  console.debug('[scratchnode] sim* helpers gated — pass ?debug=1 or #demo to enable.');
+  console.debug('[scratchnode] sim* helpers gated — pass ?debug=1 or /demo_ver... to enable.');
 }
 
 // Inject a chat row from any character
@@ -3805,12 +3832,13 @@ function runDemo() {
   simRun(script);
 }
 
-// Trigger demo via URL hash #demo
-if (location.hash === '#demo') {
+// Legacy short demo is route-gated. Production/event roots must never
+// autoplay because of query/hash leftovers.
+if (shouldRunScratchNodeLegacyDemo()) {
   setTimeout(runDemo, 600);
 }
 window.addEventListener('hashchange', function() {
-  if (location.hash === '#demo') runDemo();
+  if (shouldRunScratchNodeLegacyDemo()) runDemo();
 });
 
 // ═══════════════════════════════════════════════════════
@@ -7684,11 +7712,15 @@ window._laCueAction       = _laCueAction;
   window.SN_AGENT_OUTPUT_REGISTRY = AGENT_OUTPUT_REGISTRY;
   window.evaluateAgentOutputEnvelope = evaluateAgentOutputEnvelope;
   window.recordAgentOutputEnvelope = recordAgentOutputEnvelope;
+  window.isScratchNodeDemoRoute = isScratchNodeDemoRoute;
+  window.shouldRunScratchNodeFullDemo = shouldRunScratchNodeFullDemo;
+  window.shouldRunScratchNodeLegacyDemo = shouldRunScratchNodeLegacyDemo;
 
-  // ?demo=1 URL auto-run for one-click presentations.
+  // Demo autoplay is route-owned. Root/event/live routes never run the demo
+  // because of stale ?demo=1/#demo URLs; use /demo_ver... for presentations.
   try {
     var params = new URLSearchParams(location.search);
-    if (params.get('demo') === '1') {
+    if (shouldRunScratchNodeFullDemo()) {
       var speed = params.get('demoSpeed') || 'normal';
       // Defer until after DOMContentLoaded + small delay so live Convex bootstrap can settle.
       var kickoff = function() { setTimeout(function() { runDemoFull({ speed: speed }); }, 600); };

--- a/tests/e2e/home-v5-output-contract.spec.ts
+++ b/tests/e2e/home-v5-output-contract.spec.ts
@@ -42,3 +42,46 @@ test("home-v5 runDemoFull keeps visible invariants and L1/L2/L3 output contracts
     "ui_renderable",
   ]);
 });
+
+test("home-v5 demo autoplay is gated to /demo_ver routes", async ({ page }) => {
+  const fileUrl = `${pathToFileURL(resolve("public/proto/home-v5.html")).toString()}?demo=1#demo`;
+
+  await page.goto(fileUrl, { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () =>
+      typeof (window as any).shouldRunScratchNodeFullDemo === "function" &&
+      typeof (window as any).isScratchNodeDemoRoute === "function",
+  );
+
+  await page.waitForTimeout(1_500);
+
+  const state = await page.evaluate(() => ({
+    shouldRunHere: (window as any).shouldRunScratchNodeFullDemo(),
+    logLength: ((window as any)._demo_log ?? []).length,
+    feedText: document.getElementById("feed")?.textContent ?? "",
+    routes: {
+      root: (window as any).isScratchNodeDemoRoute("/"),
+      event: (window as any).isScratchNodeDemoRoute("/e/ai-infra-summit-2026"),
+      directProto: (window as any).isScratchNodeDemoRoute("/proto/home-v5.html"),
+      demoRoot: (window as any).isScratchNodeDemoRoute("/demo_ver"),
+      demoNumber: (window as any).isScratchNodeDemoRoute("/demo_ver1"),
+      demoSlug: (window as any).isScratchNodeDemoRoute("/demo_ver_v5"),
+      demoSlash: (window as any).isScratchNodeDemoRoute("/demo_ver/v5"),
+      nearMiss: (window as any).isScratchNodeDemoRoute("/demo_version"),
+    },
+  }));
+
+  expect(state.shouldRunHere).toBe(false);
+  expect(state.logLength).toBe(0);
+  expect(state.feedText).not.toContain("Maya from VoiceLayer");
+  expect(state.routes).toEqual({
+    root: false,
+    event: false,
+    directProto: false,
+    demoRoot: true,
+    demoNumber: true,
+    demoSlug: true,
+    demoSlash: true,
+    nearMiss: false,
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -119,6 +119,10 @@
       "destination": "https://raw.githubusercontent.com/HomenShum/nodebench-ai/main/packages/mcp-local/scripts/install.sh"
     },
     {
+      "source": "/demo_ver(.*)",
+      "destination": "/proto/home-v5.html"
+    },
+    {
       "source": "/",
       "has": [
         {


### PR DESCRIPTION
## Summary

- Gates ScratchNode demo autoplay to explicit `/demo_ver...` routes only.
- Stops stale `?demo=1` or `#demo` values from starting `runDemoFull()` or the legacy `runDemo()` on root, event, docs, or direct prototype paths.
- Adds a Vercel rewrite so `/demo_ver...` resolves to the ScratchNode v5 demo surface on production domains.
- Updates docs to point demo playback at `/demo_ver1` instead of `#demo`.

## Verification

- `npx playwright test tests/e2e/home-v5-output-contract.spec.ts --project=chromium --workers=1 --reporter=list`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`
- `npm run preflight:fast`

## Production intent

`scratchnode.live/`, `scratchnode.live/e/:slug`, and `nodebenchai.com/` must land on live surfaces without demo autoplay. The demo is now intentionally reachable through `/demo_ver1` and related `/demo_ver...` paths.