### PR TITLE
fix(scratchnode): gate demo autoplay to /demo_ver routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,32 @@ jobs:
           src/features/workspace/data/eventWorkspaceMemory.test.ts
           server/searchRoute.test.ts
 
+  scratchnode-demo-route-gate:
+    name: ScratchNode demo route gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Verify ScratchNode demo route isolation
+        run: >
+          npx playwright test
+          tests/e2e/scratchnode-demo-route-gate.spec.ts
+          --project=chromium
+          --workers=1
+          --reporter=list
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -93,6 +119,7 @@ jobs:
     needs:
       - typecheck
       - runtime-smoke
+      - scratchnode-demo-route-gate
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md
+++ b/docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md
@@ -1,6 +1,6 @@
 # Proto Surface Real Backend Dogfood
 
-Last updated: 2026-05-26
+Last updated: 2026-05-28
 
 This note removes the recurring confusion between the two prototype surfaces.
 
@@ -8,7 +8,9 @@ This note removes the recurring confusion between the two prototype surfaces.
 
 | Surface | Route | Backend status | Test expectation |
 | --- | --- | --- | --- |
-| ScratchNode v5 | `https://scratchnode.live/`, `/e/:slug` | Live Convex-backed event room. Phases 1-5 are wired, and `/ask` now uses the provider-ready `events:askAgent` action with deterministic fallback. | Must prove data moves browser -> Convex -> second browser or rendered answer/wiki/note. |
+| ScratchNode v5 landing | `https://scratchnode.live/`, `/index.html` | Landing-only shell. It must not auto-run demos and must not bootstrap Convex. | Must prove stale demo URLs like `?demo=1#demo` still render landing-only state. |
+| ScratchNode v5 event room | `https://scratchnode.live/e/:slug` | Live Convex-backed event room. Phases 1-5 are wired, and `/ask` now uses the provider-ready `events:askAgent` action with deterministic fallback. | Must prove data moves browser -> Convex -> second browser or rendered answer/wiki/note. |
+| ScratchNode v5 demo | `https://scratchnode.live/demo_ver{N}` | Scripted story-teller route only. No live Convex join. | Must prove `runDemoFull()` autoplays only on this owned route family. |
 | NodeBench v4 | `https://www.nodebenchai.com/proto/home-v4.html` | Static spec proof for notebook, artifacts, chat, mentions, backlinks, wide mode. | Must prove every interaction works, and must explicitly assert no live Convex runtime marker exists. |
 
 ## Live Dogfood Command
@@ -38,27 +40,28 @@ tests/e2e/proto-live-backend-dogfood.spec.ts
 
 The dogfood covers these live boundaries:
 
-1. Apex `scratchnode.live/` serves the `home-v5` event shell and connects to Convex.
-2. Two anonymous browser contexts join the same event.
-3. Public chat from browser A appears in browser B through `events:sendMessage` and `events:getMessages`.
-4. `/ask` creates a sourced answer through `events:askAgent`, falling back to `events:composeAnswer` only when Convex actions are unavailable.
-5. The rendered answer exposes:
+1. Apex `scratchnode.live/` serves the `home-v5` landing shell only: no demo autoplay, no `data-sn-live`, and stale `?demo=1#demo` values are ignored.
+2. `/e/ai-infra-summit-2026` serves the live Convex-backed event room.
+3. Two anonymous browser contexts join the same event.
+4. Public chat from browser A appears in browser B through `events:sendMessage` and `events:getMessages`.
+5. `/ask` creates a sourced answer through `events:askAgent`, falling back to `events:composeAnswer` only when Convex actions are unavailable.
+6. The rendered answer exposes:
    - source reuse
    - provider or deterministic-fallback trace
    - answer quality gate score
    - model/cost metadata when the provider path runs
    - `no private notes`
    - `data-answer-id`
-6. FAQ suggestion changes answer state through `events:suggestAnswerForFaq`.
-7. Host claim is attempted through `events:claimHost`.
-8. If the shared demo room is claimable, the run also promotes the answer and publishes the wiki through:
+7. FAQ suggestion changes answer state through `events:suggestAnswerForFaq`.
+8. Host claim is attempted through `events:claimHost`.
+9. If the shared demo room is claimable, the run also promotes the answer and publishes the wiki through:
    - `events:promoteAnswerToFaq`
    - `events:publishWiki`
    - `events:getPublishedWiki`
-9. If the room is already claimed, the run verifies the expected host gate instead of pretending publish happened.
-10. Private composer mode creates a Convex-backed note through `notes:createNote`.
-11. Pin and delete use `notes:togglePin` and `notes:deleteNote`.
-12. Private note text is asserted absent from:
+10. If the room is already claimed, the run verifies the expected host gate instead of pretending publish happened.
+11. Private composer mode creates a Convex-backed note through `notes:createNote`.
+12. Pin and delete use `notes:togglePin` and `notes:deleteNote`.
+13. Private note text is asserted absent from:
    - public event feed
    - second anonymous browser
 
@@ -102,4 +105,4 @@ The shared production demo event can only have one host owner. If a previous liv
 
 ## Apex Routing Note
 
