### PR TITLE
fix(scratchnode): ship live backend room lifecycle

### DIFF
--- a/convex/__tests__/scratchnode.events.test.ts
+++ b/convex/__tests__/scratchnode.events.test.ts
@@ -44,6 +44,11 @@ import {
   releaseHost,
   _adminForceReleaseHost,
   getEventBySlug,
+  createEvent,
+  updateEvent,
+  endEvent,
+  upsertEventSource,
+  deleteEventSource,
   joinEvent,
   sendMessage,
   getMessages,
@@ -483,6 +488,153 @@ describe("event room-code lookup — /e/:roomCode joins the canonical live room"
   });
 });
 
+describe("createEvent - host-created rooms are real Convex rooms", () => {
+  it("creates a live room, joins creator, issues host token, and seeds a public source", async () => {
+    process.env.CONVEX_DEPLOYMENT = "dev:test";
+    const tables: Tables = {
+      liveEvents: [],
+      liveEventMembers: [],
+      liveEventHosts: [],
+      liveEventSources: [],
+    };
+    const ctx = createCtx(tables);
+
+    const created = await (createEvent as any)._handler(ctx, {
+      title: "Launch Readiness War Room",
+      sessionId: ANONYMOUS_SESSION_A,
+      displayName: "Maya Host",
+      roomCode: "LAUNCH",
+      agendaText: "Ship live backend. Verify public chat, asks, private notes, and wiki.",
+      status: "live",
+    });
+
+    expect(created.ok).toBe(true);
+    expect(created.slug).toBe("launch-readiness-war-room");
+    expect(created.roomCode).toBe("LAUNCH");
+    expect(created.ownerKey).toMatch(/^hk1:/);
+    expect(tables.liveEvents).toHaveLength(1);
+    expect(tables.liveEventMembers).toHaveLength(1);
+    expect(tables.liveEventHosts).toHaveLength(1);
+    expect(tables.liveEventHosts[0]).toMatchObject({
+      eventId: created.eventId,
+      displayName: "Maya Host",
+      role: "owner",
+      authMethod: "claim_code",
+    });
+    expect(tables.liveEventSources).toHaveLength(1);
+    expect(tables.liveEventSources[0].body).toContain("Privacy rule");
+
+    const byRoom = await (joinEvent as any)._handler(ctx, {
+      slug: "launch",
+      sessionId: ANONYMOUS_SESSION_B,
+      displayName: "Guest",
+    });
+    expect(byRoom.eventId).toBe(created.eventId);
+
+    await (sendMessage as any)._handler(ctx, {
+      eventId: created.eventId,
+      sessionId: ANONYMOUS_SESSION_B,
+      displayName: "Guest",
+      text: "real created room chat",
+      kind: "chat",
+    });
+    const rows = await (getMessages as any)._handler(ctx, { eventId: created.eventId, limit: 10 });
+    expect(rows.some((row: any) => row.text === "real created room chat")).toBe(true);
+  });
+
+  it("host can update metadata, manage sources, and end the event", async () => {
+    process.env.CONVEX_DEPLOYMENT = "dev:test";
+    const tables: Tables = {
+      liveEvents: [],
+      liveEventMembers: [],
+      liveEventHosts: [],
+      liveEventSources: [],
+      liveEventMessages: [],
+    };
+    const ctx = createCtx(tables);
+    const created = await (createEvent as any)._handler(ctx, {
+      title: "Source Room",
+      sessionId: ANONYMOUS_SESSION_A,
+      displayName: "Host",
+      roomCode: "SOURCE1",
+      status: "draft",
+    });
+
+    await (updateEvent as any)._handler(ctx, {
+      eventId: created.eventId,
+      ownerKey: created.ownerKey,
+      title: "Source Room Live",
+      roomCode: "SOURCE2",
+      status: "live",
+    });
+    expect(tables.liveEvents[0]).toMatchObject({
+      name: "Source Room Live",
+      roomCode: "SOURCE2",
+      status: "live",
+    });
+
+    const source = await (upsertEventSource as any)._handler(ctx, {
+      eventId: created.eventId,
+      ownerKey: created.ownerKey,
+      title: "Launch agenda",
+      body: "Public agenda source for the event ask runtime.",
+      uri: "doc://source-room/agenda",
+    });
+    expect(source.created).toBe(true);
+    const updatedSource = await (upsertEventSource as any)._handler(ctx, {
+      eventId: created.eventId,
+      ownerKey: created.ownerKey,
+      title: "Launch agenda v2",
+      body: "Updated public agenda source for the event ask runtime.",
+      uri: "doc://source-room/agenda",
+    });
+    expect(updatedSource.created).toBe(false);
+    expect(tables.liveEventSources.filter((row: any) => row.uri === "doc://source-room/agenda")).toHaveLength(1);
+
+    await (deleteEventSource as any)._handler(ctx, {
+      eventId: created.eventId,
+      ownerKey: created.ownerKey,
+      sourceId: updatedSource.sourceId,
+    });
+    expect(tables.liveEventSources.some((row: any) => row._id === updatedSource.sourceId)).toBe(false);
+
+    const ended = await (endEvent as any)._handler(ctx, {
+      eventId: created.eventId,
+      ownerKey: created.ownerKey,
+    });
+    expect(ended.status).toBe("ended");
+    await expect(
+      (sendMessage as any)._handler(ctx, {
+        eventId: created.eventId,
+        sessionId: ANONYMOUS_SESSION_A,
+        displayName: "Host",
+        text: "should not send",
+        kind: "chat",
+      }),
+    ).rejects.toThrow(/event_ended|ended/);
+  });
+
+  it("attendee cannot spoof system messages", async () => {
+    const tables: Tables = {
+      liveEvents: [baseEvent()],
+      liveEventMembers: [baseMember(ANONYMOUS_SESSION_A)],
+      liveEventMessages: [],
+    };
+    const ctx = createCtx(tables);
+
+    await expect(
+      (sendMessage as any)._handler(ctx, {
+        eventId: "liveEvents:1",
+        sessionId: ANONYMOUS_SESSION_A,
+        displayName: "Attendee",
+        text: "I am a system row",
+        kind: "system",
+      }),
+    ).rejects.toThrow(/not_host|Host ownership/);
+    expect(tables.liveEventMessages).toHaveLength(0);
+  });
+});
+
 /* ========================================================================== */
 /* Test 1 — composeAnswer cache reuse                                          */
 /* ========================================================================== */
