### PR TITLE
fix(scratchnode): launch-hardening (timeout, DoS guard, UI polish)

### DIFF
--- a/convex/events.ts
+++ b/convex/events.ts
@@ -563,12 +563,21 @@ function evaluateAnswerQuality(args: {
   return { passed: failed === 0, score, checks };
 }
 
+// External-provider fetch timeouts (TIMEOUT — agentic_reliability #4). Convex
+// actions get a multi-minute budget, NOT the query budget, so without an
+// AbortController a hung provider socket would stall the /ask lane and never
+// reach the deterministic synthesizeAnswer fallback below.
+const LINKUP_TIMEOUT_MS = Number(process.env.SCRATCHNODE_LINKUP_TIMEOUT_MS) || 12000;
+const ANTHROPIC_TIMEOUT_MS = Number(process.env.SCRATCHNODE_ANTHROPIC_TIMEOUT_MS) || 20000;
+
 async function searchLinkup(question: string) {
   const apiKey = process.env.LINKUP_API_KEY;
   if (!apiKey || process.env.SCRATCHNODE_ALLOW_LINKUP !== "1") {
     return { status: "skipped" as const, sources: [], detail: "Linkup disabled or key not configured." };
   }
   const startedAt = Date.now();
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), LINKUP_TIMEOUT_MS);
   try {
     const response = await fetch("https://api.linkup.so/v1/search", {
       method: "POST",
@@ -583,6 +592,7 @@ async function searchLinkup(question: string) {
         includeSources: true,
         maxResults: MAX_LINKUP_SOURCES,
       }),
+      signal: ac.signal,
     });
     if (!response.ok) {
       return {
@@ -609,8 +619,12 @@ async function searchLinkup(question: string) {
     return {
       status: "error" as const,
       sources: [],
-      detail: `Linkup failed: ${err?.message || String(err)}`,
+      detail: ac.signal.aborted
+        ? `Linkup timed out after ${LINKUP_TIMEOUT_MS}ms.`
+        : `Linkup failed: ${err?.message || String(err)}`,
     };
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -642,6 +656,8 @@ async function generateProviderAnswer(args: {
   ].join("\n");
   const inputTokens = estimateTokens(system + "\n" + user);
   const startedAt = Date.now();
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), ANTHROPIC_TIMEOUT_MS);
   try {
     const response = await fetch("https://api.anthropic.com/v1/messages", {
       method: "POST",
@@ -657,6 +673,7 @@ async function generateProviderAnswer(args: {
         system,
         messages: [{ role: "user", content: user }],
       }),
+      signal: ac.signal,
     });
     if (!response.ok) {
       const body = await response.text().catch(() => "");
@@ -696,11 +713,15 @@ async function generateProviderAnswer(args: {
   } catch (err: any) {
     return {
       ok: false as const,
-      detail: `Anthropic request failed: ${err?.message || String(err)}`,
+      detail: ac.signal.aborted
+        ? `Anthropic timed out after ${ANTHROPIC_TIMEOUT_MS}ms.`
+        : `Anthropic request failed: ${err?.message || String(err)}`,
       model,
       inputTokens,
       elapsedMs: Date.now() - startedAt,
     };
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -451,6 +451,17 @@ export const verifySignInToken = mutation({
       });
     }
 
+    // Rate-limit verify attempts: the per-row hash scan below is the costliest
+    // path in the sign-in flow, so unbounded verify calls are a CPU-DoS vector.
+    // No email is known here (can't key by email like requestSignInLink), so a
+    // global cap bounds total scan load; a per-session cap stops a single abuser.
+    // NOT keyed on an "anon" bucket — that would false-positive and block the
+    // many new-device magic-link users who have no sessionId yet at launch.
+    await enforceRateLimit(ctx, { key: "verify:global", limit: 300, windowMs: 60_000 });
+    if (sessionId) {
+      await enforceRateLimit(ctx, { key: `verify:sess:${sessionId}`, limit: 20, windowMs: 60_000 });
+    }
+
     // We don't know the email yet — the token table is indexed by
     // tokenHash for direct lookup, but the hash binds email + token, so
     // we have to enumerate active (non-consumed) tokens and recompute the

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -165,7 +165,7 @@ button:active { transform: scale(.97); transition: transform .08s; }
   background: transparent; border: 0; outline: none;
   padding: 6px 10px; font-size: 15px; color: var(--ink);
 }
-.c-input::placeholder { color: var(--ink-faint); }
+.c-input::placeholder { color: var(--ink-muted); } /* AA contrast — placeholder is the primary "what do I type" affordance */
 
 /* Composer mode-state badge — answers "Am I public or private?" */
 .c-mode {
@@ -596,7 +596,7 @@ body[data-feed-empty="true"] #feed > .row,
 body[data-feed-empty="true"] #feed > .ans { display: none; }
 .empty-icon { font-size: 28px; opacity: .6; margin-bottom: 4px; }
 .empty-title { font-size: 14px; color: var(--ink); font-weight: 600; }
-.empty-body { font-size: 12px; color: var(--ink-faint); max-width: 280px; line-height: 1.5; }
+.empty-body { font-size: 12px; color: var(--ink-muted); max-width: 280px; line-height: 1.5; } /* AA contrast — instructional empty-state copy must be readable */
 
 /* ─── Attention pulses for first-visit ─── */
 body[data-new-user="true"] #lock,
@@ -3861,7 +3861,8 @@ var OVERLAY_REGISTRY = [
   { name: 'tour',          isOpen: function() { return !!_tourEl; },                                                                                                  close: function() { closeTour(); } },
   { name: 'mention-picker',isOpen: function() { var el = document.getElementById('mention-picker'); return el && el.getAttribute('data-open') === 'true'; },          close: function() { if (typeof closeMentionPicker === 'function') closeMentionPicker(); } },
   { name: 'sheet',         isOpen: function() { var el = document.getElementById('sheet'); return el && el.getAttribute('data-open') === 'true'; },                   close: function() { closeSheet(); } },
-  { name: 'menu',          isOpen: function() { var el = document.getElementById('menu-sheet'); return el && el.getAttribute('data-open') === 'true'; },              close: function() { closeMenu(); } }
+  { name: 'menu',          isOpen: function() { var el = document.getElementById('menu-sheet'); return el && el.getAttribute('data-open') === 'true'; },              close: function() { closeMenu(); } },
+  { name: 'live-assist',   isOpen: function() { var r = document.getElementById('live-assist-rail'); var s = document.getElementById('live-assist-sheet'); return !!((r && r.getAttribute('data-open') === 'true') || (s && s.getAttribute('data-open') === 'true')); }, close: function() { if (typeof toggleLiveAssist === 'function') toggleLiveAssist(false); } }
 ];
 function isOverlayOpen() {
   return OVERLAY_REGISTRY.some(function(o) { return o.isOpen(); });
@@ -3889,6 +3890,10 @@ function _activeDialog() {
   if (kbd && kbd.getAttribute('data-open') === 'true') return kbd;
   var menu = document.getElementById('menu-sheet');
   if (menu && menu.getAttribute('data-open') === 'true') return menu;
+  // Mobile Live Assist sheet is scrim-backed (modal-like) → trap focus.
+  // The desktop rail is role="complementary" (non-modal, coexists with chat) → do NOT trap.
+  var laSheet = document.getElementById('live-assist-sheet');
+  if (laSheet && laSheet.getAttribute('data-open') === 'true') return laSheet;
   return null;
 }
 function _focusableIn(el) {
@@ -5338,7 +5343,19 @@ window._laCueAction       = _laCueAction;
     // Wipe the hardcoded demo rows once Convex takes over — they'd otherwise
     // appear next to real messages and confuse users.
     Array.from(feedEl.querySelectorAll('.row, .ans')).forEach(el => el.remove());
+    // Bridge the wipe→first-push gap so users never stare at a blank feed on
+    // join. Neutral element (not .row/.ans) so refreshEmptyState + the mention
+    // observer ignore it. Cleared on the first getMessages push (even if empty).
+    if (!feedEl.querySelector('[data-sn-connecting]')) {
+      feedEl.insertAdjacentHTML('beforeend',
+        '<div data-sn-connecting="true" role="status" aria-live="polite" style="padding:14px 6px;color:var(--ink-muted);font-size:13px;">Connecting to the live room…</div>');
+    }
   }
+  const _clearConnecting = () => {
+    if (!feedEl) return;
+    const c = feedEl.querySelector('[data-sn-connecting]');
+    if (c) c.remove();
+  };
 
   const fmtTime = (ts) => {
     const d = new Date(ts);
@@ -5418,6 +5435,8 @@ window._laCueAction       = _laCueAction;
   client.onUpdate('events:getMessages', { eventId, limit: 200 }, (rows) => {
     if (!Array.isArray(rows)) return;
     for (const msg of rows) renderMessage(msg);
+    _clearConnecting(); // subscription responded (even if empty) — no longer "connecting"
+    if (typeof refreshEmptyState === 'function') refreshEmptyState();
   });
   client.onUpdate('events:getAnswers', { eventId, limit: 100 }, (rows) => {
     if (!Array.isArray(rows)) return;
@@ -5425,6 +5444,8 @@ window._laCueAction       = _laCueAction;
     const faqCount = rows.filter((answer) => answer && answer.faqStatus && answer.faqStatus !== 'none').length;
     const faqEl = document.getElementById('ev-faq-count');
     if (faqEl) faqEl.textContent = String(faqCount);
+    _clearConnecting();
+    if (typeof refreshEmptyState === 'function') refreshEmptyState();
   });
   client.onUpdate('events:getMembers', { eventId }, (rows) => {
     if (!Array.isArray(rows)) return;


### PR DESCRIPTION
﻿## Summary
Launch-hardening from a parallel 6-agent launch-blocker sweep (backend reliability, auth/security, frontend live-data, UI/UX a11y, routing/deploy, live-prod browser dogfood) ahead of the public scratchnode.live launch.

**Fixes**
- **TIMEOUT (P0, agentic_reliability #4)** - `askAgent` Linkup + Anthropic fetches had no `AbortController`. A hung provider socket stalled the `/ask` lane and never reached the deterministic `synthesizeAnswer` fallback (Convex actions get a multi-minute budget, not the query budget). Added 12s/20s abort timers + honest "timed out" detail; fallback now always reachable.
- **verifySignInToken rate-limit (P1)** - the per-row token-hash scan is the costliest sign-in path; unbounded verify calls were a CPU-DoS vector. Added a global cap (300/min) + per-session cap (20/min), deliberately NOT keyed on a shared "anon" bucket (would block new-device magic-link users at launch).
- **home-v5 UI polish (P1)** - Live Assist closes on Esc + traps focus on its scrim-backed mobile sheet (desktop rail left non-modal); a "Connecting to the live room" placeholder bridges the wipe->first-Convex-push gap and drives `refreshEmptyState` so empty rooms show the real empty state; composer placeholder + empty-state copy bumped to WCAG AA contrast.

Additive only - no backend contract change (no expand-contract race).

## Test plan
- [x] `npx convex codegen` clean
- [x] `npx tsc --noEmit` exit 0
- [x] `vitest run convex/__tests__/scratchnode.events.test.ts` - 50/50 pass
- [x] inline-JS parse-check on home-v5.html - 0 errors
- [ ] Post-merge: Tier-A raw-HTML + Tier-B browser dogfood on live /e/:slug

Sweep also confirmed NO P0 security issues: wiki body is server-escaped (`buildWikiHtml` wraps every field in `escapeHtml`), demo gating regex airtight, presence counts real.
