### PR TITLE
fix(scratchnode): dogfood live host lifecycle

### DIFF
--- a/convex/__tests__/scratchnode.events.test.ts
+++ b/convex/__tests__/scratchnode.events.test.ts
@@ -576,6 +576,19 @@ describe("createEvent - host-created rooms are real Convex rooms", () => {
       roomCode: "SOURCE2",
       status: "live",
     });
+    const joinedByUpdatedRoomCode = await (joinEvent as any)._handler(ctx, {
+      slug: "source2",
+      sessionId: ANONYMOUS_SESSION_B,
+      displayName: "Guest",
+    });
+    expect(joinedByUpdatedRoomCode.eventId).toBe(created.eventId);
+    await expect(
+      (joinEvent as any)._handler(ctx, {
+        slug: "source1",
+        sessionId: "sess_other_guest_123",
+        displayName: "Other Guest",
+      }),
+    ).rejects.toThrow(/event_not_found|not found|No such event slug/);
 
     const source = await (upsertEventSource as any)._handler(ctx, {
       eventId: created.eventId,
@@ -616,6 +629,13 @@ describe("createEvent - host-created rooms are real Convex rooms", () => {
         kind: "chat",
       }),
     ).rejects.toThrow(/event_ended|ended/);
+    await expect(
+      (updateEvent as any)._handler(ctx, {
+        eventId: created.eventId,
+        ownerKey: created.ownerKey,
+        status: "live",
+      }),
+    ).rejects.toThrow(/event_ended|reopened|ended/);
   });
 
   it("attendee cannot spoof system messages", async () => {
@@ -636,6 +656,41 @@ describe("createEvent - host-created rooms are real Convex rooms", () => {
       }),
     ).rejects.toThrow(/not_host|Host ownership/);
     expect(tables.liveEventMessages).toHaveLength(0);
+  });
+
+  it("rate-limits anonymous self-serve event creation", async () => {
+    process.env.CONVEX_DEPLOYMENT = "dev:test";
+    const tables: Tables = {
+      liveEvents: [],
+      liveEventMembers: [],
+      liveEventHosts: [],
+      liveEventSources: [],
+      scratchnodeRateLimits: [],
+    };
+    const ctx = createCtx(tables);
+
+    for (let i = 0; i < 5; i += 1) {
+      await (createEvent as any)._handler(ctx, {
+        title: `Launch QA Room ${i}`,
+        sessionId: ANONYMOUS_SESSION_A,
+        displayName: "Host",
+        status: "live",
+      });
+    }
+
+    await expect(
+      (createEvent as any)._handler(ctx, {
+        title: "Launch QA Room Overflow",
+        sessionId: ANONYMOUS_SESSION_A,
+        displayName: "Host",
+        status: "live",
+      }),
+    ).rejects.toThrow(/Too many requests|rate_limited/);
+    expect(tables.liveEvents).toHaveLength(5);
+    const createLimit = tables.scratchnodeRateLimits.find(
+      (row: any) => row.key === `create:${ANONYMOUS_SESSION_A}`,
+    );
+    expect(createLimit?.count).toBe(5);
   });
 });
 

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1157,6 +1157,15 @@ export const createEvent = mutation({
       });
     }
 
+    // Rate-limit self-serve room creation. Hosts can still manage an existing
+    // room with their host token, but anonymous sessions cannot create an
+    // unbounded number of durable public rooms.
+    await enforceRateLimit(ctx, {
+      key: `create:${args.sessionId}`,
+      limit: 5,
+      windowMs: 10 * 60_000,
+    });
+
     const requestedSlug = normalizeRequestedSlug(args.slug, title);
     const explicitSlug = !!(args.slug && args.slug.trim());
     const existingSlug = await ctx.db
