### PR TITLE
polish(scratchnode): handoff cascade + room-code copy flash

### DIFF
--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -6,3 +6,8 @@ Append-only lane for the ScratchNode live-event prototype and production static 
 Centralized lightweight motion tokens and added a visual polish pass across the ScratchNode room: ambient backdrop, composer focus/private-mode cues, chat and answer reveals, Live Assist card choreography, and tactile Memory Wall note transitions. The change keeps the existing public/private behavior contract intact while making the demo feel more premium on desktop and mobile.
 
 **Commit**: `this commit`. **Author**: Homen Shum + Augment Agent.
+
+## 2026-06-01 — Follow-up: handoff cascade + room-code copy flash
+Additive layer on top of the motion polish pass. Two micro-interactions that the prior pass did not cover: (1) the room-code chip now flashes a green "✓ Copied" confirmation on copy (paired with the existing toast — text + colour, not colour alone), and (2) the NodeBench handoff overlay sections cascade up after the panel slides in, so the "Now in NodeBench" moment feels composed rather than a hard cut. Both reuse the existing `--motion-*`/`--ease-out` tokens, ship `prefers-reduced-motion` guards, and leave the public/private behavior contract untouched. Verified: 7/7 e2e (output-contract + live-route-honesty), reduced-motion suppression, no mobile overflow.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -124,9 +124,12 @@ button:active { transform: scale(.97); transition: transform .08s; }
   min-height: 36px; padding: 6px 14px; border-radius: var(--r-sm);
   background: transparent; border: 1px solid var(--line);
   color: var(--accent); font-family: var(--mono); font-size: 12px; font-weight: 700;
-  letter-spacing: .18em; cursor: pointer; transition: border-color .12s;
+  letter-spacing: .18em; cursor: pointer;
+  transition: border-color var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out), background var(--motion-fast) var(--ease-out);
 }
 .h-code:hover { border-color: var(--accent); }
+/* Tactile "copied" confirmation — green flash + check, paired with the toast (text + colour, not colour alone). */
+.h-code.is-copied { color: var(--green); border-color: rgba(94,168,103,.5); background: rgba(94,168,103,.1); }
 .h-menu { width: 44px; height: 44px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--r-sm); border: 1px solid var(--line); background: transparent; color: var(--ink-muted); }
 .h-menu:hover { color: var(--ink); border-color: var(--ink-faint); }
 @media (max-width: 540px) { .h-menu { width: 44px; height: 44px; } .h-code { min-height: 44px; } }
@@ -1178,6 +1181,15 @@ body[data-role="attendee"] .host-queue { display: none; }
 .nodebench-overlay .nb-close { margin-left: auto; background: none; border: 1px solid rgba(255,255,255,.1); color: #e8e6e3; padding: 6px 12px; border-radius: 6px; font-size: 12px; }
 .nodebench-overlay .nb-body { padding: 22px; max-width: 1100px; margin: 0 auto; width: 100%; }
 .nodebench-overlay .nb-section { margin-bottom: 24px; }
+/* Cinematic handoff: after the overlay slides in, its sections cascade up so the
+   "Now in NodeBench" moment feels composed rather than a hard cut. */
+@keyframes nbSectionIn { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: translateY(0); } }
+.nodebench-overlay[data-visible="true"] .nb-body > .nb-section { animation: nbSectionIn var(--motion-slow) var(--ease-out) both; }
+.nodebench-overlay[data-visible="true"] .nb-body > .nb-section:nth-child(1) { animation-delay: .1s; }
+.nodebench-overlay[data-visible="true"] .nb-body > .nb-section:nth-child(2) { animation-delay: .18s; }
+.nodebench-overlay[data-visible="true"] .nb-body > .nb-section:nth-child(3) { animation-delay: .26s; }
+.nodebench-overlay[data-visible="true"] .nb-body > .nb-section:nth-child(n+4) { animation-delay: .32s; }
+@media (prefers-reduced-motion: reduce) { .nodebench-overlay[data-visible="true"] .nb-body > .nb-section { animation: none; } }
 .nodebench-overlay .nb-section-head { font-family: var(--mono); font-size: 10px; letter-spacing: .14em; color: rgba(255,255,255,.5); text-transform: uppercase; margin-bottom: 8px; }
 .nodebench-overlay .nb-card { padding: 14px; border-radius: 10px; background: rgba(255,255,255,.025); border: 1px solid rgba(255,255,255,.06); }
 .nodebench-overlay .nb-card + .nb-card { margin-top: 8px; }
