### PR TITLE
feat(search): tri-search rerank module (RRF + Gemini cross-encoder)

### DIFF
--- a/server/routes/triSearch.test.ts
+++ b/server/routes/triSearch.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { rrfFuse, rerankWithGemini, triSearch, RRF_K, type TriCandidate } from "./triSearch";
+
+// Scenario-based tests (.claude/rules/scenario_testing.md).
+// Persona: a founder/analyst running entity due-diligence; the grounding harness
+// has retrieved candidate sources from three legs (Linkup, web_search, entity cache)
+// and must fuse + rerank them by relevance before the answer is synthesized.
+
+const mockGeminiFetch = (orderJson: string): typeof fetch =>
+  (async () =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: orderJson }] } }] }),
+    }) as unknown as Response) as unknown as typeof fetch;
+
+function leg(source: string, ids: string[]): TriCandidate[] {
+  return ids.map((id) => ({ id, source, title: `${id} title`, snippet: `${id} snippet about the entity`, url: `https://x/${id}` }));
+}
+
+describe("rrfFuse — rank-based fusion across heterogeneous legs", () => {
+  it("happy path: a source ranked high across multiple legs wins after fusion", () => {
+    // 3 legs; "anthropic-funding" appears in all three near the top -> should fuse to #1.
+    const legs = [
+      leg("linkup", ["anthropic-funding", "anthropic-blog", "noise-a"]),
+      leg("web", ["anthropic-funding", "noise-b", "anthropic-blog"]),
+      leg("entity", ["anthropic-funding", "anthropic-team"]),
+    ];
+    const fused = rrfFuse(legs);
+    expect(fused[0].id).toBe("anthropic-funding");
+    expect(fused[0].fusedRank).toBe(0);
+    // dedup: 6 distinct ids across the 3 legs
+    expect(new Set(fused.map((c) => c.id)).size).toBe(fused.length);
+    expect(fused.length).toBe(6);
+    // fused score is monotonic non-increasing
+    for (let i = 1; i < fused.length; i++) expect(fused[i - 1].fusedScore).toBeGreaterThanOrEqual(fused[i].fusedScore);
+  });
+
+  it("uses k=60 by default and is deterministic across runs", () => {
+    const legs = [leg("linkup", ["a", "b"]), leg("web", ["b", "a"])];
+    const first = rrfFuse(legs);
+    const second = rrfFuse(legs);
+    expect(first.map((c) => c.id)).toEqual(second.map((c) => c.id));
+    // a and b each appear once at rank0 and once at rank1 -> equal score; tie broken by stable order
+    expect(first[0].fusedScore).toBeCloseTo(1 / (RRF_K + 1) + 1 / (RRF_K + 2), 10);
+  });
+
+  it("edge: empty legs and malformed candidates don't crash", () => {
+    const fused = rrfFuse([[], [{ id: "", source: "x" } as TriCandidate], leg("web", ["only"])]);
+    expect(fused.map((c) => c.id)).toEqual(["only"]);
+  });
+});
+
+describe("rerankWithGemini — precision leg with honest fallback", () => {
+  const fused = rrfFuse([leg("linkup", ["s0", "s1", "s2", "s3"])]);
+
+  it("happy path: reorders candidates per the model's index array", async () => {
+    const r = await rerankWithGemini("entity funding", fused, { topN: 3, fetchImpl: mockGeminiFetch("[2,0,1]") });
+    expect(r.rerankStatus).toBe("ok");
+    expect(r.ranked.map((c) => c.id)).toEqual(["s2", "s0", "s1"]);
+  });
+
+  it("adversarial: out-of-range + duplicate indices are sanitized, completeness preserved", async () => {
+    // Model returns garbage: dup (2), out-of-range (99, -1), valid (0). topN large enough to see completeness.
+    const r = await rerankWithGemini("q", fused, { topN: 10, fetchImpl: mockGeminiFetch("[2, 2, 99, -1, 0]") });
+    expect(r.rerankStatus).toBe("ok");
+    // valid picks first (2,0), then omitted (1,3) appended in fused order
+    expect(r.ranked.map((c) => c.id)).toEqual(["s2", "s0", "s1", "s3"]);
+    expect(new Set(r.ranked.map((c) => c.id)).size).toBe(4); // no dupes
+  });
+
+  it("sad path: missing API key -> skipped, returns fused top-N unchanged", async () => {
+    const saved = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    try {
+      const r = await rerankWithGemini("q", fused, { topN: 2 });
+      expect(r.rerankStatus).toBe("skipped");
+      expect(r.ranked.map((c) => c.id)).toEqual(["s0", "s1"]);
+    } finally {
+      if (saved !== undefined) process.env.GEMINI_API_KEY = saved;
+    }
+  });
+
+  it("degraded: non-2xx falls back to fused order, never throws", async () => {
+    const badFetch = (async () => ({ ok: false, status: 503, json: async () => ({}) }) as unknown as Response) as unknown as typeof fetch;
+    const r = await rerankWithGemini("q", fused, { topN: 4, apiKey: "test", fetchImpl: badFetch });
+    expect(r.rerankStatus).toBe("fallback");
+    expect(r.ranked.map((c) => c.id)).toEqual(["s0", "s1", "s2", "s3"]);
+  });
+
+  it("degraded: fetch throws (timeout/abort) -> fallback, fused order, honest detail", async () => {
+    const throwFetch = (async () => { const e: any = new Error("aborted"); e.name = "TimeoutError"; throw e; }) as unknown as typeof fetch;
+    const r = await rerankWithGemini("q", fused, { topN: 4, apiKey: "test", fetchImpl: throwFetch });
+    expect(r.rerankStatus).toBe("fallback");
+    expect(r.detail).toMatch(/timed out/i);
+    expect(r.ranked.length).toBe(4);
+  });
+
+  it("bound: never reranks more than MAX_RERANK_CANDIDATES", async () => {
+    const many = rrfFuse([leg("web", Array.from({ length: 30 }, (_, i) => `c${i}`))]);
+    let promptLen = 0;
+    const spyFetch = (async (_url: string, init: any) => {
+      promptLen = JSON.parse(init.body).contents[0].parts[0].text.length;
+      return { ok: true, status: 200, json: async () => ({ candidates: [{ content: { parts: [{ text: "[0,1,2,3,4]" }] } }] }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+    await rerankWithGemini("q", many, { topN: 5, apiKey: "test", fetchImpl: spyFetch });
+    // only 12 candidates ([0]..[11]) should appear in the prompt, not [12]+
+    expect(promptLen).toBeGreaterThan(0);
+  });
+});
+
+describe("triSearch — fuse + rerank end to end", () => {
+  it("returns reranked top-N with a trace-ready summary", async () => {
+    const legs = [leg("linkup", ["a", "b", "c"]), leg("web", ["b", "d"])];
+    const out = await triSearch("the query", legs, { topN: 2, apiKey: "test", fetchImpl: mockGeminiFetch("[1,0]") });
+    expect(out.fusedCount).toBe(4); // a,b,c,d
+    expect(out.rerankStatus).toBe("ok");
+    expect(out.ranked.length).toBe(2);
+    expect(typeof out.durationMs).toBe("number");
+  });
+});

--- a/server/routes/triSearch.ts
+++ b/server/routes/triSearch.ts
@@ -1,0 +1,197 @@
+/**
+ * Tri-search — the third retrieval leg for the NodeBench grounding harness.
+ *
+ * NodeBench already runs lexical (hybrid: keyword/fuzzy/n-gram/prefix/bigram)
+ * + dense (TF-IDF cosine + Agent-as-a-Graph wRRF). What the grounding/answer
+ * path lacked was a precision leg: retrieved web/Linkup/entity sources were
+ * ordered by ORIGIN (Linkup -> web -> cache), not by measured relevance. This
+ * module adds the standard "retrieve -> fuse -> rerank" precision stage:
+ *   1. Reciprocal Rank Fusion (RRF) over N ranked candidate lists.
+ *   2. A Gemini Flash-Lite cross-encoder-style relevance rerank of the top-N.
+ *
+ * Pattern: tri-search (sparse + dense + rerank), fused with RRF.
+ * Prior art:
+ *   - Reciprocal Rank Fusion — Cormack, Clarke, Buttcher (SIGIR 2009), k=60.
+ *     https://cormack.uwaterloo.ca/cormacksigir09-rrf.pdf
+ *   - Anthropic "Contextual Retrieval" — hybrid retrieval + rerank.
+ *     https://www.anthropic.com/news/contextual-retrieval
+ *   - Windsurf "Riptide" — embeddings candidate gen -> LLM reranker.
+ * See: docs/architecture/TRI_SEARCH.md (to be written)
+ *
+ * Reliability (.claude/rules/agentic_reliability.md):
+ *   TIMEOUT       — AbortSignal.timeout on the rerank call; falls back on abort.
+ *   BOUND         — candidate list capped at MAX_RERANK_CANDIDATES.
+ *   HONEST_STATUS — rerank failure returns the fused order with status="fallback";
+ *                   never fabricates a ranking.
+ *   DETERMINISTIC — temperature 0; out-of-range/duplicate indices sanitized;
+ *                   omitted candidates appended in fused order (stable completeness).
+ *   BOUND_READ    — snippet/title truncated before they enter the prompt.
+ */
+
+export interface TriCandidate {
+  /** Stable identity for dedup across legs — prefer the URL, else a label. */
+  id: string;
+  title?: string;
+  snippet?: string;
+  url?: string;
+  /** Which retrieval leg produced this candidate: "linkup" | "web" | "entity" | ... */
+  source: string;
+}
+
+export type FusedCandidate = TriCandidate & { fusedScore: number; fusedRank: number };
+
+export type RerankStatus = "ok" | "skipped" | "fallback";
+
+export interface RerankResult {
+  ranked: TriCandidate[];
+  rerankStatus: RerankStatus;
+  detail: string;
+  durationMs: number;
+}
+
+export const RRF_K = 60;
+export const MAX_RERANK_CANDIDATES = 12;
+const RERANK_MODEL = process.env.TRI_SEARCH_RERANK_MODEL || "gemini-2.5-flash-lite-preview";
+const RERANK_TIMEOUT_MS = Number(process.env.TRI_SEARCH_RERANK_TIMEOUT_MS) || 6000;
+const MAX_TITLE = 120;
+const MAX_SNIPPET = 280;
+
+/**
+ * Reciprocal Rank Fusion. Each input list is a ranked array (best first).
+ * Returns deduped candidates sorted by fused score desc, with a stable
+ * `fusedRank`. Rank-based, so heterogeneous leg scores need no normalization.
+ */
+export function rrfFuse(lists: TriCandidate[][], k = RRF_K): FusedCandidate[] {
+  const byId = new Map<string, TriCandidate & { fusedScore: number }>();
+  for (const list of lists) {
+    list.forEach((cand, idx) => {
+      if (!cand || !cand.id) return;
+      const contrib = 1 / (k + idx + 1); // idx is 0-based -> rank is idx+1
+      const existing = byId.get(cand.id);
+      if (existing) {
+        existing.fusedScore += contrib;
+        existing.title = existing.title || cand.title;
+        existing.snippet = existing.snippet || cand.snippet;
+        existing.url = existing.url || cand.url;
+      } else {
+        byId.set(cand.id, { ...cand, fusedScore: contrib });
+      }
+    });
+  }
+  return Array.from(byId.values())
+    .sort((a, b) => b.fusedScore - a.fusedScore)
+    .map((c, i) => ({ ...c, fusedRank: i }));
+}
+
+function fusedTopN(candidates: TriCandidate[], topN: number): TriCandidate[] {
+  return candidates.slice(0, topN); // input is already in fused order
+}
+
+/**
+ * Gemini Flash-Lite cross-encoder-style rerank. Reorders `candidates` by
+ * relevance to `query`. HONEST fallback: any missing key / non-2xx / timeout /
+ * unparseable response returns the input (fused) order with status reflecting why.
+ */
+export async function rerankWithGemini(
+  query: string,
+  candidates: Array<TriCandidate & { fusedRank?: number }>,
+  opts: { topN?: number; timeoutMs?: number; apiKey?: string; fetchImpl?: typeof fetch } = {},
+): Promise<RerankResult> {
+  const startedAt = Date.now();
+  const topN = opts.topN ?? 5;
+  const apiKey = opts.apiKey ?? process.env.GEMINI_API_KEY;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const bounded = candidates.slice(0, MAX_RERANK_CANDIDATES);
+
+  if (!apiKey) {
+    return { ranked: fusedTopN(bounded, topN), rerankStatus: "skipped", detail: "GEMINI_API_KEY not set; fused order kept.", durationMs: Date.now() - startedAt };
+  }
+  if (bounded.length <= 1) {
+    return { ranked: fusedTopN(bounded, topN), rerankStatus: "skipped", detail: "<=1 candidate; nothing to rerank.", durationMs: Date.now() - startedAt };
+  }
+
+  const numbered = bounded
+    .map((c, i) => `[${i}] ${(c.title || c.url || "untitled").slice(0, MAX_TITLE)} - ${(c.snippet || "").slice(0, MAX_SNIPPET)}`)
+    .join("\n");
+  const prompt = [
+    "You are a search reranker. Given a QUERY and NUMBERED candidate sources,",
+    "order the candidate indices from MOST to LEAST relevant for answering the query.",
+    "Judge by topical relevance and specificity to the query, not by their given order.",
+    `Return ONLY a JSON array of integers (no prose), e.g. [3,0,1]. Include at most the top ${topN}.`,
+    "",
+    `QUERY: ${query}`,
+    "",
+    "CANDIDATES:",
+    numbered,
+  ].join("\n");
+
+  try {
+    const resp = await doFetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${RERANK_MODEL}:generateContent?key=${encodeURIComponent(apiKey)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0, maxOutputTokens: 96 },
+        }),
+        signal: AbortSignal.timeout(opts.timeoutMs ?? RERANK_TIMEOUT_MS),
+      },
+    );
+    if (!resp.ok) {
+      return { ranked: fusedTopN(bounded, topN), rerankStatus: "fallback", detail: `rerank HTTP ${resp.status}; fused order kept.`, durationMs: Date.now() - startedAt };
+    }
+    const data: any = await resp.json();
+    const text: string = (data?.candidates?.[0]?.content?.parts ?? [])
+      .map((p: any) => p?.text ?? "")
+      .join("");
+    const match = text.match(/\[[\s\S]*?\]/);
+    if (!match) {
+      return { ranked: fusedTopN(bounded, topN), rerankStatus: "fallback", detail: "no JSON array in rerank response; fused order kept.", durationMs: Date.now() - startedAt };
+    }
+    let order: unknown;
+    try { order = JSON.parse(match[0]); } catch {
+      return { ranked: fusedTopN(bounded, topN), rerankStatus: "fallback", detail: "rerank response not valid JSON; fused order kept.", durationMs: Date.now() - startedAt };
+    }
+    if (!Array.isArray(order)) {
+      return { ranked: fusedTopN(bounded, topN), rerankStatus: "fallback", detail: "rerank response not an array; fused order kept.", durationMs: Date.now() - startedAt };
+    }
+    const seen = new Set<number>();
+    const ranked: TriCandidate[] = [];
+    for (const raw of order) {
+      const idx = Number(raw);
+      if (Number.isInteger(idx) && idx >= 0 && idx < bounded.length && !seen.has(idx)) {
+        seen.add(idx);
+        ranked.push(bounded[idx]);
+      }
+    }
+    // Append any candidate the reranker omitted, in fused order — deterministic completeness.
+    bounded.forEach((c, i) => { if (!seen.has(i)) ranked.push(c); });
+    return { ranked: ranked.slice(0, topN), rerankStatus: "ok", detail: `reranked ${bounded.length} candidates -> top ${Math.min(topN, ranked.length)}.`, durationMs: Date.now() - startedAt };
+  } catch (err: any) {
+    const aborted = err?.name === "TimeoutError" || err?.name === "AbortError";
+    return {
+      ranked: fusedTopN(bounded, topN),
+      rerankStatus: "fallback",
+      detail: aborted
+        ? `rerank timed out after ${opts.timeoutMs ?? RERANK_TIMEOUT_MS}ms; fused order kept.`
+        : `rerank failed: ${err?.message || String(err)}; fused order kept.`,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+}
+
+/**
+ * Convenience: fuse N retrieval legs with RRF, then rerank the top-N.
+ * Returns the ranked candidates plus a trace-ready summary (emit one trace
+ * step per leg upstream, then a "rerank" step with these fields).
+ */
+export async function triSearch(
+  query: string,
+  legs: TriCandidate[][],
+  opts: { topN?: number; timeoutMs?: number; apiKey?: string; fetchImpl?: typeof fetch } = {},
+): Promise<{ ranked: TriCandidate[]; fusedCount: number; rerankStatus: RerankStatus; detail: string; durationMs: number }> {
+  const fused = rrfFuse(legs);
+  const r = await rerankWithGemini(query, fused, opts);
+  return { ranked: r.ranked, fusedCount: fused.length, rerankStatus: r.rerankStatus, detail: r.detail, durationMs: r.durationMs };
+}


### PR DESCRIPTION
## Summary
Phase 1 of **tri-search** - adds the precision *third leg* to the grounding harness. NodeBench already runs lexical (hybrid: keyword/fuzzy/n-gram/prefix/bigram) + dense (TF-IDF cosine + Agent-as-a-Graph wRRF). The answer/grounding path ordered retrieved sources by ORIGIN (Linkup -> web -> cache), not measured relevance. This adds the standard **retrieve -> fuse -> rerank** stage as a self-contained, reusable module.

- `rrfFuse()` - Reciprocal Rank Fusion (Cormack 2009, k=60) over N ranked legs; rank-based, no score normalization.
- `rerankWithGemini()` - Gemini Flash-Lite cross-encoder-style rerank. agentic_reliability guards: AbortSignal timeout, MAX_RERANK_CANDIDATES bound, deterministic sanitization of out-of-range/duplicate indices, HONEST fallback to fused order (never fabricates a ranking).
- `triSearch()` - fuse + rerank convenience with a trace-ready summary.

## Scope (honest)
Ships the **reusable capability + scenario tests** only. NOT yet wired into the live grounding path or convex /ask - that's the immediate follow-up, where the **precision@5 eval-lift** is measured against the existing searchQualityEval corpus (needs dev server + GEMINI_API_KEY). Module **type-checks clean in isolation (strict)**; full local test was blocked by a corrupted local node_modules (missing @jridgewell/sourcemap-codec) - **CI verifies on clean install**.

## References
- RRF: Cormack/Clarke/Buttcher SIGIR 2009 (k=60)
- Anthropic Contextual Retrieval (hybrid + rerank)
- Windsurf Riptide (embeddings -> LLM reranker); Sourcegraph Cody (keyword + embeddings + SCIP)

## Test plan
- [ ] CI Typecheck (module)
- [ ] CI runs server/routes/triSearch.test.ts (happy/sad/adversarial/degraded)
- [ ] Follow-up: wire into search.ts company_search + measure precision@5 lift