@@ -1306,6 +1315,12 @@ export const updateEvent = mutation({
     const event = await ctx.db.get(eventId);
     if (!event) {
       throw new ConvexError({ code: "event_not_found", message: "Event no longer exists." });
+    }
+    if (event.status === "ended" && status !== undefined) {
+      throw new ConvexError({
+        code: "event_ended",
+        message: "Ended events cannot be reopened.",
+      });
     }
 
     const patch: Record<string, unknown> = {};

--- a/docs/runbooks/SCRATCHNODE_LAUNCH_BACKEND.md
+++ b/docs/runbooks/SCRATCHNODE_LAUNCH_BACKEND.md
@@ -36,6 +36,8 @@ host creates event
 - `/ask` on empty non-demo rooms must fail with `no_sources`, not invent a fake answer.
 - Public `/ask` uses public sources only. Private notes stay outside public feed, public wiki, public trace, and public cache.
 - Host tokens use `hk1:` HMAC format. Parse token fields from the right because Convex ids contain colons.
+- Self-serve event creation is rate-limited per anonymous session. This is a guest-first abuse guard, not a full IP/account quota; public launch monitoring should watch for rotated-session room spam until account-backed host quotas ship.
+- Ended events are terminal for status changes. Hosts can still publish/review, but metadata saves must not reopen public chat.
 
 ## Host controls now live
 
@@ -54,6 +56,18 @@ events:updateEvent
 events:endEvent
 ```
 
+The Host Console exposes the same lifecycle surface:
+
+```text
+Create live event
+Save room details
+Save public source
+Delete last saved source
+Publish wiki snapshot
+End session
+Rotate host claim code
+```
+
 ## Launch verification
 
 Minimum local gate:
@@ -66,6 +80,16 @@ npx playwright test tests/e2e/scratchnode-demo-route-gate.spec.ts tests/e2e/scra
 npm run build
 npm run preflight:fast
 ```
+
+Live backend dogfood gate:
+
+```powershell
+$env:PROTO_DOGFOOD_LIVE="1"
+npx playwright test tests/e2e/proto-live-backend-dogfood.spec.ts --project=chromium --workers=1 --reporter=list
+Remove-Item Env:\PROTO_DOGFOOD_LIVE
+```
+
+The `proto-live-backend-dogfood` suite creates temporary QA rooms in the live backend. If `PROTO_DOGFOOD_LIVE` is not set, the suite intentionally skips and must not be treated as a launch green.
 
 Live smoke after deploy:
 

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -690,6 +690,18 @@ body[data-new-user="true"] .h-menu::after {
 .sheet-block + .sheet-block { margin-top: 4px; }
 .sheet-block-title { font-family: var(--mono); font-size: 10px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-muted); margin-bottom: 8px; }
 .sheet-divider { height: 1px; background: var(--line); margin: 14px 0; }
+.host-console-grid { display: grid; gap: 12px; }
+.host-console-grid + .host-console-grid { margin-top: 12px; }
+.host-status-line { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 10px 12px; border: 1px solid var(--line); border-radius: var(--r-sm); background: rgba(255,255,255,.025); font-size: 12px; color: var(--ink-muted); }
+.host-status-line b { color: var(--ink); font-weight: 650; }
+.host-status-line code { font-family: var(--mono); color: var(--accent); }
+.host-action-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.sheet-button.danger { background: rgba(185,78,68,.12); border: 1px solid rgba(185,78,68,.45); color: #f4b3aa; }
+.sheet-button.danger:hover { background: rgba(185,78,68,.18); border-color: rgba(185,78,68,.7); }
+@media (max-width: 520px) {
+  .host-action-row { grid-template-columns: 1fr; }
+  .host-status-line { align-items: flex-start; flex-direction: column; }
+}
 .sn-rotate-output { padding: 10px 12px; border: 1px solid rgba(217,119,87,.25); border-radius: var(--r-sm); background: rgba(217,119,87,.05); font-family: var(--mono); font-size: 12px; color: var(--ink); word-break: break-all; }
 .sn-rotate-output .sn-rotate-code { display: block; margin-bottom: 6px; font-size: 13px; letter-spacing: .04em; color: var(--accent); }
 .sn-rotate-output .sn-rotate-hint { display: block; font-size: 10px; color: var(--ink-faint); font-family: var(--ui); margin-top: 6px; }
@@ -3247,8 +3259,8 @@ var SHEET_RENDERERS = {
   },
 
   host: function() {
-    // Two parallel paths, plus an optional host-only rotation panel.
-    // Path 1: Create a brand-new event (demo-only — toast & close).
+    // Two public paths, plus host-only management once a real token verifies.
+    // Path 1: Create a brand-new Convex-backed event.
     // Path 2: Claim host on THIS event by typing a one-time code from
     //         another device. Calls events:claimHostWithCode.
     // Path 3 (host-only): Mint a new claim code to migrate to a fresh
@@ -3257,9 +3269,39 @@ var SHEET_RENDERERS = {
     //         existingOwnerKey, then renders the plaintext code.
     var isRealAuthHost =
       document.body.getAttribute('data-role') === 'host' &&
-      !!localStorage.getItem('sn_host_owner_key_v2');
+      !!(window._sn_live && window._sn_live.hostVerified && window._sn_live.hostOwnerKey);
+    var managementPanel = '';
     var rotationPanel = '';
     if (isRealAuthHost) {
+      managementPanel =
+        '<div class="sheet-divider" role="separator" aria-hidden="true"></div>' +
+        '<section class="sheet-block" role="region" aria-label="Manage live event">' +
+        '<div class="sheet-block-title">Manage this live room</div>' +
+        '<div class="host-console-grid">' +
+        '<div class="host-status-line"><span><b>' + escapeHtml(EVENT_TITLE) + '</b></span><code>' + escapeHtml(EVENT_ROOM_CODE) + '</code></div>' +
+        '<div class="sheet-field"><label class="sheet-label" for="sheet-host-update-title">Event title</label>' +
+        '<input id="sheet-host-update-title" class="sheet-input" type="text" value="' + escapeHtml(EVENT_TITLE) + '" /></div>' +
+        '<div class="sheet-field"><label class="sheet-label" for="sheet-host-update-room-code">Room code</label>' +
+        '<input id="sheet-host-update-room-code" class="sheet-input" type="text" value="' + escapeHtml(EVENT_ROOM_CODE) + '" autocomplete="off" autocapitalize="characters" spellcheck="false" maxlength="24" /></div>' +
+        '<div class="host-action-row"><button type="button" class="sheet-button ghost" id="sn-update-event-btn" onclick="window.snUpdateEventFromHostSheet && window.snUpdateEventFromHostSheet()">Save room details</button>' +
+        '<button type="button" class="sheet-button danger" id="sn-end-event-btn" onclick="window.snEndEventFromHostSheet && window.snEndEventFromHostSheet()">End session</button></div>' +
+        '</div>' +
+        '<div id="sn-manage-event-output" class="sn-rotate-output" role="status" aria-live="polite" style="margin-top:10px;display:none"></div>' +
+        '</section>' +
+        '<div class="sheet-divider" role="separator" aria-hidden="true"></div>' +
+        '<section class="sheet-block" role="region" aria-label="Manage public sources">' +
+        '<div class="sheet-block-title">Public source context</div>' +
+        '<p class="sheet-sub" style="margin-bottom:10px">Add bounded public context for /ask. Private notes are never copied here.</p>' +
+        '<div class="sheet-field"><label class="sheet-label" for="sheet-host-source-title">Source title</label>' +
+        '<input id="sheet-host-source-title" class="sheet-input" type="text" placeholder="Agenda, transcript, speaker notes" /></div>' +
+        '<div class="sheet-field"><label class="sheet-label" for="sheet-host-source-uri">Source URI <span style="color:var(--ink-faint);font-weight:400">(optional)</span></label>' +
+        '<input id="sheet-host-source-uri" class="sheet-input" type="text" placeholder="https://... or doc://..." inputmode="url" /></div>' +
+        '<div class="sheet-field"><label class="sheet-label" for="sheet-host-source-body">Public source body</label>' +
+        '<textarea id="sheet-host-source-body" class="sheet-input" rows="4" placeholder="Paste public source text the room agent may cite."></textarea></div>' +
+        '<div class="host-action-row"><button type="button" class="sheet-button" id="sn-save-source-btn" onclick="window.snUpsertEventSourceFromHostSheet && window.snUpsertEventSourceFromHostSheet()">Save public source</button>' +
+        '<button type="button" class="sheet-button ghost" id="sn-delete-source-btn" onclick="window.snDeleteLastEventSource && window.snDeleteLastEventSource()">Delete last saved source</button></div>' +
+        '<div id="sn-source-output" class="sn-rotate-output" role="status" aria-live="polite" style="margin-top:10px;display:none"></div>' +
+        '</section>';
       rotationPanel =
         '<div class="sheet-divider" role="separator" aria-hidden="true"></div>' +
         '<section class="sheet-block" role="region" aria-label="Rotate host to a new device">' +
@@ -3271,6 +3313,7 @@ var SHEET_RENDERERS = {
     }
     return '<div class="sheet-head"><h2 id="sheet-title">Host console</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
       '<p class="sheet-sub">Claim host on this event with a code, publish the wiki, or rotate your host token to another device.</p>' +
+      managementPanel +
       // ── Section A: create a real Convex-backed live event ─────────
       '<section class="sheet-block" role="region" aria-label="Create a new event">' +
       '<div class="sheet-block-title">Create a new event</div>' +
@@ -3280,10 +3323,7 @@ var SHEET_RENDERERS = {
       '<input id="sheet-host-room-code" class="sheet-input" type="text" placeholder="e.g. Q4OFFSITE" autocomplete="off" autocapitalize="characters" spellcheck="false" maxlength="24" /></div>' +
       '<div class="sheet-field"><label class="sheet-label" for="sheet-host-agenda">Starter context <span style="color:var(--ink-faint);font-weight:400">(optional, public)</span></label>' +
       '<textarea id="sheet-host-agenda" class="sheet-input" rows="3" placeholder="Agenda, speakers, source notes, or what attendees should ask about. Public /ask can use this."></textarea></div>' +
-      '<div class="sheet-field"><label class="sheet-label">Template</label>' +
-      '<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px"><button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#127908;</span><span style="font-size:11px">Conference</span></button>' +
-      '<button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#128295;</span><span style="font-size:11px">Workshop</span></button>' +
-      '<button type="button" class="share-tile" style="padding:10px;flex-direction:column;align-items:center;text-align:center;gap:4px"><span class="icon">&#9749;</span><span style="font-size:11px">Office hrs</span></button></div></div>' +
+      '<div class="host-status-line"><span>Creates a live room, joins you as host, and seeds one public source.</span><code>Convex</code></div>' +
       '<button type="button" class="sheet-button" id="sn-create-event-btn" onclick="window.snCreateEventFromHostSheet && window.snCreateEventFromHostSheet()">Create live event</button>' +
       '<div id="sn-create-event-output" class="sn-rotate-output" role="status" aria-live="polite" style="margin-top:10px;display:none"></div>' +
       '</section>' +
@@ -5303,7 +5343,7 @@ window._laCueAction       = _laCueAction;
   }
   const eventId = joined.eventId;
   setScratchNodeLiveEventContext(joined);
-  window._sn_live = { client, eventId, sessionId, slug };
+  window._sn_live = { client, eventId, sessionId, slug, hostVerified: false };
   window._sn_my_events = {
     joined: [{ eventId, slug: joined.slug, name: joined.name, roomCode: joined.roomCode, status: joined.status, role: 'attendee' }],
     hosted: []
@@ -5570,7 +5610,7 @@ window._laCueAction       = _laCueAction;
     }).then((res) => {
       if (!res || !res.eventId || !res.ownerKey) throw new Error('Server did not return the new event.');
       localStorage.setItem('sn_host_owner_key_v2', res.ownerKey);
-      window._sn_live.hostOwnerKey = res.ownerKey;
+      _snSetVerifiedHost(res.ownerKey);
       setScratchNodeLiveEventContext(res);
       if (out) out.textContent = 'Created room ' + res.roomCode + '. Opening now...';
       toast('Event created', 'Room code ' + res.roomCode + ' is live.');
@@ -5585,6 +5625,186 @@ window._laCueAction       = _laCueAction;
         btn.textContent = 'Create live event';
       }
     });
+  };
+
+  function _snSetHostOutput(id, message) {
+    const out = document.getElementById(id);
+    if (!out) return;
+    out.style.display = 'block';
+    out.textContent = message;
+  }
+
+  function _snSetButtonBusy(id, busy, label) {
+    const btn = document.getElementById(id);
+    if (!btn) return;
+    btn.disabled = !!busy;
+    if (label) btn.textContent = label;
+  }
+
+  function _snSetVerifiedHost(ownerKey) {
+    if (!ownerKey) return;
+    document.body.setAttribute('data-role', 'host');
+    window._sn_live.hostOwnerKey = ownerKey;
+    window._sn_live.hostVerified = true;
+    var sheetContent = document.getElementById('sheet-content');
+    var alreadyShowingManagement = sheetContent && /Manage this live room/.test(sheetContent.textContent || '');
+    if (
+      document.getElementById('sheet-title') &&
+      document.getElementById('sheet-title').textContent === 'Host console' &&
+      !alreadyShowingManagement
+    ) {
+      setTimeout(function() { if (typeof openSheet === 'function') openSheet('host'); }, 0);
+    }
+  }
+
+  function _snClearVerifiedHost() {
+    window._sn_live.hostOwnerKey = null;
+    window._sn_live.hostVerified = false;
+    document.body.setAttribute('data-role', 'attendee');
+  }
+
+  function _snRequireVerifiedHostOwnerKey(outputId) {
+    const ownerKey = window._sn_live && window._sn_live.hostVerified && window._sn_live.hostOwnerKey;
+    if (ownerKey) return ownerKey;
+    _snSetHostOutput(outputId || 'sn-manage-event-output', 'Host controls require a freshly verified host token.');
+    toast('Host verification required', 'Re-open Host Console after your token verifies, or claim host with a code.');
+    return null;
+  }
+
+  window.snUpdateEventFromHostSheet = function() {
+    const ownerKey = _snRequireVerifiedHostOwnerKey('sn-manage-event-output');
+    if (!ownerKey) return;
+    const titleEl = document.getElementById('sheet-host-update-title');
+    const roomEl = document.getElementById('sheet-host-update-room-code');
+    const title = (titleEl && titleEl.value || '').trim();
+    const roomCode = (roomEl && roomEl.value || '').trim();
+    if (title.length < 3) {
+      toast('Event title required', 'Add at least 3 characters.');
+      if (titleEl) titleEl.focus();
+      return;
+    }
+    if (roomCode.length < 2) {
+      toast('Room code required', 'Use 2-24 letters, numbers, or dashes.');
+      if (roomEl) roomEl.focus();
+      return;
+    }
+    _snSetButtonBusy('sn-update-event-btn', true, 'Saving...');
+    _snSetHostOutput('sn-manage-event-output', 'Saving event metadata...');
+    client.mutation('events:updateEvent', {
+      eventId,
+      ownerKey,
+      title,
+      roomCode,
+    }).then((res) => {
+      setScratchNodeLiveEventContext(res);
+      _snSetHostOutput('sn-manage-event-output', 'Saved room ' + res.roomCode + '. Share URL updated.');
+      toast('Room updated', 'Title and room code are live.');
+      if (window.snRefreshMyEvents) window.snRefreshMyEvents();
+    }).catch((e) => {
+      const msg = (e && e.message) || String(e);
+      _snSetHostOutput('sn-manage-event-output', 'Update failed: ' + msg);
+      toast('Update blocked', msg);
+    }).finally(() => {
+      _snSetButtonBusy('sn-update-event-btn', false, 'Save room details');
+    });
+  };
+
+  window.snUpsertEventSourceFromHostSheet = function() {
+    const ownerKey = _snRequireVerifiedHostOwnerKey('sn-source-output');
+    if (!ownerKey) return;
+    const titleEl = document.getElementById('sheet-host-source-title');
+    const uriEl = document.getElementById('sheet-host-source-uri');
+    const bodyEl = document.getElementById('sheet-host-source-body');
+    const title = (titleEl && titleEl.value || '').trim();
+    const uri = (uriEl && uriEl.value || '').trim();
+    const body = (bodyEl && bodyEl.value || '').trim();
+    if (title.length < 3) {
+      toast('Source title required', 'Name the public context before saving.');
+      if (titleEl) titleEl.focus();
+      return;
+    }
+    if (body.length < 20) {
+      toast('Source body too short', 'Add enough public context for a sourced answer.');
+      if (bodyEl) bodyEl.focus();
+      return;
+    }
+    _snSetButtonBusy('sn-save-source-btn', true, 'Saving source...');
+    _snSetHostOutput('sn-source-output', 'Saving public source context...');
+    client.mutation('events:upsertEventSource', {
+      eventId,
+      ownerKey,
+      title,
+      uri: uri || undefined,
+      body,
+      excerpt: body.slice(0, 240),
+      kind: 'doc',
+    }).then((res) => {
+      window._sn_live.lastSourceId = res.sourceId;
+      try { localStorage.setItem('sn_last_event_source_' + eventId, res.sourceId); } catch (e) {}
+      _snSetHostOutput('sn-source-output', (res.created ? 'Saved' : 'Updated') + ' public source. /ask can now cite it.');
+      toast(res.created ? 'Source saved' : 'Source updated', 'Public /ask context is ready.');
+    }).catch((e) => {
+      const msg = (e && e.message) || String(e);
+      _snSetHostOutput('sn-source-output', 'Source save failed: ' + msg);
+      toast('Source blocked', msg);
+    }).finally(() => {
+      _snSetButtonBusy('sn-save-source-btn', false, 'Save public source');
+    });
+  };
+
+  window.snDeleteLastEventSource = function() {
+    const ownerKey = _snRequireVerifiedHostOwnerKey('sn-source-output');
+    if (!ownerKey) return;
+    let sourceId = window._sn_live.lastSourceId;
+    try { sourceId = sourceId || localStorage.getItem('sn_last_event_source_' + eventId); } catch (e) {}
+    if (!sourceId) {
+      _snSetHostOutput('sn-source-output', 'No source from this device to delete yet.');
+      toast('No source selected', 'Save a source first, then delete it if needed.');
+      return;
+    }
+    _snSetButtonBusy('sn-delete-source-btn', true, 'Deleting...');
+    _snSetHostOutput('sn-source-output', 'Deleting last saved source...');
+    client.mutation('events:deleteEventSource', {
+      eventId,
+      ownerKey,
+      sourceId,
+    }).then(() => {
+      window._sn_live.lastSourceId = null;
+      try { localStorage.removeItem('sn_last_event_source_' + eventId); } catch (e) {}
+      _snSetHostOutput('sn-source-output', 'Deleted the last source saved from this device.');
+      toast('Source deleted', 'The public corpus was updated.');
+    }).catch((e) => {
+      const msg = (e && e.message) || String(e);
+      _snSetHostOutput('sn-source-output', 'Delete failed: ' + msg);
+      toast('Delete blocked', msg);
+    }).finally(() => {
+      _snSetButtonBusy('sn-delete-source-btn', false, 'Delete last saved source');
+    });
+  };
+
+  window.snEndEventFromHostSheet = function() {
+    const ownerKey = _snRequireVerifiedHostOwnerKey('sn-manage-event-output');
+    if (!ownerKey) return;
+    const ok = window.confirm('End this live session? Attendees will no longer be able to post new public messages.');
+    if (!ok) return;
+    _snSetButtonBusy('sn-end-event-btn', true, 'Ending...');
+    _snSetHostOutput('sn-manage-event-output', 'Ending live session...');
+    client.mutation('events:endEvent', { eventId, ownerKey })
+      .then((res) => {
+        setScratchNodeLiveEventContext({ status: res.status || 'ended' });
+        window._sn_live.eventStatus = 'ended';
+        _snSetHostOutput('sn-manage-event-output', 'Session ended. Public chat is now closed for this event.');
+        toast('Session ended', 'Public sends are blocked for this room.');
+        if (window.snRefreshMyEvents) window.snRefreshMyEvents();
+      })
+      .catch((e) => {
+        const msg = (e && e.message) || String(e);
+        _snSetHostOutput('sn-manage-event-output', 'End session failed: ' + msg);
+        toast('End session blocked', msg);
+      })
+      .finally(() => {
+        _snSetButtonBusy('sn-end-event-btn', false, 'End session');
+      });
   };
 
   function _snReadHostOwnerKey() {
@@ -5605,18 +5825,19 @@ window._laCueAction       = _laCueAction;
       client.query('events:getHostStatus', { eventId, ownerKey: existingV2 })
         .then((status) => {
           if (status && status.isHost) {
-            document.body.setAttribute('data-role', 'host');
-            window._sn_live.hostOwnerKey = existingV2;
+            _snSetVerifiedHost(existingV2);
             if (window.snRefreshMyEvents) window.snRefreshMyEvents();
             toast('Host console re-enabled', 'Welcome back, ' + (status.displayName || hostName) + '.');
           } else {
             // Token didn't verify — clear it and re-prompt.
             localStorage.removeItem('sn_host_owner_key_v2');
+            _snClearVerifiedHost();
             window.snClaimHost();
           }
         })
         .catch(() => {
           localStorage.removeItem('sn_host_owner_key_v2');
+          _snClearVerifiedHost();
           toast('Host token expired', 'Please re-claim host with a fresh code.');
         });
       return;
@@ -5666,8 +5887,7 @@ window._laCueAction       = _laCueAction;
           if (!claimRes) return; // user backed out
           const newToken = claimRes.ownerKey;
           localStorage.setItem('sn_host_owner_key_v2', newToken);
-          document.body.setAttribute('data-role', 'host');
-          window._sn_live.hostOwnerKey = newToken;
+          _snSetVerifiedHost(newToken);
           if (window.snRefreshMyEvents) window.snRefreshMyEvents();
           toast('Host console enabled', 'Real-auth host token issued and saved.');
         })
@@ -5686,8 +5906,7 @@ window._laCueAction       = _laCueAction;
         const newToken = claimRes && claimRes.ownerKey;
         if (!newToken) throw new Error('Server did not return a host token.');
         localStorage.setItem('sn_host_owner_key_v2', newToken);
-        document.body.setAttribute('data-role', 'host');
-        window._sn_live.hostOwnerKey = newToken;
+        _snSetVerifiedHost(newToken);
         if (window.snRefreshMyEvents) window.snRefreshMyEvents();
         toast('Host console enabled', 'Code verified — host token issued.');
       })
