### PR TITLE
feat(tri-search): multi-turn /ask query condensation

### DIFF
--- a/convex/events.ts
+++ b/convex/events.ts
@@ -30,7 +30,7 @@ import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { action, query, mutation, internalMutation, internalQuery } from "./_generated/server";
 import { enforceRateLimit } from "./scratchnodeRateLimit";
-import { rerankWithGemini, type TriCandidate } from "../shared/search/triSearch";
+import { rerankWithGemini, condenseQuery, type TriCandidate } from "../shared/search/triSearch";
 
 class ConvexError<T extends Record<string, unknown>> extends Error {
   data: T;
@@ -1015,6 +1015,18 @@ export const _prepareAskAgentContext = internalQuery({
       .query("liveEventSources")
       .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
       .take(100);
+    // Asker's OWN recent turns for multi-turn query condensation. PRIVACY: filtered to
+    // this sessionId only — never other attendees' messages. Bounded recent scan.
+    const recentMsgs = await ctx.db
+      .query("liveEventMessages")
+      .withIndex("by_event_time", (q) => q.eq("eventId", args.eventId))
+      .order("desc")
+      .take(60);
+    const priorTurns = recentMsgs
+      .filter((m: any) => m.sessionId === args.sessionId && (m.kind === "chat" || m.kind === "ask") && (m.text || "").trim() && m.text.trim() !== question)
+      .slice(0, 5)
+      .reverse()
+      .map((m: any) => m.text.trim().slice(0, 300));
     return {
       event: {
         _id: event._id,
@@ -1025,6 +1037,7 @@ export const _prepareAskAgentContext = internalQuery({
       normalizedQuestion,
       cached,
       sources,
+      priorTurns,
     };
   },
 });
@@ -1737,9 +1750,15 @@ export const askAgent = action({
 
     let sources: any[] = prepared.sources || [];
 
+    // Multi-turn (rewrite-then-retrieve, the prod standard): condense the asker's OWN
+    // prior turns + this follow-up into a standalone retrieval query so "those"/"that"
+    // resolve. Raw `question` is kept verbatim for the answer (condense-plus-context).
+    const condensed = await condenseQuery(question, prepared.priorTurns || []);
+    const retrievalQuery = condensed.query;
+
     const retrievalStarted = Date.now();
     let ranked = sources
-      .map((source: any) => ({ source, score: scoreSource(question, source) }))
+      .map((source: any) => ({ source, score: scoreSource(retrievalQuery, source) }))
       .sort((a: any, b: any) => b.score - a.score || b.source.uploadedAt - a.source.uploadedAt);
     const trace: Array<{ step: string; status: "ok" | "miss" | "error"; detail?: string; durationMs: number }> = [
       {
@@ -1749,11 +1768,19 @@ export const askAgent = action({
         durationMs: retrievalStarted - startedAt,
       },
     ];
+    trace.push({
+      step: "condense_query",
+      status: condensed.status === "rewritten" ? "ok" : "miss",
+      detail: condensed.status === "rewritten"
+        ? `Rewrote follow-up from ${(prepared.priorTurns || []).length} prior turn(s) → "${retrievalQuery.slice(0, 80)}"`
+        : condensed.detail,
+      durationMs: condensed.durationMs,
+    });
 
     let externalSearches = 0;
-    if (shouldProbeLiveSearch(question, ranked)) {
+    if (shouldProbeLiveSearch(retrievalQuery, ranked)) {
       const externalStarted = Date.now();
-      const linkup = await searchLinkup(question);
+      const linkup = await searchLinkup(retrievalQuery);
       trace.push({
         step: "external_search",
         status: linkup.status === "ok" ? "ok" : linkup.status === "skipped" ? "miss" : "error",
@@ -1768,7 +1795,7 @@ export const askAgent = action({
         });
         sources = [...sources, ...rows];
         ranked = sources
-          .map((source: any) => ({ source, score: scoreSource(question, source) }))
+          .map((source: any) => ({ source, score: scoreSource(retrievalQuery, source) }))
           .sort((a: any, b: any) => b.score - a.score || b.source.uploadedAt - a.source.uploadedAt);
       }
     } else {
@@ -1808,7 +1835,7 @@ export const askAgent = action({
         url: s.uri,
         source: "event",
       }));
-      const rr = await rerankWithGemini(question, candidates, { topN: candidates.length });
+      const rr = await rerankWithGemini(retrievalQuery, candidates, { topN: candidates.length });
       // Reorder topSources to the reranked id order; append any not reranked (completeness).
       const byId = new Map<string, any>(topSources.map((s: any) => [String(s._id), s]));
       const reordered: any[] = [];

--- a/scripts/eval-harness/triSearchConversationEval.ts
+++ b/scripts/eval-harness/triSearchConversationEval.ts
@@ -1,0 +1,215 @@
+/**
+ * Tri-search MULTI-TURN conversation eval — the real workflow, not single-shot queries.
+ *
+ * Models realistic running sessions (an event attendee's /ask thread, an analyst's
+ * diligence thread) where follow-up turns reference earlier ones ("rotate THOSE",
+ * "compare THAT", "their biggest risks") and the candidate pool is full of keyword
+ * traps. Compares THREE rankers per turn:
+ *   - LEXICAL: token-overlap on the current query (baseline).
+ *   - NAIVE rerank: rerankWithGemini(currentQueryOnly) — no conversation memory.
+ *   - CONTEXT rerank: rerankWithGemini(conversationPrefix + currentQuery) — sees the thread.
+ *
+ * The thesis under test: on context-DEPENDENT follow-ups, naive rerank can't resolve
+ * "those"/"that"/"their" and mis-ranks; only the context-aware rerank wins. This is
+ * what /ask must do in a real multi-turn room. Reports NDCG@5 split by turn type
+ * (standalone vs context-dependent) so the multi-turn lift is isolated, honestly.
+ *
+ * Run: npx tsx scripts/eval-harness/triSearchConversationEval.ts
+ */
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { rerankWithGemini, condenseQuery, type TriCandidate } from "../../shared/search/triSearch";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "../..");
+function loadKey() {
+  if (process.env.GEMINI_API_KEY) return;
+  const env = readFileSync(resolve(ROOT, ".env.local"), "utf8");
+  const line = env.split(/\r?\n/).find((l) => l.trim().startsWith("GEMINI_API_KEY="));
+  if (line) process.env.GEMINI_API_KEY = line.slice(line.indexOf("=") + 1).trim().replace(/^['"]|['"]$/g, "");
+}
+
+type Cand = { id: string; title: string; snippet: string; rel: 0 | 1 | 2 };
+type Turn = { query: string; dependsOnContext: boolean; candidates: Cand[] };
+type Convo = { name: string; persona: string; turns: Turn[] };
+
+// Distractors deliberately share the follow-up's keywords ("rotate", "audit", "static",
+// "key", "compare") so a context-free reranker is tempted by them — the realistic trap.
+const CONVERSATIONS: Convo[] = [
+  {
+    name: "AI Infra Summit attendee — MCP auth deep-dive",
+    persona: "event attendee asking a running /ask thread",
+    turns: [
+      {
+        query: "What did the panel recommend for MCP enterprise authentication?",
+        dependsOnContext: false,
+        candidates: [
+          { id: "c1.1", title: "Panel: MCP enterprise auth recommendations", snippet: "Use short-lived scoped credentials over static API keys; enforce host actions server-side.", rel: 2 },
+          { id: "c1.2", title: "MCP server quickstart", snippet: "Install and run an MCP server locally.", rel: 1 },
+          { id: "c1.3", title: "Enterprise SSO pricing tiers", snippet: "Per-seat SSO pricing.", rel: 0 },
+          { id: "c1.4", title: "Auth service outage postmortem", snippet: "Login outage root cause.", rel: 0 },
+          { id: "c1.5", title: "Conference wifi login", snippet: "Authenticate to venue wifi.", rel: 0 },
+        ],
+      },
+      {
+        query: "How do I rotate those?",
+        dependsOnContext: true, // "those" = the scoped MCP credentials/secrets from turn 1
+        candidates: [
+          { id: "c2.1", title: "Rotating MCP scoped credentials safely", snippet: "Cadence and tooling to rotate the scoped API credentials issued to MCP clients.", rel: 2 },
+          { id: "c2.2", title: "How to rotate your car tires", snippet: "Rotate tires every 5,000 miles for even wear.", rel: 0 },
+          { id: "c2.3", title: "Crop rotation for home gardens", snippet: "Rotate crops each season to preserve soil.", rel: 0 },
+          { id: "c2.4", title: "Secret rotation cadence + audit", snippet: "Rotate secrets on a fixed schedule; audit each rotation.", rel: 2 },
+          { id: "c2.5", title: "Yoga: rotate your shoulders", snippet: "Shoulder rotation stretches.", rel: 0 },
+        ],
+      },
+      {
+        query: "And what's the cost of all that auditing?",
+        dependsOnContext: true, // "that auditing" = auditing tool calls / secret rotations from prior turns
+        candidates: [
+          { id: "c3.1", title: "Cost of audit logging tool calls at scale", snippet: "Storage + compute cost of auditing every MCP tool call and secret rotation.", rel: 2 },
+          { id: "c3.2", title: "Auditing 101 for accountants", snippet: "Financial audit fundamentals.", rel: 0 },
+          { id: "c3.3", title: "Movie review: 'The Audit'", snippet: "A thriller about a tax audit.", rel: 0 },
+          { id: "c3.4", title: "Annual financial audit fees", snippet: "What firms charge for a yearly audit.", rel: 0 },
+          { id: "c3.5", title: "Audit log retention + cost tradeoffs", snippet: "How retention windows drive logging cost.", rel: 1 },
+        ],
+      },
+      {
+        query: "Compare that to just using static API keys.",
+        dependsOnContext: true, // "that" = the scoped-credential + rotation approach
+        candidates: [
+          { id: "c4.1", title: "Scoped credentials vs static API keys", snippet: "Tradeoffs: blast radius, rotation, revocation for scoped creds vs long-lived static keys.", rel: 2 },
+          { id: "c4.2", title: "Static site generators compared", snippet: "Hugo vs Jekyll vs Astro.", rel: 0 },
+          { id: "c4.3", title: "Comparing mechanical keyboards", snippet: "Switch types compared.", rel: 0 },
+          { id: "c4.4", title: "API key leakage incidents", snippet: "Static keys in client code get scraped; why long-lived keys are risky.", rel: 1 },
+          { id: "c4.5", title: "Key lime pie recipe", snippet: "A classic dessert.", rel: 0 },
+        ],
+      },
+    ],
+  },
+  {
+    name: "Founder diligence thread — Acme AI",
+    persona: "analyst working a long diligence conversation",
+    turns: [
+      {
+        query: "Give me the diligence summary on Acme AI.",
+        dependsOnContext: false,
+        candidates: [
+          { id: "d1.1", title: "Acme AI diligence summary", snippet: "Founders, last round, product traction, two open flags.", rel: 2 },
+          { id: "d1.2", title: "Acme Inc. hardware manual", snippet: "Unrelated hardware company.", rel: 0 },
+          { id: "d1.3", title: "Diligence checklist template", snippet: "Generic VC diligence checklist.", rel: 1 },
+          { id: "d1.4", title: "Roadrunner cartoon trivia", snippet: "Acme products in cartoons.", rel: 0 },
+        ],
+      },
+      {
+        query: "What are their biggest risks?",
+        dependsOnContext: true, // "their" = Acme AI
+        candidates: [
+          { id: "d2.1", title: "Acme AI: top risks", snippet: "Concentration risk, thin moat, key-person dependency, runway.", rel: 2 },
+          { id: "d2.2", title: "Biggest risks of skydiving", snippet: "Parachute failure and landing injury.", rel: 0 },
+          { id: "d2.3", title: "Risk management 101", snippet: "Generic enterprise risk framework.", rel: 0 },
+          { id: "d2.4", title: "Acme AI customer concentration note", snippet: "Top 3 customers = 70% of revenue.", rel: 2 },
+          { id: "d2.5", title: "Biggest risks in mountaineering", snippet: "Altitude and weather.", rel: 0 },
+        ],
+      },
+      {
+        query: "How does that compare to their main competitor?",
+        dependsOnContext: true, // "that" = Acme's risk/profile; "their competitor"
+        candidates: [
+          { id: "d3.1", title: "Acme AI vs main competitor: risk + traction", snippet: "Side-by-side of moat, concentration, and growth vs the closest rival.", rel: 2 },
+          { id: "d3.2", title: "Comparing running shoes", snippet: "Cushioning vs weight.", rel: 0 },
+          { id: "d3.3", title: "Competitor's funding history", snippet: "The rival's rounds and valuation.", rel: 1 },
+          { id: "d3.4", title: "How to compare mortgages", snippet: "APR vs points.", rel: 0 },
+        ],
+      },
+      {
+        query: "Should I take this to the partner meeting?",
+        dependsOnContext: true, // "this" = the Acme diligence case built across the thread
+        candidates: [
+          { id: "d4.1", title: "Acme AI: partner-meeting readiness + open gaps", snippet: "What's strong, the two gaps to close, and the recommend/pass call.", rel: 2 },
+          { id: "d4.2", title: "How to run a great team meeting", snippet: "Generic meeting facilitation tips.", rel: 0 },
+          { id: "d4.3", title: "Partner yoga poses", snippet: "Two-person stretches.", rel: 0 },
+          { id: "d4.4", title: "IC memo template", snippet: "Investment committee memo structure.", rel: 1 },
+        ],
+      },
+    ],
+  },
+];
+
+const tokenize = (s: string) => s.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+function lexicalScore(q: string, text: string): number {
+  const qs = new Set(tokenize(q));
+  let n = 0; for (const t of tokenize(text)) if (qs.has(t)) n++; return n;
+}
+function dcg(g: number[], k: number) { let s = 0; for (let i = 0; i < Math.min(k, g.length); i++) s += (2 ** g[i] - 1) / Math.log2(i + 2); return s; }
+function ndcg5(ordered: number[], all: number[]) { const idcg = dcg([...all].sort((a, b) => b - a), 5); return idcg ? dcg(ordered, 5) / idcg : 0; }
+const r3 = (n: number) => Math.round(n * 1000) / 1000;
+const mean = (xs: number[]) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+async function rankNdcg(query: string, cands: Cand[], grades: Record<string, number>, mode: "lexical" | "rerank"): Promise<number> {
+  const all = cands.map((c) => c.rel);
+  if (mode === "lexical") {
+    const ordered = [...cands].sort((a, b) => lexicalScore(query, `${b.title} ${b.snippet}`) - lexicalScore(query, `${a.title} ${a.snippet}`));
+    return ndcg5(ordered.map((c) => grades[c.id]), all);
+  }
+  // baseline order into the reranker = lexical (so rerank competes from the same start)
+  const lexOrder = [...cands].sort((a, b) => lexicalScore(query, `${b.title} ${b.snippet}`) - lexicalScore(query, `${a.title} ${a.snippet}`));
+  const tc: TriCandidate[] = lexOrder.map((c) => ({ id: c.id, title: c.title, snippet: c.snippet, source: "corpus" }));
+  const rr = await rerankWithGemini(query, tc, { topN: tc.length });
+  const seen = new Set(rr.ranked.map((c) => c.id));
+  const ids = [...rr.ranked.map((c) => c.id), ...lexOrder.map((c) => c.id).filter((id) => !seen.has(id))];
+  return ndcg5(ids.map((id) => grades[id]), all);
+}
+
+async function main() {
+  loadKey();
+  if (!process.env.GEMINI_API_KEY) { console.error("no GEMINI_API_KEY"); process.exit(2); }
+  console.log("Tri-search MULTI-TURN conversation eval — lexical vs naive-rerank vs context-rerank\n");
+
+  const rows: Array<{ convo: string; turn: number; dep: boolean; lex: number; naive: number; ctx: number; rw: number }> = [];
+
+  for (const convo of CONVERSATIONS) {
+    console.log(`\n# ${convo.name}`);
+    const history: string[] = [];
+    for (let t = 0; t < convo.turns.length; t++) {
+      const turn = convo.turns[t];
+      const grades: Record<string, number> = {};
+      for (const c of turn.candidates) grades[c.id] = c.rel;
+
+      const lex = await rankNdcg(turn.query, turn.candidates, grades, "lexical");
+      const naive = await rankNdcg(turn.query, turn.candidates, grades, "rerank");
+      const ctxQuery = history.length
+        ? `Conversation so far:\n${history.map((q, i) => `  ${i + 1}. ${q}`).join("\n")}\nCurrent question: ${turn.query}`
+        : turn.query;
+      const ctx = await rankNdcg(ctxQuery, turn.candidates, grades, "rerank");
+      // REWRITE path (what /ask now does): condense history+follow-up → standalone query, then rerank.
+      const cond = await condenseQuery(turn.query, history);
+      const rw = await rankNdcg(cond.query, turn.candidates, grades, "rerank");
+
+      rows.push({ convo: convo.name, turn: t + 1, dep: turn.dependsOnContext, lex: r3(lex), naive: r3(naive), ctx: r3(ctx), rw: r3(rw) });
+      const flag = turn.dependsOnContext ? "↳ctx-dep" : "standalone";
+      console.log(`  T${t + 1} ${flag.padEnd(11)} NDCG@5 lex ${r3(lex)} | naive ${r3(naive)} | append ${r3(ctx)} | rewrite ${r3(rw)}  "${turn.query.slice(0, 36)}"`);
+      history.push(turn.query);
+    }
+  }
+
+  const dep = rows.filter((r) => r.dep);
+  const standalone = rows.filter((r) => !r.dep);
+  const agg = (rs: typeof rows) => ({ lex: r3(mean(rs.map((r) => r.lex))), naive: r3(mean(rs.map((r) => r.naive))), ctx: r3(mean(rs.map((r) => r.ctx))), rw: r3(mean(rs.map((r) => r.rw))) });
+  const summary = { turns: rows.length, contextDependent: agg(dep), standalone: agg(standalone), overall: agg(rows) };
+
+  console.log("\n=== AGGREGATE NDCG@5 (lexical → naive → append → rewrite) ===");
+  for (const [label, a] of [["context-dependent turns", summary.contextDependent], ["standalone turns", summary.standalone], ["overall", summary.overall]] as const) {
+    console.log(`  ${label.padEnd(24)} ${a.lex} → ${a.naive} → ${a.ctx} → ${a.rw}   (rewrite vs naive: ${(a.rw - a.naive >= 0 ? "+" : "")}${r3(a.rw - a.naive)}; rewrite vs append: ${(a.rw - a.ctx >= 0 ? "+" : "")}${r3(a.rw - a.ctx)})`);
+  }
+
+  const outDir = resolve(HERE, "results");
+  mkdirSync(outDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  writeFileSync(resolve(outDir, `triSearch-convo-${stamp}.json`), JSON.stringify({ at: new Date().toISOString(), summary, rows }, null, 2));
+
+  const rwLiftOnDeps = summary.contextDependent.rw - summary.contextDependent.naive;
+  const rwVsAppend = summary.contextDependent.rw - summary.contextDependent.ctx;
+  console.log(`\nVERDICT: on context-dependent follow-ups, REWRITE-then-rerank (what /ask now does) beats naive current-query-only by NDCG@5 ${rwLiftOnDeps >= 0 ? "+" : ""}${r3(rwLiftOnDeps)}; vs raw-append ${rwVsAppend >= 0 ? "+" : ""}${r3(rwVsAppend)} (rewrite ${rwVsAppend >= -0.02 ? "matches/beats" : "trails"} append — confirms the prod-standard choice).`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/shared/search/triSearch.test.ts
+++ b/shared/search/triSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { rrfFuse, rerankWithGemini, triSearch, RRF_K, type TriCandidate } from "./triSearch";
+import { rrfFuse, rerankWithGemini, triSearch, condenseQuery, RRF_K, type TriCandidate } from "./triSearch";
 
 // Scenario-based tests (.claude/rules/scenario_testing.md).
 // Persona: a founder/analyst running entity due-diligence; the grounding harness
@@ -117,5 +117,56 @@ describe("triSearch — fuse + rerank end to end", () => {
     expect(out.rerankStatus).toBe("ok");
     expect(out.ranked.length).toBe(2);
     expect(typeof out.durationMs).toBe("number");
+  });
+});
+
+// Multi-turn condense (rewrite-then-retrieve). Persona: an event attendee asking a
+// running /ask thread with context-dependent follow-ups ("how do I rotate those?").
+describe("condenseQuery — multi-turn query rewrite", () => {
+  it("passthrough: no prior turns → raw question unchanged (no LLM call)", async () => {
+    const r = await condenseQuery("how do I rotate those?", [], { apiKey: "test" });
+    expect(r.status).toBe("passthrough");
+    expect(r.query).toBe("how do I rotate those?");
+  });
+
+  it("happy path: rewrites the follow-up into a standalone query using history", async () => {
+    const r = await condenseQuery("how do I rotate those?", ["What did the panel say about MCP enterprise auth?"], {
+      apiKey: "test",
+      fetchImpl: mockGeminiFetch("rotate MCP scoped credentials"),
+    });
+    expect(r.status).toBe("rewritten");
+    expect(r.query).toBe("rotate MCP scoped credentials");
+  });
+
+  it("sad path: missing API key → fallback to raw question", async () => {
+    const saved = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    try {
+      const r = await condenseQuery("compare that to static keys", ["scoped creds vs static keys"]);
+      expect(r.status).toBe("fallback");
+      expect(r.query).toBe("compare that to static keys");
+    } finally {
+      if (saved !== undefined) process.env.GEMINI_API_KEY = saved;
+    }
+  });
+
+  it("degraded: non-2xx → fallback to raw question, never throws", async () => {
+    const bad = (async () => ({ ok: false, status: 503, json: async () => ({}) }) as unknown as Response) as unknown as typeof fetch;
+    const r = await condenseQuery("and the cost?", ["audit tool calls"], { apiKey: "test", fetchImpl: bad });
+    expect(r.status).toBe("fallback");
+    expect(r.query).toBe("and the cost?");
+  });
+
+  it("bound: only the last maxTurns of history reach the prompt", async () => {
+    let promptText = "";
+    const spy = (async (_u: string, init: any) => {
+      promptText = JSON.parse(init.body).contents[0].parts[0].text;
+      return { ok: true, status: 200, json: async () => ({ candidates: [{ content: { parts: [{ text: "rewritten" }] } }] }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const turns = Array.from({ length: 12 }, (_, i) => `turn ${i}`);
+    const r = await condenseQuery("now what?", turns, { apiKey: "test", maxTurns: 3, fetchImpl: spy });
+    expect(r.status).toBe("rewritten");
+    expect(promptText).toContain("turn 11"); // last turn included
+    expect(promptText).not.toContain("turn 0"); // beyond the last 3 → excluded
   });
 });

--- a/shared/search/triSearch.ts
+++ b/shared/search/triSearch.ts
@@ -201,3 +201,84 @@ export async function triSearch(
   const r = await rerankWithGemini(query, fused, opts);
   return { ranked: r.ranked, fusedCount: fused.length, rerankStatus: r.rerankStatus, detail: r.detail, durationMs: r.durationMs };
 }
+
+export type CondenseStatus = "rewritten" | "passthrough" | "fallback";
+
+/**
+ * Multi-turn query condensation — the production "rewrite-then-retrieve" standard
+ * (LangChain history-aware retriever, LlamaIndex CondensePlusContext, Glean
+ * decontextualize, Perplexity/ChatGPT reformulate). Turns the asker's recent OWN
+ * turns + the current follow-up into ONE standalone retrieval/rerank query that
+ * resolves pronouns/ellipsis ("those", "that", "their", "it").
+ *
+ * Why rewrite (not raw-history-append): cross-encoder rerankers score one query×doc
+ * blob — dumping history dilutes the signal + triggers lost-in-the-middle. Rewrite
+ * keeps the query sharp. Raw follow-up is kept by the CALLER for answer synthesis.
+ *
+ * PRIVACY: callers MUST pass only the asker's own turns — never other attendees'.
+ * HONEST fallback: no history / no key / non-2xx / timeout / empty → returns the raw
+ * question unchanged (status passthrough|fallback) so retrieval never breaks.
+ * thinkingBudget:0 so the thinking model returns the bare query, not a preamble.
+ */
+export async function condenseQuery(
+  question: string,
+  priorTurns: string[],
+  opts: { maxTurns?: number; timeoutMs?: number; apiKey?: string; fetchImpl?: typeof fetch } = {},
+): Promise<{ query: string; status: CondenseStatus; detail: string; durationMs: number }> {
+  const startedAt = Date.now();
+  const recent = (priorTurns || []).filter((t) => t && t.trim()).slice(-(opts.maxTurns ?? 5));
+  if (recent.length === 0) {
+    return { query: question, status: "passthrough", detail: "no prior turns; raw question used", durationMs: 0 };
+  }
+  const apiKey = opts.apiKey ?? process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    return { query: question, status: "fallback", detail: "GEMINI_API_KEY not set; raw question used", durationMs: 0 };
+  }
+  const doFetch = opts.fetchImpl ?? fetch;
+  const history = recent.map((t, i) => `${i + 1}. ${t.slice(0, 300)}`).join("\n");
+  const prompt = [
+    "Rewrite the FOLLOW-UP into a single standalone search query.",
+    "Resolve pronouns/ellipsis ('those', 'that', 'their', 'it') using the conversation so far.",
+    "Stay faithful — do NOT answer it, do NOT invent facts, do NOT add commentary.",
+    "Return ONLY the rewritten query text — no quotes, no preamble.",
+    "",
+    "Conversation so far (same user):",
+    history,
+    "",
+    `Follow-up: ${question}`,
+  ].join("\n");
+  try {
+    const resp = await doFetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${RERANK_MODEL}:generateContent?key=${encodeURIComponent(apiKey)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0, maxOutputTokens: 128, thinkingConfig: { thinkingBudget: 0 } },
+        }),
+        signal: AbortSignal.timeout(opts.timeoutMs ?? RERANK_TIMEOUT_MS),
+      },
+    );
+    if (!resp.ok) {
+      return { query: question, status: "fallback", detail: `condense HTTP ${resp.status}; raw question used`, durationMs: Date.now() - startedAt };
+    }
+    const data: any = await resp.json();
+    const text: string = (data?.candidates?.[0]?.content?.parts ?? []).map((p: any) => p?.text ?? "").join("").trim();
+    const cleaned = text.replace(/^["'`]+|["'`]+$/g, "").trim().slice(0, 400);
+    if (!cleaned) {
+      return { query: question, status: "fallback", detail: "empty condense response; raw question used", durationMs: Date.now() - startedAt };
+    }
+    return { query: cleaned, status: "rewritten", detail: cleaned, durationMs: Date.now() - startedAt };
+  } catch (err: any) {
+    const aborted = err?.name === "TimeoutError" || err?.name === "AbortError";
+    return {
+      query: question,
+      status: "fallback",
+      detail: aborted
+        ? `condense timed out after ${opts.timeoutMs ?? RERANK_TIMEOUT_MS}ms; raw question used`
+        : `condense failed: ${err?.message || String(err)}; raw question used`,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Multi-turn `/ask` follow-ups now retrieve correctly. A question like "how do I rotate **those**?" used to fail — the pronoun never resolved against the conversation, so `scoreSource` + the Gemini rerank scored a context-free query and surfaced the wrong sources.

This adopts the production **rewrite-then-retrieve** standard (LangChain history-aware retriever, LlamaIndex `CondensePlusContext`, Glean decontextualize, Perplexity/ChatGPT reformulate): condense the asker's prior turns + the follow-up into ONE standalone retrieval query, while keeping the **raw question verbatim** for answer synthesis (condense-plus-context).

- **`shared/search/triSearch.ts` → `condenseQuery(question, priorTurns, opts)`**
  - Uses `RERANK_MODEL` (`gemini-3.5-flash`) with `thinkingConfig.thinkingBudget: 0` so the thinking model returns the bare rewritten query, not a reasoning preamble.
  - **Honest fallback on every failure path**: no history → `passthrough`; no key / non-2xx / empty / timeout → `fallback`, always returning the raw question so retrieval never breaks.
  - Bounded (`maxTurns=5`, char slices); injectable `fetchImpl` for deterministic tests.
- **Privacy**: in a public event room we condense **only the asker's own session turns**. `_prepareAskAgentContext` returns `priorTurns` filtered to `args.sessionId` — never other attendees' messages.
- **`convex/events.ts` `askAgent`**: condense → `retrievalQuery` drives `scoreSource`, `shouldProbeLiveSearch`, `searchLinkup`, and `rerankWithGemini`; the raw `question` is kept for `generateProviderAnswer`/persist. New `condense_query` trace step makes the rewrite visible in "Show trace".

## Why rewrite, not raw-history-append

A cross-encoder reranker scores one `query × doc` blob — dumping raw history dilutes the signal and triggers lost-in-the-middle (arXiv:2307.03172). Rewrite keeps the query sharp; the raw follow-up is preserved by the caller for the answer.

## Measurably better (multi-turn eval)

`scripts/eval-harness/triSearchConversationEval.ts` — 2 conversations × 4 turns, NDCG@5 split by context-dependent vs standalone turns:

| Mode | NDCG@5 on context-dependent follow-ups |
|---|---|
| lexical | 0.800 |
| naive rerank (current query) | 0.917 |
| raw-history-append rerank | 1.000 |
| **rewrite rerank (this PR)** | **1.000** |

Rewrite matches raw-history-append (+0.083 over naive) **without** the history-dilution / lost-in-the-middle cost.

## Test plan

- [x] `npx vitest run shared/search/triSearch.test.ts` → **15/15 pass** (5 new `condenseQuery` scenarios: passthrough, happy rewrite, no-key fallback, non-2xx fallback, maxTurns bound — all deterministic via injected `fetchImpl`, no live API)
- [x] Multi-turn conversation eval green (table above)
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx convex codegen` → clean
- [ ] Post-merge: live `/ask` follow-up shows `condense_query: ok` + `rerank_sources: ok` in the prod trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
