### PR TITLE
chore(scratchnode): track demo/export tooling + public-split runbook

### DIFF
--- a/docs/runbooks/PUBLIC_SCRATCHNODE_LIVE_SPLIT.md
+++ b/docs/runbooks/PUBLIC_SCRATCHNODE_LIVE_SPLIT.md
@@ -1,0 +1,206 @@
+# Public ScratchNode Live Split
+
+Date: 2026-05-29
+
+## Decision
+
+Keep `nodebench-ai` as the canonical backend/runtime monorepo. Publish `scratchnode-live` as a sanitized public frontend and public-edge repository.
+
+```text
+scratchnode-live public repo
+= ScratchNode event-room shell
+= public docs and Open Graph assets
+= minimal Vercel routing/config endpoint
+= route honesty and output-contract tests
+= mirrored public contracts
+
+nodebench-ai monorepo
+= Convex source of truth
+= ScratchNode backend functions
+= NodeBench private workspace
+= MCP/API/headless services
+= provider integrations, evals, internal dogfood, deploy orchestration
+```
+
+This preserves backend compatibility while making the public repo understandable and safe to inspect.
+
+## Current Production Reality
+
+`scratchnode.live` is already deployed on Vercel. Exact event routes such as `/e/:slug` load the ScratchNode v5 shell and fetch `/api/scratchnode-config`, which exposes the live Convex URL by design.
+
+Do not confuse this with repo-readiness. The site can be live while the full monorepo remains unsafe to publish.
+
+## Non-Negotiable Invariants
+
+- Demo automation runs only on `/demo_ver*`.
+- Production room routes must be Convex-backed.
+- Missing production rooms must show an honest missing-room state, not fixture chat.
+- Normal public chat never invokes the agent.
+- Public `/ask` shows the parent ask and a trace that says no private notes were used.
+- Private notes never enter public chat, public wiki, public trace, or public cache.
+- Attendees suggest FAQ entries; hosts promote them.
+
+## Export Allowlist
+
+The public split may include:
+
+```text
+public/proto/home-v5.html
+public/proto/docs.html
+public/og-scratchnode.png
+public/og-scratchnode.svg
+api/scratchnode-config.js
+docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md
+docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md
+docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md
+src/shared/agentOutputContract.ts -> contracts/agentOutputContract.ts
+src/shared/riskAttackEvaluator.ts -> contracts/riskAttackEvaluator.ts
+tests/e2e/scratchnode-demo-route-gate.spec.ts
+tests/e2e/scratchnode-live-route-honesty.spec.ts
+tests/e2e/home-v5-output-contract.spec.ts
+tests/e2e/proto-live-backend-dogfood.spec.ts
+LICENSE
+```
+
+The export script also generates:
+
+```text
+README.md
+CONTRIBUTING.md
+SECURITY.md
+MANIFEST.md
+package.json
+vercel.json
+robots.txt
+sitemap.xml
+.env.example
+.gitignore
+docs/invariants.md
+docs/prototype-vs-production.md
+contracts/scratchnode-live-api.json
+```
+
+## Explicit Exclusions
+
+Never copy these into the public split:
+
+```text
+convex/
+server/
+apps/
+packages/
+mcp-services/
+python-mcp-servers/
+mobile/
+services/
+remotion/
+public/dogfood/
+public/benchmarks/
+public/assets/
+public/logos/
+public/proto/home-v4.html
+public/proto/home-v3.html
+public/proto/home-v2.html
+public/agent-setup.txt
+.env*
+.vercel/
+.worktrees/
+.tmp*
+.claude/
+.serena/
+.mcp.json
+node_modules/
+current .github/workflows/
+```
+
+## P0 Before Publishing Any Full Repo
+
+If this monorepo is ever made public, stop and fix these first:
+
+- Revoke and rotate any token-like values in `.mcp.json` and `packages/mcp-local/.mcpregistry_registry_token`.
+- Remove tracked credential artifacts and purge them from public history, or publish from a fresh sanitized export with no inherited history.
+- Exclude operator/harness routes, filesystem execution routes, internal dogfood traces, and benchmark/debug artifacts.
+- Replace hard-coded service secrets with env-only fail-closed auth.
+- Review unauthenticated agent, voice, webhook, and metrics routes before exposing them to public traffic.
+
+The public `scratchnode-live` repo should be created from an allowlist export, not by making this monorepo public.
+
+## Export Command
+
+```powershell
+node scripts/repo/export-scratchnode-live-public.mjs --out .tmp/scratchnode-live-public-export --force
+```
+
+The script:
+
+- copies only the allowlisted files,
+- rewrites public docs links that would otherwise point at missing local prototype files,
+- generates public repo metadata,
+- creates a minimal ScratchNode-only `vercel.json`,
+- writes the public Convex API/string-call contract,
+- scans the output for forbidden files and sensitive strings,
+- exits non-zero on export safety failures.
+
+## Backend Compatibility Rule
+
+Backend changes remain in `nodebench-ai` and must be additive-first:
+
+```text
+1. Deploy compatible Convex/backend changes from nodebench-ai.
+2. Export or update scratchnode-live frontend.
+3. Deploy scratchnode-live.
+4. Run route honesty and live two-browser room smoke.
+5. Remove deprecated backend fields only after the public frontend no longer calls them.
+```
+
+`home-v5.html` currently calls Convex functions by string name. Treat these names as a public contract:
+
+```text
+events:getEventBySlug
+events:joinEvent
+events:sendMessage
+events:createEvent
+events:updateEvent
+events:endEvent
+events:publishWiki
+events:rotateHostClaimCode
+events:upsertEventSource
+events:deleteEventSource
+events:suggestFAQ
+events:promoteFAQ
+notes:createPrivateNote
+notes:listMyPrivateNotes
+notes:updatePrivateNote
+notes:deletePrivateNote
+users:mergeGuestSession
+```
+
+## Public Repo Positioning
+
+Use this framing:
+
+> ScratchNode Live is a public event-room prototype where people join with a code, chat normally, use `/ask` for sourced answers, and leave behind a public event wiki. Private notes stay private and can sync into NodeBench later.
+
+Do not claim the public split is the full NodeBench backend. Do not claim every URL contract is fully implemented just because the Vercel catch-all returns `200`.
+
+## Release Verification
+
+After exporting:
+
+```powershell
+Set-Location .tmp/scratchnode-live-public-export
+npm install
+npm run verify
+```
+
+After deployment:
+
+```text
+1. Open scratchnode.live/e/<room-code> in two incognito windows.
+2. Send chat in window A. It appears in B without refresh.
+3. Send chat in window B. It appears in A without refresh.
+4. Open scratchnode.live/e/not-a-room. It shows missing-room alert, not mock chat.
+5. Open scratchnode.live/demo_ver1. Demo automation may run there only.
+6. Open scratchnode.live/api/scratchnode-config. It returns only public config.
+```
+

