### PR TITLE
fix(scratchnode): P0 — room-code URL lookup for /e/:slug (live chat sync hotfix)

### DIFF
--- a/convex/events.ts
+++ b/convex/events.ts
@@ -711,9 +711,19 @@ async function buildWikiHtml(ctx: any, eventName: string, answers: any[], source
 // ─── QUERIES ──────────────────────────────────────────────────────────────
 
 /**
- * Fetch an event by its slug. Returns null if missing — callers (UI) should
- * fall back to the demo event flow.
+ * Resolve a user-facing path segment to an event. Tries slug first, then
+ * roomCode (case-insensitive, normalized to UPPERCASE). Returns null if
+ * neither resolves — callers (UI) should fall back / surface "not found".
+ *
+ * Why both: the share copy on every event card says "join with code
+ * ORBITAL". Users type the room code into the URL bar (`/e/orbital`)
+ * expecting it to work — the v1 launch bug was exactly this: slug-only
+ * lookup → null → silent local-only chat → no cross-tab sync.
  */
+function isRoomCodeShape(s: string): boolean {
+  return /^[A-Z0-9][A-Z0-9-]{1,23}$/.test(s);
+}
+
 export const getEventBySlug = query({
   args: { slug: v.string() },
   handler: async (ctx, { slug }) => {
@@ -722,7 +732,14 @@ export const getEventBySlug = query({
       .query("liveEvents")
       .withIndex("by_slug", (q) => q.eq("slug", slug))
       .first();
-    return event;
+    if (event) return event;
+    // Fallback: treat the path segment as a room code.
+    const roomCode = slug.trim().toUpperCase();
+    if (!isRoomCodeShape(roomCode)) return null;
+    return await ctx.db
+      .query("liveEvents")
+      .withIndex("by_roomCode", (q) => q.eq("roomCode", roomCode))
+      .first();
   },
 });
 
@@ -1090,9 +1107,22 @@ export const joinEvent = mutation({
       .withIndex("by_slug", (q) => q.eq("slug", slug))
       .first();
 
+    // Fallback: roomCode lookup. Share copy on event cards reads "join
+    // with code ORBITAL" — users type the code into the URL bar
+    // (`/e/orbital`). Without this, both windows render the static mock
+    // chat, sendMessage fails silently, and cross-tab sync never works.
+    const normalizedRoomCode = slug.trim().toUpperCase();
+    if (!event && isRoomCodeShape(normalizedRoomCode)) {
+      event = await ctx.db
+        .query("liveEvents")
+        .withIndex("by_roomCode", (q) => q.eq("roomCode", normalizedRoomCode))
+        .first();
+    }
+
     // Auto-seed the demo event so the first visitor to scratchnode.live
-    // doesn't hit an empty room.
-    if (!event && slug === "ai-infra-summit-2026") {
+    // doesn't hit an empty room. Triggers on either the canonical slug
+    // OR the canonical room code (typed as a URL slug — case-insensitive).
+    if (!event && (slug === "ai-infra-summit-2026" || normalizedRoomCode === "ORBITAL")) {
       const id = await ctx.db.insert("liveEvents", {
         slug: "ai-infra-summit-2026",
         name: "AI Infra Summit",

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -5168,6 +5168,21 @@ window._laCueAction       = _laCueAction;
   } catch (e) {
     console.warn('[scratchnode] joinEvent failed, prototype mode:', e.message || e);
     client.close && client.close();
+    // HONEST_STATUS: don't silently render mock chat when the slug/code
+    // doesn't resolve. Users typing /e/whatever expected to land in a
+    // real room; silent fallback leads them to think their messages
+    // sent when nothing was persisted.
+    var errCode = (e && e.data && e.data.code) || '';
+    var notFound = errCode === 'event_not_found' || /event_not_found/i.test(String(e && e.message || ''));
+    try {
+      var banner = document.createElement('div');
+      banner.setAttribute('role', 'alert');
+      banner.style.cssText = 'position:sticky;top:0;z-index:50;padding:10px 14px;background:#3a2a24;color:#f1d6c8;border-bottom:1px solid #5a3a30;font:500 13px/1.4 var(--ui,system-ui);text-align:center;';
+      banner.innerHTML = notFound
+        ? 'No room matches <code style="font-family:var(--mono,monospace);background:#2a1f1c;padding:2px 6px;border-radius:4px">/e/' + (slug.replace(/[<>&"]/g, '') || '?') + '</code>. <a href="/" style="color:#f1d6c8;text-decoration:underline">Back to landing</a> or check your room code.'
+        : 'Could not connect to the live room. <a href="javascript:location.reload()" style="color:#f1d6c8;text-decoration:underline">Retry</a>';
+      document.body.insertBefore(banner, document.body.firstChild);
+    } catch (_) { /* belt-and-suspenders — never throw from error handler */ }
     return;
   }
   const eventId = joined.eventId;


### PR DESCRIPTION
## Summary — P0 launch hotfix

User reported during live dogfood: open two tabs on `scratchnode.live/e/orbital`, send a message in tab A, tab B never sees it. The mock chat history made it LOOK like the room loaded — but writes were going to local DOM only, never to Convex.

## Root cause (5-whys)

1. Messages didn't sync → not persisted to Convex
2. `sendMessage` mutation never ran with a real `eventId`
3. Bootstrap (`home-v5.html:5167`) called `joinEvent`, which threw `event_not_found`; the catch returned silently
4. `joinEvent` + `getEventBySlug` matched `slug` exactly. The seeded event has slug `ai-infra-summit-2026`, roomCode `ORBITAL`. URL `/e/orbital` → slug `"orbital"` → no match → null
5. **Design gap.** The share copy on every event card reads "join with code ORBITAL". Users type the code into the URL bar expecting it to work. Schema had `by_roomCode` index since day one (`eventsSchema.ts:37`) — query never used it.

## Fix (3 layers — analyst, not bandaid)

1. **`convex/events.ts getEventBySlug`** — slug lookup first, then roomCode fallback (case-insensitive, normalized UPPERCASE).
2. **`convex/events.ts joinEvent`** — same slug-then-roomCode resolution + extends the auto-seed special-case so both `/e/ai-infra-summit-2026` AND `/e/orbital` (any case) bootstrap the demo event on cold-start. New helper `isRoomCodeShape()` gates `/^[A-Z0-9][A-Z0-9-]{1,23}$/` before burning the index lookup.
3. **`public/proto/home-v5.html` bootstrap catch** — HONEST_STATUS (per `agentic_reliability` rule). When `joinEvent` throws `event_not_found`, inserts a role=alert banner ("No room matches `/e/X`. Back to landing or check your room code.") instead of silently rendering mock chat. Non-fatal errors get a "Retry" link.

## Why this is the right fix vs. a bandaid

- ❌ Bandaid: hardcode `/e/orbital → ai-infra-summit-2026` redirect in middleware. Doesn't fix new events.
- ❌ Bandaid: catch the error and seed the room from frontend. Frontend can't write to Convex without auth.
- ✅ Structural: resolver matches slug OR roomCode. Works for the demo event AND every future event. Users typing `/e/<their-code>` always lands on the right room.

## Verification

- `npx tsc --noEmit` — 0 errors
- Existing `convex/__tests__/scratchnode.events.test.ts` uses proper slug lookups → backward compatible (slug match is still tried first, roomCode is a fallback)
- Pre-existing 8-point reliability invariants on `users.ts` and `events.ts` preserved

## Test plan after merge + deploy

- [ ] Open `scratchnode.live/e/orbital` in two tabs (incognito + regular)
- [ ] Send a message from tab A → confirm it appears in tab B within ~1s (Convex subscription)
- [ ] Send a message from tab B → confirm it appears in tab A
- [ ] Open `scratchnode.live/e/ORBITAL` (uppercase) → same behavior
- [ ] Open `scratchnode.live/e/AI-Infra-Summit-2026` (mixed-case slug) — should resolve via slug-exact match (no behavior change)
- [ ] Open `scratchnode.live/e/zzz-nonexistent` → confirm honest "No room matches" banner appears, NOT silent mock chat

## Follow-up (separate PR, not blocking launch)

- Scenario test for the roomCode fallback (`scratchnode.events.test.ts`)
- Scenario test for the event-not-found banner

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
