### PR TITLE
fix(scratchnode): launch-blocking live route honesty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,35 @@ jobs:
           src/features/product/lib/captureRouter.test.ts
           src/features/workspace/lib/eventWorkspacePersistence.test.ts
           src/features/workspace/data/eventWorkspaceMemory.test.ts
+          convex/__tests__/scratchnode.events.test.ts
           server/searchRoute.test.ts
+
+  scratchnode-launch-gates:
+    name: ScratchNode launch gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Verify demo route gate and live route honesty
+        run: >
+          npx playwright test
+          tests/e2e/scratchnode-demo-route-gate.spec.ts
+          tests/e2e/scratchnode-live-route-honesty.spec.ts
+          --project=chromium
+          --workers=1
+          --reporter=list
 
   build:
     name: Build
@@ -93,6 +121,7 @@ jobs:
     needs:
       - typecheck
       - runtime-smoke
+      - scratchnode-launch-gates
     steps:
       - uses: actions/checkout@v6
 

--- a/convex/__tests__/scratchnode.events.test.ts
+++ b/convex/__tests__/scratchnode.events.test.ts
@@ -37,7 +37,17 @@
 import { describe, expect, it } from "vitest";
 
 import * as eventsModule from "../events";
-import { publishWiki, claimHost, requestHostClaim, releaseHost, _adminForceReleaseHost } from "../events";
+import {
+  publishWiki,
+  claimHost,
+  requestHostClaim,
+  releaseHost,
+  _adminForceReleaseHost,
+  getEventBySlug,
+  joinEvent,
+  sendMessage,
+  getMessages,
+} from "../events";
 import {
   deleteNote,
   createNoteAnchor,
@@ -374,6 +384,104 @@ function baseMessage(messageId: string, eventId = "liveEvents:1"): TableRecord {
     createdAt: 1_700_000_000_000,
   };
 }
+
+/* ========================================================================== */
+/* P0 launch gate — room-code URL lookup powers realtime chat                  */
+/* ========================================================================== */
+
+describe("event room-code lookup — /e/:roomCode joins the canonical live room", () => {
+  /**
+   * Scenario:    Two attendees open scratchnode.live/e/orbital because the
+   *              event card tells them the room code is ORBITAL.
+   * User:        Anonymous public attendees in separate browser windows.
+   * Goal:        Both windows join the same Convex event and messages persist
+   *              into the shared realtime stream instead of local-only DOM.
+   * Prior state: Canonical event exists as slug ai-infra-summit-2026 with
+   *              roomCode ORBITAL.
+   * Duration:    Single join/send/read round trip.
+   */
+  it("resolves lowercase room codes and persists shared messages to the canonical event", async () => {
+    const ctx = createCtx({
+      liveEvents: [baseEvent()],
+      liveEventMembers: [],
+      liveEventMessages: [],
+      liveEventSources: baseSources(),
+    });
+
+    const resolved = await (getEventBySlug as any)._handler(ctx, { slug: "orbital" });
+    expect(resolved?._id).toBe("liveEvents:1");
+    expect(resolved?.slug).toBe("ai-infra-summit-2026");
+
+    const joinA = await (joinEvent as any)._handler(ctx, {
+      slug: "orbital",
+      sessionId: ANONYMOUS_SESSION_A,
+      displayName: "Alice",
+    });
+    const joinB = await (joinEvent as any)._handler(ctx, {
+      slug: "ORBITAL",
+      sessionId: ANONYMOUS_SESSION_B,
+      displayName: "Bob",
+    });
+
+    expect(joinA.eventId).toBe("liveEvents:1");
+    expect(joinB.eventId).toBe("liveEvents:1");
+    expect(joinA.slug).toBe("ai-infra-summit-2026");
+    expect(joinA.roomCode).toBe("ORBITAL");
+
+    await (sendMessage as any)._handler(ctx, {
+      eventId: joinA.eventId,
+      sessionId: ANONYMOUS_SESSION_A,
+      displayName: "Alice",
+      text: "hello from /e/orbital",
+      kind: "chat",
+    });
+
+    const rows = await (getMessages as any)._handler(ctx, { eventId: joinB.eventId, limit: 10 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      eventId: "liveEvents:1",
+      sessionId: ANONYMOUS_SESSION_A,
+      text: "hello from /e/orbital",
+      kind: "chat",
+    });
+  });
+
+  it("does not cross-wire room-code messages between separate rooms", async () => {
+    const ctx = createCtx({
+      liveEvents: [
+        baseEvent({ _id: "liveEvents:alpha", slug: "alpha-event", name: "Alpha Event", roomCode: "ALPHA" }),
+        baseEvent({ _id: "liveEvents:beta", slug: "beta-event", name: "Beta Event", roomCode: "BETA" }),
+      ],
+      liveEventMembers: [],
+      liveEventMessages: [],
+    });
+
+    const alpha = await (joinEvent as any)._handler(ctx, {
+      slug: "alpha",
+      sessionId: ANONYMOUS_SESSION_A,
+      displayName: "Alice",
+    });
+    const beta = await (joinEvent as any)._handler(ctx, {
+      slug: "beta",
+      sessionId: ANONYMOUS_SESSION_B,
+      displayName: "Bob",
+    });
+
+    expect(alpha.eventId).toBe("liveEvents:alpha");
+    expect(beta.eventId).toBe("liveEvents:beta");
+
+    await (sendMessage as any)._handler(ctx, {
+      eventId: alpha.eventId,
+      sessionId: ANONYMOUS_SESSION_A,
+      displayName: "Alice",
+      text: "alpha-only launch check",
+      kind: "chat",
+    });
+
+    const betaRows = await (getMessages as any)._handler(ctx, { eventId: beta.eventId, limit: 10 });
+    expect(betaRows).toEqual([]);
+  });
+});
 
 /* ========================================================================== */
 /* Test 1 — composeAnswer cache reuse                                          */