@@ -5727,8 +5946,7 @@ window._laCueAction       = _laCueAction;
         const newToken = claimRes && claimRes.ownerKey;
         if (!newToken) throw new Error('Server did not return a host token.');
         localStorage.setItem('sn_host_owner_key_v2', newToken);
-        document.body.setAttribute('data-role', 'host');
-        window._sn_live.hostOwnerKey = newToken;
+        _snSetVerifiedHost(newToken);
         if (window.snRefreshMyEvents) window.snRefreshMyEvents();
         if (input) input.value = '';
         toast('You are now host', 'Code verified — host token issued.');
@@ -5828,9 +6046,10 @@ window._laCueAction       = _laCueAction;
     ownerKey: _bootstrapKey,
   }).then((status) => {
     if (status && status.isHost) {
-      document.body.setAttribute('data-role', 'host');
-      window._sn_live.hostOwnerKey = _bootstrapKey;
+      _snSetVerifiedHost(_bootstrapKey);
       if (window.snRefreshMyEvents) window.snRefreshMyEvents();
+    } else {
+      window._sn_live.hostVerified = false;
     }
   }).catch(() => {});
 

--- a/tests/e2e/proto-live-backend-dogfood.spec.ts
+++ b/tests/e2e/proto-live-backend-dogfood.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 const RUN_LIVE = process.env.PROTO_DOGFOOD_LIVE === "1";
 const SCRATCHNODE_APEX_URL = process.env.SCRATCHNODE_APEX_URL ?? "https://scratchnode.live/";