@@ -580,8 +732,8 @@ describe("composeAnswer — cache reuse across attendees", () => {
    * Duration:    Sub-second
    * Expected:    Throws ConvexError with code=no_sources; no liveEventAnswers
    *              row created.
-   * Edge:        Demo event auto-seeds sources; non-demo event with 0 sources
-   *              must surface the gap honestly.
+   * Edge:        No production path auto-seeds sources; empty rooms must surface
+   *              the gap honestly until a host adds public source context.
    */
   it("rejects /ask when no event sources exist (HONEST_STATUS)", async () => {
     const tables: Tables = {

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -9,10 +9,11 @@
  *   - getMessages({ eventId, limit? })            // realtime subscription
  *   - getMembers({ eventId })                     // realtime subscription
  *   - getMyEvents({ sessionId, ownerKey, limit? }) // lightweight account/event state
+ *   - createEvent({ title, sessionId, displayName, ... }) // creates live room + host token
  *   - joinEvent({ slug, sessionId, displayName }) // returns { eventId, ... }
  *   - sendMessage({ eventId, sessionId, displayName, text, kind, replyToMessageId? })
  *   - heartbeat({ eventId, sessionId })
- *   - ensureDemoEvent()                            // seeds ai-infra-summit-2026 if missing
+ *   - ensureDemoEvent()                            // dev/explicit demo seed only
  *
  * Privacy invariants (release-blocker, per docs.html):
  *   - This file only handles PUBLIC chat. Private notes will be a separate
@@ -26,7 +27,7 @@
  */
 
 import { v } from "convex/values";
-import { api, internal } from "./_generated/api";
+import { internal } from "./_generated/api";
 import { action, query, mutation, internalMutation, internalQuery } from "./_generated/server";
 
 class ConvexError<T extends Record<string, unknown>> extends Error {
@@ -43,6 +44,9 @@ class ConvexError<T extends Record<string, unknown>> extends Error {
 // ─── Constants ────────────────────────────────────────────────────────────
 const MAX_DISPLAY_NAME = 40;
 const MAX_MESSAGE_TEXT = 4000;
+const MAX_EVENT_NAME = 90;
+const MAX_EVENT_SLUG = 80;
+const MAX_EVENT_CONTEXT = 2_000;
 const DEFAULT_MESSAGE_LIMIT = 200;
 const MAX_MESSAGE_LIMIT = 500;
 const PRESENCE_TTL_MS = 5 * 60 * 1000; // 5 min
@@ -135,6 +139,30 @@ const stableHash = (value: string) => {
 const normalizeQuestion = (value: string) =>
   value.toLowerCase().replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim().slice(0, 240);
 
+const normalizeEventTitle = (value: string) =>
+  (value || "").replace(/\s+/g, " ").trim().slice(0, MAX_EVENT_NAME);
+
+const slugifyEventTitle = (value: string): string => {
+  const base = normalizeEventTitle(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_EVENT_SLUG)
+    .replace(/-+$/g, "");
+  return base || "event";
+};
+
+const normalizeRequestedSlug = (value: string | undefined, title: string): string => {
+  const raw = (value || "").trim();
+  return slugifyEventTitle(raw || title);
+};
+
+const normalizeRequestedRoomCode = (value: string | undefined): string | null => {
+  const raw = (value || "").trim().toUpperCase().replace(/[^A-Z0-9-]+/g, "");
+  if (!raw) return null;
+  return raw.slice(0, 24);
+};
+
 const tokenize = (value: string) =>
   new Set(normalizeQuestion(value).split(" ").filter((token) => token.length > 2));
 
@@ -215,6 +243,12 @@ const getHostAuthSecret = (): string => {
     message:
       "SCRATCHNODE_HOST_TOKEN_SECRET env var required. Run: npx convex env set SCRATCHNODE_HOST_TOKEN_SECRET <random-32+-char-string>",
   });
+};
+
+const canSeedDemoEvent = (): boolean => {
+  const allow = (globalThis as any)?.process?.env?.SCRATCHNODE_ALLOW_DEMO_SEED;
+  const deployment = (globalThis as any)?.process?.env?.CONVEX_DEPLOYMENT;
+  return allow === "1" || (typeof deployment === "string" && deployment.startsWith("dev:"));
 };
 
 // Convex runtime exposes Web Crypto (`crypto.subtle`) and
@@ -304,8 +338,14 @@ const verifyHostToken = async (
   if (!ownerKey.startsWith(HOST_TOKEN_PREFIX)) return false;
   const body = ownerKey.slice(HOST_TOKEN_PREFIX.length);
   const parts = body.split(":");
-  if (parts.length !== 4) return false;
-  const [eventIdShort, nonce, issuedAtStr, hmacShort] = parts;
+  // Convex ids contain ":" (for example "liveEvents:123"), so parse the
+  // token from the right instead of assuming exactly four colon-separated
+  // segments.
+  if (parts.length < 4) return false;
+  const hmacShort = parts.pop() || "";
+  const issuedAtStr = parts.pop() || "";
+  const nonce = parts.pop() || "";
+  const eventIdShort = parts.join(":");
   if (!eventIdShort || !nonce || !issuedAtStr || !hmacShort) return false;
   if (eventIdShort !== eventId.slice(0, 16)) return false;
   const issuedAt = Number(issuedAtStr);
@@ -1080,8 +1120,342 @@ export const _persistAgentAnswer = internalMutation({
 // ─── MUTATIONS ────────────────────────────────────────────────────────────
 
 /**
+ * Create a real ScratchNode event room and return a server-issued host token.
+ *
+ * This is the launch replacement for the old Host Console "SOLARIS" toast.
+ * The mutation creates the event, joins the creator, registers them as host,
+ * and inserts one public starter source so `/ask` has a bounded public corpus
+ * from the first minute. Private notes are not read or copied.
+ */
+export const createEvent = mutation({
+  args: {
+    title: v.string(),
+    sessionId: v.string(),
+    displayName: v.string(),
+    slug: v.optional(v.string()),
+    roomCode: v.optional(v.string()),
+    agendaText: v.optional(v.string()),
+    status: v.optional(v.union(v.literal("draft"), v.literal("live"))),
+  },
+  handler: async (ctx, args) => {
+    // Fail before writing if production host-token env is missing.
+    // `issueHostToken` calls this again after we have the event id.
+    void getHostAuthSecret();
+
+    const title = normalizeEventTitle(args.title);
+    if (title.length < 3) {
+      throw new ConvexError({
+        code: "invalid_event_title",
+        message: "Event title must be at least 3 characters.",
+      });
+    }
+    if (!args.sessionId || args.sessionId.length < 8 || args.sessionId.length > 64) {
+      throw new ConvexError({
+        code: "invalid_session",
+        message: "sessionId must be a 8-64 char UUID-like string.",
+      });
+    }
+
+    const requestedSlug = normalizeRequestedSlug(args.slug, title);
+    const explicitSlug = !!(args.slug && args.slug.trim());
+    const existingSlug = await ctx.db
+      .query("liveEvents")
+      .withIndex("by_slug", (q) => q.eq("slug", requestedSlug))
+      .first();
+    if (existingSlug && explicitSlug) {
+      throw new ConvexError({
+        code: "slug_taken",
+        message: "That event slug is already in use.",
+      });
+    }
+
+    let slug = requestedSlug;
+    if (existingSlug) {
+      for (let i = 0; i < 8; i += 1) {
+        const suffix = randomString(4, "abcdefghjkmnpqrstuvwxyz23456789").toLowerCase();
+        const candidate = `${requestedSlug.slice(0, Math.max(1, MAX_EVENT_SLUG - 5))}-${suffix}`;
+        const collision = await ctx.db
+          .query("liveEvents")
+          .withIndex("by_slug", (q) => q.eq("slug", candidate))
+          .first();
+        if (!collision) {
+          slug = candidate;
+          break;
+        }
+      }
+      if (slug === requestedSlug) {
+        throw new ConvexError({
+          code: "slug_generation_failed",
+          message: "Could not generate a unique event slug. Try another title.",
+        });
+      }
+    }
+
+    const requestedRoomCode = normalizeRequestedRoomCode(args.roomCode);
+    if (requestedRoomCode && !isRoomCodeShape(requestedRoomCode)) {
+      throw new ConvexError({
+        code: "invalid_room_code",
+        message: "Room code must be 2-24 letters, numbers, or dashes.",
+      });
+    }
+
+    let roomCode = requestedRoomCode || "";
+    if (roomCode) {
+      const existingRoom = await ctx.db
+        .query("liveEvents")
+        .withIndex("by_roomCode", (q) => q.eq("roomCode", roomCode))
+        .first();
+      if (existingRoom) {
+        throw new ConvexError({
+          code: "room_code_taken",
+          message: "That room code is already in use.",
+        });
+      }
+    } else {
+      for (let i = 0; i < 12; i += 1) {
+        const candidate = randomString(6, "ABCDEFGHJKLMNPQRSTUVWXYZ23456789");
+        const existingRoom = await ctx.db
+          .query("liveEvents")
+          .withIndex("by_roomCode", (q) => q.eq("roomCode", candidate))
+          .first();
+        if (!existingRoom) {
+          roomCode = candidate;
+          break;
+        }
+      }
+      if (!roomCode) {
+        throw new ConvexError({
+          code: "room_code_generation_failed",
+          message: "Could not generate a room code. Try again.",
+        });
+      }
+    }
+
+    const now = Date.now();
+    const status = args.status || "live";
+    const eventId = await ctx.db.insert("liveEvents", {
+      slug,
+      name: title,
+      roomCode,
+      status,
+      startedAt: now,
+    });
+
+    const safeName = (args.displayName || "Host").slice(0, MAX_DISPLAY_NAME).trim() || "Host";
+    await ctx.db.insert("liveEventMembers", {
+      eventId,
+      sessionId: args.sessionId,
+      displayName: safeName,
+      joinedAt: now,
+      lastSeenAt: now,
+    });
+
+    const ownerKey = await issueHostToken(eventId, now);
+    const hostId = await ctx.db.insert("liveEventHosts", {
+      eventId,
+      ownerKey,
+      displayName: safeName,
+      role: "owner",
+      authMethod: "claim_code",
+      createdAt: now,
+    });
+
+    const agenda = (args.agendaText || "").replace(/\s+/g, " ").trim().slice(0, MAX_EVENT_CONTEXT);
+    const sourceBody = [
+      `${title} live room starter context.`,
+      agenda || "The host has not uploaded a detailed agenda yet. Use public chat and host-approved sources as the event develops.",
+      "Privacy rule: public answers use public event context only. Private attendee notes are excluded from public answers, public wiki compaction, and public cache.",
+    ].join("\n");
+    const sourceId = await ctx.db.insert("liveEventSources", {
+      eventId,
+      uri: `event://${slug}/starter-context`,
+      kind: "doc",
+      title: `${title} starter context`,
+      excerpt: (agenda || `Host-created room ${roomCode}. Public answers exclude private notes.`).slice(0, 280),
+      body: sourceBody.slice(0, MAX_SOURCE_BODY),
+      sourceHash: stableHash(`${slug}|${sourceBody}`),
+      isSeeded: true,
+      uploadedAt: now,
+    });
+
+    return {
+      ok: true as const,
+      eventId,
+      slug,
+      name: title,
+      roomCode,
+      status,
+      ownerKey,
+      hostId,
+      sourceId,
+    };
+  },
+});
+
+export const updateEvent = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    ownerKey: v.string(),
+    title: v.optional(v.string()),
+    roomCode: v.optional(v.string()),
+    status: v.optional(v.union(v.literal("draft"), v.literal("live"))),
+  },
+  handler: async (ctx, { eventId, ownerKey, title, roomCode, status }) => {
+    await requireHost(ctx, eventId, ownerKey);
+    const event = await ctx.db.get(eventId);
+    if (!event) {
+      throw new ConvexError({ code: "event_not_found", message: "Event no longer exists." });
+    }
+
+    const patch: Record<string, unknown> = {};
+    if (title !== undefined) {
+      const cleanTitle = normalizeEventTitle(title);
+      if (cleanTitle.length < 3) {
+        throw new ConvexError({
+          code: "invalid_event_title",
+          message: "Event title must be at least 3 characters.",
+        });
+      }
+      patch.name = cleanTitle;
+    }
+    if (status !== undefined) {
+      patch.status = status;
+      if (status === "live" && event.status === "draft") {
+        patch.startedAt = Date.now();
+      }
+    }
+    if (roomCode !== undefined) {
+      const nextRoomCode = normalizeRequestedRoomCode(roomCode);
+      if (!nextRoomCode || !isRoomCodeShape(nextRoomCode)) {
+        throw new ConvexError({
+          code: "invalid_room_code",
+          message: "Room code must be 2-24 letters, numbers, or dashes.",
+        });
+      }
+      if (nextRoomCode !== event.roomCode) {
+        const existingRoom = await ctx.db
+          .query("liveEvents")
+          .withIndex("by_roomCode", (q) => q.eq("roomCode", nextRoomCode))
+          .first();
+        if (existingRoom && existingRoom._id !== eventId) {
+          throw new ConvexError({
+            code: "room_code_taken",
+            message: "That room code is already in use.",
+          });
+        }
+        patch.roomCode = nextRoomCode;
+      }
+    }
+
+    if (Object.keys(patch).length > 0) {
+      await ctx.db.patch(eventId, patch);
+    }
+    const updated = await ctx.db.get(eventId);
+    return {
+      ok: true as const,
+      eventId,
+      slug: updated?.slug ?? event.slug,
+      name: updated?.name ?? event.name,
+      roomCode: updated?.roomCode ?? event.roomCode,
+      status: updated?.status ?? event.status,
+    };
+  },
+});
+
+export const endEvent = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    ownerKey: v.string(),
+  },
+  handler: async (ctx, { eventId, ownerKey }) => {
+    await requireHost(ctx, eventId, ownerKey);
+    const event = await ctx.db.get(eventId);
+    if (!event) {
+      throw new ConvexError({ code: "event_not_found", message: "Event no longer exists." });
+    }
+    const endedAt = Date.now();
+    await ctx.db.patch(eventId, { status: "ended", endedAt });
+    return { ok: true as const, eventId, status: "ended" as const, endedAt };
+  },
+});
+
+export const upsertEventSource = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    ownerKey: v.string(),
+    title: v.string(),
+    body: v.string(),
+    uri: v.optional(v.string()),
+    excerpt: v.optional(v.string()),
+    kind: v.optional(v.union(
+      v.literal("transcript"),
+      v.literal("doc"),
+      v.literal("url"),
+      v.literal("slide"),
+    )),
+  },
+  handler: async (ctx, args) => {
+    await requireHost(ctx, args.eventId, args.ownerKey);
+    const event = await ctx.db.get(args.eventId);
+    if (!event) {
+      throw new ConvexError({ code: "event_not_found", message: "Event no longer exists." });
+    }
+    const title = (args.title || "").replace(/\s+/g, " ").trim().slice(0, 180);
+    const body = (args.body || "").replace(/\s+/g, " ").trim().slice(0, MAX_SOURCE_BODY);
+    if (title.length < 2 || body.length < 10) {
+      throw new ConvexError({
+        code: "invalid_source",
+        message: "Source title and body are required.",
+      });
+    }
+    const uri = (args.uri || `event://${event.slug}/source/${stableHash(`${title}|${body}`).slice(0, 10)}`)
+      .trim()
+      .slice(0, 500);
+    const excerpt = (args.excerpt || body).replace(/\s+/g, " ").trim().slice(0, 280);
+    const existing = await ctx.db
+      .query("liveEventSources")
+      .withIndex("by_event_uri", (q) => q.eq("eventId", args.eventId).eq("uri", uri))
+      .first();
+    const patch = {
+      eventId: args.eventId,
+      uri,
+      kind: args.kind || "doc",
+      title,
+      excerpt,
+      body,
+      sourceHash: stableHash(`${uri}|${body}`),
+      isSeeded: false,
+      uploadedAt: Date.now(),
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+      return { ok: true as const, sourceId: existing._id, created: false };
+    }
+    const sourceId = await ctx.db.insert("liveEventSources", patch);
+    return { ok: true as const, sourceId, created: true };
+  },
+});
+
+export const deleteEventSource = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    ownerKey: v.string(),
+    sourceId: v.id("liveEventSources"),
+  },
+  handler: async (ctx, { eventId, ownerKey, sourceId }) => {
+    await requireHost(ctx, eventId, ownerKey);
+    const source = await ctx.db.get(sourceId);
+    if (!source || source.eventId !== eventId) {
+      throw new ConvexError({ code: "source_not_found", message: "Source no longer exists." });
+    }
+    await ctx.db.delete(sourceId);
+    return { ok: true as const, sourceId };
+  },
+});
+
+/**
  * Idempotent join: upsert liveEventMembers by (eventId, sessionId).
- * Auto-creates the demo event on first call if missing.
+ * Missing rooms fail honestly; production join never creates demo fixtures.
  */
 export const joinEvent = mutation({
   args: {
@@ -1119,24 +1493,8 @@ export const joinEvent = mutation({
         .first();
     }
 
-    // Auto-seed the demo event so the first visitor to scratchnode.live
-    // doesn't hit an empty room. Triggers on either the canonical slug
-    // OR the canonical room code (typed as a URL slug — case-insensitive).
-    if (!event && (slug === "ai-infra-summit-2026" || normalizedRoomCode === "ORBITAL")) {
-      const id = await ctx.db.insert("liveEvents", {
-        slug: "ai-infra-summit-2026",
-        name: "AI Infra Summit",
-        roomCode: "ORBITAL",
-        status: "live",
-        startedAt: Date.now(),
-      });
-      event = await ctx.db.get(id);
-    }
     if (!event) {
       throw new ConvexError({ code: "event_not_found", message: "No such event slug." });
-    }
-    if (event.slug === "ai-infra-summit-2026") {
-      await ensureDemoSourcesForEvent(ctx, event._id);
     }
 
     const now = Date.now();
@@ -1186,6 +1544,7 @@ export const sendMessage = mutation({
     text: v.string(),
     kind: v.union(v.literal("chat"), v.literal("ask"), v.literal("system")),
     replyToMessageId: v.optional(v.id("liveEventMessages")),
+    ownerKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const text = (args.text || "").trim();
@@ -1217,6 +1576,16 @@ export const sendMessage = mutation({
     }
 
     // Verify the sender is a member (presence row exists) — prevents drive-by sends.
+    if (args.kind === "system") {
+      if (!args.ownerKey) {
+        throw new ConvexError({
+          code: "not_host",
+          message: "Host ownership is required for system messages.",
+        });
+      }
+      await requireHost(ctx, args.eventId, args.ownerKey);
+    }
+
     const member = await ctx.db
       .query("liveEventMembers")
       .withIndex("by_event_session", (q) =>
@@ -1313,15 +1682,6 @@ export const askAgent = action({
     }
 
     let sources: any[] = prepared.sources || [];
-    if (sources.length === 0 && prepared.event?.slug === "ai-infra-summit-2026") {
-      await ctx.runMutation((api as any).events.ensureDemoEvent, {});
-      prepared = await ctx.runQuery((internal as any).events._prepareAskAgentContext, {
-        eventId: args.eventId,
-        sessionId: args.sessionId,
-        question,
-      });
-      sources = prepared.sources || [];
-    }
 
     const retrievalStarted = Date.now();
     let ranked = sources
@@ -1470,10 +1830,6 @@ export const composeAnswer = mutation({
       throw new ConvexError({ code: "event_ended", message: "This event has ended." });
     }
     await requireMember(ctx, args.eventId, args.sessionId);
-    if (event.slug === "ai-infra-summit-2026") {
-      await ensureDemoSourcesForEvent(ctx, args.eventId);
-    }
-
     const normalizedQuestion = normalizeQuestion(question);
     const cached = await ctx.db
       .query("liveEventAnswers")
@@ -2112,6 +2468,12 @@ export const heartbeat = mutation({
 export const ensureDemoEvent = mutation({
   args: {},
   handler: async (ctx) => {
+    if (!canSeedDemoEvent()) {
+      throw new ConvexError({
+        code: "demo_seed_disabled",
+        message: "Demo seeding is disabled on this deployment.",
+      });
+    }
     const existing = await ctx.db
       .query("liveEvents")
       .withIndex("by_slug", (q) => q.eq("slug", "ai-infra-summit-2026"))

--- a/docs/runbooks/SCRATCHNODE_LAUNCH_BACKEND.md
+++ b/docs/runbooks/SCRATCHNODE_LAUNCH_BACKEND.md
@@ -1,0 +1,81 @@
+# ScratchNode Launch Backend Notes
+
+Date: 2026-05-28
+
+## Public launch boundary
+
+Production ScratchNode rooms must be Convex-backed. Do not silently fall back to fixture chat, fixture people, or demo wiki content on `/`, `/e/:slug`, or `/join/:code`.
+
+Demo automation is allowed only on owned demo routes:
+
+```text
+/demo_ver1
+/demo_ver2
+...
+```
+
+The launch room path is:
+
+```text
+host creates event
+-> Convex `events:createEvent`
+-> liveEvents row
+-> liveEventMembers creator row
+-> liveEventHosts owner row with hk1 host token
+-> starter liveEventSources row for public `/ask`
+-> attendees join by slug or room code
+-> messages persist through `events:sendMessage`
+```
+
+## Backend invariants
+
+- `joinEvent` resolves exact slug first, then case-insensitive room code.
+- `joinEvent` does not create demo rows in production.
+- `ensureDemoEvent` is dev/explicit only via `SCRATCHNODE_ALLOW_DEMO_SEED=1` or a `dev:` Convex deployment.
+- `sendMessage(kind: "system")` is host-only. Attendees can send public chat/ask rows, not system rows.
+- `/ask` on empty non-demo rooms must fail with `no_sources`, not invent a fake answer.
+- Public `/ask` uses public sources only. Private notes stay outside public feed, public wiki, public trace, and public cache.
+- Host tokens use `hk1:` HMAC format. Parse token fields from the right because Convex ids contain colons.
+
+## Host controls now live
+
+Host Console "Create a new event" is wired to the live mutation. The UI stores the returned owner token in:
+
+```text
+localStorage.sn_host_owner_key_v2
+```
+
+Source management mutations are available for host-owned rooms:
+
+```text
+events:upsertEventSource
+events:deleteEventSource
+events:updateEvent
+events:endEvent
+```
+
+## Launch verification
+
+Minimum local gate:
+
+```powershell
+npx vitest run convex/__tests__/scratchnode.events.test.ts
+npx tsc --noEmit --pretty false
+npx tsc -p convex --noEmit --pretty false
+npx playwright test tests/e2e/scratchnode-demo-route-gate.spec.ts tests/e2e/scratchnode-live-route-honesty.spec.ts --project=chromium --workers=1 --reporter=list
+npm run build
+npm run preflight:fast
+```
+
+Live smoke after deploy:
+
+```text
+1. Open scratchnode.live/e/<room-code> in two incognito windows.
+2. Send chat in window A. It must appear in B without refresh.
+3. Send chat in window B. It must appear in A without refresh.
+4. Open scratchnode.live/e/not-a-room. It must show a missing-room alert, not mock chat.
+5. Open scratchnode.live/demo_ver1. Demo may run there only.
+6. In Host Console, create a fresh event, then join it by its room code.
+```
+
+Known local caveat: `npx convex dev --once --typecheck=enable` can prompt for project configuration in a fresh worktree. Use `npx tsc -p convex --noEmit --pretty false` for non-interactive type checking unless the worktree has Convex project config loaded.

--- a/public/proto/docs.html
+++ b/public/proto/docs.html
@@ -1209,7 +1209,7 @@ curl -sL https://nodebenchai.com/ | grep -E <span class="str">'(VITE|root|index)
           <li class="done"><input type="checkbox" checked disabled> <span>Wire <code>onbeforeunload</code> to send a final heartbeat with stale-flag (optional)</span></li>
         </ul>
 
-        <p class="accept">Open <code>https://scratchnode.live/e/ai-infra-summit-2026</code> in Chrome and Safari (or two different browsers). Type "hi from chrome" in one; within 1s the other should show that message. The 318/47/38 counters stay hardcoded for now — that's Phase 5.</p>
+        <p class="accept">Open <code>https://scratchnode.live/e/ai-infra-summit-2026</code> in Chrome and Safari (or two different browsers). Type "hi from chrome" in one; within 1s the other should show that message. Event title, room code, member count, FAQ count, people, and unpublished-wiki state now hydrate from the live room instead of stale static counts.</p>
         <p class="risk">Convex action budget on free tier (1M function calls/month). Heartbeat at 30s × 100 users × 1 event = 3M/month — so heartbeats must be cheap (return early if state unchanged), or move presence to a Redis-style hot layer later (Phase 6).</p>
       </div>
     </div>
@@ -1612,7 +1612,7 @@ eventAnswers: <span class="fn">defineTable</span>({
     <p>Roster of attendees with name, role, online status. Tap a row to open their @-mentions and questions (toast in current proto).</p>
 
     <h3 id="v5-host">Host / create event</h3>
-    <p>Launch surface supports claiming host on an existing room, rotating a host claim code, reviewing FAQ suggestions, and publishing the wiki. New room creation is hidden until the live <code>createEvent</code> mutation ships.</p>
+    <p>Launch surface supports creating a real Convex-backed room, claiming host on an existing room, rotating a host claim code, reviewing FAQ suggestions, managing host-owned sources, ending events, and publishing the wiki. <code>createEvent</code> creates the event, joins the creator, issues a server-signed host token, and inserts a starter public source so <code>/ask</code> has honest context without demo fallback.</p>
 
     <h2 id="v5-landing">Landing &amp; onboarding <a class="anchor" href="#v5-landing">#</a></h2>
     <p>First-visit IIFE (<code>detectFirstVisit</code>) routes new users to the landing surface and persists their last view mode. Onboarding tour: 3 pulse-positioned steps over the composer and identity row.</p>

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1788,7 +1788,7 @@ function _landingJoin(ev) {
   <div class="h-logo"><span class="h-logo-dot"></span>Scratch<span>Node</span></div>
   <span class="h-live">LIVE</span>
   <div class="h-spacer"></div>
-  <button class="h-code" type="button" onclick="copyRoom()" aria-label="Room code — click to copy join link">ORBITAL</button>
+  <button class="h-code" id="sn-room-code-btn" type="button" onclick="copyRoom()" aria-label="Room code — click to copy join link">ORBITAL</button>
   <button class="h-menu" type="button" onclick="openMenu()" aria-label="Menu">
     <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>
   </button>
@@ -1796,13 +1796,13 @@ function _landingJoin(ev) {
 
 <!-- Persistent event-identity strip — answers Q1: "What event am I in?" -->
 <div class="event-strip" role="region" aria-label="Event identity">
-  <b>AI Infra Summit</b>
+  <b id="sn-event-title-strip">AI Infra Summit</b>
   <span class="dot">·</span>
   <span>MCP Auth breakout</span>
   <span class="dot">·</span>
-  <span><b style="color:var(--ink)" id="ev-joined-count">318</b> joined</span>
+  <span><b style="color:var(--ink)" id="ev-joined-count">0</b> joined</span>
   <span class="dot">·</span>
-  <span><b style="color:var(--ink)">47</b> FAQ</span>
+  <span><b style="color:var(--ink)" id="ev-faq-count">0</b> FAQ</span>
   <button type="button" class="ev-mode" id="ev-mode-btn" onclick="openModePicker()" aria-label="Event mode" title="Switch event mode">
     <span class="icon">●</span><span id="ev-mode-label">Event</span>
   </button>
@@ -1827,8 +1827,8 @@ function _landingJoin(ev) {
   </div>
 
   <section class="hero">
-    <h1>AI Infra Summit <button type="button" class="about-link" onclick="showAbout()" aria-label="What is this?">what is this?</button></h1>
-    <p class="hero-meta">May 22–23 · <b>318</b> in the room · hosted by Orbital Labs</p>
+    <h1><span id="sn-event-title-hero">AI Infra Summit</span> <button type="button" class="about-link" onclick="showAbout()" aria-label="What is this?">what is this?</button></h1>
+    <p class="hero-meta" id="sn-event-hero-meta">Live public room · <b id="sn-hero-joined-count">0</b> joined</p>
   </section>
 
   <!-- Identity row -->
@@ -2006,7 +2006,7 @@ function _landingJoin(ev) {
   <!-- Always visible to everyone -->
   <h4 data-show-for="all">This event</h4>
   <button type="button" onclick="openWiki()">Wiki<span class="sub">Need to know · What changed · Sources</span></button>
-  <button type="button" onclick="openPeople()">People in the room<span class="sub">318 joined · 24 online</span></button>
+  <button type="button" onclick="openPeople()">People in the room<span class="sub" id="menu-people-sub">Live members</span></button>
   <button type="button" onclick="openShare()">Share<span class="sub">QR · Copy link · Social</span></button>
   <!-- Notes appear once user has set a name (matches the privacy/identity contract) -->
   <h4 style="margin-top:14px" data-show-for="named">Your notes</h4>
@@ -2079,6 +2079,8 @@ var PUBLIC_BASE_URL = (function() {
   }
 })();
 var EVENT_SLUG = 'ai-infra-summit-2026';
+var EVENT_TITLE = 'AI Infra Summit';
+var EVENT_ROOM_CODE = 'ORBITAL';
 var EVENT_URL = PUBLIC_BASE_URL + '/e/' + EVENT_SLUG;
 // NodeBench is the deeper private workspace. ScratchNode keeps lightweight
 // event account state, host controls, joined events, and private annotations
@@ -2134,8 +2136,35 @@ function shouldRunScratchNodeLegacyDemo() {
   }
 }
 
+function refreshEventUrl() {
+  EVENT_URL = PUBLIC_BASE_URL + '/e/' + encodeURIComponent(EVENT_SLUG);
+}
+
+function setScratchNodeLiveEventContext(event) {
+  if (!event) return;
+  EVENT_SLUG = event.slug || EVENT_SLUG;
+  EVENT_TITLE = event.name || event.title || EVENT_TITLE;
+  EVENT_ROOM_CODE = event.roomCode || EVENT_ROOM_CODE;
+  refreshEventUrl();
+  var codeBtn = document.getElementById('sn-room-code-btn');
+  if (codeBtn) {
+    codeBtn.textContent = EVENT_ROOM_CODE;
+    codeBtn.setAttribute('aria-label', 'Room code ' + EVENT_ROOM_CODE + ' — click to copy join link');
+  }
+  var stripTitle = document.getElementById('sn-event-title-strip');
+  if (stripTitle) stripTitle.textContent = EVENT_TITLE;
+  var heroTitle = document.getElementById('sn-event-title-hero');
+  if (heroTitle) heroTitle.textContent = EVENT_TITLE;
+  var heroMeta = document.getElementById('sn-event-hero-meta');
+  if (heroMeta) heroMeta.innerHTML = 'Live public room · <b id="sn-hero-joined-count">0</b> joined · code ' + escapeHtml(EVENT_ROOM_CODE);
+  var peopleSub = document.getElementById('menu-people-sub');
+  if (peopleSub) peopleSub.textContent = 'Live members';
+  var mode = document.getElementById('ev-mode-label');
+  if (mode) mode.textContent = (event.status || 'Event');
+}
+
 function buildNodeBenchEventPrivateUrl() {
-  var roomCode = 'ORBITAL';
+  var roomCode = EVENT_ROOM_CODE;
   try {
     var room = getRoomContext();
     roomCode = (room && room.roomCode) || roomCode;
@@ -2496,16 +2525,16 @@ function ask(text) {
 
 // ── Room code copy + share ──
 function copyRoom() {
-  var url = location.href.split('#')[0];
-  var text = 'Join AI Infra Summit on ScratchNode\nCode: ORBITAL\n' + url;
+  var url = EVENT_URL || location.href.split('#')[0];
+  var text = 'Join ' + EVENT_TITLE + ' on ScratchNode\nCode: ' + EVENT_ROOM_CODE + '\n' + url;
   if (navigator.share) {
-    navigator.share({ title: 'AI Infra Summit · ScratchNode', text: text }).catch(function(){});
+    navigator.share({ title: EVENT_TITLE + ' · ScratchNode', text: text }).catch(function(){});
     return;
   }
   if (navigator.clipboard) {
-    navigator.clipboard.writeText(text).then(function(){ toast('Copied join link', 'ORBITAL · paste in any chat.'); });
+    navigator.clipboard.writeText(text).then(function(){ toast('Copied join link', EVENT_ROOM_CODE + ' · paste in any chat.'); });
   } else {
-    toast('Room: ORBITAL', 'Share this URL with attendees.');
+    toast('Room: ' + EVENT_ROOM_CODE, 'Share this URL with attendees.');
   }
 }
 
@@ -2983,7 +3012,7 @@ var SHEET_RENDERERS = {
 
   share: function() {
     var url = EVENT_URL;
-    return '<div class="sheet-head"><h2 id="sheet-title">Share AI Infra Summit</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
+    return '<div class="sheet-head"><h2 id="sheet-title">Share ' + escapeHtml(EVENT_TITLE) + '</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
       '<div class="share-url-box"><code>' + url + '</code><button type="button" onclick="copyShareUrl()">Copy</button></div>' +
       '<div class="share-grid">' +
       '<button type="button" class="share-tile" onclick="shareTo(\'twitter\')"><span class="icon">&#119909;</span><span>Post on X</span></button>' +
@@ -2992,8 +3021,8 @@ var SHEET_RENDERERS = {
       '<button type="button" class="share-tile" onclick="shareTo(\'native\')"><span class="icon">&#10548;</span><span>More&hellip;</span></button>' +
       '</div>' +
       '<div class="sheet-section"><h3>Or scan to join on mobile</h3>' +
-      '<div style="display:flex;justify-content:center;padding:16px;background:#fff;border-radius:var(--r-sm)"><img src="https://api.qrserver.com/v1/create-qr-code/?size=140x140&amp;margin=4&amp;data=' + encodeURIComponent(url + '#room=ORBITAL') + '" alt="QR code" width="140" height="140" loading="lazy" /></div></div>' +
-      '<div style="margin-top:12px;font-size:11px;color:var(--ink-faint);text-align:center;font-family:var(--mono)">318 already joined &middot; 47 FAQ &middot; 38 sources</div>';
+      '<div style="display:flex;justify-content:center;padding:16px;background:#fff;border-radius:var(--r-sm)"><img src="https://api.qrserver.com/v1/create-qr-code/?size=140x140&amp;margin=4&amp;data=' + encodeURIComponent(url + '#room=' + EVENT_ROOM_CODE) + '" alt="QR code" width="140" height="140" loading="lazy" /></div></div>' +
+      '<div style="margin-top:12px;font-size:11px;color:var(--ink-faint);text-align:center;font-family:var(--mono)">Live room code ' + escapeHtml(EVENT_ROOM_CODE) + ' &middot; realtime chat backed by Convex</div>';
   },
 
   notes: function() {
@@ -3021,10 +3050,16 @@ var SHEET_RENDERERS = {
 
   wiki: function() {
     if (window._sn_published_wiki_body) {
-      return '<div class="sheet-head"><h2 id="sheet-title">AI Infra Summit &middot; Wiki</h2><span class="badge">live Convex</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
+      return '<div class="sheet-head"><h2 id="sheet-title">' + escapeHtml(EVENT_TITLE) + ' &middot; Wiki</h2><span class="badge">live Convex</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
         '<div class="wiki-shell"><aside class="wiki-toc" aria-label="Table of contents"><div class="wiki-toc-label">Source</div><a class="wiki-toc-link active">Published snapshot</a></aside>' +
         '<article class="wiki-article" id="wiki-article">' + window._sn_published_wiki_body + '</article>' +
         '<aside class="wiki-onpage" aria-label="Actions"><div class="wiki-onpage-label">Actions</div><a onclick="window.snPublishWiki && window.snPublishWiki()">Republish</a></aside></div>';
+    }
+    if (window._sn_live && window._sn_live.eventId) {
+      return '<div class="sheet-head"><h2 id="sheet-title">' + escapeHtml(EVENT_TITLE) + ' &middot; Wiki</h2><span class="badge">not published</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
+        '<div class="sheet-section"><h3>Wiki not published yet</h3>' +
+        '<p class="sheet-sub">This room is live. The public wiki appears here only after a host promotes answers and publishes a snapshot. Private notes are excluded.</p>' +
+        '<button type="button" class="sheet-button ghost host-only" onclick="window.snPublishWiki && window.snPublishWiki()">Publish wiki snapshot</button></div>';
     }
     var h = [];
     h.push('<div class="sheet-head"><h2 id="sheet-title">AI Infra Summit &middot; Wiki</h2><span class="badge">v1 &middot; live</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>');
@@ -3122,6 +3157,18 @@ var SHEET_RENDERERS = {
   },
 
   people: function() {
+    if (window._sn_live && Array.isArray(window._sn_live_members)) {
+      var liveRows = window._sn_live_members.slice(0, 50).map(function(p) {
+        var name = escapeHtml(p.displayName || 'Anonymous Guest');
+        var initial = name.charAt(0).toUpperCase() || 'G';
+        return '<div class="people-row"><div class="people-avatar">' + initial + '</div>' +
+          '<div class="people-info"><div class="people-name">' + name + '</div><div class="people-role">Joined this live room</div></div>' +
+          '<span class="people-status">online</span></div>';
+      }).join('');
+      return '<div class="sheet-head"><h2 id="sheet-title">People in the room</h2><span class="badge">' + window._sn_live_members.length + ' online</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
+        '<p class="sheet-sub">Live presence from Convex. Private notes and private markers are never shown here.</p>' +
+        '<div class="people-list">' + (liveRows || '<p class="sheet-sub">No active attendees yet.</p>') + '</div>';
+    }
     var folks = [
       { name: 'Alex Chen', role: 'Founder · Orbital Labs', color: '#d97757', initial: 'A', online: true },
       { name: 'Dario Amodei', role: 'CEO · Anthropic', color: '#a78bfa', initial: 'D', online: true },
@@ -3224,16 +3271,21 @@ var SHEET_RENDERERS = {
     }
     return '<div class="sheet-head"><h2 id="sheet-title">Host console</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
       '<p class="sheet-sub">Claim host on this event with a code, publish the wiki, or rotate your host token to another device.</p>' +
-      // ── Section A: create event (demo) ────────────────────────────
-      '<section class="sheet-block" role="region" aria-label="Create a new event" hidden style="display:none">' +
+      // ── Section A: create a real Convex-backed live event ─────────
+      '<section class="sheet-block" role="region" aria-label="Create a new event">' +
       '<div class="sheet-block-title">Create a new event</div>' +
       '<div class="sheet-field"><label class="sheet-label" for="sheet-host-title">Event title</label>' +
       '<input id="sheet-host-title" class="sheet-input" type="text" placeholder="e.g. Q4 Strategy Offsite" autocapitalize="words" /></div>' +
+      '<div class="sheet-field"><label class="sheet-label" for="sheet-host-room-code">Room code <span style="color:var(--ink-faint);font-weight:400">(optional)</span></label>' +
+      '<input id="sheet-host-room-code" class="sheet-input" type="text" placeholder="e.g. Q4OFFSITE" autocomplete="off" autocapitalize="characters" spellcheck="false" maxlength="24" /></div>' +
+      '<div class="sheet-field"><label class="sheet-label" for="sheet-host-agenda">Starter context <span style="color:var(--ink-faint);font-weight:400">(optional, public)</span></label>' +
+      '<textarea id="sheet-host-agenda" class="sheet-input" rows="3" placeholder="Agenda, speakers, source notes, or what attendees should ask about. Public /ask can use this."></textarea></div>' +
       '<div class="sheet-field"><label class="sheet-label">Template</label>' +
       '<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px"><button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#127908;</span><span style="font-size:11px">Conference</span></button>' +
       '<button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#128295;</span><span style="font-size:11px">Workshop</span></button>' +
       '<button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#9749;</span><span style="font-size:11px">Office hrs</span></button></div></div>' +
-      '<button type="button" class="sheet-button ghost" disabled aria-disabled="true" title="Create event is disabled until the live createEvent mutation ships">Create event unavailable for launch</button>' +
+      '<button type="button" class="sheet-button" id="sn-create-event-btn" onclick="window.snCreateEventFromHostSheet && window.snCreateEventFromHostSheet()">Create live event</button>' +
+      '<div id="sn-create-event-output" class="sn-rotate-output" role="status" aria-live="polite" style="margin-top:10px;display:none"></div>' +
       '</section>' +
       '<div class="sheet-divider" role="separator" aria-hidden="true"></div>' +
       // ── Section B: claim host with one-time code ─────────────────
@@ -3690,21 +3742,24 @@ function refreshNotesBadge() {
 
 // ── Share platform handlers ──
 function copyShareUrl() {
+  refreshEventUrl();
   if (navigator.clipboard) {
     navigator.clipboard.writeText(EVENT_URL).then(function() { toast('Copied', EVENT_URL); haptic(); });
   }
 }
 function shareTo(p) {
+  refreshEventUrl();
   var url = encodeURIComponent(EVENT_URL);
-  var text = encodeURIComponent('Joining the AI Infra Summit on ScratchNode — room code ORBITAL.');
+  var dynamicShareText = 'Joining ' + EVENT_TITLE + ' on ScratchNode - room code ' + EVENT_ROOM_CODE + '.';
+  var text = encodeURIComponent(dynamicShareText);
   if (p === 'native' && navigator.share) {
-    navigator.share({ title: 'AI Infra Summit', text: 'Join — room code ORBITAL', url: EVENT_URL }).catch(function(){});
+    navigator.share({ title: EVENT_TITLE, text: 'Join - room code ' + EVENT_ROOM_CODE, url: EVENT_URL }).catch(function(){});
     closeSheet(); return;
   }
   var dest = {
     twitter: 'https://twitter.com/intent/tweet?text=' + text + '&url=' + url,
     linkedin: 'https://www.linkedin.com/sharing/share-offsite/?url=' + url,
-    email: 'mailto:?subject=' + encodeURIComponent('AI Infra Summit') + '&body=' + text + '%0A%0A' + url
+    email: 'mailto:?subject=' + encodeURIComponent(EVENT_TITLE) + '&body=' + text + '%0A%0A' + url
   }[p];
   if (dest) { window.open(dest, '_blank', 'noopener'); closeSheet(); haptic(); }
 }
@@ -5247,6 +5302,7 @@ window._laCueAction       = _laCueAction;
     return;
   }
   const eventId = joined.eventId;
+  setScratchNodeLiveEventContext(joined);
   window._sn_live = { client, eventId, sessionId, slug };
   window._sn_my_events = {
     joined: [{ eventId, slug: joined.slug, name: joined.name, roomCode: joined.roomCode, status: joined.status, role: 'attendee' }],
@@ -5366,6 +5422,20 @@ window._laCueAction       = _laCueAction;
   client.onUpdate('events:getAnswers', { eventId, limit: 100 }, (rows) => {
     if (!Array.isArray(rows)) return;
     for (const answer of rows) renderAnswer(answer);
+    const faqCount = rows.filter((answer) => answer && answer.faqStatus && answer.faqStatus !== 'none').length;
+    const faqEl = document.getElementById('ev-faq-count');
+    if (faqEl) faqEl.textContent = String(faqCount);
+  });
+  client.onUpdate('events:getMembers', { eventId }, (rows) => {
+    if (!Array.isArray(rows)) return;
+    window._sn_live_members = rows;
+    const count = String(rows.length);
+    const stripCount = document.getElementById('ev-joined-count');
+    if (stripCount) stripCount.textContent = count;
+    const heroCount = document.getElementById('sn-hero-joined-count');
+    if (heroCount) heroCount.textContent = count;
+    const menuPeopleSub = document.getElementById('menu-people-sub');
+    if (menuPeopleSub) menuPeopleSub.textContent = count + ' live member' + (rows.length === 1 ? '' : 's');
   });
 
   // ─── Override the send pipeline to route public chat through Convex ─
@@ -5467,6 +5537,56 @@ window._laCueAction       = _laCueAction;
   // available — expand-contract per
   // .claude/rules/backend_contract_migration.md — but no longer the
   // default path from this UI.
+  window.snCreateEventFromHostSheet = function() {
+    const titleEl = document.getElementById('sheet-host-title');
+    const roomEl = document.getElementById('sheet-host-room-code');
+    const agendaEl = document.getElementById('sheet-host-agenda');
+    const btn = document.getElementById('sn-create-event-btn');
+    const out = document.getElementById('sn-create-event-output');
+    const title = (titleEl && titleEl.value || '').trim();
+    const roomCode = (roomEl && roomEl.value || '').trim();
+    const agendaText = (agendaEl && agendaEl.value || '').trim();
+    if (title.length < 3) {
+      toast('Event title required', 'Add at least 3 characters.');
+      if (titleEl) titleEl.focus();
+      return;
+    }
+    if (btn) {
+      btn.disabled = true;
+      btn.textContent = 'Creating live event...';
+    }
+    if (out) {
+      out.style.display = 'block';
+      out.textContent = 'Creating Convex event room and host token...';
+    }
+    const liveName = (window._userName && String(window._userName).trim()) || 'Host';
+    client.mutation('events:createEvent', {
+      title,
+      sessionId,
+      displayName: liveName,
+      roomCode: roomCode || undefined,
+      agendaText: agendaText || undefined,
+      status: 'live',
+    }).then((res) => {
+      if (!res || !res.eventId || !res.ownerKey) throw new Error('Server did not return the new event.');
+      localStorage.setItem('sn_host_owner_key_v2', res.ownerKey);
+      window._sn_live.hostOwnerKey = res.ownerKey;
+      setScratchNodeLiveEventContext(res);
+      if (out) out.textContent = 'Created room ' + res.roomCode + '. Opening now...';
+      toast('Event created', 'Room code ' + res.roomCode + ' is live.');
+      window.location.assign('/e/' + encodeURIComponent(res.slug || res.roomCode));
+    }).catch((e) => {
+      const msg = (e && e.message) || String(e);
+      if (out) out.textContent = 'Create failed: ' + msg;
+      toast('Create event blocked', msg);
+    }).finally(() => {
+      if (btn) {
+        btn.disabled = false;
+        btn.textContent = 'Create live event';
+      }
+    });
+  };
+
   function _snReadHostOwnerKey() {
     return (
       window._sn_live.hostOwnerKey ||

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -58,6 +58,19 @@ async function fulfillScratchNodePage(
               }
               return Promise.resolve({ messageId: 'liveEventMessages:1' });
             }
+            if (name === 'events:createEvent') {
+              window.__snCreatedEventArgs = args;
+              localStorage.setItem('__snCreatedEventArgs', JSON.stringify(args));
+              return Promise.resolve({
+                ok: true,
+                eventId: 'liveEvents:new',
+                slug: 'launch-room',
+                name: args.title,
+                roomCode: args.roomCode || 'LAUNCH',
+                status: 'live',
+                ownerKey: 'hk1:liveEvents:new:nonce:1770000000000:abcdefabcdefabcdefabcdefabcdef12',
+              });
+            }
             return Promise.resolve({});
           }
           query(name) {
@@ -67,7 +80,11 @@ async function fulfillScratchNodePage(
             return Promise.resolve([]);
           }
           action() { return Promise.resolve(null); }
-          onUpdate() {}
+          onUpdate(name, _args, cb) {
+            if (name === 'events:getMembers') {
+              setTimeout(() => cb([{ displayName: 'Mock Host' }, { displayName: 'Mock Guest' }]), 0);
+            }
+          }
         }
       `,
     });
@@ -140,5 +157,51 @@ test.describe("ScratchNode live route honesty", () => {
       })
       .toBe(0);
     await expect(page.locator("#ci")).toHaveValue("this must not be local-only");
+  });
+
+  test("live wiki and people sheets do not show stale static launch counts", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+
+    await page.evaluate(() => (window as any).openWiki());
+    await expect(page.locator("#sheet-title")).toContainText("AI Infra Summit");
+    await expect(page.locator("#sheet-content")).toContainText("Wiki not published yet");
+    await expect(page.locator("#sheet-content")).not.toContainText("318 attendees");
+    await page.evaluate(() => (window as any).closeSheet());
+
+    await page.evaluate(() => (window as any).openPeople());
+    await expect(page.locator("#sheet-title")).toContainText("People in the room");
+    await expect(page.locator("#sheet-content")).toContainText("Mock Host");
+    await expect(page.locator("#sheet-content")).not.toContainText("318 joined");
+  });
+
+  test("host create event uses live mutation and navigates to the created room", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+
+    await page.evaluate(() => (window as any).openSheet("host"));
+    await expect(page.locator("#sheet-title")).toContainText("Host console");
+    await expect(page.locator("#sn-create-event-btn")).toBeEnabled();
+    await page.fill("#sheet-host-title", "Launch Room");
+    await page.fill("#sheet-host-room-code", "LAUNCH");
+    await page.fill("#sheet-host-agenda", "Public starter source for launch.");
+    await page.click("#sn-create-event-btn");
+
+    await expect
+      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("__snCreatedEventArgs") || "{}")), { timeout: 5_000 })
+      .toMatchObject({
+        title: "Launch Room",
+        roomCode: "LAUNCH",
+        agendaText: "Public starter source for launch.",
+        status: "live",
+      });
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toContain("/e/launch-room");
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("sn_host_owner_key_v2")))
+      .toContain("hk1:");
   });
 });


### PR DESCRIPTION
## Summary

Ships the remaining launch-critical ScratchNode live backend path:

- Adds real Convex event lifecycle mutations: events:createEvent, events:updateEvent, events:endEvent, events:upsertEventSource, events:deleteEventSource.
- Wires Host Console event creation to the live mutation and stores the returned host owner token.
- Removes production demo auto-seeding from public join/ask paths; demo seeding is now dev/explicit only.
- Hardens public chat so attendees cannot spoof system rows.
- Fixes HMAC host token verification by parsing token fields from the right because Convex ids contain colons.
- Makes live UI state honest: dynamic event title/room code/member count/FAQ count, unpublished wiki state, live people sheet, dynamic share copy.
- Extends launch route tests and adds a runbook for future sessions.

## Verification

- npx vitest run convex/__tests__/scratchnode.events.test.ts --testNamePattern "createEvent|event room-code lookup|composeAnswer" --reporter=verbose
- npx playwright test tests/e2e/scratchnode-live-route-honesty.spec.ts --project=chromium --workers=1 --reporter=list
- npx vitest run convex/__tests__/scratchnode.events.test.ts --reporter=verbose
- npx tsc --noEmit --pretty false
- npx playwright test tests/e2e/scratchnode-demo-route-gate.spec.ts tests/e2e/scratchnode-live-route-honesty.spec.ts --project=chromium --workers=1 --reporter=list
- npm run build
- npm run preflight:fast
- npx tsc -p convex --noEmit --pretty false

## Notes

npx convex dev --once --typecheck=enable could not run in this fresh worktree because Convex CLI tried to prompt for project configuration in a non-interactive terminal. The non-interactive Convex TypeScript project check passed via npx tsc -p convex --noEmit --pretty false.