-`home-v5.html` now treats `scratchnode.live/` and `scratchnode.live/index.html` as aliases for the canonical `ai-infra-summit-2026` event slug before bootstrapping Convex. Without that explicit alias, the HTML could serve correctly while the live runtime exited early because the URL was not `/e/:slug`.
+`home-v5.html` now treats `scratchnode.live/` and `scratchnode.live/index.html` as landing-only routes. Live Convex boot is owned by explicit `/e/:slug` event routes. Scripted demo autoplay is owned only by `/demo_ver{N}` routes, so old `?demo=1` or `#demo` URLs cannot turn the public landing page or event room into a demo run.

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,22 +2,22 @@
 //
 // Why this file exists:
 //
-//   Vercel's static-file matching runs BEFORE the rewrites in vercel.json.
+//   Vercel's static-file matching runs before the rewrites in vercel.json.
 //   For the apex path "/", Vercel resolves to dist/index.html (NodeBench AI's
 //   Vite-built bundle) and never reaches the rewrites array. That means the
-//   rewrite { source: "/", has: [scratchnode.live] } → /proto/home-v5.html
+//   rewrite { source: "/", has: [scratchnode.live] } -> /proto/home-v5.html
 //   was dead code: it never fired.
 //
 //   Diagnostic on 2026-05-26 17:30Z confirmed:
-//     - scratchnode.live/docs              → docs.html  (rewrite worked)
-//     - scratchnode.live/e/:slug           → home-v5.html (rewrite worked)
-//     - scratchnode.live/random-path-xyz   → home-v5.html (catch-all worked)
-//     - scratchnode.live/                  → NodeBench (rewrite DID NOT fire)
-//     - scratchnode.live/index.html        → NodeBench (static file won)
+//     - scratchnode.live/docs              -> docs.html  (rewrite worked)
+//     - scratchnode.live/e/:slug           -> home-v5.html (rewrite worked)
+//     - scratchnode.live/random-path-xyz   -> home-v5.html (catch-all worked)
+//     - scratchnode.live/                  -> NodeBench (rewrite did not fire)
+//     - scratchnode.live/index.html        -> NodeBench (static file won)
 //
-//   Edge Middleware runs at the edge BEFORE any rewrites or static matching,
-//   which lets us rewrite the path for scratchnode.live hosts only — without
-//   touching nodebenchai.com behavior.
+//   Edge Middleware runs at the edge before rewrites/static matching, which
+//   lets us rewrite the path for scratchnode.live hosts only without touching
+//   nodebenchai.com behavior.
 //
 // Cost note: Vercel charges per middleware invocation. The matcher below is
 // intentionally limited to the two paths that can be stolen by static-file
@@ -25,8 +25,7 @@
 //
 // Related rules:
 //   - .claude/rules/live_dom_verification.md
-//   - .claude/rules/backend_contract_migration.md (different problem class,
-//     same root vibe: routing assumptions need verification at the live URL)
+//   - .claude/rules/backend_contract_migration.md
 
 import { next, rewrite } from '@vercel/edge';
 
@@ -34,45 +33,37 @@ export const config = {
   // Keep middleware cost bounded: event/docs/random-path routing remains in
   // vercel.json because those rewrites already fire correctly.
   //
-  // /demo_ver:n* is intentionally included so /demo_ver1, /demo_ver2, etc.
-  // all rewrite to /proto/home-v5.html while PRESERVING the URL bar so the
-  // page-side detector can read location.pathname.
-  matcher: ['/', '/index.html', '/demo_ver:n*'],
+  // /demo_ver{N} routes are intentionally not matched here. They are handled
+  // by the scratchnode.live catch-all rewrite in vercel.json, which preserves
+  // the URL bar so home-v5.html can read location.pathname and run the demo.
+  // Keeping this matcher to exact static-steal paths avoids invalid dynamic
+  // matcher syntax and prevents middleware from running on every demo path.
+  matcher: ['/', '/index.html'],
 };