@@ -9,6 +9,7 @@ const SCRATCHNODE_EVENT_URL =
 const NODEBENCH_V4_URL =
   process.env.NODEBENCH_V4_URL ?? "https://www.nodebenchai.com/proto/home-v4.html";
 const ARTIFACT_DIR = join(process.cwd(), ".tmp", "proto-live-backend-dogfood");
+const HOME_V5_HTML = readFileSync(resolve("public/proto/home-v5.html"), "utf8");
 
 test.skip(!RUN_LIVE, "Set PROTO_DOGFOOD_LIVE=1 to run real production backend dogfood.");
 test.describe.configure({ mode: "serial", timeout: 180_000 });
@@ -35,6 +36,19 @@ async function waitForScratchNodeLive(page: import("@playwright/test").Page) {
       phases: "1,2,3,4,5",
       eventId: expect.any(String),
     });
+}
+
+async function routeLocalScratchNodeHome(
+  target: import("@playwright/test").BrowserContext | import("@playwright/test").Page,
+) {
+  const scratchnodeOrigin = new URL(SCRATCHNODE_APEX_URL).origin;
+  await target.route(`${scratchnodeOrigin}/**`, async (route) => {
+    if (route.request().resourceType() === "document") {
+      await route.fulfill({ status: 200, contentType: "text/html", body: HOME_V5_HTML });
+      return;
+    }
+    await route.fallback();
+  });
 }
 
 async function sendComposer(page: import("@playwright/test").Page, text: string) {
@@ -84,6 +98,8 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
   const qaId = `proto-v5-${Date.now()}`;
   const contextA = await browser.newContext();
   const contextB = await browser.newContext();
+  await routeLocalScratchNodeHome(contextA);
+  await routeLocalScratchNodeHome(contextB);
   const pageA = await contextA.newPage();
   const pageB = await contextB.newPage();
 
@@ -376,11 +392,137 @@ test("home-v5 runs the live Convex event-room loop across shipped phases", async
   }
 });
 