--- a/docs/runbooks/SCRATCHNODE_LAUNCH_DAY.md
+++ b/docs/runbooks/SCRATCHNODE_LAUNCH_DAY.md
@@ -11,7 +11,7 @@
 
 ## TL;DR
 
-- **GO** if PR #423 lands + the green checks below pass.
+- **GO** if #423, #425, and the launch honesty hotfix land + the green checks below pass.
 - **NO-GO** if any P0 in the [Open P0 list](#open-p0-list) is still red 30 min before launch.
 - **Rollback path:** force-redeploy the last known-good Vercel build (commit `141b8c10`, PR #419). See [Rollback](#rollback-procedure-5-min).
 
@@ -22,10 +22,12 @@
 | Change | PR | Status | Why it matters |
 |---|---|---|---|
 | Apex landing split (apex = landing, `/demo_ver{N}` = demo) | #419 | Merged + live | Stops bare apex from rendering as a fake live event |
-| Strict autoplay gate (`?demo=1` no longer triggers demo) | #423 | In review, auto-merge enabled | Stale bookmarks like `/e/:slug?demo=1` can no longer hijack real events with demo content |
-| Generic OG / title / canonical on apex | #423 (same PR) | In review | Bare apex social-shares no longer preview as "AI Infra Summit · 318 in the room · 47 sourced answers" |
-| `getMembers` bounded at 500 active | #423 (same PR) | In review | Launch-day join spike on a viral event no longer scans + serializes the full member set on every refresh |
-| `/docs` canonical + OG | #423 (same PR) | In review | Docs page indexable + shareable |
+| Strict autoplay gate (`?demo=1` no longer triggers demo) | #423 + launch honesty hotfix | Merged + reinforced | Stale bookmarks like `/e/:slug?demo=1` can no longer hijack real events with demo content |
+| Generic OG / title / canonical on apex | #423 (same PR) | Merged + live | Bare apex social-shares no longer preview as "AI Infra Summit · 318 in the room · 47 sourced answers" |
+| `getMembers` bounded at 500 active | #423 (same PR) | Merged + live | Launch-day join spike on a viral event no longer scans + serializes the full member set on every refresh |
+| `/docs` canonical + OG | #423 (same PR) | Merged + live | Docs page indexable + shareable |
+| Room-code URL lookup (`/e/orbital`) | #425 | Merged + live | Room-code links now join the canonical event instead of silently falling back to local-only chat |
+| Live-route honesty gates | launch honesty hotfix | In review | Config/join/send failures clear mock rows, disable public send, and restore drafts instead of pretending messages synced |
 
 ---
 
@@ -141,7 +143,7 @@ Visit and confirm NodeBench landing loads, not ScratchNode content.
 | 8 | V3 | Demo screenshot images eager-loaded below fold | `public/proto/home-v5.html` | Wasted bytes on landing-mode load |
 | 9 | V3 | Polling intervals (`setInterval`) not gated by `document.hidden` | `public/proto/home-v5.html` lines 4507, 5620 | Battery drain when tab inactive |
 | 10 | V3 | 30+ `addEventListener` without `removeEventListener` | `public/proto/home-v5.html` | Memory bloat if user navigates many events in one tab |
-| 11 | V5 | `/scratchnode-events` on scratchnode.live falls into landing mode (route catch-all rewrites to home-v5.html) | `vercel.json` + `public/proto/home-v5.html` | Currently NO user-facing CTA points here, so non-issue today. If we add a cross-host handoff CTA, link it to `https://www.nodebenchai.com/scratchnode-events` (absolute) |
+| 11 | V5 | `/scratchnode-events` on scratchnode.live falls into landing mode (route catch-all rewrites to home-v5.html) | `vercel.json` + `public/proto/home-v5.html` | ScratchNode CTA must use absolute `https://nodebenchai.com/scratchnode-events?...`; relative links are launch-blocking |
 | 12 | V5 | Per-route event OG cards (currently brand-only on all rewritten paths) | new — OG function | Each event shares as generic brand card; nice-to-have, not blocking |
 | 13 | V5 | "Event not found" → blank page edge case unverified live | `public/proto/home-v5.html` | Test by visiting `/e/zzz-does-not-exist-zzz` after launch |
 

--- a/public/proto/docs.html
+++ b/public/proto/docs.html
@@ -1477,7 +1477,7 @@ eventAnswers: <span class="fn">defineTable</span>({
 
     <h2 id="quick-start">Quick start <a class="anchor" href="#quick-start">#</a></h2>
     <p>Open <a href="home-v5.html">home-v5.html</a> directly in a browser. No build, no npm. To skip onboarding and land mid-conversation:</p>
-    <pre><span class="lang">url</span>home-v5.html<span class="kw">#demo</span></pre>
+    <pre><span class="lang">url</span>/demo_ver1<span class="kw">?demoSpeed=instant</span></pre>
     <p>To replay onboarding from a specific step:</p>
     <pre><span class="lang">url</span>home-v5.html<span class="kw">#wiz=</span><span class="num">2</span></pre>
     <div class="callout note"><span class="icon">⚡</span><div><strong>Tip:</strong> All demo controls are also exposed as functions on <code>window</code> — see <a href="#js-api">JS API</a>.</div></div>
@@ -1612,7 +1612,7 @@ eventAnswers: <span class="fn">defineTable</span>({
     <p>Roster of attendees with name, role, online status. Tap a row to open their @-mentions and questions (toast in current proto).</p>
 
     <h3 id="v5-host">Host / create event</h3>
-    <p>Title input + template chips (Conference / Workshop / Office hrs). Calls <code>toast()</code> with the generated room code (<code>SOLARIS</code> in demo).</p>
+    <p>Launch surface supports claiming host on an existing room, rotating a host claim code, reviewing FAQ suggestions, and publishing the wiki. New room creation is hidden until the live <code>createEvent</code> mutation ships.</p>
 
     <h2 id="v5-landing">Landing &amp; onboarding <a class="anchor" href="#v5-landing">#</a></h2>
     <p>First-visit IIFE (<code>detectFirstVisit</code>) routes new users to the landing surface and persists their last view mode. Onboarding tour: 3 pulse-positioned steps over the composer and identity row.</p>
@@ -1723,7 +1723,7 @@ eventAnswers: <span class="fn">defineTable</span>({
     <table>
       <thead><tr><th>Hash</th><th>Effect</th></tr></thead>
       <tbody>
-        <tr><td><code>#demo</code></td><td>Triggers <code>runDemo()</code> — full live timeline of incoming messages, /ask answers, mentions, reactions.</td></tr>
+        <tr><td><code>/demo_ver1</code></td><td>Triggers <code>runDemoFull()</code> — full live timeline of incoming messages, /ask answers, mentions, reactions. Stale <code>?demo=1</code> and <code>#demo</code> links are ignored on live routes.</td></tr>
         <tr><td><code>#wiz=1</code> / <code>2</code> / <code>3</code></td><td>Jump directly to onboarding step N.</td></tr>
         <tr><td><code>#empty</code></td><td>Clears the feed and shows the empty-state CTA.</td></tr>
         <tr><td><code>#viewmode=workspace</code></td><td>(v4) sets view mode without going through landing.</td></tr>
@@ -1806,7 +1806,7 @@ eventAnswers: <span class="fn">defineTable</span>({
 
     <h2 id="closing">What's next <a class="anchor" href="#closing">#</a></h2>
     <p>The two prototypes are deliberately parallel: v4 proves the full feature surface; v5 proves you can ship 10% of it and still earn the room. The docs page you're reading is the canonical reference between them.</p>
-    <p>Open v5 with <code>#demo</code> to see all of it animated end-to-end. Open v4 to see the spec proof at full fidelity.</p>
+    <p>Open v5 at <code>/demo_ver1</code> to see all of it animated end-to-end. Open v4 to see the spec proof at full fidelity.</p>
   </article>
 
   <!-- ─── Right rail: on-page nav ─── -->

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -2099,6 +2099,41 @@ var ON_PUBLIC_DOMAIN = (function() {
   catch (e) { return false; }
 })();
 
+function isScratchNodeDemoRoute(pathname) {
+  try {
+    var p = String(pathname || location.pathname || '/').toLowerCase();
+    // Owned demo routes: /demo_ver1, /demo_ver2, etc.
+    // Deliberately does not match /, /e/:slug, /proto/home-v5.html, or /demo_version.
+    return /^\/demo_ver\d+\/?$/.test(p);
+  } catch (e) {
+    return false;
+  }
+}
+
+function shouldRunScratchNodeFullDemo() {
+  try {
+    if (!isScratchNodeDemoRoute(location.pathname)) return false;
+    var params = new URLSearchParams(location.search);
+    var demo = (params.get('demo') || '').toLowerCase();
+    var autorun = (params.get('autorun') || '').toLowerCase();
+    if (location.hash === '#legacy-demo') return false;
+    if (demo === 'legacy' || demo === '0' || autorun === '0') return false;
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function shouldRunScratchNodeLegacyDemo() {
+  try {
+    if (!isScratchNodeDemoRoute(location.pathname)) return false;
+    var params = new URLSearchParams(location.search);
+    return (params.get('demo') || '').toLowerCase() === 'legacy' || location.hash === '#legacy-demo';
+  } catch (e) {
+    return false;
+  }
+}
+
 function buildNodeBenchEventPrivateUrl() {
   var roomCode = 'ORBITAL';
   try {
@@ -2106,8 +2141,9 @@ function buildNodeBenchEventPrivateUrl() {
     roomCode = (room && room.roomCode) || roomCode;
   } catch (e) {}
   return WORKSPACE_BASE_URL +
-    '/events/' + encodeURIComponent(EVENT_SLUG) +
-    '/private?source=scratchnode&room=' + encodeURIComponent(roomCode) +
+    '/scratchnode-events?source=scratchnode' +
+    '&event=' + encodeURIComponent(EVENT_SLUG) +
+    '&room=' + encodeURIComponent(roomCode) +
     '&return=' + encodeURIComponent(EVENT_URL);
 }
 
@@ -3187,9 +3223,9 @@ var SHEET_RENDERERS = {
         '</section>';
     }
     return '<div class="sheet-head"><h2 id="sheet-title">Host console</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
-      '<p class="sheet-sub">Create a new event, claim host on this one with a code, or rotate your host token to another device.</p>' +
+      '<p class="sheet-sub">Claim host on this event with a code, publish the wiki, or rotate your host token to another device.</p>' +
       // ── Section A: create event (demo) ────────────────────────────
-      '<section class="sheet-block" role="region" aria-label="Create a new event">' +
+      '<section class="sheet-block" role="region" aria-label="Create a new event" hidden style="display:none">' +
       '<div class="sheet-block-title">Create a new event</div>' +
       '<div class="sheet-field"><label class="sheet-label" for="sheet-host-title">Event title</label>' +
       '<input id="sheet-host-title" class="sheet-input" type="text" placeholder="e.g. Q4 Strategy Offsite" autocapitalize="words" /></div>' +
@@ -3197,7 +3233,7 @@ var SHEET_RENDERERS = {
       '<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px"><button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#127908;</span><span style="font-size:11px">Conference</span></button>' +
       '<button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#128295;</span><span style="font-size:11px">Workshop</span></button>' +
       '<button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#9749;</span><span style="font-size:11px">Office hrs</span></button></div></div>' +
-      '<button type="button" class="sheet-button" onclick="toast(\'Event created!\',\'Room code: SOLARIS · Share the link with attendees.\'); closeSheet();">Create event &rarr;</button>' +
+      '<button type="button" class="sheet-button ghost" disabled aria-disabled="true" title="Create event is disabled until the live createEvent mutation ships">Create event unavailable for launch</button>' +
       '</section>' +
       '<div class="sheet-divider" role="separator" aria-hidden="true"></div>' +
       // ── Section B: claim host with one-time code ─────────────────
@@ -3845,7 +3881,7 @@ setTimeout(refreshEmptyState, 100);
 //   • Dario Amodei (Anthropic CEO)
 //   • Sarah Kim (Google DeepMind VP Eng)
 //   • Alex Chen (Orbital Labs founder)
-// Run with #demo in URL hash, or call runDemo() from console.
+// Run legacy demo only on /demo_ver{N}?demo=legacy or /demo_ver{N}#legacy-demo.
 // ═══════════════════════════════════════════════════════
 
 var CHAR_COLORS = {
@@ -3864,16 +3900,16 @@ function _time() {
 
 // ─── Debug-gated prototype simulators ───────────────────────────────────────
 // All sim* helpers are scaffolding for live demos and screenshots. They are
-// NOT shipped to production unless the user opts in via ?debug=1 or #demo in
-// the URL. Production builds should keep DEBUG_MODE false and remove this
-// block entirely (it is marked Prototype in docs.html).
+// NOT shipped to production unless the user opts in via ?debug=1 or the URL is
+// an explicit /demo_ver{N} route. Production builds should keep DEBUG_MODE
+// false and remove this block entirely (it is marked Prototype in docs.html).
 var _DEBUG_HELPERS_ON = (function() {
   if (DEBUG_MODE) return true;
-  try { return location.hash.indexOf('demo') !== -1; } catch (e) { return false; }
+  try { return isScratchNodeDemoRoute(location.pathname); } catch (e) { return false; }
 })();
 if (!_DEBUG_HELPERS_ON) {
   // Production / non-debug: leave window.sim* undefined and skip the rest of this block.
-  console.debug('[scratchnode] sim* helpers gated — pass ?debug=1 or #demo to enable.');
+  console.debug('[scratchnode] sim* helpers gated — pass ?debug=1 or use /demo_ver{N} to enable.');
 }
 
 // Inject a chat row from any character
@@ -4052,12 +4088,12 @@ function runDemo() {
   simRun(script);
 }
 
-// Trigger demo via URL hash #demo
-if (location.hash === '#demo') {
+// Trigger the older short demo only from explicit demo routes.
+if (shouldRunScratchNodeLegacyDemo()) {
   setTimeout(runDemo, 600);
 }
 window.addEventListener('hashchange', function() {
-  if (location.hash === '#demo') runDemo();
+  if (shouldRunScratchNodeLegacyDemo()) runDemo();
 });
 
 // ═══════════════════════════════════════════════════════
@@ -5118,6 +5154,34 @@ window._laCueAction       = _laCueAction;
   if (!slugMatch) return; // landing & demo modes stay prototype-only
   if (pageMode === 'landing' || pageMode === 'demo') return; // belt-and-suspenders
   const slug = slugMatch[1];
+  const feedEl = document.getElementById('feed');
+
+  const clearPrototypeFeed = () => {
+    if (!feedEl) return;
+    Array.from(feedEl.querySelectorAll('.row, .ans')).forEach(el => el.remove());
+  };
+
+  const showLiveRoomError = (messageHtml) => {
+    clearPrototypeFeed();
+    try {
+      var input = document.getElementById('ci');
+      if (input) {
+        input.value = '';
+        input.setAttribute('disabled', 'disabled');
+        input.setAttribute('placeholder', 'Live room unavailable - reload to retry');
+      }
+      var existing = document.querySelector('[data-sn-live-error="true"]');
+      if (existing) existing.remove();
+      var banner = document.createElement('div');
+      banner.setAttribute('role', 'alert');
+      banner.setAttribute('data-sn-live-error', 'true');
+      banner.style.cssText = 'position:sticky;top:0;z-index:50;padding:10px 14px;background:#3a2a24;color:#f1d6c8;border-bottom:1px solid #5a3a30;font:500 13px/1.4 var(--ui,system-ui);text-align:center;';
+      banner.innerHTML = messageHtml;
+      document.body.insertBefore(banner, document.body.firstChild);
+    } catch (_) {
+      // Never throw from the error surface.
+    }
+  };
 
   // Stable anonymous session UUID — persists across reloads, per-device.
   let sessionId;
@@ -5139,11 +5203,13 @@ window._laCueAction       = _laCueAction;
     if (!r.ok) throw new Error('config ' + r.status);
     cfg = await r.json();
   } catch (e) {
-    console.debug('[scratchnode] config fetch failed, staying in prototype mode:', e.message);
+    console.debug('[scratchnode] config fetch failed, live room unavailable:', e.message);
+    showLiveRoomError('Could not load live room config. <a href="javascript:location.reload()" style="color:#f1d6c8;text-decoration:underline">Retry</a>');
     return;
   }
   if (!cfg.convexUrl) {
-    console.debug('[scratchnode] no convexUrl in config — prototype mode');
+    console.debug('[scratchnode] no convexUrl in config - live room unavailable');
+    showLiveRoomError('Live room config is missing Convex. <a href="javascript:location.reload()" style="color:#f1d6c8;text-decoration:underline">Retry</a>');
     return;
   }
 
@@ -5154,7 +5220,8 @@ window._laCueAction       = _laCueAction;
     ConvexClient = mod.ConvexClient;
     if (!ConvexClient) throw new Error('ConvexClient export missing');
   } catch (e) {
-    console.warn('[scratchnode] Convex client load failed, prototype mode:', e.message);
+    console.warn('[scratchnode] Convex client load failed, live room unavailable:', e.message);
+    showLiveRoomError('Could not load the realtime client. <a href="javascript:location.reload()" style="color:#f1d6c8;text-decoration:underline">Retry</a>');
     return;
   }
 
@@ -5166,7 +5233,7 @@ window._laCueAction       = _laCueAction;
   try {
     joined = await client.mutation('events:joinEvent', { slug, sessionId, displayName });
   } catch (e) {
-    console.warn('[scratchnode] joinEvent failed, prototype mode:', e.message || e);
+    console.warn('[scratchnode] joinEvent failed, live room unavailable:', e.message || e);
     client.close && client.close();
     // HONEST_STATUS: don't silently render mock chat when the slug/code
     // doesn't resolve. Users typing /e/whatever expected to land in a
@@ -5174,15 +5241,9 @@ window._laCueAction       = _laCueAction;
     // sent when nothing was persisted.
     var errCode = (e && e.data && e.data.code) || '';
     var notFound = errCode === 'event_not_found' || /event_not_found/i.test(String(e && e.message || ''));
-    try {
-      var banner = document.createElement('div');
-      banner.setAttribute('role', 'alert');
-      banner.style.cssText = 'position:sticky;top:0;z-index:50;padding:10px 14px;background:#3a2a24;color:#f1d6c8;border-bottom:1px solid #5a3a30;font:500 13px/1.4 var(--ui,system-ui);text-align:center;';
-      banner.innerHTML = notFound
-        ? 'No room matches <code style="font-family:var(--mono,monospace);background:#2a1f1c;padding:2px 6px;border-radius:4px">/e/' + (slug.replace(/[<>&"]/g, '') || '?') + '</code>. <a href="/" style="color:#f1d6c8;text-decoration:underline">Back to landing</a> or check your room code.'
-        : 'Could not connect to the live room. <a href="javascript:location.reload()" style="color:#f1d6c8;text-decoration:underline">Retry</a>';
-      document.body.insertBefore(banner, document.body.firstChild);
-    } catch (_) { /* belt-and-suspenders — never throw from error handler */ }
+    showLiveRoomError(notFound
+      ? 'No room matches <code style="font-family:var(--mono,monospace);background:#2a1f1c;padding:2px 6px;border-radius:4px">/e/' + (slug.replace(/[<>&"]/g, '') || '?') + '</code>. <a href="/" style="color:#f1d6c8;text-decoration:underline">Back to landing</a> or check your room code.'
+      : 'Could not connect to the live room. <a href="javascript:location.reload()" style="color:#f1d6c8;text-decoration:underline">Retry</a>');
     return;
   }
   const eventId = joined.eventId;
@@ -5217,7 +5278,6 @@ window._laCueAction       = _laCueAction;
   }
 
   // ─── Replace pre-baked feed rows with realtime Convex rows ─────────
-  const feedEl = document.getElementById('feed');
   if (feedEl) {
     // Wipe the hardcoded demo rows once Convex takes over — they'd otherwise
     // appear next to real messages and confuse users.
@@ -5314,6 +5374,7 @@ window._laCueAction       = _laCueAction;
     const input = document.getElementById('ci');
     const intent = window.parseComposerIntent && window.parseComposerIntent(input.value);
     if (!intent) { input.focus(); return; }
+    const submittedValue = input.value;
 
     // Private mode stays 100% prototype-side (Phase 3 wires this to Convex).
     if (intent.visibility === 'private') {
@@ -5323,13 +5384,15 @@ window._laCueAction       = _laCueAction;
     // Public chat or /ask — send to Convex. The agent answer for /ask is Phase 2;
     // for now the message just shows up in the feed.
     const liveName = (window._userName && String(window._userName).trim()) || 'Anonymous Guest';
-    client.mutation('events:sendMessage', {
+    const messagePayload = {
       eventId,
       sessionId,
       displayName: liveName,
       text: intent.clean,
       kind: intent.kind === 'agent_ask' ? 'ask' : 'chat',
-    }).then((res) => {
+    };
+    const postMessage = () => client.mutation('events:sendMessage', messagePayload);
+    const runAskIfNeeded = (res) => {
       if (intent.kind !== 'agent_ask') return null;
       const payload = {
         eventId,
@@ -5345,12 +5408,32 @@ window._laCueAction       = _laCueAction;
         : client.mutation('events:composeAnswer', payload);
       return runAsk.then((answer) => {
         if (answer) renderAnswer(answer);
+      }).catch((askError) => {
+        console.warn('[scratchnode] /ask answer failed:', askError.message || askError);
+        if (typeof toast === 'function') {
+          toast('Question saved', 'The message posted, but the answer did not complete. Try again in a moment.');
+        }
       });
-    }).catch((e) => {
-      console.warn('[scratchnode] sendMessage failed:', e.message || e);
-      // Fall back to prototype DOM append so the message isn't lost in the void.
-      _origSend.call(this);
-    });
+    };
+
+    postMessage()
+      .catch((e) => {
+        const code = (e && e.data && e.data.code) || '';
+        const notJoined = code === 'not_joined' || /not_joined/i.test(String(e && e.message || ''));
+        if (!notJoined) throw e;
+        return client
+          .mutation('events:joinEvent', { slug, sessionId, displayName: liveName })
+          .then(() => postMessage());
+      })
+      .then(runAskIfNeeded)
+      .catch((e) => {
+        console.warn('[scratchnode] sendMessage failed:', e.message || e);
+        input.value = submittedValue;
+        input.focus();
+        if (typeof toast === 'function') {
+          toast('Message not sent', 'The live room did not confirm it. Your draft was restored.');
+        }
+      });
 
     // Clear composer; Convex subscription will render the new row when it lands.
     input.value = '';
@@ -7947,6 +8030,9 @@ window._laCueAction       = _laCueAction;
   window.runRiskAttackQA = runRiskAttackQA;
   window.demoReset   = demoReset;
   window.demoStep    = demoStep;
+  window.isScratchNodeDemoRoute = isScratchNodeDemoRoute;
+  window.shouldRunScratchNodeFullDemo = shouldRunScratchNodeFullDemo;
+  window.shouldRunScratchNodeLegacyDemo = shouldRunScratchNodeLegacyDemo;
   window.SN_AGENT_OUTPUT_REGISTRY = AGENT_OUTPUT_REGISTRY;
   window.evaluateAgentOutputEnvelope = evaluateAgentOutputEnvelope;
   window.recordAgentOutputEnvelope = recordAgentOutputEnvelope;
@@ -7960,9 +8046,7 @@ window._laCueAction       = _laCueAction;
   // honored for pacing on demo routes.
   try {
     var params = new URLSearchParams(location.search);
-    var demoVerMatch = location.pathname.match(/^\/demo_ver(\d+)\/?$/);
-    var isDemoRoute = !!demoVerMatch;
-    if (isDemoRoute) {
+    if (shouldRunScratchNodeFullDemo()) {
       var speed = params.get('demoSpeed') || 'normal';
       // Defer until after DOMContentLoaded + small delay so live Convex bootstrap can settle.
       var kickoff = function() { setTimeout(function() { runDemoFull({ speed: speed }); }, 600); };

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -92,8 +92,15 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
       waitUntil: "domcontentloaded",
       timeout: 45_000,
     });
-    await waitForScratchNodeLive(pageA);
     await expect(pageA).toHaveTitle(/ScratchNode/i);
+    const apexState = await pageA.evaluate(() => ({
+      pageMode: document.body.getAttribute("data-page-mode"),
+      live: document.body.getAttribute("data-sn-live"),
+      demoLogLength: Array.isArray((window as any)._demo_log)
+        ? (window as any)._demo_log.length
+        : 0,
+    }));
+    expect(apexState).toMatchObject({ pageMode: "landing", live: null, demoLogLength: 0 });
     const boundary = await pageA.evaluate(() => {
       const win = window as any;
       return {
@@ -111,19 +118,20 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
     expect(boundary.eventUrl).not.toContain("scratchnode.com");
     expect(boundary.workspaceBaseUrl).toBe("https://nodebenchai.com");
     expect(boundary.privateHandoffUrl).toContain(
-      "https://nodebenchai.com/events/ai-infra-summit-2026/private",
+      "https://nodebenchai.com/scratchnode-events",
     );
     expect(boundary.privateHandoffUrl).toContain("source=scratchnode");
+    expect(boundary.privateHandoffUrl).toContain("event=ai-infra-summit-2026");
     expect(boundary.privateHandoffUrl).toContain("room=ORBITAL");
     expect(decodeURIComponent(boundary.privateHandoffUrl)).toContain(
       `return=${expectedPublicOrigin}/e/ai-infra-summit-2026`,
     );
     expect(decodeURIComponent(boundary.signInHandoffUrl)).toContain(
-      "/events/ai-infra-summit-2026/private",
+      "/scratchnode-events",
     );
     expect(boundary.hasOpenHandoff).toBe("function");
     await pageA.screenshot({
-      path: join(ARTIFACT_DIR, `${qaId}-apex-live.png`),
+      path: join(ARTIFACT_DIR, `${qaId}-apex-landing.png`),
       fullPage: true,
     });
 
@@ -307,7 +315,7 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
     await expect(pageA.locator("#sn-nodebench-private-handoff")).toBeVisible();
     await expect(pageA.locator("#sheet-content")).toContainText("Open NodeBench event notebook");
     await expect(pageA.locator("#sheet-content")).toContainText(
-      "https://nodebenchai.com/events/ai-infra-summit-2026/private",
+      "https://nodebenchai.com/scratchnode-events",
     );
     await pageA.evaluate(() => (window as any).closeSheet());
 

--- a/tests/e2e/scratchnode-demo-route-gate.spec.ts
+++ b/tests/e2e/scratchnode-demo-route-gate.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const HOME_V5_HTML = readFileSync(resolve("public/proto/home-v5.html"), "utf8");
+
+async function fulfillHomeV5(page: import("@playwright/test").Page) {
+  await page.route("https://scratchnode.live/**", async (route) => {
+    if (route.request().resourceType() === "document") {
+      await route.fulfill({ status: 200, contentType: "text/html", body: HOME_V5_HTML });
+      return;
+    }
+    if (route.request().url().includes("/api/scratchnode-config")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ convexUrl: "https://example.convex.cloud" }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+}
+
+async function getDemoState(page: import("@playwright/test").Page) {
+  return await page.evaluate(() => ({
+    pageMode: document.body.getAttribute("data-page-mode"),
+    live: document.body.getAttribute("data-sn-live"),
+    fullDemoAllowed: (window as any).shouldRunScratchNodeFullDemo?.(),
+    legacyDemoAllowed: (window as any).shouldRunScratchNodeLegacyDemo?.(),
+    simPostType: typeof (window as any).simPost,
+    demoLogLength: Array.isArray((window as any)._demo_log)
+      ? (window as any)._demo_log.length
+      : 0,
+    feedText: document.querySelector("#feed")?.textContent ?? "",
+  }));
+}
+
+test.describe("ScratchNode demo route gate", () => {
+  test("stale demo query/hash does not arm helpers or autoplay on apex", async ({ page }) => {
+    await fulfillHomeV5(page);
+
+    await page.goto("https://scratchnode.live/?demo=1#demo", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => typeof (window as any).runDemoFull === "function");
+    await page.waitForTimeout(900);
+
+    expect(await getDemoState(page)).toMatchObject({
+      pageMode: "landing",
+      fullDemoAllowed: false,
+      legacyDemoAllowed: false,
+      simPostType: "undefined",
+      demoLogLength: 0,
+    });
+  });
+
+  test("stale demo query/hash does not autoplay on live event routes", async ({ page }) => {
+    await fulfillHomeV5(page);
+
+    await page.goto("https://scratchnode.live/e/orbital?demo=1#demo", {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForFunction(() => typeof (window as any).runDemoFull === "function");
+    await page.waitForTimeout(900);
+
+    const state = await getDemoState(page);
+    expect(state.pageMode).toBe("event");
+    expect(state.fullDemoAllowed).toBe(false);
+    expect(state.legacyDemoAllowed).toBe(false);
+    expect(state.simPostType).toBe("undefined");
+    expect(state.demoLogLength).toBe(0);
+    expect(state.feedText).not.toContain("Maya from VoiceLayer");
+  });
+
+  test("/demo_ver route is the only full-demo autoplay route", async ({ page }) => {
+    await fulfillHomeV5(page);
+
+    await page.goto("https://scratchnode.live/demo_ver1?demoSpeed=instant", {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForFunction(() => (window as any)._demo_log?.length === 14, {
+      timeout: 10_000,
+    });
+
+    expect(await getDemoState(page)).toMatchObject({
+      pageMode: "demo",
+      fullDemoAllowed: true,
+      legacyDemoAllowed: false,
+      simPostType: "function",
+      demoLogLength: 14,
+    });
+  });
+
+  test("/demo_ver route can be loaded without autoplay", async ({ page }) => {
+    await fulfillHomeV5(page);
+
+    await page.goto("https://scratchnode.live/demo_ver1?demo=0", {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForFunction(() => typeof (window as any).runDemoFull === "function");
+    await page.waitForTimeout(900);
+
+    expect(await getDemoState(page)).toMatchObject({
+      pageMode: "demo",
+      fullDemoAllowed: false,
+      legacyDemoAllowed: false,
+      simPostType: "function",
+      demoLogLength: 0,
+    });
+  });
+});

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const HOME_V5_HTML = readFileSync(resolve("public/proto/home-v5.html"), "utf8");
+
+async function fulfillScratchNodePage(
+  page: import("@playwright/test").Page,
+  options: {
+    configStatus?: number;
+    joinMode?: "ok" | "not-found";
+  } = {},
+) {
+  await page.route("https://scratchnode.live/api/scratchnode-config", async (route) => {
+    if (options.configStatus && options.configStatus >= 400) {
+      await route.fulfill({ status: options.configStatus, body: "config unavailable" });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ convexUrl: "https://example.convex.cloud" }),
+    });
+  });
+
+  await page.route("https://esm.sh/convex@1.29.0/browser", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/javascript",
+      body: `
+        export class ConvexClient {
+          constructor(url) {
+            window.__snMockClientUrl = url;
+            window.__snMockMutations = [];
+          }
+          close() { window.__snMockClosed = true; }
+          mutation(name, args) {
+            window.__snMockMutations.push({ name, args });
+            if (name === 'events:joinEvent') {
+              if (window.__snJoinMode === 'not-found') {
+                const err = new Error('event_not_found');
+                err.data = { code: 'event_not_found' };
+                return Promise.reject(err);
+              }
+              return Promise.resolve({
+                eventId: 'liveEvents:1',
+                slug: 'ai-infra-summit-2026',
+                name: 'AI Infra Summit',
+                roomCode: 'ORBITAL',
+                status: 'live'
+              });
+            }
+            if (name === 'events:sendMessage') {
+              if (window.__snSendMode === 'fail') {
+                const err = new Error('network_down');
+                err.data = { code: 'network_down' };
+                return Promise.reject(err);
+              }
+              return Promise.resolve({ messageId: 'liveEventMessages:1' });
+            }
+            return Promise.resolve({});
+          }
+          query(name) {
+            if (name === 'events:getMyEvents') return Promise.resolve({ joined: [], hosted: [] });
+            if (name === 'events:getPublishedWiki') return Promise.resolve(null);
+            if (name === 'events:getHostStatus') return Promise.resolve({ isHost: false });
+            return Promise.resolve([]);
+          }
+          action() { return Promise.resolve(null); }
+          onUpdate() {}
+        }
+      `,
+    });
+  });
+
+  await page.addInitScript((joinMode) => {
+    (window as any).__snJoinMode = joinMode;
+  }, options.joinMode ?? "ok");
+
+  await page.route("https://scratchnode.live/**", async (route) => {
+    if (route.request().resourceType() === "document") {
+      await route.fulfill({ status: 200, contentType: "text/html", body: HOME_V5_HTML });
+      return;
+    }
+    await route.fallback();
+  });
+}
+
+test.describe("ScratchNode live route honesty", () => {
+  test("event routes do not show mock chat when config is unavailable", async ({ page }) => {
+    await fulfillScratchNodePage(page, { configStatus: 500 });
+
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator('[data-sn-live-error="true"]')).toContainText(
+      "Could not load live room config",
+    );
+    await expect(page.locator("#ci")).toBeDisabled();
+    await expect(page.locator(".row, .ans")).toHaveCount(0);
+    await expect(page.locator("body")).not.toHaveAttribute("data-sn-live", "true");
+  });
+
+  test("missing event/room code shows an alert instead of static mock chat", async ({ page }) => {
+    await fulfillScratchNodePage(page, { joinMode: "not-found" });
+
+    await page.goto("https://scratchnode.live/e/zzz-fake", { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator('[data-sn-live-error="true"]')).toContainText(
+      "No room matches /e/zzz-fake",
+    );
+    await expect(page.locator("#ci")).toBeDisabled();
+    await expect(page.locator(".row, .ans")).toHaveCount(0);
+    await expect(page.locator("body")).not.toHaveAttribute("data-sn-live", "true");
+  });
+
+  test("successful room-code join uses Convex and public send failures do not append local rows", async ({
+    page,
+  }) => {
+    await fulfillScratchNodePage(page);
+
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+
+    const joinCall = await page.evaluate(() =>
+      (window as any).__snMockMutations.find((call: any) => call.name === "events:joinEvent"),
+    );
+    expect(joinCall.args.slug).toBe("orbital");
+
+    await page.evaluate(() => {
+      (window as any).__snSendMode = "fail";
+      const input = document.getElementById("ci") as HTMLInputElement;
+      input.value = "this must not be local-only";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      (window as any).sendComposerMessage();
+    });
+
+    await expect
+      .poll(() => page.locator(".row-text", { hasText: "this must not be local-only" }).count(), {
+        timeout: 5_000,
+      })
+      .toBe(0);
+    await expect(page.locator("#ci")).toHaveValue("this must not be local-only");
+  });
+});


### PR DESCRIPTION
Supersedes stale PR #424 and builds on merged PR #425. Fixes launch blockers from parallel review: demo helpers/autoplay only arm on /demo_ver routes; live event failures clear mock rows, disable composer, and show role=alert; public send failures no longer append local-only rows and restore drafts; ScratchNode to NodeBench handoff targets /scratchnode-events instead of broken /events/:slug/private; host create-event UI is hidden/disabled until a real createEvent mutation ships. Verified locally with targeted Convex room-code tests, ScratchNode demo/live route Playwright gates, home-v5 contract, tsc, ScratchnodeEventsSurface tests, proto-live dogfood skip check, preflight:fast, npm run build, and git diff --check. Do not merge #424 as-is; it is stale and can revert newer launch assets.