-
-// /demo_ver{N} where N is one or more digits. Trailing slash optional.
-const DEMO_VER_RE = /^\/demo_ver\d+\/?$/;
 
 export default function middleware(request: Request): Response {
   const url = new URL(request.url);
   const host = request.headers.get('host') ?? '';
 
-  // Only act on the scratchnode apex. www → apex is handled by the redirect
+  // Only act on the scratchnode apex. www -> apex is handled by the redirect
   // already in vercel.json; nodebenchai.com is unaffected.
   if (host !== 'scratchnode.live') {
     return next();
   }
 
   // Path-specific routing for scratchnode.live:
-  //   /                → /proto/home-v5.html   (apex landing — minimal page)
-  //   /index.html      → /proto/home-v5.html   (defensive)
-  //   /demo_ver{N}     → /proto/home-v5.html   (URL bar preserved by rewrite;
-  //                                            page-side reads location.pathname
-  //                                            to set data-page-mode="demo" and
-  //                                            auto-run runDemoFull)
-  //   /docs            → handled by vercel.json rewrite
-  //   /e/:slug*        → handled by vercel.json rewrite
-  //   /(any other)     → handled by vercel.json catch-all
+  //   /            -> /proto/home-v5.html  (apex landing)
+  //   /index.html  -> /proto/home-v5.html  (defensive)
+  //   /demo_ver{N} -> handled by vercel.json catch-all; URL bar preserved.
   //
-  // Per-file landing-vs-demo split inside home-v5.html itself —
-  // see public/proto/home-v5.html "page-mode detector" block.
+  // Per-file landing-vs-demo split lives inside the home-v5.html page-mode
+  // detector block.
   const pathname = url.pathname;
   const isApex = pathname === '/' || pathname === '/index.html';
-  const isDemoVer = DEMO_VER_RE.test(pathname);
-  if (isApex || isDemoVer) {
+  if (isApex) {
     const destination = new URL('/proto/home-v5.html', request.url);
-    // Preserve search params (e.g. ?demoSpeed=fast) so they still reach the
-    // page-side runDemoFull options parser.
+    // Preserve search params so stale demo URLs like ?demo=1#demo still reach
+    // home-v5.html and are explicitly ignored by the page-side route gate.
     destination.search = url.search;
     return rewrite(destination);
   }

--- a/public/og-scratchnode-ai-infra-summit.svg
+++ b/public/og-scratchnode-ai-infra-summit.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">ScratchNode Live - AI Infra Summit</title>
+  <desc id="desc">Open Graph card for the ScratchNode Live AI Infra Summit room.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#101614"/>
+      <stop offset="0.56" stop-color="#192520"/>
+      <stop offset="1" stop-color="#251913"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" x2="1">
+      <stop offset="0" stop-color="#3ddc97"/>
+      <stop offset="1" stop-color="#f6a35d"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="44" y="44" width="1112" height="542" rx="28" fill="rgba(255,255,255,0.045)" stroke="rgba(255,255,255,0.16)"/>
+  <circle cx="93" cy="92" r="18" fill="none" stroke="url(#accent)" stroke-width="3"/>
+  <circle cx="93" cy="92" r="7" fill="#3ddc97"/>
+  <text x="126" y="99" font-family="Inter, Arial, sans-serif" font-size="19" font-weight="700" fill="#d7efe5" letter-spacing="2">SCRATCHNODE LIVE</text>
+  <rect x="928" y="70" width="164" height="44" rx="22" fill="rgba(61,220,151,0.12)" stroke="rgba(61,220,151,0.35)"/>
+  <circle cx="954" cy="92" r="6" fill="#3ddc97"/>
+  <text x="972" y="100" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800" fill="#eafff5">LIVE</text>
+  <text x="1025" y="100" font-family="Inter, Arial, sans-serif" font-size="16" fill="#a9c7bc">ORBITAL</text>
+  <text x="72" y="206" font-family="Inter, Arial, sans-serif" font-size="66" font-weight="900" fill="#ffffff">AI Infra Summit</text>
+  <text x="76" y="260" font-family="Inter, Arial, sans-serif" font-size="28" fill="#c8d8d0">Public event room with sourced Q&amp;A, private notes, and a publishable wiki.</text>
+  <g transform="translate(76 335)">
+    <rect x="0" y="0" width="318" height="78" rx="18" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+    <text x="24" y="32" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="800" fill="#9ddfbc" letter-spacing="1.8">ROOM CODE</text>
+    <text x="24" y="61" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="900" fill="#ffffff">ORBITAL</text>
+  </g>
+  <g transform="translate(430 335)">
+    <rect x="0" y="0" width="318" height="78" rx="18" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+    <text x="24" y="32" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="800" fill="#f6c889" letter-spacing="1.8">ROOM SIGNAL</text>
+    <text x="24" y="61" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="900" fill="#ffffff">318 joined</text>
+  </g>
+  <g transform="translate(784 335)">
+    <rect x="0" y="0" width="318" height="78" rx="18" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+    <text x="24" y="32" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="800" fill="#a7c8ff" letter-spacing="1.8">EVENT WIKI</text>
+    <text x="24" y="61" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="900" fill="#ffffff">47 FAQ</text>
+  </g>
+  <line x1="76" y1="492" x2="1124" y2="492" stroke="rgba(255,255,255,0.14)"/>
+  <text x="76" y="535" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700" fill="#dbe9e2">Agent answers only on /ask. Private notes never enter the public feed.</text>
+  <text x="1124" y="535" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700" text-anchor="end" fill="#9fb8ad">scratchnode.live</text>
+</svg>

--- a/public/proto/docs.html
+++ b/public/proto/docs.html
@@ -1462,8 +1462,8 @@ eventAnswers: <span class="fn">defineTable</span>({
     </ul>
 
     <h2 id="quick-start">Quick start <a class="anchor" href="#quick-start">#</a></h2>
-    <p>Open <a href="home-v5.html">home-v5.html</a> directly in a browser. No build, no npm. To skip onboarding and land mid-conversation:</p>
-    <pre><span class="lang">url</span>home-v5.html<span class="kw">#demo</span></pre>
+    <p>Open <a href="home-v5.html">home-v5.html</a> directly in a browser. No build, no npm. Demo autoplay is production-route gated; use the dedicated public route:</p>
+    <pre><span class="lang">url</span>/demo_ver1</pre>
     <p>To replay onboarding from a specific step:</p>
     <pre><span class="lang">url</span>home-v5.html<span class="kw">#wiz=</span><span class="num">2</span></pre>
     <div class="callout note"><span class="icon">⚡</span><div><strong>Tip:</strong> All demo controls are also exposed as functions on <code>window</code> — see <a href="#js-api">JS API</a>.</div></div>
@@ -1703,13 +1703,15 @@ eventAnswers: <span class="fn">defineTable</span>({
     </ul>
 
     <h2 id="demo-controls">Demo controls <a class="anchor" href="#demo-controls">#</a></h2>
-    <p>Every demoable state is reachable from either a URL hash or a window-scoped function. Use URL hashes when driving headless screenshots (Chromium can't always exec JS); use functions when you're hand-driving a live demo.</p>
+    <p>Demo autoplay only belongs on <code>/demo_ver{N}</code> routes such as <code>/demo_ver1</code>. Root, event, docs, and live production routes ignore stale <code>?demo=1</code> or <code>#demo</code> values.</p>
 
-    <h3 id="hash-routes">URL hashes</h3>
+    <h3 id="hash-routes">Demo routes</h3>
     <table>
-      <thead><tr><th>Hash</th><th>Effect</th></tr></thead>
+      <thead><tr><th>Route</th><th>Effect</th></tr></thead>
       <tbody>
-        <tr><td><code>#demo</code></td><td>Triggers <code>runDemo()</code> — full live timeline of incoming messages, /ask answers, mentions, reactions.</td></tr>
+        <tr><td><code>/demo_ver1</code></td><td>Triggers <code>runDemoFull()</code> - full end-to-end ScratchNode + NodeBench handoff demo.</td></tr>
+        <tr><td><code>/demo_ver1?demo=legacy</code></td><td>Triggers legacy <code>runDemo()</code> for the short conversation simulator.</td></tr>
+        <tr><td><code>/demo_ver1?demo=0</code></td><td>Loads the demo surface without autoplay for manual console driving.</td></tr>
         <tr><td><code>#wiz=1</code> / <code>2</code> / <code>3</code></td><td>Jump directly to onboarding step N.</td></tr>
         <tr><td><code>#empty</code></td><td>Clears the feed and shows the empty-state CTA.</td></tr>
         <tr><td><code>#viewmode=workspace</code></td><td>(v4) sets view mode without going through landing.</td></tr>
@@ -1792,7 +1794,7 @@ eventAnswers: <span class="fn">defineTable</span>({
 
     <h2 id="closing">What's next <a class="anchor" href="#closing">#</a></h2>
     <p>The two prototypes are deliberately parallel: v4 proves the full feature surface; v5 proves you can ship 10% of it and still earn the room. The docs page you're reading is the canonical reference between them.</p>
-    <p>Open v5 with <code>#demo</code> to see all of it animated end-to-end. Open v4 to see the spec proof at full fidelity.</p>
+    <p>Open v5 through <code>/demo_ver1</code> to see all of it animated end-to-end. Open v4 to see the spec proof at full fidelity.</p>
   </article>
 
   <!-- ─── Right rail: on-page nav ─── -->

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -14,7 +14,7 @@
 <meta property="og:description" content="318 in the room · 47 sourced answers · join with code ORBITAL — no account needed.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://scratchnode.live/e/ai-infra-summit-2026">
-<meta property="og:image" content="https://scratchnode.live/og/ai-infra-summit-2026.png">
+<meta property="og:image" content="https://scratchnode.live/og-scratchnode-ai-infra-summit.svg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="ScratchNode · AI Infra Summit · LIVE · Room code ORBITAL">
@@ -24,7 +24,7 @@
 <meta name="twitter:site" content="@scratchnode">
 <meta name="twitter:title" content="AI Infra Summit · LIVE on ScratchNode">
 <meta name="twitter:description" content="318 in the room · 47 sourced answers · join with code ORBITAL.">
-<meta name="twitter:image" content="https://scratchnode.live/og/ai-infra-summit-2026.png">
+<meta name="twitter:image" content="https://scratchnode.live/og-scratchnode-ai-infra-summit.svg">
 <meta name="twitter:image:alt" content="ScratchNode · AI Infra Summit · LIVE">
 
 <!-- Lightweight favicon (replace with branded SVG before prod launch) -->
@@ -1694,7 +1694,7 @@ body[data-page-mode="landing"] .welcome {
                    No event auto-join, no demo auto-play, no event shell.
     - "demo"     — `/demo_ver{N}` paths (rewritten by middleware.ts to this
                    HTML but URL bar preserved). Full mockup + auto-play
-                   runDemoFull. Also triggered by legacy `?demo=1` query.
+                   runDemoFull.
     - "event"    — `/e/:slug` real event rooms. Convex bootstrap takes over.
 
   Why inline + early: prevents a flash of demo content on the bare apex.
@@ -1705,13 +1705,11 @@ body[data-page-mode="landing"] .welcome {
 (function () {
   try {
     var path = location.pathname || '/';
-    var search = location.search || '';
-    var demoVerMatch = path.match(/^\/demo_ver(\d+)\/?$/);
+    var demoVerMatch = path.match(/^\/demo_ver(\d+)\/?$/i);
     var isLandingPath = (path === '/' || path === '/index.html');
     var isEventPath   = /^\/e\/[a-z0-9][a-z0-9-]{0,60}\/?$/i.test(path);
-    var hasDemoQuery  = new URLSearchParams(search).get('demo') === '1';
     var pageMode;
-    if (demoVerMatch || hasDemoQuery) {
+    if (demoVerMatch) {
       pageMode = 'demo';
     } else if (isEventPath) {
       pageMode = 'event';
@@ -1723,9 +1721,7 @@ body[data-page-mode="landing"] .welcome {
       pageMode = 'landing';
     }
     document.body.dataset.pageMode = pageMode;
-    if (demoVerMatch) {
-      document.body.dataset.demoVer = demoVerMatch[1];
-    }
+    if (demoVerMatch) document.body.dataset.demoVer = demoVerMatch[1];
   } catch (e) {
     // If detection throws, default to landing — safer than leaking demo.
     try { document.body.dataset.pageMode = 'landing'; } catch (e2) {}
@@ -2090,6 +2086,33 @@ var ON_PUBLIC_DOMAIN = (function() {
   try { return location.hostname === CANONICAL_PUBLIC_HOST || location.hostname.endsWith('.' + CANONICAL_PUBLIC_HOST); }
   catch (e) { return false; }
 })();
+
+function isScratchNodeDemoRoute(pathname) {
+  var p = String(pathname || '/').toLowerCase();
+  // Owned demo routes: /demo_ver1, /demo_ver2, etc.
+  // Deliberately does not match /, /e/:slug, /proto/home-v5.html, or /demo_version.
+  return /^\/demo_ver\d+\/?$/.test(p);
+}
+
+function shouldRunScratchNodeFullDemo() {
+  if (!isScratchNodeDemoRoute(location.pathname)) return false;
+  if (location.hash === '#legacy-demo') return false;
+  try {
+    var params = new URLSearchParams(location.search);
+    return params.get('demo') !== '0' && params.get('autorun') !== '0' && params.get('demo') !== 'legacy';
+  } catch (e) {
+    return true;
+  }
+}
+
+function shouldRunScratchNodeLegacyDemo() {
+  if (!isScratchNodeDemoRoute(location.pathname)) return false;
+  try {
+    var params = new URLSearchParams(location.search);
+    if (params.get('demo') === 'legacy') return true;
+  } catch (e) {}
+  return location.hash === '#legacy-demo';
+}
 
 function buildNodeBenchEventPrivateUrl() {
   var roomCode = 'ORBITAL';
@@ -3837,7 +3860,7 @@ setTimeout(refreshEmptyState, 100);
 //   • Dario Amodei (Anthropic CEO)
 //   • Sarah Kim (Google DeepMind VP Eng)
 //   • Alex Chen (Orbital Labs founder)
-// Run with #demo in URL hash, or call runDemo() from console.
+// Run on /demo_ver{N}?demo=legacy, or call runDemo() from console.
 // ═══════════════════════════════════════════════════════
 
 var CHAR_COLORS = {
@@ -3856,16 +3879,16 @@ function _time() {
 
 // ─── Debug-gated prototype simulators ───────────────────────────────────────
 // All sim* helpers are scaffolding for live demos and screenshots. They are
-// NOT shipped to production unless the user opts in via ?debug=1 or #demo in
-// the URL. Production builds should keep DEBUG_MODE false and remove this
+// NOT shipped to production unless the user opts in via ?debug=1 or /demo_ver{N}
+// in the URL. Production builds should keep DEBUG_MODE false and remove this
 // block entirely (it is marked Prototype in docs.html).
 var _DEBUG_HELPERS_ON = (function() {
   if (DEBUG_MODE) return true;
-  try { return location.hash.indexOf('demo') !== -1; } catch (e) { return false; }
+  try { return isScratchNodeDemoRoute(location.pathname); } catch (e) { return false; }
 })();
 if (!_DEBUG_HELPERS_ON) {
   // Production / non-debug: leave window.sim* undefined and skip the rest of this block.
-  console.debug('[scratchnode] sim* helpers gated — pass ?debug=1 or #demo to enable.');
+  console.debug('[scratchnode] sim* helpers gated — pass ?debug=1 or /demo_ver1 to enable.');
 }
 
 // Inject a chat row from any character
@@ -4044,12 +4067,13 @@ function runDemo() {
   simRun(script);
 }
 
-// Trigger demo via URL hash #demo
-if (location.hash === '#demo') {
+// Legacy short demo is route-gated. Production/event roots must never
+// autoplay because of query/hash leftovers.
+if (shouldRunScratchNodeLegacyDemo()) {
   setTimeout(runDemo, 600);
 }
 window.addEventListener('hashchange', function() {
-  if (location.hash === '#demo') runDemo();
+  if (shouldRunScratchNodeLegacyDemo()) runDemo();
 });
 
 // ═══════════════════════════════════════════════════════
@@ -7927,19 +7951,15 @@ window._laCueAction       = _laCueAction;
   window.SN_AGENT_OUTPUT_REGISTRY = AGENT_OUTPUT_REGISTRY;
   window.evaluateAgentOutputEnvelope = evaluateAgentOutputEnvelope;
   window.recordAgentOutputEnvelope = recordAgentOutputEnvelope;
+  window.isScratchNodeDemoRoute = isScratchNodeDemoRoute;
+  window.shouldRunScratchNodeFullDemo = shouldRunScratchNodeFullDemo;
+  window.shouldRunScratchNodeLegacyDemo = shouldRunScratchNodeLegacyDemo;
 
-  // Auto-run runDemoFull for one-click presentations. Triggers:
-  //   - /demo_ver{N} routes (rewritten by middleware.ts → home-v5.html with
-  //     URL bar preserved; we detect via location.pathname)
-  //   - Legacy `?demo=1` query (preserved for shareable demo links and
-  //     backwards compatibility with prior PRs).
-  // Does NOT fire on bare apex `/` or `/index.html` — that's the landing
-  // mode and the whole point of this refactor is no demo content there.
+  // Demo autoplay is route-owned. Root/event/live routes never run the demo
+  // because of stale ?demo=1/#demo URLs; use /demo_ver{N} for presentations.
   try {
     var params = new URLSearchParams(location.search);
-    var demoVerMatch = location.pathname.match(/^\/demo_ver(\d+)\/?$/);
-    var isDemoRoute = !!demoVerMatch || params.get('demo') === '1';
-    if (isDemoRoute) {
+    if (shouldRunScratchNodeFullDemo()) {
       var speed = params.get('demoSpeed') || 'normal';
       // Defer until after DOMContentLoaded + small delay so live Convex bootstrap can settle.
       var kickoff = function() { setTimeout(function() { runDemoFull({ speed: speed }); }, 600); };

--- a/tests/e2e/home-v5-output-contract.spec.ts
+++ b/tests/e2e/home-v5-output-contract.spec.ts
@@ -42,3 +42,50 @@ test("home-v5 runDemoFull keeps visible invariants and L1/L2/L3 output contracts
     "ui_renderable",
   ]);
 });
+
+test("home-v5 demo autoplay is gated to /demo_ver routes", async ({ page }) => {
+  const fileUrl = `${pathToFileURL(resolve("public/proto/home-v5.html")).toString()}?demo=1#demo`;
+
+  await page.goto(fileUrl, { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () =>
+      typeof (window as any).shouldRunScratchNodeFullDemo === "function" &&
+      typeof (window as any).isScratchNodeDemoRoute === "function",
+  );
+
+  await page.waitForTimeout(1_500);
+
+  const state = await page.evaluate(() => ({
+    shouldRunHere: (window as any).shouldRunScratchNodeFullDemo(),
+    pageMode: document.body.dataset.pageMode,
+    logLength: ((window as any)._demo_log ?? []).length,
+    feedText: document.getElementById("feed")?.textContent ?? "",
+    routes: {
+      root: (window as any).isScratchNodeDemoRoute("/"),
+      event: (window as any).isScratchNodeDemoRoute("/e/ai-infra-summit-2026"),
+      directProto: (window as any).isScratchNodeDemoRoute("/proto/home-v5.html"),
+      demoNumber: (window as any).isScratchNodeDemoRoute("/demo_ver1"),
+      demoNumberSlash: (window as any).isScratchNodeDemoRoute("/demo_ver1/"),
+      demoRoot: (window as any).isScratchNodeDemoRoute("/demo_ver"),
+      demoSlug: (window as any).isScratchNodeDemoRoute("/demo_ver_v5"),
+      demoSlash: (window as any).isScratchNodeDemoRoute("/demo_ver/v5"),
+      nearMiss: (window as any).isScratchNodeDemoRoute("/demo_version"),
+    },
+  }));
+
+  expect(state.shouldRunHere).toBe(false);
+  expect(state.pageMode).toBe("landing");
+  expect(state.logLength).toBe(0);
+  expect(state.feedText).not.toContain("Maya from VoiceLayer");
+  expect(state.routes).toEqual({
+    root: false,
+    event: false,
+    directProto: false,
+    demoNumber: true,
+    demoNumberSlash: true,
+    demoRoot: false,
+    demoSlug: false,
+    demoSlash: false,
+    nearMiss: false,
+  });
+});

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -79,6 +79,71 @@ async function waitForHostRole(page: import("@playwright/test").Page, timeoutMs 
   return false;
 }
 
+test("home-v5 apex is landing-only and never autoplays the demo", async ({ page }) => {
+  mkdirSync(ARTIFACT_DIR, { recursive: true });
+  const qaId = `proto-v5-apex-${Date.now()}`;
+
+  await page.goto(withQa(SCRATCHNODE_APEX_URL, qaId), {
+    waitUntil: "domcontentloaded",
+    timeout: 45_000,
+  });
+  await expect(page).toHaveTitle(/ScratchNode/i);
+  await expect(page.locator(".landing")).toContainText("ScratchNode Live");
+  await expect
+    .poll(() => page.evaluate(() => document.body.getAttribute("data-page-mode")), {
+      timeout: 15_000,
+    })
+    .toBe("landing");
+  await expect(page.locator("body")).not.toContainText("Maya from VoiceLayer");
+
+  const apexState = await page.evaluate(() => ({
+    live: document.body.getAttribute("data-sn-live"),
+    logLength: ((window as any)._demo_log || []).length,
+    fullDemo:
+      typeof (window as any).shouldRunScratchNodeFullDemo === "function"
+        ? (window as any).shouldRunScratchNodeFullDemo()
+        : null,
+    legacyDemo:
+      typeof (window as any).shouldRunScratchNodeLegacyDemo === "function"
+        ? (window as any).shouldRunScratchNodeLegacyDemo()
+        : null,
+  }));
+  expect(apexState).toMatchObject({
+    live: null,
+    logLength: 0,
+    fullDemo: false,
+    legacyDemo: false,
+  });
+
+  const staleDemoUrl = new URL(SCRATCHNODE_APEX_URL);
+  staleDemoUrl.searchParams.set("demo", "1");
+  staleDemoUrl.hash = "demo";
+  await page.goto(withQa(staleDemoUrl.toString(), `${qaId}-stale-demo`), {
+    waitUntil: "domcontentloaded",
+    timeout: 45_000,
+  });
+  await page.waitForTimeout(1_500);
+  const staleState = await page.evaluate(() => ({
+    pageMode: document.body.getAttribute("data-page-mode"),
+    live: document.body.getAttribute("data-sn-live"),
+    logLength: ((window as any)._demo_log || []).length,
+    fullDemo: (window as any).shouldRunScratchNodeFullDemo?.() ?? null,
+    legacyDemo: (window as any).shouldRunScratchNodeLegacyDemo?.() ?? null,
+    feedText: document.getElementById("feed")?.textContent || "",
+  }));
+  expect(staleState.pageMode).toBe("landing");
+  expect(staleState.live).toBeNull();
+  expect(staleState.logLength).toBe(0);
+  expect(staleState.fullDemo).toBe(false);
+  expect(staleState.legacyDemo).toBe(false);
+  expect(staleState.feedText).not.toContain("Maya from VoiceLayer");
+
+  await page.screenshot({
+    path: join(ARTIFACT_DIR, `${qaId}-apex-landing.png`),
+    fullPage: true,
+  });
+});
+
 test("home-v5 runs the live Convex event-room loop across shipped phases", async ({ browser }) => {
   mkdirSync(ARTIFACT_DIR, { recursive: true });
   const qaId = `proto-v5-${Date.now()}`;
@@ -88,7 +153,7 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
   const pageB = await contextB.newPage();
 
   try {
-    await pageA.goto(withQa(SCRATCHNODE_APEX_URL, `${qaId}-apex`), {
+    await pageA.goto(withQa(SCRATCHNODE_EVENT_URL, `${qaId}-a`), {
       waitUntil: "domcontentloaded",
       timeout: 45_000,
     });
@@ -105,7 +170,7 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
         hasOpenHandoff: typeof win.openNodeBenchPrivateHandoff,
       };
     });
-    const expectedPublicOrigin = new URL(SCRATCHNODE_APEX_URL).origin;
+    const expectedPublicOrigin = new URL(SCRATCHNODE_EVENT_URL).origin;
     expect(boundary.publicBaseUrl).toBe(expectedPublicOrigin);
     expect(boundary.eventUrl).toBe(`${expectedPublicOrigin}/e/ai-infra-summit-2026`);
     expect(boundary.eventUrl).not.toContain("scratchnode.com");
@@ -123,14 +188,10 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
     );
     expect(boundary.hasOpenHandoff).toBe("function");
     await pageA.screenshot({
-      path: join(ARTIFACT_DIR, `${qaId}-apex-live.png`),
+      path: join(ARTIFACT_DIR, `${qaId}-event-live.png`),
       fullPage: true,
     });
 
-    await pageA.goto(withQa(SCRATCHNODE_EVENT_URL, `${qaId}-a`), {
-      waitUntil: "domcontentloaded",
-      timeout: 45_000,
-    });
     await pageB.goto(withQa(SCRATCHNODE_EVENT_URL, `${qaId}-b`), {
       waitUntil: "domcontentloaded",
       timeout: 45_000,

--- a/tests/e2e/scratchnode-demo-route-gate.spec.ts
+++ b/tests/e2e/scratchnode-demo-route-gate.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const HOME_V5_HTML = readFileSync(resolve("public/proto/home-v5.html"), "utf8");
+
+async function fulfillHomeV5(page: Page) {
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (url.hostname === "scratchnode.live" && request.resourceType() === "document") {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: HOME_V5_HTML,
+      });
+      return;
+    }
+
+    if (url.hostname === "scratchnode.live" && url.pathname === "/api/scratchnode-config") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ convexUrl: null, realtime: false }),
+      });
+      return;
+    }
+
+    await route.fulfill({ status: 204, body: "" });
+  });
+}
+
+async function waitForDemoGate(page: Page) {
+  await page.waitForFunction(
+    () =>
+      typeof (window as any).isScratchNodeDemoRoute === "function" &&
+      typeof (window as any).shouldRunScratchNodeFullDemo === "function" &&
+      typeof (window as any).shouldRunScratchNodeLegacyDemo === "function" &&
+      typeof (window as any).runDemoFull === "function",
+    null,
+    { timeout: 15_000 },
+  );
+}
+
+async function readGateState(page: Page) {
+  return await page.evaluate(() => ({
+    pageMode: document.body.dataset.pageMode,
+    live: document.body.dataset.snLive ?? null,
+    fullDemo: (window as any).shouldRunScratchNodeFullDemo(),
+    legacyDemo: (window as any).shouldRunScratchNodeLegacyDemo(),
+    logLength: ((window as any)._demo_log || []).length,
+    hasInjectedDemoRows: !!document.querySelector('[data-demo-injected="true"]'),
+    hasMayaDemoText: (document.getElementById("feed")?.textContent || "").includes(
+      "Maya from VoiceLayer",
+    ),
+    hasSimPost: typeof (window as any).simPost === "function",
+  }));
+}
+
+test.describe("ScratchNode demo route gate", () => {
+  test("stale demo query/hash does not autoplay on scratchnode.live apex", async ({ page }) => {
+    await fulfillHomeV5(page);
+    await page.goto("https://scratchnode.live/?demo=1#demo", { waitUntil: "domcontentloaded" });
+    await waitForDemoGate(page);
+    await page.waitForTimeout(1_000);
+
+    await expect(await readGateState(page)).toMatchObject({
+      pageMode: "landing",
+      live: null,
+      fullDemo: false,
+      legacyDemo: false,
+      logLength: 0,
+      hasInjectedDemoRows: false,
+      hasMayaDemoText: false,
+    });
+  });
+
+  test("stale demo query/hash does not autoplay on live event route", async ({ page }) => {
+    await fulfillHomeV5(page);
+    await page.goto("https://scratchnode.live/e/ai-infra-summit-2026?demo=1#demo", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForDemoGate(page);
+    await page.waitForTimeout(1_000);
+
+    await expect(await readGateState(page)).toMatchObject({
+      pageMode: "event",
+      fullDemo: false,
+      legacyDemo: false,
+      logLength: 0,
+      hasInjectedDemoRows: false,
+      hasMayaDemoText: false,
+      hasSimPost: false,
+    });
+  });
+
+  test("stale demo query/hash does not autoplay on direct proto path", async ({ page }) => {
+    await fulfillHomeV5(page);
+    await page.goto("https://scratchnode.live/proto/home-v5.html?demo=1#demo", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForDemoGate(page);
+    await page.waitForTimeout(1_000);
+
+    await expect(await readGateState(page)).toMatchObject({
+      pageMode: "landing",
+      fullDemo: false,
+      legacyDemo: false,
+      logLength: 0,
+      hasInjectedDemoRows: false,
+      hasMayaDemoText: false,
+    });
+  });
+
+  test("/demo_ver route is the only full-demo autoplay route", async ({ page }) => {
+    await fulfillHomeV5(page);
+    await page.goto("https://scratchnode.live/demo_ver1?demoSpeed=instant", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForDemoGate(page);
+
+    await expect
+      .poll(() => page.evaluate(() => ((window as any)._demo_log || []).length), {
+        timeout: 15_000,
+      })
+      .toBe(14);
+
+    await expect(await readGateState(page)).toMatchObject({
+      pageMode: "demo",
+      fullDemo: true,
+      legacyDemo: false,
+      logLength: 14,
+      hasInjectedDemoRows: true,
+    });
+  });
+
+  test("/demo_ver route can be loaded without autoplay", async ({ page }) => {
+    await fulfillHomeV5(page);
+    await page.goto("https://scratchnode.live/demo_ver1?demo=0", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForDemoGate(page);
+    await page.waitForTimeout(1_500);
+
+    await expect(await readGateState(page)).toMatchObject({
+      pageMode: "demo",
+      fullDemo: false,
+      legacyDemo: false,
+      logLength: 0,
+      hasInjectedDemoRows: false,
+      hasMayaDemoText: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Gates ScratchNode v5 demo autoplay to explicit `/demo_ver{N}` routes only.
- Removes stale `?demo=1` / `#demo` triggers from root, event, docs, and direct prototype paths.
- Keeps `scratchnode.live/` and `/index.html` landing-only, `/e/:slug` Convex-backed live event-only, and `/demo_ver{N}` scripted demo-only.
- Fixes the Vercel middleware matcher by limiting it to exact static-steal paths (`/`, `/index.html`) instead of the invalid `/demo_ver:n*` dynamic matcher.
- Adds CI coverage for production-like ScratchNode route isolation and updates the live dogfood runbook/test to match apex landing vs event live behavior.
- Replaces the missing ScratchNode OG PNG with a static SVG OG card so social previews do not hit the catch-all HTML route.

## Deep-check notes from parallel subagents

- Route review flagged `?demo=1` / `#demo` as the actual non-owned autoplay path. Fixed.
- Test review flagged that file-url tests were not enough. Added production-like `https://scratchnode.live/...` Playwright coverage with the local HTML fulfilled at those URLs.
- Release-risk review flagged the invalid middleware matcher and stale dogfood docs expecting apex Convex. Fixed both.

## Verification

- `npx playwright test tests/e2e/home-v5-output-contract.spec.ts tests/e2e/scratchnode-demo-route-gate.spec.ts --project=chromium --workers=1 --reporter=list`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `npm run preflight:fast`
- `npx playwright test tests/e2e/proto-live-backend-dogfood.spec.ts --project=chromium --workers=1 --reporter=list` (expected skip unless `PROTO_DOGFOOD_LIVE=1`)
- `git diff --check`
- Middleware matcher parse check against `path-to-regexp`

## Production intent

`scratchnode.live/`, `scratchnode.live/e/:slug`, and `nodebenchai.com/` must land on live/non-demo surfaces. The scripted public demo is intentionally reachable only through `/demo_ver1` and related `/demo_ver{N}` paths.