+test("home-v5 dogfoods host-created room lifecycle against the live backend", async ({ browser }) => {
+  mkdirSync(ARTIFACT_DIR, { recursive: true });
+  const qaId = `proto-v5-create-${Date.now()}`;
+  const roomCode = `QA${Date.now().toString(36).toUpperCase().slice(-8)}`;
+  const updatedRoomCode = `${roomCode}B`.slice(0, 24);
+  const hostContext = await browser.newContext();
+  const guestContext = await browser.newContext();
+  await routeLocalScratchNodeHome(hostContext);
+  await routeLocalScratchNodeHome(guestContext);
+  const hostPage = await hostContext.newPage();
+  const guestPage = await guestContext.newPage();
+
+  try {
+    await hostPage.goto(withQa(SCRATCHNODE_EVENT_URL, `${qaId}-host`), {
+      waitUntil: "domcontentloaded",
+      timeout: 45_000,
+    });
+    await waitForScratchNodeLive(hostPage);
+
+    await hostPage.evaluate(() => (window as any).openSheet("host"));
+    await expect(hostPage.locator("#sheet-title")).toContainText("Host console");
+    await hostPage.fill("#sheet-host-title", `QA Dogfood Room ${qaId}`);
+    await hostPage.fill("#sheet-host-room-code", roomCode);
+    await hostPage.fill(
+      "#sheet-host-agenda",
+      "Production dogfood room for ScratchNode live backend lifecycle verification.",
+    );
+    await hostPage.click("#sn-create-event-btn");
+    await expect.poll(() => hostPage.url(), { timeout: 30_000 }).toContain("/e/");
+    await waitForScratchNodeLive(hostPage);
+    await expect
+      .poll(() => hostPage.evaluate(() => localStorage.getItem("sn_host_owner_key_v2")), {
+        timeout: 15_000,
+      })
+      .toContain("hk1:");
+    await expect.poll(() => waitForHostRole(hostPage, 1_000), { timeout: 15_000 }).toBe(true);
+
+    await hostPage.evaluate(() => (window as any).openSheet("host"));
+    await expect(hostPage.locator("#sheet-content")).toContainText("Manage this live room");
+    await hostPage.fill("#sheet-host-update-title", `QA Dogfood Room ${qaId} Updated`);
+    await hostPage.fill("#sheet-host-update-room-code", updatedRoomCode);
+    await hostPage.click("#sn-update-event-btn");
+    await expect(hostPage.locator("#sn-manage-event-output")).toContainText("Saved room", {
+      timeout: 15_000,
+    });
+
+    await hostPage.fill("#sheet-host-source-title", "QA lifecycle source");
+    await hostPage.fill("#sheet-host-source-uri", `doc://${qaId}/source`);
+    await hostPage.fill(
+      "#sheet-host-source-body",
+      "QA lifecycle source: the host-created ScratchNode room can add public source context, answer public questions from that source, and exclude private notes.",
+    );
+    await hostPage.click("#sn-save-source-btn");
+    await expect(hostPage.locator("#sn-source-output")).toContainText("public source", {
+      timeout: 15_000,
+    });
+
+    await guestPage.goto(withQa(`${new URL(SCRATCHNODE_EVENT_URL).origin}/e/${updatedRoomCode.toLowerCase()}`, `${qaId}-guest`), {
+      waitUntil: "domcontentloaded",
+      timeout: 45_000,
+    });
+    await waitForScratchNodeLive(guestPage);
+
+    const chatText = `QA created room chat ${qaId}`;
+    await sendComposer(hostPage, chatText);
+    await expect
+      .poll(
+        () =>
+          guestPage.evaluate((text) =>
+            Array.from(document.querySelectorAll(".row-text")).some((node) =>
+              node.textContent?.includes(text),
+            ),
+          chatText),
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+
+    const question = `what does the QA lifecycle source prove ${qaId}`;
+    await sendComposer(hostPage, `/ask ${question}`);
+    await expect
+      .poll(() => findAnswerForQuestion(hostPage, question), { timeout: 60_000 })
+      .toMatchObject({ id: expect.any(String) });
+    const answer = await findAnswerForQuestion(hostPage, question);
+    expect(answer?.text).toContain("no private notes");
+    expect(answer?.id).toBeTruthy();
+    const answerRecord = await queryAnswer(hostPage, answer!.id!);
+    expect(answerRecord?.sources.some((source: any) => source.title === "QA lifecycle source")).toBe(true);
+
+    await hostPage.click("#sn-delete-source-btn");
+    await expect(hostPage.locator("#sn-source-output")).toContainText("Deleted the last source", {
+      timeout: 15_000,
+    });
+
+    await hostPage.once("dialog", (dialog) => dialog.accept());
+    await hostPage.click("#sn-end-event-btn");
+    await expect(hostPage.locator("#sn-manage-event-output")).toContainText("Session ended", {
+      timeout: 15_000,
+    });
+
+    const endedSend = await hostPage.evaluate(async () => {
+      const live = (window as any)._sn_live;
+      try {
+        await live.client.mutation("events:sendMessage", {
+          eventId: live.eventId,
+          sessionId: live.sessionId,
+          displayName: "QA Host",
+          text: "should not send after end",
+          kind: "chat",
+        });
+        return { blocked: false };
+      } catch (err: any) {
+        return { blocked: true, message: String(err?.message ?? err) };
+      }
+    });
+    expect(endedSend.blocked).toBe(true);
+
+    await hostPage.screenshot({
+      path: join(ARTIFACT_DIR, `${qaId}-host-created-lifecycle.png`),
+      fullPage: true,
+    });
+  } finally {
+    await hostContext.close();
+    await guestContext.close();
+  }
+});
+
 test("home-v5 runDemoFull emits evaluated L1/L2/L3 output envelopes", async ({ page }) => {
   mkdirSync(ARTIFACT_DIR, { recursive: true });
   const qaId = `proto-v5-contract-${Date.now()}`;
-  const parsed = new URL(SCRATCHNODE_EVENT_URL);
-  parsed.searchParams.set("demo", "1");
+  await routeLocalScratchNodeHome(page);
+  const parsed = new URL("/demo_ver1", SCRATCHNODE_APEX_URL);
   parsed.searchParams.set("demoSpeed", "instant");
   parsed.searchParams.set("qa", qaId);
 
@@ -438,6 +580,7 @@ test("home-v5 Phase 4 host-auth surface rejects unauthorized requestHostClaim an
   mkdirSync(ARTIFACT_DIR, { recursive: true });
   const qaId = `proto-v5-phase4-${Date.now()}`;
   const context = await browser.newContext();
+  await routeLocalScratchNodeHome(context);
   const page = await context.newPage();
 
   try {

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -71,12 +71,42 @@ async function fulfillScratchNodePage(
                 ownerKey: 'hk1:liveEvents:new:nonce:1770000000000:abcdefabcdefabcdefabcdefabcdef12',
               });
             }
+            if (name === 'events:updateEvent') {
+              window.__snUpdatedEventArgs = args;
+              localStorage.setItem('__snUpdatedEventArgs', JSON.stringify(args));
+              return Promise.resolve({
+                ok: true,
+                eventId: args.eventId,
+                slug: 'ai-infra-summit-2026',
+                name: args.title,
+                roomCode: args.roomCode,
+                status: args.status || 'live',
+              });
+            }
+            if (name === 'events:upsertEventSource') {
+              window.__snUpsertedSourceArgs = args;
+              localStorage.setItem('__snUpsertedSourceArgs', JSON.stringify(args));
+              return Promise.resolve({ ok: true, sourceId: 'liveEventSources:qa', created: true });
+            }
+            if (name === 'events:deleteEventSource') {
+              window.__snDeletedSourceArgs = args;
+              localStorage.setItem('__snDeletedSourceArgs', JSON.stringify(args));
+              return Promise.resolve({ ok: true, sourceId: args.sourceId });
+            }
+            if (name === 'events:endEvent') {
+              window.__snEndedEventArgs = args;
+              localStorage.setItem('__snEndedEventArgs', JSON.stringify(args));
+              return Promise.resolve({ ok: true, eventId: args.eventId, status: 'ended' });
+            }
             return Promise.resolve({});
           }
           query(name) {
             if (name === 'events:getMyEvents') return Promise.resolve({ joined: [], hosted: [] });
             if (name === 'events:getPublishedWiki') return Promise.resolve(null);
-            if (name === 'events:getHostStatus') return Promise.resolve({ isHost: false });
+            if (name === 'events:getHostStatus') {
+              const token = localStorage.getItem('sn_host_owner_key_v2');
+              return Promise.resolve(token ? { isHost: true, role: 'owner', displayName: 'Mock Host' } : { isHost: false });
+            }
             return Promise.resolve([]);
           }
           action() { return Promise.resolve(null); }
@@ -186,9 +216,12 @@ test.describe("ScratchNode live route honesty", () => {
     await page.evaluate(() => (window as any).openSheet("host"));
     await expect(page.locator("#sheet-title")).toContainText("Host console");
     await expect(page.locator("#sn-create-event-btn")).toBeEnabled();
-    await page.fill("#sheet-host-title", "Launch Room");
-    await page.fill("#sheet-host-room-code", "LAUNCH");
-    await page.fill("#sheet-host-agenda", "Public starter source for launch.");
+    await page.evaluate(() => {
+      (document.getElementById("sheet-host-title") as HTMLInputElement).value = "Launch Room";
+      (document.getElementById("sheet-host-room-code") as HTMLInputElement).value = "LAUNCH";
+      (document.getElementById("sheet-host-agenda") as HTMLTextAreaElement).value = "Public starter source for launch.";
+    });
+    await expect(page.locator("#sheet-host-room-code")).toHaveValue("LAUNCH");
     await page.click("#sn-create-event-btn");
 
     await expect
@@ -203,5 +236,58 @@ test.describe("ScratchNode live route honesty", () => {
     await expect
       .poll(() => page.evaluate(() => localStorage.getItem("sn_host_owner_key_v2")))
       .toContain("hk1:");
+  });
+
+  test("verified host can manage room metadata, public sources, and end session", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+    page.on("dialog", (dialog) => dialog.accept());
+    await page.addInitScript(() => {
+      localStorage.setItem("sn_host_owner_key_v2", "hk1:liveEvents:1:nonce:1770000000000:abcdefabcdefabcdefabcdefabcdef12");
+    });
+
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+    await expect.poll(() => page.evaluate(() => document.body.getAttribute("data-role")), { timeout: 5_000 }).toBe("host");
+    await expect.poll(() => page.evaluate(() => (window as any)._sn_live?.hostVerified === true), { timeout: 5_000 }).toBe(true);
+    await page.evaluate(() => (window as any).openSheet("host"));
+
+    await expect(page.locator("#sheet-content")).toContainText("Manage this live room");
+    await expect(page.locator("#sheet-content")).toContainText("Public source context");
+    await page.fill("#sheet-host-update-title", "Launch QA Room");
+    await page.fill("#sheet-host-update-room-code", "QA-ROOM");
+    await page.click("#sn-update-event-btn");
+    await expect
+      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("__snUpdatedEventArgs") || "{}")), { timeout: 5_000 })
+      .toMatchObject({ title: "Launch QA Room", roomCode: "QA-ROOM" });
+    await expect
+      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("__snUpdatedEventArgs") || "{}").status ?? null), { timeout: 5_000 })
+      .toBeNull();
+    await expect(page.locator("#sn-manage-event-output")).toContainText("Saved room QA-ROOM");
+
+    await page.fill("#sheet-host-source-title", "Launch source");
+    await page.fill("#sheet-host-source-uri", "doc://launch/source");
+    await page.fill("#sheet-host-source-body", "This is public launch source context for the event ask runtime and wiki.");
+    await page.click("#sn-save-source-btn");
+    await expect
+      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("__snUpsertedSourceArgs") || "{}")), { timeout: 5_000 })
+      .toMatchObject({
+        title: "Launch source",
+        uri: "doc://launch/source",
+        kind: "doc",
+      });
+    await expect(page.locator("#sn-source-output")).toContainText("Saved public source");
+
+    await page.click("#sn-delete-source-btn");
+    await expect
+      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("__snDeletedSourceArgs") || "{}")), { timeout: 5_000 })
+      .toMatchObject({ sourceId: "liveEventSources:qa" });
+    await expect(page.locator("#sn-source-output")).toContainText("Deleted the last source");
+
+    await page.click("#sn-end-event-btn");
+    await expect
+      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("__snEndedEventArgs") || "{}")), { timeout: 5_000 })
+      .toMatchObject({ eventId: "liveEvents:1" });
+    await expect(page.locator("#sn-manage-event-output")).toContainText("Session ended");
+    await expect(page.locator("#ev-mode-label")).toContainText("ended");
   });
 });


