### PR TITLE
feat(scratchnode): Memory Wall backend — spatial overlay over the event stream

### DIFF
--- a/convex/__tests__/scratchnode.wall.test.ts
+++ b/convex/__tests__/scratchnode.wall.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Scenario-based tests for the Memory Wall backend (convex/wall.ts).
+ *
+ * Per .claude/rules/scenario_testing.md every test names a persona, a goal,
+ * prior state, scale, duration, and adversarial edges. The Wall is a PUBLIC,
+ * collaborative-open spatial overlay over the canonical event stream, so the
+ * threat surface is: cross-event id smuggling, unbounded batches, injection
+ * via color/text, private-note leakage, and rate-limit evasion.
+ *
+ * Invocation idiom mirrors scratchnode.events.test.ts: registered Convex
+ * functions expose their handler as `._handler`, called against an in-memory
+ * MockDb whose withIndex understands the eq filters wall.ts uses.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  listWallItems,
+  pinToWall,
+  createWallNote,
+  moveWallItems,
+  recolorWallItem,
+  editWallNote,
+  groupWallItems,
+  ungroupWallItems,
+  removeWallItems,
+} from "../wall";
+
+/* -------------------------------------------------------------------------- */
+/* Compact in-memory MockDb — supports get / insert / patch / delete and       */
+/* withIndex(...).first()/take(). wall.ts only uses eq() filters in withIndex.  */
+/* -------------------------------------------------------------------------- */
+type Row = Record<string, any>;
+type Tables = Record<string, Row[]>;
+
+class IdxBuilder {
+  filters: Array<{ field: string; value: unknown }> = [];
+  eq(field: string, value: unknown) {
+    this.filters.push({ field, value });
+    return this;
+  }
+  // wall.ts never uses gte/lt in withIndex, but keep them no-op-safe.
+  gte() {
+    return this;
+  }
+  lt() {
+    return this;
+  }
+}
+
+class Chain {
+  constructor(private rows: Row[]) {}
+  order() {
+    return this;
+  }
+  async first() {
+    return this.rows[0] ?? null;
+  }
+  async take(n: number) {
+    return this.rows.slice(0, n);
+  }
+  async collect() {
+    return this.rows;
+  }
+}
+
+class MockDb {
+  public inserts: Array<{ table: string; value: Row }> = [];
+  public deletes: string[] = [];
+  private idCounter = 0;
+  constructor(private tables: Tables) {}
+
+  async get(id: string): Promise<any> {
+    for (const rows of Object.values(this.tables)) {
+      const row = rows.find((r) => r._id === id);
+      if (row) return row;
+    }
+    return null;
+  }
+
+  query(table: string) {
+    const rows = this.tables[table] ?? [];
+    return {
+      withIndex: (_name: string, build: (b: IdxBuilder) => IdxBuilder) => {
+        const filters = build(new IdxBuilder()).filters;
+        const matched = rows.filter((r) =>
+          filters.every(({ field, value }) => r[field] === value),
+        );
+        return new Chain(matched);
+      },
+    };
+  }
+
+  async insert(table: string, value: Row) {
+    this.idCounter += 1;
+    const inserted = { _id: `${table}:${this.idCounter}`, ...value };
+    if (!this.tables[table]) this.tables[table] = [];
+    this.tables[table].push(inserted);
+    this.inserts.push({ table, value: inserted });
+    return inserted._id;
+  }
+
+  async patch(id: string, value: Row) {
+    for (const rows of Object.values(this.tables)) {
+      const row = rows.find((r) => r._id === id);
+      if (row) {
+        Object.assign(row, value);
+        return;
+      }
+    }
+    throw new Error(`Missing row ${id}`);
+  }
+
+  async delete(id: string) {
+    for (const [table, rows] of Object.entries(this.tables)) {
+      const idx = rows.findIndex((r) => r._id === id);
+      if (idx >= 0) {
+        this.tables[table] = [...rows.slice(0, idx), ...rows.slice(idx + 1)];
+        this.deletes.push(id);
+        return;
+      }
+    }
+    throw new Error(`Missing row ${id}`);
+  }
+}
+
+const SESSION_A = "session-anon-aaaaaaaa";
+const SESSION_B = "session-anon-bbbbbbbb";
+const EVENT_A = "liveEvents:A";
+const EVENT_B = "liveEvents:B";
+
+function event(id = EVENT_A, status = "live"): Row {
+  return { _id: id, slug: `slug-${id}`, name: "Test Event", roomCode: "ORBITAL", status, startedAt: 1 };
+}
+function member(sessionId: string, eventId = EVENT_A): Row {
+  return {
+    _id: `liveEventMembers:${eventId}:${sessionId}`,
+    eventId,
+    sessionId,
+    displayName: "Guest",
+    joinedAt: 1,
+    lastSeenAt: 1,
+  };
+}
+function message(id: string, eventId = EVENT_A): Row {
+  return { _id: id, eventId, sessionId: SESSION_A, displayName: "Guest", text: "hi", kind: "chat", createdAt: 1 };
+}
+function answer(id: string, eventId = EVENT_A): Row {
+  return {
+    _id: id,
+    eventId,
+    questionMessageId: "liveEventMessages:q",
+    question: "q",
+    normalizedQuestion: "q",
+    body: "a",
+    sourceIds: [],
+    trace: [],
+    cacheHit: false,
+    faqStatus: "none",
+    createdAt: 1,
+  };
+}
+function ctxWith(tables: Partial<Tables>) {
+  return {
+    db: new MockDb({
+      liveEvents: [],
+      liveEventMembers: [],
+      liveEventMessages: [],
+      liveEventAnswers: [],
+      liveEventWallItems: [],
+      scratchnodeRateLimits: [],
+      ...tables,
+    } as Tables),
+  };
+}
+const call = (fn: any, ctx: any, args: any) => (fn as any)._handler(ctx, args);
+
+/* ========================================================================== */
+describe("Memory Wall — pin idempotency + dedup", () => {
+  /**
+   * Scenario:    Power user double-taps "pin to wall" on the same answer card.
+   * User:        Authenticated member, fast clicker (double-fire).
+   * Prior state: One answer exists; wall empty.
+   * Scale:       1 user, 2 rapid calls.
+   * Expected:    Second pin returns the SAME item (alreadyPinned), no duplicate.
+   * Edge:        A duplicate card on the wall is the bug we're preventing.
+   */
+  it("re-pinning the same content returns the existing card, never a duplicate", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event()],
+      liveEventMembers: [member(SESSION_A)],
+      liveEventAnswers: [answer("liveEventAnswers:1")],
+    });
+    const first = await call(pinToWall, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      refType: "answer",
+      refAnswerId: "liveEventAnswers:1",
+    });
+    const second = await call(pinToWall, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      refType: "answer",
+      refAnswerId: "liveEventAnswers:1",
+    });
+    expect(first.alreadyPinned).toBe(false);
+    expect(second.alreadyPinned).toBe(true);
+    expect(second.itemId).toBe(first.itemId);
+    const items = await call(listWallItems, ctx, { eventId: EVENT_A });
+    expect(items).toHaveLength(1);
+  });
+});
+
+describe("Memory Wall — cross-event id smuggling (adversarial)", () => {
+  /**
+   * Scenario:    Attacker in room A crafts a pin pointing at room B's message.
+   * User:        Adversarial member of A.
+   * Expected:    Rejected — the ref must belong to THIS event.
+   */
+  it("rejects pinning a message that belongs to another event", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event(EVENT_A), event(EVENT_B)],
+      liveEventMembers: [member(SESSION_A, EVENT_A)],
+      liveEventMessages: [message("liveEventMessages:fromB", EVENT_B)],
+    });
+    await expect(
+      call(pinToWall, ctx, {
+        eventId: EVENT_A,
+        sessionId: SESSION_A,
+        refType: "message",
+        refMessageId: "liveEventMessages:fromB",
+      }),
+    ).rejects.toMatchObject({ data: { code: "ref_not_found" } });
+  });
+
+  it("skips (does not throw on) move updates for items from another event", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event(EVENT_A)],
+      liveEventMembers: [member(SESSION_A, EVENT_A)],
+      liveEventWallItems: [
+        { _id: "liveEventWallItems:mine", eventId: EVENT_A, refType: "note", text: "x", x: 0, y: 0, w: 180, color: "#f3d77b", z: 1, createdBySessionId: SESSION_A, createdAt: 1, updatedAt: 1 },
+        { _id: "liveEventWallItems:foreign", eventId: EVENT_B, refType: "note", text: "y", x: 0, y: 0, w: 180, color: "#f3d77b", z: 1, createdBySessionId: SESSION_B, createdAt: 1, updatedAt: 1 },
+      ],
+    });
+    const res = await call(moveWallItems, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      updates: [
+        { id: "liveEventWallItems:mine", x: 50, y: 60 },
+        { id: "liveEventWallItems:foreign", x: 999, y: 999 },
+      ],
+    });
+    expect(res.moved).toBe(1); // only the in-event item moved
+    const foreign = await ctx.db.get("liveEventWallItems:foreign");
+    expect(foreign.x).toBe(0); // untouched
+  });
+});
+
+describe("Memory Wall — create + move round trip with coordinate clamping", () => {
+  /**
+   * Scenario:    User drops a sticky, then drags it; a buggy client sends NaN.
+   * Duration:    Single gesture commit.
+   * Expected:    Position persists; NaN/Infinity never reach the DB.
+   */
+  it("creates a note then commits a move, clamping non-finite coords", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event()],
+      liveEventMembers: [member(SESSION_A)],
+    });
+    const created = await call(createWallNote, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      text: "  follow up with Orbital  ",
+    });
+    const itemId = created.itemId;
+    const stored = await ctx.db.get(itemId);
+    expect(stored.text).toBe("follow up with Orbital"); // trimmed
+    expect(stored.refType).toBe("note");
+
+    // Finite-but-out-of-range coords clamp to the board limit (±COORD_LIMIT).
+    const moved = await call(moveWallItems, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      updates: [{ id: itemId, x: 999_999, y: -999_999 }],
+    });
+    expect(moved.moved).toBe(1);
+    let after = await ctx.db.get(itemId);
+    expect(after.x).toBe(100_000);
+    expect(after.y).toBe(-100_000);
+
+    // Non-finite coords (NaN / Infinity) are rejected as garbage and fall back
+    // to the last-good value — never snapped to an edge, never persisted as NaN.
+    await call(moveWallItems, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      updates: [{ id: itemId, x: Number.NaN, y: Infinity }],
+    });
+    after = await ctx.db.get(itemId);
+    expect(Number.isFinite(after.x)).toBe(true);
+    expect(Number.isFinite(after.y)).toBe(true);
+    expect(after.x).toBe(100_000); // unchanged last-good
+    expect(after.y).toBe(-100_000); // unchanged last-good
+  });
+});
+
+describe("Memory Wall — deterministic grouping (FigJam-style)", () => {
+  /**
+   * Scenario:    User marquee-selects 3 stickies and groups them, then ungroups.
+   * Expected:    groupId is deterministic (g: + smallest id); ungroup clears it.
+   */
+  it("derives a stable groupId from the smallest member id and ungroups cleanly", async () => {
+    const items = ["liveEventWallItems:c", "liveEventWallItems:a", "liveEventWallItems:b"].map((id) => ({
+      _id: id, eventId: EVENT_A, refType: "note", text: id, x: 0, y: 0, w: 180, color: "#f3d77b", z: 1, createdBySessionId: SESSION_A, createdAt: 1, updatedAt: 1,
+    }));
+    const ctx = ctxWith({
+      liveEvents: [event()],
+      liveEventMembers: [member(SESSION_A)],
+      liveEventWallItems: items,
+    });
+    const grouped = await call(groupWallItems, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      itemIds: ["liveEventWallItems:c", "liveEventWallItems:a", "liveEventWallItems:b"],
+    });
+    expect(grouped.groupId).toBe("g:liveEventWallItems:a"); // lexicographically smallest
+    expect(grouped.count).toBe(3);
+    for (const id of ["liveEventWallItems:a", "liveEventWallItems:b", "liveEventWallItems:c"]) {
+      expect((await ctx.db.get(id)).groupId).toBe("g:liveEventWallItems:a");
+    }
+
+    // Regrouping the same selection yields the SAME id (determinism).
+    const regrouped = await call(groupWallItems, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      itemIds: ["liveEventWallItems:b", "liveEventWallItems:c", "liveEventWallItems:a"],
+    });
+    expect(regrouped.groupId).toBe("g:liveEventWallItems:a");
+
+    const ungrouped = await call(ungroupWallItems, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      itemIds: ["liveEventWallItems:a", "liveEventWallItems:b", "liveEventWallItems:c"],
+    });
+    expect(ungrouped.ungrouped).toBe(3);
+    expect((await ctx.db.get("liveEventWallItems:a")).groupId).toBeUndefined();
+  });
+
+  it("rejects a group of fewer than two items", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event()],
+      liveEventMembers: [member(SESSION_A)],
+      liveEventWallItems: [{ _id: "liveEventWallItems:solo", eventId: EVENT_A, refType: "note", text: "x", x: 0, y: 0, w: 180, color: "#f3d77b", z: 1, createdBySessionId: SESSION_A, createdAt: 1, updatedAt: 1 }],
+    });
+    await expect(
+      call(groupWallItems, ctx, { eventId: EVENT_A, sessionId: SESSION_A, itemIds: ["liveEventWallItems:solo"] }),
+    ).rejects.toMatchObject({ data: { code: "group_too_small" } });
+  });
+});
+
+describe("Memory Wall — BOUND enforcement (adversarial scale)", () => {
+  /**
+   * Scenario:    Abuser tries to move 201 items in one call / a 600-item wall.
+   * Scale:       Batch overflow + list overflow.
+   * Expected:    Batch rejected; list capped at 500.
+   */
+  it("rejects a move batch larger than 200", async () => {
+    const ctx = ctxWith({ liveEvents: [event()], liveEventMembers: [member(SESSION_A)] });
+    const updates = Array.from({ length: 201 }, (_, i) => ({ id: `liveEventWallItems:${i}`, x: i, y: i }));
+    await expect(
+      call(moveWallItems, ctx, { eventId: EVENT_A, sessionId: SESSION_A, updates }),
+    ).rejects.toMatchObject({ data: { code: "batch_too_large" } });
+  });
+
+  it("caps listWallItems at 500 even when the wall holds 600", async () => {
+    const wallItems = Array.from({ length: 600 }, (_, i) => ({
+      _id: `liveEventWallItems:${i}`, eventId: EVENT_A, refType: "note", text: `n${i}`, x: 0, y: 0, w: 180, color: "#f3d77b", z: i, createdBySessionId: SESSION_A, createdAt: 1, updatedAt: 1,
+    }));
+    const ctx = ctxWith({ liveEvents: [event()], liveEventMembers: [member(SESSION_A)], liveEventWallItems: wallItems });
+    const items = await call(listWallItems, ctx, { eventId: EVENT_A });
+    expect(items).toHaveLength(500);
+  });
+});
+
+describe("Memory Wall — membership + lifecycle gates", () => {
+  it("rejects a non-member trying to pin", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event()],
+      liveEventMembers: [], // SESSION_A never joined
+      liveEventMessages: [message("liveEventMessages:1")],
+    });
+    await expect(
+      call(pinToWall, ctx, { eventId: EVENT_A, sessionId: SESSION_A, refType: "message", refMessageId: "liveEventMessages:1" }),
+    ).rejects.toMatchObject({ data: { code: "not_joined" } });
+  });
+
+  it("rejects a too-short session id", async () => {
+    const ctx = ctxWith({ liveEvents: [event()] });
+    await expect(
+      call(createWallNote, ctx, { eventId: EVENT_A, sessionId: "short", text: "hi" }),
+    ).rejects.toMatchObject({ data: { code: "invalid_session" } });
+  });
+
+  it("refuses writes to an ended event", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event(EVENT_A, "ended")],
+      liveEventMembers: [member(SESSION_A)],
+    });
+    await expect(
+      call(createWallNote, ctx, { eventId: EVENT_A, sessionId: SESSION_A, text: "too late" }),
+    ).rejects.toMatchObject({ data: { code: "event_ended" } });
+  });
+});
+
+describe("Memory Wall — input sanitation (adversarial injection)", () => {
+  /**
+   * Scenario:    Attacker sends a CSS/script payload as the sticky color.
+   * Expected:    Color falls back to the allowlist — never reaches inline style.
+   */
+  it("coerces an off-allowlist color to a safe palette value", async () => {
+    const ctx = ctxWith({ liveEvents: [event()], liveEventMembers: [member(SESSION_A)] });
+    const created = await call(createWallNote, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      text: "payload",
+      color: "red; } </style><script>alert(1)</script>",
+    });
+    const stored = await ctx.db.get(created.itemId);
+    expect(stored.color).toBe("#f3d77b"); // allowlist[0]
+  });
+
+  it("rejects empty and over-long sticky text", async () => {
+    const ctx = ctxWith({ liveEvents: [event()], liveEventMembers: [member(SESSION_A)] });
+    await expect(
+      call(createWallNote, ctx, { eventId: EVENT_A, sessionId: SESSION_A, text: "   " }),
+    ).rejects.toMatchObject({ data: { code: "empty_note" } });
+    await expect(
+      call(createWallNote, ctx, { eventId: EVENT_A, sessionId: SESSION_A, text: "x".repeat(2001) }),
+    ).rejects.toMatchObject({ data: { code: "note_too_long" } });
+  });
+
+  it("refuses to edit text on a message pin (only stickies are editable)", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event()],
+      liveEventMembers: [member(SESSION_A)],
+      liveEventMessages: [message("liveEventMessages:1")],
+    });
+    const pinned = await call(pinToWall, ctx, { eventId: EVENT_A, sessionId: SESSION_A, refType: "message", refMessageId: "liveEventMessages:1" });
+    await expect(
+      call(editWallNote, ctx, { eventId: EVENT_A, sessionId: SESSION_A, itemId: pinned.itemId, text: "rewrite the message" }),
+    ).rejects.toMatchObject({ data: { code: "not_editable" } });
+  });
+});
+
+describe("Memory Wall — collaborative-open + unpin semantics (multi-user)", () => {
+  /**
+   * Scenario:    User A drops a sticky; user B rearranges it (shared board).
+   * User:        Two distinct members, same room.
+   * Expected:    B's move succeeds — the wall is collaborative-open like FigJam.
+   */
+  it("lets a different member move another member's item", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event()],
+      liveEventMembers: [member(SESSION_A), member(SESSION_B)],
+    });
+    const created = await call(createWallNote, ctx, { eventId: EVENT_A, sessionId: SESSION_A, text: "A's note" });
+    const moved = await call(moveWallItems, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_B, // different member
+      updates: [{ id: created.itemId, x: 300, y: 200 }],
+    });
+    expect(moved.moved).toBe(1);
+    expect((await ctx.db.get(created.itemId)).x).toBe(300);
+  });
+
+  /**
+   * Scenario:    Unpin a message card — the source message must survive.
+   * Expected:    Wall item removed; liveEventMessages row untouched.
+   */
+  it("unpins a message without deleting the source message", async () => {
+    const ctx = ctxWith({
+      liveEvents: [event()],
+      liveEventMembers: [member(SESSION_A)],
+      liveEventMessages: [message("liveEventMessages:keep")],
+    });
+    const pinned = await call(pinToWall, ctx, { eventId: EVENT_A, sessionId: SESSION_A, refType: "message", refMessageId: "liveEventMessages:keep" });
+    const removed = await call(removeWallItems, ctx, { eventId: EVENT_A, sessionId: SESSION_A, itemIds: [pinned.itemId] });
+    expect(removed.removed).toBe(1);
+    expect(await ctx.db.get(pinned.itemId)).toBeNull(); // wall item gone
+    expect(await ctx.db.get("liveEventMessages:keep")).not.toBeNull(); // source survives
+  });
+});
+
+describe("Memory Wall — rate limiting (sustained burst)", () => {
+  /**
+   * Scenario:    Spam bot floods createWallNote in one window.
+   * Duration:    61 calls inside the same 60s window.
+   * Expected:    61st rejected; the independent move bucket still works.
+   */
+  it("caps wall ops at 60/min/session and keeps the move bucket independent", async () => {
+    const ctx = ctxWith({ liveEvents: [event()], liveEventMembers: [member(SESSION_A)] });
+    let firstItemId = "";
+    for (let i = 0; i < 60; i++) {
+      const r = await call(createWallNote, ctx, { eventId: EVENT_A, sessionId: SESSION_A, text: `n${i}` });
+      if (i === 0) firstItemId = r.itemId;
+    }
+    await expect(
+      call(createWallNote, ctx, { eventId: EVENT_A, sessionId: SESSION_A, text: "one too many" }),
+    ).rejects.toMatchObject({ data: { code: "rate_limited" } });
+
+    // The wallmove: bucket is separate — a move still goes through.
+    const moved = await call(moveWallItems, ctx, {
+      eventId: EVENT_A,
+      sessionId: SESSION_A,
+      updates: [{ id: firstItemId, x: 10, y: 10 }],
+    });
+    expect(moved.moved).toBe(1);
+  });
+});