@@ -2899,10 +2911,25 @@ function copyRoom() {
     return;
   }
   if (navigator.clipboard) {
-    navigator.clipboard.writeText(text).then(function(){ toast('Copied join link', EVENT_ROOM_CODE + ' · paste in any chat.'); });
+    navigator.clipboard.writeText(text).then(function(){ toast('Copied join link', EVENT_ROOM_CODE + ' · paste in any chat.'); flashRoomCode(); });
   } else {
     toast('Room: ' + EVENT_ROOM_CODE, 'Share this URL with attendees.');
   }
+}
+// Brief inline "copied" confirmation on the room-code chip (check + green flash), then restore.
+// Pairs with the toast — text + colour, not colour alone.
+function flashRoomCode() {
+  var btn = document.getElementById('sn-room-code-btn');
+  if (!btn || btn.dataset.flashing === '1') return;
+  var original = btn.textContent;
+  btn.dataset.flashing = '1';
+  btn.classList.add('is-copied');
+  btn.textContent = '✓ Copied';
+  setTimeout(function() {
+    btn.classList.remove('is-copied');
+    btn.textContent = original;
+    delete btn.dataset.flashing;
+  }, 1300);
 }
 
 // ── Menu ──


### PR DESCRIPTION
## What

Additive follow-up on top of the shipped motion pass (`0ec4c9d3`). Adds the **two micro-interactions the prior pass did not cover**, on `public/proto/home-v5.html`:

1. **Room-code copy flash** — clicking the room-code chip now flashes a green `✓ Copied` confirmation (paired with the existing toast — text + colour, not colour alone), then restores the code.
2. **Handoff cascade** — the NodeBench handoff overlay sections cascade up (`nbSectionIn`) after the panel slides in, so the "Now in NodeBench" moment feels composed instead of a hard cut.

Both reuse the existing `--motion-fast/med/slow` + `--ease-out` token system added in `0ec4c9d3` — no new token system, no overlap with the existing `feedRowIn`/`answerReveal`/`laCardIn`/`snNotePop`/`composerSheen`/`privateSeal` motion.

## Why these two only

A parallel pass (`0ec4c9d3`) already shipped composer focus glow (`--glow-accent`/`composerSheen`), private-mode differentiation + lock pulse (`--glow-private`/`privateSeal`), message/answer reveals, Live Assist stagger, and Memory Wall pop. These two were the remaining gaps.

## Safety

- No change to the public/private behaviour contract or the live send/render path.
- `prefers-reduced-motion` guard on the cascade.

## Verification

- `7/7` e2e on chromium: `home-v5-output-contract` (runs the 13-phase demo + 17 QA invariants + Live Assist counts) and all 6 `scratchnode-live-route-honesty` guarantees (no mock chat on config-fail, composer stays disabled, no local rows on send failure).
- All 4 inline `<script>` blocks parse clean.
- Behavioral: room-code chip → `is-copied` + `✓ Copied` + green; handoff sections → `nbSectionIn` with staggered delays `0.1s / 0.18s / 0.26s`; reduced-motion → `animationName: none`; mobile 375px → no horizontal overflow.

> Live-DOM verification (fetch `scratchnode.live` + grep raw HTML) should be run **post-merge/deploy** per `.claude/rules/live_dom_verification.md` — not done here since this PR is not yet deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