--- a/scripts/repo/export-scratchnode-live-public.mjs
+++ b/scripts/repo/export-scratchnode-live-public.mjs
@@ -1,0 +1,546 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+const rawArgs = process.argv.slice(2);
+const args = new Set(rawArgs);
+const outIndex = rawArgs.indexOf("--out");
+const outArg = outIndex >= 0 ? rawArgs[outIndex + 1] : null;
+const force = args.has("--force");
+const dryRun = args.has("--dry-run");
+const targetDir = path.resolve(repoRoot, outArg || ".tmp/scratchnode-live-public-export");
+
+const copyEntries = [
+  ["public/proto/home-v5.html", "public/proto/home-v5.html", transformHomeV5],
+  ["public/proto/docs.html", "public/proto/docs.html", transformDocsHtml],
+  ["public/og-scratchnode.png", "public/og-scratchnode.png"],
+  ["public/og-scratchnode.svg", "public/og-scratchnode.svg"],
+  ["api/scratchnode-config.js", "api/scratchnode-config.js"],
+  ["docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md", "docs/architecture/SCRATCHNODE_NODEBENCH_BOUNDARY.md"],
+  ["docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md", "docs/architecture/PRODUCT_SURFACE_RUNTIME_OWNERSHIP.md"],
+  ["docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md", "docs/architecture/PROTO_SURFACE_REAL_BACKEND_DOGFOOD.md"],
+  ["src/shared/agentOutputContract.ts", "contracts/agentOutputContract.ts"],
+  ["src/shared/riskAttackEvaluator.ts", "contracts/riskAttackEvaluator.ts"],
+  ["tests/e2e/scratchnode-demo-route-gate.spec.ts", "tests/e2e/scratchnode-demo-route-gate.spec.ts"],
+  ["tests/e2e/scratchnode-live-route-honesty.spec.ts", "tests/e2e/scratchnode-live-route-honesty.spec.ts"],
+  ["tests/e2e/home-v5-output-contract.spec.ts", "tests/e2e/home-v5-output-contract.spec.ts"],
+  ["tests/e2e/proto-live-backend-dogfood.spec.ts", "tests/e2e/proto-live-backend-dogfood.spec.ts"],
+  ["LICENSE", "LICENSE"],
+];
+
+const forbiddenRelativePaths = [
+  ".mcp.json",
+  "packages/mcp-local/.mcpregistry_registry_token",
+  "packages/mcp-local/.mcpregistry_github_token",
+  "public/dogfood",
+  "public/benchmarks",
+  "public/proto/home-v4.html",
+  "convex",
+  "server",
+  "apps",
+  "packages",
+  "mcp-services",
+  "python-mcp-servers",
+  "node_modules",
+  ".env",
+  ".vercel",
+  ".worktrees",
+  ".claude",
+  ".serena",
+];
+
+const forbiddenContentPatterns = [
+  { label: "hard-coded development service secret", pattern: /nodebench_dev_secret/i },
+  { label: "OpenAI-style secret key", pattern: /sk-[A-Za-z0-9_-]{20,}/ },
+  { label: "GitHub token", pattern: /gh[pousr]_[A-Za-z0-9_]{20,}/ },
+  { label: "local Windows workspace path", pattern: /D:\\\\VSCode Projects/i },
+];
+
+function ensureParent(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function writeText(relativePath, content) {
+  const destination = path.join(targetDir, relativePath);
+  ensureParent(destination);
+  fs.writeFileSync(destination, content);
+}
+
+function transformHomeV5(content) {
+  return content;
+}
+
+function transformDocsHtml(content) {
+  return content
+    .replaceAll('href="home-v4.html"', 'href="https://www.nodebenchai.com/proto/home-v4.html"')
+    .replaceAll('href="home-v5.html"', 'href="/"');
+}
+
+function copyAllowlistedEntries() {
+  const copied = [];
+  for (const [sourceRelative, destinationRelative, transform] of copyEntries) {
+    const source = path.join(repoRoot, sourceRelative);
+    if (!fs.existsSync(source)) {
+      throw new Error(`Missing allowlisted source: ${sourceRelative}`);
+    }
+
+    const destination = path.join(targetDir, destinationRelative);
+    ensureParent(destination);
+
+    const stat = fs.statSync(source);
+    if (stat.isDirectory()) {
+      fs.cpSync(source, destination, { recursive: true });
+    } else if (transform) {
+      fs.writeFileSync(destination, transform(readText(source)));
+    } else {
+      fs.copyFileSync(source, destination);
+    }
+    copied.push(`${sourceRelative} -> ${destinationRelative}`);
+  }
+  return copied;
+}
+
+function writeGeneratedFiles(copiedEntries) {
+  writeText("README.md", buildReadme());
+  writeText("CONTRIBUTING.md", buildContributing());
+  writeText("SECURITY.md", buildSecurity());
+  writeText("MANIFEST.md", buildManifest(copiedEntries));
+  writeText("package.json", `${JSON.stringify(buildPackageJson(), null, 2)}\n`);
+  writeText("vercel.json", `${JSON.stringify(buildVercelJson(), null, 2)}\n`);
+  writeText("robots.txt", buildRobotsTxt());
+  writeText("sitemap.xml", buildSitemapXml());
+  writeText(".env.example", buildEnvExample());
+  writeText(".gitignore", buildGitignore());
+  writeText("docs/invariants.md", buildInvariantsDoc());
+  writeText("docs/prototype-vs-production.md", buildPrototypeStatusDoc());
+  writeText("contracts/scratchnode-live-api.json", `${JSON.stringify(buildApiContract(), null, 2)}\n`);
+  writeVerifyScript();
+}
+
+function buildReadme() {
+  return `# ScratchNode Live
+
+**Live rooms that remember.**
+
+ScratchNode is a public event-room prototype where people join with a code, chat normally, use \`/ask\` for sourced answers, and leave behind a public wiki. Private notes stay private and can sync into NodeBench later.
+
+- No app required.
+- No account required for public room join.
+- Public chat stays human.
+- \`/ask\` calls the agent.
+- Private notes never enter the public feed.
+- Hosts promote useful answers into the event wiki.
+
+> ScratchNode Live is the public room. NodeBench AI is the private workspace.
+
+## Try It
+
+Production: https://scratchnode.live
+
+Local static preview:
+
+\`\`\`bash
+npm run dev
+\`\`\`
+
+## Core Loop
+
+1. Join with a room code.
+2. Chat with the room.
+3. Use \`/ask\` for a sourced public answer.
+4. Save private notes.
+5. Host promotes useful answers to FAQ.
+6. Event compacts into a public wiki.
+7. Private work continues in NodeBench.
+
+## Status
+
+This is a sanitized public frontend split. The Convex backend, NodeBench workspace, MCP services, internal evals, and deploy orchestration remain in the private \`nodebench-ai\` monorepo.
+
+See [docs/prototype-vs-production.md](docs/prototype-vs-production.md).
+
+## Release-Blocker Invariants
+
+See [docs/invariants.md](docs/invariants.md).
+
+## Architecture
+
+\`\`\`text
+scratchnode.live
+  -> public event room shell
+  -> /ask and private-note UI
+  -> public docs and route honesty tests
+
+NodeBench Runtime
+  -> Convex durable state
+  -> agent orchestration
+  -> search, trace, cache, cost controls
+
+nodebenchai.com
+  -> private workspace continuation
+\`\`\`
+
+## Verify
+
+\`\`\`bash
+npm install
+npm run verify
+\`\`\`
+`;
+}
+
+function buildContributing() {
+  return `# Contributing
+
+This repo is intentionally narrow. Keep ScratchNode simple:
+
+- join room
+- public chat
+- \`/ask\`
+- public answer card and trace
+- private note
+- FAQ suggest/promote
+- wiki publish
+- sign-in / my events entry points
+
+Do not add NodeBench workspace depth, MCP services, Convex implementation, internal dogfood, or provider integrations to this public split.
+`;
+}
+
+function buildSecurity() {
+  return `# Security
+
+Please report security issues privately to the maintainers instead of opening a public issue.
+
+## Public Boundary
+
+This repo should not contain secrets, deploy tokens, dogfood traces, internal MCP services, or backend implementation. The public frontend talks to a configured Convex deployment through documented public APIs.
+
+## Privacy Invariant
+
+Private notes must never enter public chat, public wiki, public traces, or public cache entries.
+`;
+}
+
+function buildManifest(copiedEntries) {
+  return `# ScratchNode Live Public Export
+
+Generated from \`nodebench-ai\` on ${new Date().toISOString()}.
+
+## Included
+
+${copiedEntries.map((entry) => `- \`${entry}\``).join("\n")}
+
+## Excluded On Purpose
+
+- Convex implementation
+- NodeBench private workspace implementation
+- MCP/API/headless services
+- internal dogfood and benchmark artifacts
+- provider integrations
+- deployment secrets and local config
+- historical prototype files other than \`home-v5.html\` and public docs
+
+## Backend Compatibility
+
+The backend source of truth remains the private monorepo. Any Convex function rename or contract change must be deployed additively before this frontend is updated.
+`;
+}
+
+function buildPackageJson() {
+  return {
+    name: "scratchnode-live",
+    version: "0.1.0",
+    private: true,
+    type: "module",
+    description: "Live event rooms that turn public chat and /ask answers into a wiki while private notes stay private.",
+    scripts: {
+      dev: "vercel dev",
+      verify: "npm run verify:static",
+      "verify:static": "node scripts/verify-public-export.mjs",
+      "test:e2e": "playwright test tests/e2e/scratchnode-demo-route-gate.spec.ts tests/e2e/scratchnode-live-route-honesty.spec.ts tests/e2e/home-v5-output-contract.spec.ts --project=chromium --workers=1",
+    },
+    devDependencies: {
+      "@playwright/test": "^1.53.0",
+      vercel: "^41.6.0",
+    },
+  };
+}
+
+function buildVercelJson() {
+  return {
+    redirects: [
+      {
+        source: "/(.*)",
+        has: [{ type: "host", value: "www.scratchnode.live" }],
+        destination: "https://scratchnode.live/$1",
+        permanent: true,
+      },
+    ],
+    rewrites: [
+      { source: "/api/scratchnode-config", destination: "/api/scratchnode-config.js" },
+      { source: "/docs", destination: "/proto/docs.html" },
+      { source: "/docs.html", destination: "/proto/docs.html" },
+      { source: "/og-scratchnode.png", destination: "/og-scratchnode.png" },
+      { source: "/og-scratchnode.svg", destination: "/og-scratchnode.svg" },
+      { source: "/(.*)", destination: "/proto/home-v5.html" },
+    ],
+    headers: [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        ],
+      },
+    ],
+  };
+}
+
+function buildRobotsTxt() {
+  return `User-agent: *
+Allow: /
+
+Sitemap: https://scratchnode.live/sitemap.xml
+`;
+}
+
+function buildSitemapXml() {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://scratchnode.live/</loc></url>
+  <url><loc>https://scratchnode.live/docs</loc></url>
+</urlset>
+`;
+}
+
+function buildEnvExample() {
+  return `# ScratchNode Live public frontend
+
+# Required. Public Convex deployment URL used by /api/scratchnode-config.
+CONVEX_URL=https://your-project.convex.cloud
+
+# Optional alias for local Vite-style environments.
+VITE_CONVEX_URL=https://your-project.convex.cloud
+`;
+}
+
+function buildGitignore() {
+  return `node_modules/
+.vercel/
+.env
+.env.*
+!.env.example
+playwright-report/
+test-results/
+.tmp/
+.DS_Store
+*.log
+.mcp.json
+.mcpregistry_registry_token
+.mcpregistry_github_token
+`;
+}
+
+function buildInvariantsDoc() {
+  return `# Release-Blocker Invariants
+
+These are product safety rules, not preferences.
+
+1. Private notes never enter the public feed.
+2. Normal chat never invokes the agent.
+3. Agent answers always show their parent \`/ask\`.
+4. Public users suggest FAQ entries; hosts promote them.
+5. Public traces show "No private notes used."
+6. Demo automation runs only on \`/demo_ver*\`.
+7. Missing live rooms show an honest missing-room state, not mock chat.
+`;
+}
+
+function buildPrototypeStatusDoc() {
+  return `# Prototype vs Production
+
+| Area | Public split | Production source of truth |
+| --- | --- | --- |
+| Event-room UI | \`public/proto/home-v5.html\` | This repo's public shell |
+| Durable state | Public Convex API calls | Private \`nodebench-ai\` monorepo |
+| Private notes | UI + public contract | Convex backend and NodeBench handoff |
+| Agent runtime | Public answer cards and traces | NodeBench Runtime |
+| Search/cache | Public contract docs | Typesense/Redis/Linkup/pi-ai in private backend |
+| NodeBench workspace | External handoff URL | \`nodebenchai.com\` |
+
+This repo should stay focused on the public live room. Backend runtime changes happen in \`nodebench-ai\` and are deployed additively before frontend contract changes.
+`;
+}
+
+function buildApiContract() {
+  return {
+    convexFunctions: [
+      "events:getEventBySlug",
+      "events:joinEvent",
+      "events:sendMessage",
+      "events:createEvent",
+      "events:updateEvent",
+      "events:endEvent",
+      "events:publishWiki",
+      "events:rotateHostClaimCode",
+      "events:upsertEventSource",
+      "events:deleteEventSource",
+      "events:suggestFAQ",
+      "events:promoteFAQ",
+      "notes:createPrivateNote",
+      "notes:listMyPrivateNotes",
+      "notes:updatePrivateNote",
+      "notes:deletePrivateNote",
+      "users:mergeGuestSession",
+    ],
+    localStorageKeys: [
+      "sn_session_id",
+      "sn_host_owner_key_v2",
+      "sn_host_owner_key",
+    ],
+    privacyInvariants: [
+      "private notes never create eventMessages rows",
+      "public ask traces say no private notes used",
+      "private note markers are owner-only",
+    ],
+  };
+}
+
+function writeVerifyScript() {
+  const script = `import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const required = [
+  "public/proto/home-v5.html",
+  "public/proto/docs.html",
+  "api/scratchnode-config.js",
+  "contracts/scratchnode-live-api.json",
+  "docs/invariants.md",
+  "vercel.json",
+];
+
+const missing = required.filter((relativePath) => !fs.existsSync(path.join(root, relativePath)));
+if (missing.length) {
+  console.error("Missing required files:\\n" + missing.map((entry) => " - " + entry).join("\\n"));
+  process.exit(1);
+}
+
+const forbidden = [
+  ".mcp.json",
+  "packages/mcp-local/.mcpregistry_registry_token",
+  "public/dogfood",
+  "public/benchmarks",
+  "convex",
+  "server",
+  "apps",
+  "packages",
+];
+
+const presentForbidden = forbidden.filter((relativePath) => fs.existsSync(path.join(root, relativePath)));
+if (presentForbidden.length) {
+  console.error("Forbidden paths present:\\n" + presentForbidden.map((entry) => " - " + entry).join("\\n"));
+  process.exit(1);
+}
+
+console.log("ScratchNode public export verification passed.");
+`;
+  writeText("scripts/verify-public-export.mjs", script);
+}
+
+function scanOutputForSafetyIssues() {
+  const failures = [];
+
+  for (const relativePath of forbiddenRelativePaths) {
+    if (fs.existsSync(path.join(targetDir, relativePath))) {
+      failures.push(`Forbidden path present: ${relativePath}`);
+    }
+  }
+
+  const files = listFiles(targetDir);
+  for (const filePath of files) {
+    const relativePath = path.relative(targetDir, filePath).replaceAll(path.sep, "/");
+    const stat = fs.statSync(filePath);
+    if (stat.size > 1_000_000) continue;
+
+    let content;
+    try {
+      content = fs.readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    for (const { label, pattern } of forbiddenContentPatterns) {
+      if (pattern.test(content)) {
+        failures.push(`Forbidden content (${label}) in ${relativePath}`);
+      }
+    }
+  }
+
+  return failures;
+}
+
+function listFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...listFiles(fullPath));
+    else files.push(fullPath);
+  }
+  return files;
+}
+
+function isForceDeleteSafe(target) {
+  const relative = path.relative(repoRoot, target);
+  const insideRepo = !relative.startsWith("..") && !path.isAbsolute(relative);
+  const normalized = target.replaceAll(path.sep, "/");
+  return insideRepo && normalized.includes("/.tmp/");
+}
+
+function main() {
+  if (args.has("--help")) {
+    console.log("Usage: node scripts/repo/export-scratchnode-live-public.mjs --out .tmp/scratchnode-live-public-export [--force] [--dry-run]");
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`Would export ScratchNode public repo to ${targetDir}`);
+    console.log(copyEntries.map(([source, destination]) => `${source} -> ${destination}`).join("\n"));
+    return;
+  }
+
+  if (fs.existsSync(targetDir)) {
+    if (!force) {
+      throw new Error(`Target exists: ${targetDir}. Re-run with --force to replace it.`);
+    }
+    if (!isForceDeleteSafe(targetDir)) {
+      throw new Error(`Refusing to --force delete outside repo .tmp/: ${targetDir}`);
+    }
+    fs.rmSync(targetDir, { recursive: true, force: true });
+  }
+
+  fs.mkdirSync(targetDir, { recursive: true });
+  const copiedEntries = copyAllowlistedEntries();
+  writeGeneratedFiles(copiedEntries);
+
+  const failures = scanOutputForSafetyIssues();
+  if (failures.length) {
+    console.error("Public export failed safety scan:");
+    console.error(failures.map((failure) => `- ${failure}`).join("\n"));
+    process.exit(1);
+  }
+
+  console.log(`Created ScratchNode public export at ${targetDir}`);
+}
+
+main();