--- a/convex/events.runtime-boundary.test.ts
+++ b/convex/events.runtime-boundary.test.ts
@@ -6,7 +6,15 @@ import { dirname, join } from "node:path";
 const here = dirname(fileURLToPath(import.meta.url));
 const eventsSource = readFileSync(join(here, "events.ts"), "utf8");
 const notesSource = readFileSync(join(here, "notes.ts"), "utf8");
+const wallSource = readFileSync(join(here, "wall.ts"), "utf8");
 const eventsSchemaSource = readFileSync(join(here, "schema", "eventsSchema.ts"), "utf8");
+
+function wallFunctionBlock(name: string, kind: "query" | "mutation" = "mutation"): string {
+  const start = wallSource.indexOf(`export const ${name} = ${kind}({`);
+  expect(start, `${name} ${kind} should exist in wall.ts`).toBeGreaterThanOrEqual(0);
+  const next = wallSource.indexOf("\nexport const ", start + 1);
+  return wallSource.slice(start, next > start ? next : undefined);
+}
 
 function functionBlock(name: string, kind: "query" | "mutation" | "action" | "internalQuery" | "internalMutation" = "mutation"): string {
   const start = eventsSource.indexOf(`export const ${name} = ${kind}({`);
@@ -155,5 +163,86 @@ describe("scratchnode Phase 4 host auth", () => {
     // Production with no secret throws ConvexError (not a hardcoded
     // default that ships with the binary)
     expect(fn).toContain("host_auth_secret_missing");
+  });
+});
+
+// ─── Phase 8: Memory Wall (convex/wall.ts) — privacy + reliability invariants ──
+//
+// The Wall is a PUBLIC, collaborative-open overlay over the canonical event
+// stream. These static-source assertions catch the obvious regressions:
+// private-note leakage, removed BOUND/membership/rate-limit gates, and missing
+// cross-event integrity checks.
+describe("scratchnode Phase 8 Memory Wall boundaries", () => {
+  it("the public wall NEVER references private user notes", () => {
+    // The single most important invariant: a public spatial surface must not
+    // be able to read or surface private, owner-keyed notes.
+    //
+    // Check for ACTUAL ACCESS, not mentions: a Convex table is only reached via
+    // a quoted string literal — query("userNotes") / db access. Prose in the
+    // module header legitimately names userNotes to DOCUMENT the invariant, so
+    // we assert the quoted form, never the bare word.
+    expect(wallSource).not.toContain('"userNotes"');
+    expect(wallSource).not.toContain('"liveEventNoteAnchors"');
+    expect(wallSource).not.toContain("getPrivate");
+    expect(wallSource).not.toContain(".ownerKey");
+    // It only ever dereferences PUBLIC content tables.
+    expect(wallSource).toContain('"liveEventMessages"');
+    expect(wallSource).toContain('"liveEventAnswers"');
+  });
+
+  it("listWallItems is BOUND (no unbounded scan of a hot public table)", () => {
+    const listWallItems = wallFunctionBlock("listWallItems", "query");
+    expect(listWallItems).toContain("MAX_WALL_ITEMS");
+    expect(listWallItems).toContain(".take(");
+    // The cap constant itself is defined and finite.
+    expect(wallSource).toMatch(/const MAX_WALL_ITEMS = \d+/);
+  });
+
+  it("every wall mutation gates on membership before writing", () => {
+    for (const name of [
+      "pinToWall",
+      "createWallNote",
+      "moveWallItems",
+      "recolorWallItem",
+      "editWallNote",
+      "groupWallItems",
+      "ungroupWallItems",
+      "removeWallItems",
+    ]) {
+      expect(wallFunctionBlock(name)).toContain("requireMember");
+    }
+  });
+
+  it("every wall mutation enforces a rate limit", () => {
+    for (const name of [
+      "pinToWall",
+      "createWallNote",
+      "moveWallItems",
+      "recolorWallItem",
+      "editWallNote",
+      "groupWallItems",
+      "ungroupWallItems",
+      "removeWallItems",
+    ]) {
+      expect(wallFunctionBlock(name)).toContain("enforceRateLimit");
+    }
+  });
+
+  it("batch mutations are BOUND and id-mutations enforce cross-event integrity", () => {
+    for (const name of ["moveWallItems", "groupWallItems", "ungroupWallItems", "removeWallItems"]) {
+      const block = wallFunctionBlock(name);
+      expect(block, `${name} should cap batch size`).toContain("MAX_WALL_BATCH");
+    }
+    // pin + move + recolor + edit + remove all verify the row belongs to the
+    // event before touching it (prevents cross-event id smuggling).
+    for (const name of ["moveWallItems", "recolorWallItem", "editWallNote", "removeWallItems"]) {
+      expect(wallFunctionBlock(name)).toContain("item.eventId !== args.eventId");
+    }
+    expect(wallFunctionBlock("pinToWall")).toContain("!== args.eventId");
+  });
+
+  it("color writes are constrained to an allowlist (no arbitrary inline style)", () => {
+    expect(wallSource).toContain("WALL_COLORS");
+    expect(wallSource).toContain("safeColor");
   });
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -36,6 +36,7 @@ import {
   liveEventHosts,
   liveEventWikiVersions,
   liveEventNoteAnchors,
+  liveEventWallItems,
   scratchnodeRateLimits,
 } from "./schema/eventsSchema";
 
@@ -4900,6 +4901,7 @@ export default defineSchema({
   liveEventHosts,
   liveEventWikiVersions,
   liveEventNoteAnchors,
+  liveEventWallItems,
   scratchnodeRateLimits,
   // Step 8: persistent user identity + magic-link sign-in tokens.
   // Aliased to scratchnodeUsers to avoid collision with @convex-dev/auth `users`.

--- a/convex/schema/eventsSchema.ts
+++ b/convex/schema/eventsSchema.ts
@@ -302,3 +302,64 @@ export const scratchnodeRateLimits = defineTable({
 })
   .index("by_key_window", ["key", "windowStart"])
   .index("by_expiresAt", ["expiresAt"]);
+
+// ------------------------------------------------------------------
+// liveEventWallItems — Phase 8: the spatial "Memory Wall" overlay.
+//
+// LAYOUT-ONLY overlay over PUBLIC content. A wall item carries a
+// position (x,y), size (w), style (color), optional flat group, and a
+// z-order, and POINTS at content that already lives elsewhere:
+//   - refType "message" -> refMessageId (a public chat message)
+//   - refType "answer"  -> refAnswerId  (a public /ask answer)
+//   - refType "note"    -> text         (a short free-text sticky
+//                                         authored directly on the wall)
+//
+// Content/layout separation (NodeBench-original adaptation of the
+// FigJam/Miro "frame holds widgets" model): message/answer text is
+// NEVER duplicated — the card renders by dereferencing the pointer.
+// Only a "note" sticky stores its own inline text, and that text is
+// PUBLIC by construction (every member of the room sees the wall),
+// exactly like a chat message. This keeps Chat and Wall a single
+// source of truth — the "Twitch" model of one stream, two render lanes.
+//
+// Privacy invariant (mirrors liveEventNoteAnchors): the Wall is a
+// PUBLIC surface. It may ONLY reference public content — NEVER
+// userNotes (private, owner-keyed). There is intentionally no field
+// or index that can reach a private note from a wall item.
+//
+// Reliability (per .claude/rules/agentic_reliability.md):
+//   - BOUND: listWallItems caps at MAX_WALL_ITEMS = 500 (mirrors getMembers);
+//     every id[] mutation caps at MAX_WALL_BATCH = 200.
+//   - HONEST_STATUS: mutations throw typed ConvexError on validation.
+//   - DETERMINISTIC: server-stamped createdAt/updatedAt; groupId derived
+//     from the lexicographically smallest member id ("g:" + minId), so the
+//     same selection always groups to the same id.
+//
+// Conflict resolution: position writes commit once on pointerup via
+// moveWallItems. Convex's serializable txn ordering IS the last-write-
+// wins resolver — no CRDT needed at room scale.
+// ------------------------------------------------------------------
+export const liveEventWallItems = defineTable({
+  eventId: v.id("liveEvents"),
+  refType: v.union(
+    v.literal("message"),
+    v.literal("answer"),
+    v.literal("note"),
+  ),
+  refMessageId: v.optional(v.id("liveEventMessages")),  // refType "message"
+  refAnswerId: v.optional(v.id("liveEventAnswers")),    // refType "answer"
+  text: v.optional(v.string()),                         // refType "note" — inline PUBLIC text
+  x: v.number(),
+  y: v.number(),
+  w: v.number(),
+  color: v.string(),                                    // validated vs WALL_COLORS in wall.ts
+  groupId: v.optional(v.string()),                      // flat Figma-style group model
+  z: v.number(),                                        // stacking order; bumped on interaction
+  createdBySessionId: v.string(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+})
+  .index("by_event", ["eventId"])
+  .index("by_event_updated", ["eventId", "updatedAt"])
+  .index("by_event_message", ["eventId", "refMessageId"])  // pin-dedup for messages
+  .index("by_event_answer", ["eventId", "refAnswerId"]);   // pin-dedup for answers

--- a/convex/wall.ts
+++ b/convex/wall.ts
@@ -1,0 +1,619 @@
+/**
+ * convex/wall.ts — Phase 8: the spatial "Memory Wall" overlay for live events.
+ *
+ * The Wall is a SECOND render lane over the SAME event stream the chat feed
+ * shows (the "Twitch" model: one stream, two synchronized views). A wall item
+ * is layout-only metadata that POINTS at public content:
+ *   - pinToWall({ refType:"message"|"answer", ... })  → pins existing content
+ *   - createWallNote({ text })                         → a fresh public sticky
+ * and is positioned / styled by:
+ *   - moveWallItems({ updates:[{id,x,y}] })   ← the ONE write per drag (pointerup)
+ *   - recolorWallItem / editWallNote / groupWallItems / ungroupWallItems
+ *   - removeWallItems  (unpin / delete sticky — never touches the source content)
+ *
+ * Read side:
+ *   - listWallItems({ eventId })  → realtime subscription (Convex re-runs on change)
+ *
+ * Public API path: api.wall.<fn> (these are the contracts public/proto/wall.html
+ * and home-v5.html call from the browser).
+ *
+ * Privacy invariant (release-blocker, mirrors convex/events.ts + notes.ts):
+ *   The Wall is PUBLIC. It only ever references liveEventMessages /
+ *   liveEventAnswers. It NEVER reads or references userNotes (private). A
+ *   "note" wall item is public inline text, identical in visibility to a chat
+ *   message.
+ *
+ * Reliability (per .claude/rules/agentic_reliability.md):
+ *   - BOUND: listWallItems ≤ MAX_WALL_ITEMS; every id[] mutation ≤ MAX_WALL_BATCH.
+ *   - HONEST_STATUS: typed ConvexError on every validation failure, no fake ok.
+ *   - HONEST_SCORES: n/a (no scoring here).
+ *   - TIMEOUT: Convex's default mutation/query budgets apply.
+ *   - SSRF / BOUND_READ: n/a (no external fetch).
+ *   - DETERMINISTIC: server-stamped timestamps; groupId derived from min(id).
+ *
+ * Pattern: FigJam / Miro spatial board + content/layout separation.
+ * Prior art:
+ *   - FigJam — frames hold widgets; stickies carry position + color only.
+ *   - Miro — board items reference content; one delta moves a whole selection.
+ *   - tldraw — shape store; we deliberately do NOT adopt its store so Chat and
+ *     Wall stay a single source of truth (the canonical event stream).
+ * NodeBench-original: the overlay points at the canonical event stream rather
+ * than owning a parallel shape store. See public/proto/wall.html for the
+ * matching client-side smooth-drag engine.
+ */
+
+import { v } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { enforceRateLimit } from "./scratchnodeRateLimit";
+
+// Local ConvexError shim — mirrors convex/events.ts and convex/scratchnodeRateLimit.ts
+// so the thrown error serializes to the client with `data` intact (code + message).
+class ConvexError<T extends Record<string, unknown>> extends Error {
+  data: T;
+
+  constructor(data: T) {
+    super(String(data.message ?? JSON.stringify(data)));
+    this.name = "ConvexError";
+    this.data = data;
+    (this as Record<PropertyKey, unknown>)[Symbol.for("ConvexError")] = true;
+  }
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+// BOUND — listWallItems hard cap (mirrors getMembers' MAX_ACTIVE_MEMBERS=500).
+const MAX_WALL_ITEMS = 500;
+// BOUND — max ids/updates accepted by one move/remove/group call. A group of
+// 200 stickies is already enormous; anything larger is abuse, rejected honestly.
+const MAX_WALL_BATCH = 200;
+// A sticky is short by design (it's a wall note, not a document).
+const MAX_WALL_NOTE_TEXT = 2_000;
+// Position + size clamps — keep the board finite and reject NaN/Infinity, which
+// would otherwise serialize into the client's inline transform and break layout.
+const MIN_W = 80;
+const MAX_W = 1_200;
+const COORD_LIMIT = 100_000;
+const DEFAULT_W = 180;
+// Rate limits. Moves are the high-frequency path (one commit per pointerup);
+// other ops (create / pin / recolor / edit / group / delete) are bursty-but-rare.
+const WALL_MOVE_LIMIT = 180; // /min ≈ 3 drag-drops/sec sustained — far above human cadence
+const WALL_MOVE_WINDOW = 60_000;
+const WALL_OP_LIMIT = 60; // /min — create/pin/recolor/edit/group/delete
+const WALL_OP_WINDOW = 60_000;
+
+// Palette allowlist — matches public/proto/wall.html COLORS. Validating against
+// an allowlist (not just "is a string") keeps arbitrary values out of the
+// client's inline `style` — defense-in-depth even though it's only a color slot.
+const WALL_COLORS = [
+  "#f3d77b",
+  "#f5b8c4",
+  "#a9d8f0",
+  "#bfe3b6",
+  "#e7b48f",
+  "#d8c9f2",
+];
+
+function clampCoord(n: unknown, fallback: number): number {
+  if (typeof n !== "number" || !Number.isFinite(n)) return fallback;
+  return Math.max(-COORD_LIMIT, Math.min(COORD_LIMIT, Math.round(n)));
+}
+
+function clampW(n: unknown): number {
+  if (typeof n !== "number" || !Number.isFinite(n)) return DEFAULT_W;
+  return Math.max(MIN_W, Math.min(MAX_W, Math.round(n)));
+}
+
+function safeColor(c: unknown): string {
+  return typeof c === "string" && WALL_COLORS.includes(c) ? c : WALL_COLORS[0];
+}
+
+// requireMember — minimal membership gate. Intentionally duplicated from the
+// (non-exported) helper in convex/events.ts rather than importing it: keeping
+// wall.ts free of an events.ts import avoids coupling the wall to that module's
+// action graph, and the gate is 12 lines with identical semantics. If a third
+// caller needs it, extract to convex/scratchnodeShared.ts then.
+async function requireMember(ctx: any, eventId: any, sessionId: string) {
+  if (!sessionId || sessionId.length < 8) {
+    throw new ConvexError({
+      code: "invalid_session",
+      message: "Must join the event first.",
+    });
+  }
+  const member = await ctx.db
+    .query("liveEventMembers")
+    .withIndex("by_event_session", (q: any) =>
+      q.eq("eventId", eventId).eq("sessionId", sessionId),
+    )
+    .first();
+  if (!member) {
+    throw new ConvexError({
+      code: "not_joined",
+      message: "Call joinEvent before using the wall.",
+    });
+  }
+  return member;
+}
+
+// Loads + validates the event is usable for writes. Throws on missing/ended.
+async function requireLiveEvent(ctx: any, eventId: any) {
+  const event = await ctx.db.get(eventId);
+  if (!event) {
+    throw new ConvexError({
+      code: "event_not_found",
+      message: "Event no longer exists.",
+    });
+  }
+  if (event.status === "ended") {
+    throw new ConvexError({
+      code: "event_ended",
+      message: "This event has ended.",
+    });
+  }
+  return event;
+}
+
+/* ========================================================================== */
+/* Read — realtime subscription                                                */
+/* ========================================================================== */
+
+/**
+ * Realtime wall snapshot. The Convex client re-runs this on every change, so
+ * remote moves/pins/deletes stream into every viewer's board.
+ *
+ * BOUND at MAX_WALL_ITEMS (mirrors getMembers). A room past 500 pinned items
+ * shows the first 500; the UI surfaces a "500+ on the wall" treatment (same
+ * precedent as the member roster). Sorted by z ascending so render order
+ * matches stacking order.
+ */
+export const listWallItems = query({
+  args: { eventId: v.id("liveEvents") },
+  handler: async (ctx, { eventId }) => {
+    const rows = await ctx.db
+      .query("liveEventWallItems")
+      .withIndex("by_event", (q) => q.eq("eventId", eventId))
+      .take(MAX_WALL_ITEMS);
+    rows.sort((a, b) => (a.z || 0) - (b.z || 0));
+    return rows;
+  },
+});
+
+/* ========================================================================== */
+/* Create — pin existing content, or author a fresh sticky                     */
+/* ========================================================================== */
+
+/**
+ * Pin an existing public message or /ask answer onto the wall.
+ *
+ * Integrity: the referenced row must EXIST and belong to THIS event — prevents
+ * pinning cross-event content or fabricated ids. Idempotent: re-pinning the
+ * same content returns the existing item (no duplicate cards), mirroring the
+ * reserveAskSlot idempotency pattern.
+ */
+export const pinToWall = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    refType: v.union(v.literal("message"), v.literal("answer")),
+    refMessageId: v.optional(v.id("liveEventMessages")),
+    refAnswerId: v.optional(v.id("liveEventAnswers")),
+    x: v.optional(v.number()),
+    y: v.optional(v.number()),
+    w: v.optional(v.number()),
+    color: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.eventId, args.sessionId);
+    await enforceRateLimit(ctx, {
+      key: `wall:${args.sessionId}`,
+      limit: WALL_OP_LIMIT,
+      windowMs: WALL_OP_WINDOW,
+    });
+    await requireLiveEvent(ctx, args.eventId);
+
+    let refMessageId: any = undefined;
+    let refAnswerId: any = undefined;
+    let existing: any = null;
+
+    if (args.refType === "message") {
+      if (!args.refMessageId) {
+        throw new ConvexError({
+          code: "missing_ref",
+          message: "refMessageId is required for message pins.",
+        });
+      }
+      const msg = await ctx.db.get(args.refMessageId);
+      if (!msg || msg.eventId !== args.eventId) {
+        throw new ConvexError({
+          code: "ref_not_found",
+          message: "That message isn't part of this event.",
+        });
+      }
+      refMessageId = args.refMessageId;
+      existing = await ctx.db
+        .query("liveEventWallItems")
+        .withIndex("by_event_message", (q) =>
+          q.eq("eventId", args.eventId).eq("refMessageId", refMessageId),
+        )
+        .first();
+    } else {
+      if (!args.refAnswerId) {
+        throw new ConvexError({
+          code: "missing_ref",
+          message: "refAnswerId is required for answer pins.",
+        });
+      }
+      const ans = await ctx.db.get(args.refAnswerId);
+      if (!ans || ans.eventId !== args.eventId) {
+        throw new ConvexError({
+          code: "ref_not_found",
+          message: "That answer isn't part of this event.",
+        });
+      }
+      refAnswerId = args.refAnswerId;
+      existing = await ctx.db
+        .query("liveEventWallItems")
+        .withIndex("by_event_answer", (q) =>
+          q.eq("eventId", args.eventId).eq("refAnswerId", refAnswerId),
+        )
+        .first();
+    }
+
+    // Idempotent: re-pinning returns the existing card.
+    if (existing) {
+      return { itemId: existing._id, alreadyPinned: true };
+    }
+
+    const now = Date.now();
+    const itemId = await ctx.db.insert("liveEventWallItems", {
+      eventId: args.eventId,
+      refType: args.refType,
+      refMessageId,
+      refAnswerId,
+      x: clampCoord(args.x, 40),
+      y: clampCoord(args.y, 40),
+      w: clampW(args.w),
+      color: safeColor(args.color),
+      z: now, // monotonic-ish; moveWallItems bumps it on interaction
+      createdBySessionId: args.sessionId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { itemId, alreadyPinned: false };
+  },
+});
+
+/**
+ * Author a fresh sticky note directly on the wall. Its text is PUBLIC — every
+ * member of the room sees it (identical visibility to a chat message). Private
+ * notes never come through here; they live in convex/notes.ts (userNotes).
+ */
+export const createWallNote = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    text: v.string(),
+    x: v.optional(v.number()),
+    y: v.optional(v.number()),
+    w: v.optional(v.number()),
+    color: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.eventId, args.sessionId);
+    await enforceRateLimit(ctx, {
+      key: `wall:${args.sessionId}`,
+      limit: WALL_OP_LIMIT,
+      windowMs: WALL_OP_WINDOW,
+    });
+    await requireLiveEvent(ctx, args.eventId);
+
+    const text = (args.text || "").trim();
+    if (!text) {
+      throw new ConvexError({
+        code: "empty_note",
+        message: "Sticky note text is required.",
+      });
+    }
+    if (text.length > MAX_WALL_NOTE_TEXT) {
+      throw new ConvexError({
+        code: "note_too_long",
+        message: `Max ${MAX_WALL_NOTE_TEXT} chars.`,
+      });
+    }
+
+    const now = Date.now();
+    const itemId = await ctx.db.insert("liveEventWallItems", {
+      eventId: args.eventId,
+      refType: "note",
+      text,
+      x: clampCoord(args.x, 40),
+      y: clampCoord(args.y, 40),
+      w: clampW(args.w),
+      color: safeColor(args.color),
+      z: now,
+      createdBySessionId: args.sessionId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { itemId };
+  },
+});
+
+/* ========================================================================== */
+/* Move — the ONE write per drag gesture (fired on pointerup)                  */
+/* ========================================================================== */
+
+/**
+ * Commit a drag. ONE mutation moves a whole selection (group-move is a single
+ * call with N updates, not N calls). Convex's serializable txn ordering is the
+ * last-write-wins conflict resolver — two users dragging the same item just
+ * means the later commit wins, no CRDT needed.
+ *
+ * Collaborative-open by design (any member may rearrange any item, like
+ * FigJam/Miro). Host-scoped locking is a deliberate future gate, not a v1 need.
+ * Integrity: updates for items that don't exist or belong to another event are
+ * skipped (not thrown) so one stale id can't fail an otherwise-valid batch.
+ */
+export const moveWallItems = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    updates: v.array(
+      v.object({
+        id: v.id("liveEventWallItems"),
+        x: v.number(),
+        y: v.number(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.eventId, args.sessionId);
+    if (args.updates.length === 0) {
+      return { moved: 0 };
+    }
+    if (args.updates.length > MAX_WALL_BATCH) {
+      throw new ConvexError({
+        code: "batch_too_large",
+        message: `Max ${MAX_WALL_BATCH} items per move.`,
+      });
+    }
+    await enforceRateLimit(ctx, {
+      key: `wallmove:${args.sessionId}`,
+      limit: WALL_MOVE_LIMIT,
+      windowMs: WALL_MOVE_WINDOW,
+    });
+
+    const now = Date.now();
+    let moved = 0;
+    for (const u of args.updates) {
+      const item = await ctx.db.get(u.id);
+      if (!item || item.eventId !== args.eventId) continue; // integrity skip
+      await ctx.db.patch(u.id, {
+        x: clampCoord(u.x, item.x),
+        y: clampCoord(u.y, item.y),
+        z: now, // dragged items come to front (matches the client engine)
+        updatedAt: now,
+      });
+      moved += 1;
+    }
+    return { moved };
+  },
+});
+
+/* ========================================================================== */
+/* Edit — recolor, retext (note only), group, ungroup                          */
+/* ========================================================================== */
+
+/** Recolor any wall item. Color validated against the allowlist. */
+export const recolorWallItem = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    itemId: v.id("liveEventWallItems"),
+    color: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.eventId, args.sessionId);
+    await enforceRateLimit(ctx, {
+      key: `wall:${args.sessionId}`,
+      limit: WALL_OP_LIMIT,
+      windowMs: WALL_OP_WINDOW,
+    });
+    const item = await ctx.db.get(args.itemId);
+    if (!item || item.eventId !== args.eventId) {
+      throw new ConvexError({
+        code: "item_not_found",
+        message: "That wall item isn't part of this event.",
+      });
+    }
+    await ctx.db.patch(args.itemId, {
+      color: safeColor(args.color),
+      updatedAt: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+/**
+ * Edit a sticky's text. ONLY refType "note" is editable — message/answer cards
+ * are immutable public content edited at their source, not on the wall.
+ */
+export const editWallNote = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    itemId: v.id("liveEventWallItems"),
+    text: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.eventId, args.sessionId);
+    await enforceRateLimit(ctx, {
+      key: `wall:${args.sessionId}`,
+      limit: WALL_OP_LIMIT,
+      windowMs: WALL_OP_WINDOW,
+    });
+    const item = await ctx.db.get(args.itemId);
+    if (!item || item.eventId !== args.eventId) {
+      throw new ConvexError({
+        code: "item_not_found",
+        message: "That wall item isn't part of this event.",
+      });
+    }
+    if (item.refType !== "note") {
+      throw new ConvexError({
+        code: "not_editable",
+        message:
+          "Only sticky notes can be edited on the wall; messages and answers are edited at their source.",
+      });
+    }
+    const text = (args.text || "").trim();
+    if (!text) {
+      throw new ConvexError({
+        code: "empty_note",
+        message: "Sticky note text is required.",
+      });
+    }
+    if (text.length > MAX_WALL_NOTE_TEXT) {
+      throw new ConvexError({
+        code: "note_too_long",
+        message: `Max ${MAX_WALL_NOTE_TEXT} chars.`,
+      });
+    }
+    await ctx.db.patch(args.itemId, { text, updatedAt: Date.now() });
+    return { ok: true };
+  },
+});
+
+/**
+ * Group a selection. DETERMINISTIC: groupId = "g:" + the lexicographically
+ * smallest member id, so the same selection always groups to the same id (and
+ * since an item belongs to one group at a time, that anchor is collision-free
+ * across distinct groups). Requires ≥2 items; BOUND at MAX_WALL_BATCH.
+ */
+export const groupWallItems = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    itemIds: v.array(v.id("liveEventWallItems")),
+  },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.eventId, args.sessionId);
+    if (args.itemIds.length < 2) {
+      throw new ConvexError({
+        code: "group_too_small",
+        message: "Select at least two items to group.",
+      });
+    }
+    if (args.itemIds.length > MAX_WALL_BATCH) {
+      throw new ConvexError({
+        code: "batch_too_large",
+        message: `Max ${MAX_WALL_BATCH} items per group.`,
+      });
+    }
+    await enforceRateLimit(ctx, {
+      key: `wall:${args.sessionId}`,
+      limit: WALL_OP_LIMIT,
+      windowMs: WALL_OP_WINDOW,
+    });
+
+    // Validate every item belongs to this event before mutating any.
+    const items: any[] = [];
+    for (const id of args.itemIds) {
+      const item = await ctx.db.get(id);
+      if (!item || item.eventId !== args.eventId) {
+        throw new ConvexError({
+          code: "item_not_found",
+          message: "One or more items isn't part of this event.",
+        });
+      }
+      items.push(item);
+    }
+
+    const minId = [...args.itemIds].map(String).sort()[0];
+    const groupId = `g:${minId}`;
+    const now = Date.now();
+    for (const item of items) {
+      await ctx.db.patch(item._id, { groupId, updatedAt: now });
+    }
+    return { groupId, count: items.length };
+  },
+});
+
+/** Ungroup a selection — clears groupId on each item in this event. */
+export const ungroupWallItems = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    itemIds: v.array(v.id("liveEventWallItems")),
+  },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.eventId, args.sessionId);
+    if (args.itemIds.length === 0) {
+      return { ungrouped: 0 };
+    }
+    if (args.itemIds.length > MAX_WALL_BATCH) {
+      throw new ConvexError({
+        code: "batch_too_large",
+        message: `Max ${MAX_WALL_BATCH} items per ungroup.`,
+      });
+    }
+    await enforceRateLimit(ctx, {
+      key: `wall:${args.sessionId}`,
+      limit: WALL_OP_LIMIT,
+      windowMs: WALL_OP_WINDOW,
+    });
+
+    const now = Date.now();
+    let ungrouped = 0;
+    for (const id of args.itemIds) {
+      const item = await ctx.db.get(id);
+      if (!item || item.eventId !== args.eventId) continue; // integrity skip
+      if (item.groupId === undefined) continue;
+      await ctx.db.patch(id, { groupId: undefined, updatedAt: now });
+      ungrouped += 1;
+    }
+    return { ungrouped };
+  },
+});
+
+/* ========================================================================== */
+/* Remove — unpin a card / delete a sticky                                     */
+/* ========================================================================== */
+
+/**
+ * Remove wall items. Removing a message/answer pin only UNPINS it — the source
+ * content (liveEventMessages / liveEventAnswers) is untouched. Removing a "note"
+ * deletes the sticky entirely (its text lived only on the wall). BOUND at
+ * MAX_WALL_BATCH; integrity-checked per id.
+ */
+export const removeWallItems = mutation({
+  args: {
+    eventId: v.id("liveEvents"),
+    sessionId: v.string(),
+    itemIds: v.array(v.id("liveEventWallItems")),
+  },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.eventId, args.sessionId);
+    if (args.itemIds.length === 0) {
+      return { removed: 0 };
+    }
+    if (args.itemIds.length > MAX_WALL_BATCH) {
+      throw new ConvexError({
+        code: "batch_too_large",
+        message: `Max ${MAX_WALL_BATCH} items per remove.`,
+      });
+    }
+    await enforceRateLimit(ctx, {
+      key: `wall:${args.sessionId}`,
+      limit: WALL_OP_LIMIT,
+      windowMs: WALL_OP_WINDOW,
+    });
+
+    let removed = 0;
+    for (const id of args.itemIds) {
+      const item = await ctx.db.get(id);
+      if (!item || item.eventId !== args.eventId) continue; // integrity skip
+      await ctx.db.delete(id);
+      removed += 1;
+    }
+    return { removed };
+  },
+});