### PR DESCRIPTION
## What changed
- Polished the ScratchNode Host Console so verified hosts can create rooms, update title/code, save/delete public source context, and end sessions from one live panel.
- Hardened live backend semantics: self-serve event creation is rate-limited, ended events cannot be reopened via metadata saves, system messages stay host-only, and updated room codes are covered through the real join resolver.
- Tightened host UI authority: destructive/manage controls render only after `events:getHostStatus` or a fresh claim verifies the host token, not just localStorage.
- Expanded launch QA: live route honesty, demo-route isolation, host lifecycle, source-backed `/ask`, end-session blocking, and a production-gated dogfood suite that loads this branch UI against the live backend.
- Updated launch runbook so the live dogfood command cannot false-green when `PROTO_DOGFOOD_LIVE` is missing.

## Dogfood and verification
- `npx tsc --noEmit --pretty false`
- `npx tsc -p convex --noEmit --pretty false`
- `npx vitest run convex/__tests__/scratchnode.events.test.ts --reporter=verbose`
- `npx playwright test tests/e2e/scratchnode-demo-route-gate.spec.ts tests/e2e/scratchnode-live-route-honesty.spec.ts --project=chromium --workers=1 --reporter=list`
- `$env:PROTO_DOGFOOD_LIVE='1'; npx playwright test tests/e2e/proto-live-backend-dogfood.spec.ts --project=chromium --workers=1 --reporter=list`
- `npm run build`
- `npm run preflight:fast`
- `git diff --check`

## Notes
The live dogfood suite now routes ScratchNode document requests to this branch's `public/proto/home-v5.html` while using the real production ScratchNode config and Convex backend. That lets us validate the PR UI against live backend behavior before deploy.