--- a/scripts/ui/judgeScratchnodeChatVideo.mjs
+++ b/scripts/ui/judgeScratchnodeChatVideo.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Gemini video-understanding judge for the LIVE ScratchNode chat.
+ * Answers ONE question honestly: "Would this chat be good for real users today?"
+ *
+ * Uploads a real recording (from recordScratchnodeChatDemo.mjs) to the Gemini
+ * File API, asks gemini-2.5-flash to evaluate it as a product reviewer would,
+ * and prints a structured verdict. No hardcoded scores — the model scores what
+ * it actually sees in the video.
+ *
+ * Usage:
+ *   node scripts/ui/judgeScratchnodeChatVideo.mjs --video <path.webm> [--surface desktop|mobile]
+ */
+import { GoogleGenAI } from "@google/genai";
+import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const getArg = (f, d) => { const i = args.indexOf(f); return i >= 0 && args[i + 1] ? args[i + 1] : d; };
+const VIDEO = getArg("--video", "");
+const SURFACE = getArg("--surface", "desktop");
+const MODEL = getArg("--model", "gemini-3.5-flash"); // latest Gemini 3.5 Flash (thinking model → thinkingBudget:0 set below)
+if (!VIDEO || !fs.existsSync(VIDEO)) { console.error("ERR: --video <existing path> required"); process.exit(1); }
+
+function loadKey() {
+  if (process.env.GEMINI_API_KEY) return process.env.GEMINI_API_KEY;
+  const envPath = path.resolve(".env.local");
+  if (fs.existsSync(envPath)) {
+    const m = fs.readFileSync(envPath, "utf8").match(/^GEMINI_API_KEY=(.+)$/m);
+    if (m) return m[1].trim().replace(/^["']|["']$/g, "");
+  }
+  return null;
+}
+const KEY = loadKey();
+if (!KEY) { console.error("ERR: GEMINI_API_KEY not found (env or .env.local)"); process.exit(1); }
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const PROMPT = `You are a senior product designer reviewing a screen recording of a LIVE web product before launch.
+This is "ScratchNode" — a live-event Q&A room: attendees chat, and "/ask" returns sourced AI answers. You are looking at the ${SURFACE.toUpperCase()} view.
+
+Judge ONLY what you can see in the video. Do not assume features you cannot observe. Be a tough but fair reviewer — the question that matters is: "Would this be good for REAL users today?"
+
+Score each dimension 0-10 (10 = best-in-class, comparable to Slack/Discord/Linear):
+- visual_clarity: is text readable, is contrast sufficient, are elements sharp
+- hierarchy: are author avatars, names, timestamps, and message bodies clearly distinguished
+- chat_convention: does it read like a real chat app (per-author avatars, grouped consecutive messages, a clear composer)${SURFACE === "mobile" ? "; on MOBILE the message input/composer should be pinned to the BOTTOM of the screen" : ""}
+- ${SURFACE === "mobile" ? "mobile_usability: composer reachable at the bottom, no horizontal overflow, touch targets large enough, text not cramped" : "information_density: balanced — informative without overwhelming"}
+- professionalism: does it feel like a finished product vs an unpolished prototype
+
+Return ONLY JSON:
+{
+  "surface": "${SURFACE}",
+  "dimensions": { "visual_clarity": {"score": n, "note": "..."}, "hierarchy": {"score": n, "note": "..."}, "chat_convention": {"score": n, "note": "..."}, "${SURFACE === "mobile" ? "mobile_usability" : "information_density"}": {"score": n, "note": "..."}, "professionalism": {"score": n, "note": "..."} },
+  "readiness_score": n,            // 0-100 overall, weighted by your judgment
+  "verdict": "good_for_users" | "minor_polish_then_ship" | "needs_work",
+  "strengths": ["...", "..."],     // concrete things you SAW that work
+  "issues": ["...", "..."],        // concrete problems you SAW, ordered by severity (empty array if none)
+  "one_line": "single honest sentence a founder could quote"
+}`;
+
+(async () => {
+  const ai = new GoogleGenAI({ apiKey: KEY });
+  let fileName = null;
+  try {
+    const up = await ai.files.upload({ file: VIDEO, config: { mimeType: "video/webm" } });
+    fileName = up.name;
+    // Poll until ACTIVE (bounded — fail honestly if it never processes).
+    let file = await ai.files.get({ name: fileName });
+    for (let i = 0; i < 40 && file.state === "PROCESSING"; i++) { await sleep(3000); file = await ai.files.get({ name: fileName }); }
+    if (file.state !== "ACTIVE") throw new Error(`upload not ACTIVE (state=${file.state}) after polling`);
+
+    const result = await ai.models.generateContent({
+      model: MODEL,
+      contents: [{ role: "user", parts: [{ fileData: { fileUri: file.uri, mimeType: "video/webm" } }, { text: PROMPT }] }],
+      config: { responseMimeType: "application/json", temperature: 0.2, maxOutputTokens: 3500, thinkingConfig: { thinkingBudget: 0 } },
+    });
+    const text = (result.text || "").trim();
+    let parsed;
+    try { parsed = JSON.parse(text); } catch { throw new Error("Gemini returned non-JSON: " + text.slice(0, 300)); }
+    console.log(JSON.stringify({ video: path.basename(VIDEO), model: MODEL, ...parsed }, null, 2));
+  } finally {
+    if (fileName) { try { await ai.files.delete({ name: fileName }); } catch { /* best-effort cleanup */ } }
+  }
+})().catch((e) => { console.error("JUDGE_FAILED:", e && e.message); process.exit(1); });

--- a/scripts/ui/recordScratchnodeChatDemo.mjs
+++ b/scripts/ui/recordScratchnodeChatDemo.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Record a read-only walkthrough of the LIVE ScratchNode chat (web + mobile)
+ * for Gemini video-understanding QA. Captures the deployed product as a real
+ * user sees it — colored avatars, author grouping, the ScratchNode bot answers,
+ * an expanded trace, and (mobile) the bottom-pinned composer.
+ *
+ * Read-only: scroll / hover / expand only. NO /ask, NO writes — the public
+ * showcase room is never polluted.
+ *
+ * Usage:
+ *   node scripts/ui/recordScratchnodeChatDemo.mjs [--url <liveUrl>] [--out <dir>]
+ *
+ * Output: <out>/scratchnode-chat-desktop.webm, <out>/scratchnode-chat-mobile.webm
+ */
+import { chromium } from "playwright";
+import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const getArg = (flag, def) => {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : def;
+};
+const URL = getArg("--url", "https://scratchnode.live/e/ai-infra-summit-2026");
+const OUT = path.resolve(getArg("--out", ".tmp/scratchnode-demo"));
+fs.mkdirSync(OUT, { recursive: true });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Slowly scroll an element/window so the clip is watchable (not a jump-cut). */
+async function smoothScroll(page, totalPx, steps, perStepMs) {
+  const per = Math.round(totalPx / steps);
+  for (let i = 0; i < steps; i++) {
+    await page.evaluate((y) => {
+      const sc = document.scrollingElement || document.documentElement;
+      sc.scrollTop += y;
+    }, per);
+    await sleep(perStepMs);
+  }
+}
+
+async function waitForChat(page, label) {
+  // Feed must have rendered at least one decorated row (avatar = the redesign).
+  try {
+    await page.waitForSelector("#feed .row", { timeout: 25000 });
+  } catch {
+    throw new Error(`[${label}] #feed .row never appeared — room did not load at ${URL}`);
+  }
+  // Give decorateRow + Convex a beat to paint avatars/grouping.
+  await sleep(2500);
+  const avatars = await page.locator("#feed .row-avatar").count();
+  const ansBots = await page.locator("#feed .ans-bot").count();
+  return { avatars, ansBots };
+}
+
+async function recordViewport({ browser, name, viewport, mobile }) {
+  const ctx = await browser.newContext({
+    viewport,
+    deviceScaleFactor: mobile ? 2 : 1,
+    isMobile: !!mobile,
+    hasTouch: !!mobile,
+    recordVideo: { dir: OUT, size: viewport },
+  });
+  const page = await ctx.newPage();
+  const consoleErrors = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text().slice(0, 200));
+  });
+  let signal = { avatars: 0, ansBots: 0 };
+  let videoPath = null;
+  try {
+    await page.goto(URL, { waitUntil: "domcontentloaded", timeout: 30000 });
+    signal = await waitForChat(page, name);
+    // Establish the room: let the top (identity + first messages) breathe.
+    await sleep(1800);
+    // Walk the conversation slowly so avatars / grouping / bot answers are visible.
+    await smoothScroll(page, mobile ? 900 : 1100, 9, 420);
+    await sleep(1000);
+    // Expand the first "Show trace" to reveal the trace UI.
+    const trace = page.locator("#feed .ans-show, #feed .ans button", { hasText: /show trace/i }).first();
+    if (await trace.count()) {
+      try {
+        await trace.scrollIntoViewIfNeeded();
+        await sleep(600);
+        await trace.click({ timeout: 4000 });
+        await sleep(1800);
+      } catch { /* trace optional */ }
+    }
+    await smoothScroll(page, mobile ? 700 : 800, 7, 420);
+    await sleep(1200);
+  } finally {
+    const v = page.video();
+    await ctx.close(); // flush video
+    if (v) videoPath = await v.path().catch(() => null);
+  }
+  return { name, viewport, videoPath, signal, consoleErrors };
+}
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+  try {
+    results.push(await recordViewport({ browser, name: "desktop", viewport: { width: 1280, height: 800 }, mobile: false }));
+    results.push(await recordViewport({ browser, name: "mobile", viewport: { width: 390, height: 844 }, mobile: true }));
+  } finally {
+    await browser.close();
+  }
+  // Rename the auto-generated video files to stable names.
+  const out = {};
+  for (const r of results) {
+    if (r.videoPath && fs.existsSync(r.videoPath)) {
+      const dest = path.join(OUT, `scratchnode-chat-${r.name}.webm`);
+      fs.renameSync(r.videoPath, dest);
+      out[r.name] = { path: dest, ...r.signal, consoleErrors: r.consoleErrors.length };
+    } else {
+      out[r.name] = { path: null, error: "no video produced", ...r.signal };
+    }
+  }
+  console.log(JSON.stringify({ url: URL, outDir: OUT, results: out }, null, 2));
+})().catch((e) => {
+  console.error("RECORD_FAILED:", e && e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Housekeeping: get 4 untracked work-products (demo recorder/judge, public-split export script, runbook) under version control. Docs + standalone scripts only -> not Vercel-relevant -> Tier B skips -> fast merge. Secret-scanned clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)