--- a/public/proto/wall.html
+++ b/public/proto/wall.html
@@ -1,0 +1,416 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+<title>ScratchNode — Memory Wall (smooth post-it engine prototype)</title>
+<!--
+  SMOOTH POST-IT WALL — engineering prototype.
+  Proves the "buttery" recipe with the LEAST code, ready to drop into home-v5's Wall view.
+
+  Smoothness levers (in priority order):
+    1. transform: translate3d() for position — GPU-composited, never top/left (no reflow).
+    2. Optimistic local transform during drag; ONE commit on pointerup. (In prod that commit
+       is a single Convex `moveNotes` mutation — see commitMoves(). Convex's serializable
+       txn ordering IS the last-write-wins conflict resolver Figma hand-built.)
+    3. pointermove coalesced into ONE requestAnimationFrame per frame.
+    4. setPointerCapture + touch-action:none — unified mouse/touch/pen, no lost drags.
+    5. Single board transform for pan/zoom; the N notes inherit it as one composited layer.
+    6. will-change:transform ONLY on the actively-dragged notes.
+  Groups = flat note.groupId + a client-only selection Set; group-move = one delta to all.
+  Snap = grid + alignment guides computed from CACHED geometry (never getBoundingClientRect mid-drag).
+-->
+<style>
+  :root{
+    --bg:#151413; --panel:#1d1b19; --edge:rgba(255,255,255,.08); --ink:#f4efe9;
+    --ink-faint:#9a9088; --accent:#d97757; --accent-soft:rgba(217,119,87,.16);
+    --grid:rgba(255,255,255,.035);
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%;background:var(--bg);color:var(--ink);
+    font-family:Manrope,system-ui,-apple-system,Segoe UI,sans-serif;overflow:hidden;
+    -webkit-font-smoothing:antialiased}
+
+  /* ── Viewport: clips, owns pan/zoom + marquee + create gestures ── */
+  .viewport{position:fixed;inset:0;touch-action:none;cursor:default;
+    background:
+      linear-gradient(var(--grid) 1px,transparent 1px),
+      linear-gradient(90deg,var(--grid) 1px,transparent 1px);
+    background-size:24px 24px;background-position:0 0;}
+  .viewport.panning{cursor:grabbing}
+  .viewport.space{cursor:grab}
+
+  /* ── Board: the single transformed surface ── */
+  .board{position:absolute;top:0;left:0;width:0;height:0;
+    transform:translate3d(var(--pan-x,0),var(--pan-y,0),0) scale(var(--zoom,1));
+    transform-origin:0 0;will-change:transform;}
+
+  /* ── Note (post-it) ── */
+  .note{position:absolute;top:0;left:0;width:var(--w,180px);min-height:120px;
+    transform:translate3d(var(--x,0),var(--y,0),0);
+    touch-action:none;contain:layout paint;cursor:grab;
+    border-radius:12px;padding:12px 13px 30px;
+    background:var(--c,#f3d77b);color:#2a2118;
+    box-shadow:0 1px 2px rgba(0,0,0,.25),0 10px 24px rgba(0,0,0,.22);
+    font-size:14px;line-height:1.42;user-select:none;
+    transition:box-shadow .15s ease;}
+  .note:hover{box-shadow:0 1px 2px rgba(0,0,0,.3),0 14px 30px rgba(0,0,0,.3)}
+  .note.dragging{will-change:transform;cursor:grabbing;
+    box-shadow:0 2px 4px rgba(0,0,0,.3),0 24px 50px rgba(0,0,0,.42);z-index:50}
+  .note.remote{transition:transform 160ms ease-out}        /* interpolate remote moves (prod) */
+  .note.selected{outline:2px solid var(--accent);outline-offset:2px}
+  .note .handle{position:absolute;left:0;top:0;right:0;height:18px;border-radius:12px 12px 0 0;
+    cursor:grab;opacity:0;transition:opacity .12s}
+  .note:hover .handle{opacity:.001}
+  .note .body{outline:none;white-space:pre-wrap;word-break:break-word;min-height:64px;
+    user-select:text;-webkit-user-select:text;cursor:text}
+  .note .body:empty:before{content:attr(data-ph);color:rgba(42,33,24,.45)}
+  .note .meta{position:absolute;left:13px;bottom:9px;font-size:10px;letter-spacing:.04em;
+    color:rgba(42,33,24,.5);text-transform:uppercase;font-weight:700}
+  .note .del{position:absolute;right:6px;bottom:6px;width:20px;height:20px;border:none;
+    border-radius:6px;background:rgba(42,33,24,.08);color:rgba(42,33,24,.6);cursor:pointer;
+    font-size:13px;line-height:1;opacity:0;transition:opacity .12s}
+  .note:hover .del{opacity:1}
+  .note.grp::after{content:'';position:absolute;left:7px;top:7px;width:7px;height:7px;
+    border-radius:50%;background:var(--accent);box-shadow:0 0 0 2px rgba(255,255,255,.5)}
+
+  /* ── Marquee + alignment guides (children of board, in board space) ── */
+  .marquee{position:absolute;top:0;left:0;border:1.5px solid var(--accent);
+    background:var(--accent-soft);border-radius:4px;pointer-events:none;
+    transform:translate3d(var(--mx,0),var(--my,0),0);width:var(--mw,0);height:var(--mh,0)}
+  .guide{position:absolute;background:var(--accent);pointer-events:none;opacity:.9}
+  .guide.v{top:0;left:0;width:1px;transform:translate3d(var(--gx,0),var(--gy,0),0);height:var(--gh,0)}
+  .guide.h{top:0;left:0;height:1px;transform:translate3d(var(--gx,0),var(--gy,0),0);width:var(--gw,0)}
+
+  /* ── Chrome ── */
+  .bar{position:fixed;top:14px;left:50%;transform:translateX(-50%);z-index:100;
+    display:flex;gap:8px;align-items:center;background:rgba(29,27,25,.86);
+    backdrop-filter:blur(12px);border:1px solid var(--edge);border-radius:14px;
+    padding:7px 10px;box-shadow:0 12px 32px rgba(0,0,0,.4)}
+  .bar b{font-size:12.5px;letter-spacing:.02em;margin-right:4px}
+  .bar .sep{width:1px;height:18px;background:var(--edge)}
+  .btn{border:1px solid var(--edge);background:rgba(255,255,255,.03);color:var(--ink);
+    font:inherit;font-size:12px;font-weight:600;padding:6px 11px;border-radius:9px;cursor:pointer;
+    transition:background .12s,border-color .12s}
+  .btn:hover{background:rgba(255,255,255,.07);border-color:rgba(255,255,255,.16)}
+  .btn.primary{background:var(--accent);border-color:var(--accent);color:#1a120e}
+  .btn.primary:hover{filter:brightness(1.06)}
+  .swatch{width:18px;height:18px;border-radius:5px;border:1.5px solid rgba(0,0,0,.18);cursor:pointer;
+    transition:transform .1s}
+  .swatch:hover{transform:scale(1.14)}
+  .hint{position:fixed;left:14px;bottom:14px;z-index:100;font-size:11.5px;color:var(--ink-faint);
+    background:rgba(29,27,25,.8);border:1px solid var(--edge);border-radius:10px;padding:9px 12px;
+    line-height:1.7;max-width:320px}
+  .hint kbd{font-family:JetBrains Mono,monospace;font-size:10.5px;background:rgba(255,255,255,.07);
+    border:1px solid var(--edge);border-radius:4px;padding:1px 5px;color:var(--ink)}
+  .zoom{position:fixed;right:14px;bottom:14px;z-index:100;font-size:11.5px;color:var(--ink-faint);
+    background:rgba(29,27,25,.8);border:1px solid var(--edge);border-radius:10px;padding:7px 10px;
+    font-family:JetBrains Mono,monospace}
+</style>
+</head>
+<body>
+  <div class="bar">
+    <b>Memory Wall</b>
+    <button class="btn primary" id="add">+ Note</button>
+    <div class="sep"></div>
+    <span style="display:flex;gap:6px" id="palette"></span>
+    <div class="sep"></div>
+    <button class="btn" id="group" title="Cmd/Ctrl+G">Group</button>
+    <button class="btn" id="ungroup">Ungroup</button>
+    <button class="btn" id="fit">Fit</button>
+  </div>
+
+  <div class="viewport" id="vp">
+    <div class="board" id="board"></div>
+  </div>
+
+  <div class="hint">
+    <b style="color:var(--ink)">Buttery test:</b> drag a note — it tracks your finger at native
+    framerate (translate3d + rAF, no reflow).<br>
+    Drag empty = <b>marquee select</b> · <kbd>Shift</kbd>+click adds · drag any selected = <b>group-move</b><br>
+    Double-click empty = new note · double-click note = edit · <kbd>Space</kbd>+drag or wheel = pan ·
+    <kbd>⌘/Ctrl</kbd>+wheel = zoom · <kbd>Del</kbd> = delete · <kbd>⌘/Ctrl+G</kbd> = group
+  </div>
+  <div class="zoom" id="zoomlabel">100%</div>
+
+<script>
+(function(){
+  "use strict";
+
+  // ── State (in prod this is a Convex useQuery result; selection stays client-only) ──
+  const COLORS = ["#f3d77b","#f5b8c4","#a9d8f0","#bfe3b6","#e7b48f","#d8c9f2"];
+  let notes = [];                 // {id,x,y,w,text,color,groupId}
+  const selected = new Set();     // ephemeral — NEVER persisted
+  let activeColor = COLORS[0];
+  let nextId = 1, nextZ = 1;
+  let pan = {x: 160, y: 120}, zoom = 1;
+
+  const vp = document.getElementById('vp');
+  const board = document.getElementById('board');
+  const els = new Map();          // id -> note element (avoid re-query)
+
+  // ── Coordinate transform: screen → board space (inverse of pan/zoom) ──
+  function toBoard(clientX, clientY){
+    const r = vp.getBoundingClientRect();
+    return { x:(clientX - r.left - pan.x)/zoom, y:(clientY - r.top - pan.y)/zoom };
+  }
+  function applyBoard(){
+    board.style.setProperty('--pan-x', pan.x+'px');
+    board.style.setProperty('--pan-y', pan.y+'px');
+    board.style.setProperty('--zoom', zoom);
+    document.getElementById('zoomlabel').textContent = Math.round(zoom*100)+'%';
+  }
+
+  // ── Render: build/patch note DOM from state (idempotent) ──
+  function noteEl(n){
+    let el = els.get(n.id);
+    if(!el){
+      el = document.createElement('div');
+      el.className = 'note'; el.dataset.id = n.id;
+      el.innerHTML =
+        '<div class="handle"></div>'+
+        '<div class="body" contenteditable="false" data-ph="Type a note, a question, a link…"></div>'+
+        '<div class="meta">sticky</div>'+
+        '<button class="del" title="Delete">×</button>';
+      board.appendChild(el); els.set(n.id, el);
+      wireNote(el, n.id);
+    }
+    el.style.setProperty('--x', n.x+'px');
+    el.style.setProperty('--y', n.y+'px');
+    el.style.setProperty('--w', (n.w||180)+'px');
+    el.style.setProperty('--c', n.color);
+    el.classList.toggle('selected', selected.has(n.id));
+    el.classList.toggle('grp', !!n.groupId);
+    const body = el.querySelector('.body');
+    if(document.activeElement !== body && body.textContent !== n.text) body.textContent = n.text;
+    el.style.zIndex = n.z || 1;
+    return el;
+  }
+  function render(){
+    const live = new Set(notes.map(n=>n.id));
+    for(const [id,el] of els){ if(!live.has(id)){ el.remove(); els.delete(id);} }
+    notes.forEach(noteEl);
+  }
+  function rowById(id){ return notes.find(n=>n.id===id); }
+
+  // ── COMMIT POINT: in prod, each is ONE Convex mutation (see convex/wall.ts). ──
+  // The backend contracts now exist; this standalone prototype keeps a local
+  // model so it runs without a Convex client. To go live, swap each stub body
+  // for the matching api.wall.* call and let listWallItems (a reactive query)
+  // stream remote changes back in.
+  function commitMoves(updates){
+    // updates:[{id,x,y}] → await convex.mutation(api.wall.moveWallItems,
+    //   { eventId, sessionId, updates })   — Convex txn ordering IS the LWW resolver.
+    updates.forEach(u=>{ const n=rowById(u.id); if(n){ n.x=u.x; n.y=u.y; } });
+  }
+  function commitCreate(n){
+    // note  → api.wall.createWallNote({ eventId, sessionId, text, x, y, w, color })
+    // pin   → api.wall.pinToWall({ eventId, sessionId, refType, refMessageId|refAnswerId })
+    notes.push(n); render();
+  }
+  function commitDelete(ids){
+    // → api.wall.removeWallItems({ eventId, sessionId, itemIds:[...ids] })
+    notes = notes.filter(n=>!ids.has(n.id)); render();
+  }
+
+  // ── DRAG ENGINE (notes + group): pointer capture + rAF + optimistic transform ──
+  let drag = null;   // {ids, origins, start, raf, latest, guides}
+  function wireNote(el, id){
+    const body = el.querySelector('.body');
+    el.querySelector('.del').onclick = (e)=>{ e.stopPropagation(); commitDelete(new Set([id])); selected.delete(id); };
+
+    // double-click → edit text (and suppress drag while editing)
+    el.addEventListener('dblclick',(e)=>{ if(e.target===body||body.contains(e.target)) return;
+      enterEdit(body); });
+    body.addEventListener('dblclick',()=>enterEdit(body));
+    body.addEventListener('blur',()=>{ body.setAttribute('contenteditable','false');
+      const n=rowById(id); if(n){ n.text = body.textContent; /* editNote(id,{text}) */ } });
+
+    el.addEventListener('pointerdown',(e)=>{
+      if(body.getAttribute('contenteditable')==='true') return;     // editing → no drag
+      if(e.target.classList.contains('del')) return;
+      if(spaceDown){ return; }                                       // space = pan, let vp handle
+      e.stopPropagation();
+      el.setPointerCapture(e.pointerId);
+
+      // selection logic (Figma-like): shift toggles; clicking an unselected note selects just it
+      if(e.shiftKey){ selected.has(id)?selected.delete(id):selected.add(id); }
+      else if(!selected.has(id)){ selected.clear(); selected.add(id); }
+      // bring to front
+      const n=rowById(id); n.z = ++nextZ;
+      render();
+
+      // expand to whole group(s) of every selected note
+      const ids = new Set();
+      selected.forEach(sid=>{ ids.add(sid); const g=rowById(sid)?.groupId;
+        if(g) notes.forEach(o=>{ if(o.groupId===g) ids.add(o.id); }); });
+
+      const origins = new Map();
+      ids.forEach(i=>{ const r=rowById(i); origins.set(i,{x:r.x,y:r.y}); els.get(i).classList.add('dragging'); });
+      // cache OTHER notes' edges once for alignment snap (no live layout reads mid-drag)
+      const others = notes.filter(n=>!ids.has(n.id)).map(n=>({x:n.x,y:n.y,w:n.w||180,h:el.offsetHeight||120}));
+      drag = { ids, origins, start: toBoard(e.clientX,e.clientY), raf:null, latest:e, others, w:el.offsetWidth, h:el.offsetHeight };
+    });
+  }
+  function enterEdit(body){ body.setAttribute('contenteditable','true'); body.focus();
+    const r=document.createRange(); r.selectNodeContents(body); r.collapse(false);
+    const s=getSelection(); s.removeAllRanges(); s.addRange(r); }
+
+  function onMove(e){ if(!drag) return; drag.latest=e; if(!drag.raf) drag.raf=requestAnimationFrame(applyDrag); }
+  function applyDrag(){
+    drag.raf=null;
+    const p=toBoard(drag.latest.clientX, drag.latest.clientY);
+    let dx=p.x-drag.start.x, dy=p.y-drag.start.y;
+    // GRID snap (cheap, always on)
+    const GRID=8;
+    // ALIGNMENT snap vs cached neighbour edges (the "Figma feel")
+    const lead = drag.origins.values().next().value;       // anchor = first dragged note's origin
+    const movingL=lead.x+dx, movingT=lead.y+dy, movingR=movingL+drag.w, movingB=movingT+drag.h;
+    const movingCX=movingL+drag.w/2, movingCY=movingT+drag.h/2;
+    const TH=6; let gx=null, gy=null;
+    for(const o of drag.others){
+      for(const [edge,val] of [['l',o.x],['r',o.x+o.w],['cx',o.x+o.w/2]]){
+        if(Math.abs(movingL-val)<TH){ dx+= val-movingL; gx=val; }
+        else if(Math.abs(movingR-val)<TH){ dx+= val-movingR; gx=val; }
+        else if(Math.abs(movingCX-val)<TH){ dx+= val-movingCX; gx=val; }
+      }
+      for(const val of [o.y,o.y+o.h,o.y+o.h/2]){
+        if(Math.abs(movingT-val)<TH){ dy+= val-movingT; gy=val; }
+        else if(Math.abs(movingB-val)<TH){ dy+= val-movingB; gy=val; }
+        else if(Math.abs(movingCY-val)<TH){ dy+= val-movingCY; gy=val; }
+      }
+    }
+    if(gx===null){ dx=Math.round((lead.x+dx)/GRID)*GRID-lead.x; }
+    if(gy===null){ dy=Math.round((lead.y+dy)/GRID)*GRID-lead.y; }
+    for(const [id,o] of drag.origins){
+      const el=els.get(id);
+      el.style.setProperty('--x',(o.x+dx)+'px'); el.style.setProperty('--y',(o.y+dy)+'px');
+    }
+    drag._dx=dx; drag._dy=dy;
+    showGuides(gx,gy);
+    // PROD: throttledPresence(dx,dy) on a SEPARATE ephemeral channel (~20-30Hz), never the doc.
+  }
+  function endDrag(e){
+    if(!drag) return;
+    const dx=drag._dx||0, dy=drag._dy||0;
+    const updates=[]; for(const [id,o] of drag.origins){ updates.push({id,x:o.x+dx,y:o.y+dy}); els.get(id).classList.remove('dragging'); }
+    commitMoves(updates);                  // ← the ONE write (Convex moveNotes in prod)
+    clearGuides(); drag=null;
+  }
+
+  // ── Alignment guide rendering ──
+  let guideEls=[];
+  function showGuides(gx,gy){ clearGuides();
+    if(gx!==null){ const g=document.createElement('div'); g.className='guide v';
+      g.style.setProperty('--gx',gx+'px'); g.style.setProperty('--gy','-4000px'); g.style.setProperty('--gh','8000px');
+      board.appendChild(g); guideEls.push(g); }
+    if(gy!==null){ const g=document.createElement('div'); g.className='guide h';
+      g.style.setProperty('--gy',gy+'px'); g.style.setProperty('--gx','-4000px'); g.style.setProperty('--gw','8000px');
+      board.appendChild(g); guideEls.push(g); }
+  }
+  function clearGuides(){ guideEls.forEach(g=>g.remove()); guideEls=[]; }
+
+  // ── MARQUEE select + PAN (on the viewport / empty space) ──
+  let marquee=null, panning=null, spaceDown=false;
+  vp.addEventListener('pointerdown',(e)=>{
+    if(e.target!==vp && e.target!==board) return;       // only on empty space
+    vp.setPointerCapture(e.pointerId);
+    if(spaceDown || e.button===1){                       // pan
+      panning={sx:e.clientX,sy:e.clientY,px:pan.x,py:pan.y}; vp.classList.add('panning');
+    } else {                                             // marquee select
+      if(!e.shiftKey) selected.clear();
+      const s=toBoard(e.clientX,e.clientY);
+      marquee={sx:s.x,sy:s.y,raf:null,latest:e,base:new Set(selected)};
+      const m=document.createElement('div'); m.className='marquee'; m.id='__mq'; board.appendChild(m);
+      render();
+    }
+  });
+  function vpMove(e){
+    if(panning){ pan.x=panning.px+(e.clientX-panning.sx); pan.y=panning.py+(e.clientY-panning.sy);
+      if(!panning.raf){ panning.raf=requestAnimationFrame(()=>{panning.raf=null;applyBoard();}); } return; }
+    if(marquee){ marquee.latest=e; if(!marquee.raf) marquee.raf=requestAnimationFrame(applyMarquee); }
+  }
+  function applyMarquee(){
+    marquee.raf=null; const p=toBoard(marquee.latest.clientX,marquee.latest.clientY);
+    const x=Math.min(marquee.sx,p.x), y=Math.min(marquee.sy,p.y), w=Math.abs(p.x-marquee.sx), h=Math.abs(p.y-marquee.sy);
+    const m=document.getElementById('__mq');
+    if(m){ m.style.setProperty('--mx',x+'px'); m.style.setProperty('--my',y+'px');
+      m.style.setProperty('--mw',w+'px'); m.style.setProperty('--mh',h+'px'); }
+    // live selection: base ∪ intersecting
+    selected.clear(); marquee.base.forEach(i=>selected.add(i));
+    for(const n of notes){ const el=els.get(n.id); const nh=el?el.offsetHeight:120, nw=n.w||180;
+      if(n.x < x+w && n.x+nw > x && n.y < y+h && n.y+nh > y) selected.add(n.id); }
+    notes.forEach(n=>els.get(n.id).classList.toggle('selected',selected.has(n.id)));
+  }
+  function vpUp(){
+    if(panning){ panning=null; vp.classList.remove('panning'); }
+    if(marquee){ const m=document.getElementById('__mq'); if(m) m.remove(); marquee=null; render(); }
+  }
+
+  // ── Global pointer move/up (capture continues anywhere) ──
+  window.addEventListener('pointermove',(e)=>{ onMove(e); vpMove(e); });
+  window.addEventListener('pointerup',(e)=>{ endDrag(e); vpUp(e); });
+
+  // ── Pan via wheel; zoom via ctrl/cmd+wheel (anchored at cursor) ──
+  vp.addEventListener('wheel',(e)=>{
+    e.preventDefault();
+    if(e.ctrlKey||e.metaKey){
+      const before=toBoard(e.clientX,e.clientY);
+      zoom=Math.min(3,Math.max(.3, zoom*(1 - e.deltaY*0.0015)));
+      const after=toBoard(e.clientX,e.clientY);
+      pan.x += (after.x-before.x)*zoom; pan.y += (after.y-before.y)*zoom;   // keep cursor anchored
+    } else { pan.x-=e.deltaX; pan.y-=e.deltaY; }
+    applyBoard();
+  },{passive:false});
+
+  // ── Keyboard: space=pan, delete, group ──
+  window.addEventListener('keydown',(e)=>{
+    if(e.code==='Space' && document.activeElement.tagName!=='DIV'){ spaceDown=true; vp.classList.add('space'); }
+    const editing=document.activeElement.getAttribute && document.activeElement.getAttribute('contenteditable')==='true';
+    if(editing) return;
+    if((e.key==='Delete'||e.key==='Backspace') && selected.size){ e.preventDefault(); commitDelete(new Set(selected)); selected.clear(); }
+    if((e.metaKey||e.ctrlKey) && e.key.toLowerCase()==='g'){ e.preventDefault(); e.shiftKey?ungroup():group(); }
+    if(e.key==='Escape'){ selected.clear(); render(); }
+  });
+  window.addEventListener('keyup',(e)=>{ if(e.code==='Space'){ spaceDown=false; vp.classList.remove('space'); } });
+
+  // ── Group / ungroup (flat groupId model) ──
+  function group(){ if(selected.size<2) return; const gid='g'+(nextId++);
+    selected.forEach(id=>{ const n=rowById(id); if(n) n.groupId=gid; }); render(); }
+  function ungroup(){ selected.forEach(id=>{ const n=rowById(id); if(n) n.groupId=null; }); render(); }
+
+  // ── Create / palette / chrome ──
+  function makeNote(bx,by){ return { id:'n'+(nextId++), x:Math.round(bx/8)*8, y:Math.round(by/8)*8,
+    w:180, text:'', color:activeColor, z:++nextZ }; }
+  vp.addEventListener('dblclick',(e)=>{ if(e.target!==vp && e.target!==board) return;
+    const p=toBoard(e.clientX,e.clientY); const n=makeNote(p.x-90,p.y-60); commitCreate(n);
+    selected.clear(); selected.add(n.id); render(); enterEdit(els.get(n.id).querySelector('.body')); });
+  document.getElementById('add').onclick=()=>{ const c=toBoard(vp.clientWidth/2,vp.clientHeight/2);
+    const n=makeNote(c.x-90,c.y-60); commitCreate(n); selected.clear(); selected.add(n.id); render();
+    enterEdit(els.get(n.id).querySelector('.body')); };
+  document.getElementById('group').onclick=group;
+  document.getElementById('ungroup').onclick=ungroup;
+  document.getElementById('fit').onclick=()=>{ pan={x:160,y:120}; zoom=1; applyBoard(); };
+
+  const pal=document.getElementById('palette');
+  COLORS.forEach(c=>{ const s=document.createElement('div'); s.className='swatch'; s.style.background=c;
+    s.onclick=()=>{ activeColor=c; if(selected.size){ selected.forEach(id=>{ const n=rowById(id); if(n) n.color=c; }); render(); } };
+    pal.appendChild(s); });
+
+  // ── Seed a few notes so it's alive on open ──
+  function seed(){
+    const demo=[
+      {t:'What did the panel say about MCP enterprise auth?',c:COLORS[2],x:40,y:40},
+      {t:'/ask p95 latency budget for agent loops',c:COLORS[0],x:260,y:90},
+      {t:'Scoped, revocable credentials > static API keys',c:COLORS[3],x:90,y:230},
+      {t:'🔒 my note: follow up with Orbital on pricing',c:COLORS[1],x:300,y:300},
+      {t:'Healthcare pilots cluster around intake + note-prep',c:COLORS[4],x:540,y:160},
+      {t:'Audit every agent action → person/policy/source',c:COLORS[5],x:520,y:360},
+    ];
+    demo.forEach(d=>notes.push({id:'n'+(nextId++),x:d.x,y:d.y,w:180,text:d.t,color:d.c,z:++nextZ}));
+  }
+  seed(); applyBoard(); render();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Phase 8 of ScratchNode: the **Memory Wall** backend — a layout-only spatial overlay over the canonical live-event stream. A wall item carries position/size/color/group and **points at** public content (`liveEventMessages` / `liveEventAnswers`) or holds a short public sticky. It's a second render lane over the same stream the chat feed shows — the "Twitch" model: one stream, two synchronized views, so Chat and Wall stay a single source of truth.

This is the backend + canonical data model + the smooth-drag prototype it pairs with. **No live UI surface changes** (home-v5 Chat is untouched); mounting the Wall lane behind a Chat|Wall toggle is the next PR.

## Files

| File | Change |
|---|---|
| `convex/schema/eventsSchema.ts` | `+ liveEventWallItems` table (4 indexes, pin-dedup) |
| `convex/schema.ts` | register table (import + map) |
| `convex/wall.ts` | **new** — 1 query + 8 mutations |
| `convex/__tests__/scratchnode.wall.test.ts` | **new** — 17 scenario tests |
| `convex/events.runtime-boundary.test.ts` | `+ 6` static privacy/BOUND assertions |
| `public/proto/wall.html` | smooth-drag engine prototype; commit stubs name the real `api.wall.*` contracts |

## Data model — content vs. layout separation

Message/answer text is **never duplicated**. A wall item dereferences a pointer; only a `"note"` stores inline text (public by construction, like a chat message). Position commits **once on pointerup** via `moveWallItems` — Convex's serializable txn ordering is the last-write-wins resolver, no CRDT needed at room scale.

## Reliability (`.claude/rules/agentic_reliability.md`)

- **BOUND** — `listWallItems` capped at 500; every `id[]` mutation capped at 200
- **HONEST_STATUS** — typed `ConvexError` on every validation failure
- **Gates** — `requireMember` + DB-backed `enforceRateLimit` on every mutation (separate `wall:` / `wallmove:` buckets so drags can't starve creates)
- **Input sanitation** — coordinate clamping (NaN/Infinity → last-good; finite-out-of-range → ±1e5); color **allowlist** (no arbitrary inline style)
- **DETERMINISTIC** — `groupId = "g:" + smallest member id`; server-stamped timestamps
- **Integrity** — every ref/item verified to belong to the event (no cross-event id smuggling)

## Privacy invariant

The public Wall **never** references `userNotes` (private, owner-keyed). A `"note"` item is public inline text. Enforced by a static-source boundary test (`not.toContain('"userNotes"')` + no `.ownerKey` / `getPrivate`).

## Tests (scenario-based per `.claude/rules/scenario_testing.md`)

17 behavioral + 6 static. Personas/edges covered: pin idempotency & dedup (double-fire), cross-event id smuggling (adversarial), coordinate clamp branches (degraded input), deterministic grouping + ungroup, BOUND batch/list overflow (scale), membership + ended-event gates, color/text injection, collaborative-open move by a *different* member (multi-user), unpin-keeps-source, rate-limit bucket independence (sustained burst).

## Verification

- `npx convex codegen` — clean
- `npx tsc --noEmit` — clean
- `npx vitest run` (wall + boundary) — **33 passed**
- `npx vitest run scratchnode.events` (regression) — **50 passed / 1 skip**
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
