### PR TITLE
fix(tri-search): reranker honest-status (GPT-5.5 review finding 6)

### DIFF
--- a/shared/search/triSearch.test.ts
+++ b/shared/search/triSearch.test.ts
@@ -69,6 +69,17 @@ describe("rerankWithGemini — precision leg with honest fallback", () => {
     expect(new Set(r.ranked.map((c) => c.id)).size).toBe(4); // no dupes
   });
 
+  it("HONEST_STATUS: zero usable indices ([], all out-of-range, non-numeric) -> fallback, not a phantom 'ok'", async () => {
+    // The model returned an array, but nothing in it maps to a real candidate. The result is pure
+    // fused order — so the status MUST be fallback, not "ok" (which would lie that a rerank happened).
+    for (const garbage of ["[]", "[999, -1, 7]", "[\"x\", \"y\"]"]) {
+      const r = await rerankWithGemini("q", fused, { topN: 4, apiKey: "test", fetchImpl: mockGeminiFetch(garbage) });
+      expect(r.rerankStatus).toBe("fallback");
+      expect(r.ranked.map((c) => c.id)).toEqual(["s0", "s1", "s2", "s3"]); // untouched fused order
+      expect(r.detail).toMatch(/no valid index/i);
+    }
+  });
+
   it("sad path: missing API key -> skipped, returns fused top-N unchanged", async () => {
     const saved = process.env.GEMINI_API_KEY;
     delete process.env.GEMINI_API_KEY;

--- a/shared/search/triSearch.ts
+++ b/shared/search/triSearch.ts
@@ -171,9 +171,16 @@ export async function rerankWithGemini(
         ranked.push(bounded[idx]);
       }
     }
+    // HONEST_STATUS: if the model produced NO usable index (e.g. [], [999], ["x"]), the result is
+    // pure fused order — it was not reranked. Report that truthfully so the trace can't claim a
+    // rerank that didn't happen.
+    if (seen.size === 0) {
+      const peek = JSON.stringify(order).slice(0, 60);
+      return { ranked: fusedTopN(bounded, topN), rerankStatus: "fallback", detail: `rerank produced no valid index (model returned ${peek}); fused order kept.`, durationMs: Date.now() - startedAt };
+    }
     // Append any candidate the reranker omitted, in fused order — deterministic completeness.
     bounded.forEach((c, i) => { if (!seen.has(i)) ranked.push(c); });
-    return { ranked: ranked.slice(0, topN), rerankStatus: "ok", detail: `reranked ${bounded.length} candidates -> top ${Math.min(topN, ranked.length)}.`, durationMs: Date.now() - startedAt };
+    return { ranked: ranked.slice(0, topN), rerankStatus: "ok", detail: `reranked ${seen.size}/${bounded.length} candidates -> top ${Math.min(topN, ranked.length)}.`, durationMs: Date.now() - startedAt };
   } catch (err: any) {
     const aborted = err?.name === "TimeoutError" || err?.name === "AbortError";
     return {


### PR DESCRIPTION
## Summary

First fix from the **GPT-5.5 xhigh adversarial review** of the `/ask` pipeline (Finding 6). HONEST_STATUS violation in the reranker, in code I shipped this session.

`rerankWithGemini` sanitizes the model's index array, then appends any omitted candidates in fused order. But when the model returns **zero usable indices** (`[]`, `[999]`, `["x"]`), the result is *pure fused order* — yet the function still returned `rerankStatus: "ok"`, so the `/ask` trace would claim a rerank that never happened.

Fix: if no valid index survived (`seen.size === 0`), return `rerankStatus: "fallback"` with an honest detail. The `"ok"` path now reports `seen.size/total` (how many the model actually placed).

Per [`.claude/rules/agentic_reliability.md`](.claude/rules/agentic_reliability.md) #2 — never report success when the operation didn't happen.

## Test plan
- [x] +1 scenario test: zero usable indices over `[]`, all-out-of-range, and non-numeric arrays → `fallback`, fused order preserved
- [x] `npx vitest run shared/search/triSearch.test.ts` → **16/16 pass**
- [x] `npx tsc --noEmit` → 0 errors

## Remaining from the review (next, focused PR)
Findings 1–5 are a coherent hardening of the live `askAgent` action in `convex/events.ts` (cache-before-condense, server-derived question, per-session ask rate-limit + idempotency, source-freshness cache key, **enforcing** the public/private gate). Those touch live `/ask` traffic with privacy implications, so they get their own carefully-QA'd PR (codegen + convex test + deploy + live re-verify) — not bundled into this isolated fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
