### PR TITLE
feat(loop): cycle C002 — expand detectors + ship first real fixes

### DIFF
--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -6,3 +6,8 @@ Append-only lane for the ScratchNode live-event prototype and production static 
 Centralized lightweight motion tokens and added a visual polish pass across the ScratchNode room: ambient backdrop, composer focus/private-mode cues, chat and answer reveals, Live Assist card choreography, and tactile Memory Wall note transitions. The change keeps the existing public/private behavior contract intact while making the demo feel more premium on desktop and mobile.
 
 **Commit**: `this commit`. **Author**: Homen Shum + Augment Agent.
+
+## 2026-06-02 — a11y: explicit type="button" on 3 buttons (loop C002)
+Self-improvement loop cycle C002 added `type="button"` to the Memory Wall sticky-delete button and the two onboarding-tour buttons (Next/Skip) — they had onclick handlers but no explicit type (implicit-submit footgun). Validated as not inside a <form>; no behavior change. e2e honesty + output-contract green.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.

--- a/CHANGELOG/scripts/improvement-loop.md
+++ b/CHANGELOG/scripts/improvement-loop.md
@@ -6,3 +6,8 @@ Append-only lane for NodeBench's continuous self-driving improvement loop.
 Created the loop substrate (`scan.mjs` deterministic opportunity detectors + scoring, `run-cycle.mjs` orchestrator, durable `ledger.json`), the agent operating manual (`.claude/rules/self_improvement_loop.md`), and the design doc (`docs/architecture/SELF_IMPROVEMENT_LOOP.md`). Unifies existing dogfood/eval loops; ships only through CI-gated PRs; honesty contract human-gated. Cycle C001 ran clean after rejecting 6 false-positive candidates and hardening 2 detectors. Convex ledger graduation queued (unverified-locally → not shipped).
 
 **Commit**: `this commit`. **Author**: Homen Shum + Claude.
+
+## 2026-06-02 — Cycle C002: expand detectors + ship first real fixes
+Added 3 detectors (button-without-type w/ form-context safety gating, target=_blank missing rel=noopener, img missing alt) and CSS/HTML comment-masking so example markup in comments is not flagged. The cycle found 1 false positive (rejected -> hardened) and 3 real button fixes (shipped). Demonstrates the loop converging: post-fix scan is clean.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -2164,7 +2164,7 @@ function _landingJoin(ev) {
       if(!el){
         el=document.createElement('div');
         el.className='sn-note'; el.tabIndex=0; el.setAttribute('role','group'); el.dataset.id=item._id;
-        el.innerHTML='<button class="sn-del" title="Remove" aria-label="Remove sticky">&times;</button>'+
+        el.innerHTML='<button type="button" class="sn-del" title="Remove" aria-label="Remove sticky">&times;</button>'+
                      '<div class="sn-body"></div><div class="sn-meta">sticky</div>';
         board.appendChild(el); els.set(item._id, el); wireNote(el, item._id);
       }
@@ -3237,7 +3237,7 @@ function renderTourStep() {
     var r = target.getBoundingClientRect();
     var el = document.createElement('div');
     el.className = 'tip-popover';
-    el.innerHTML = step.text + '<br><button onclick="nextTour()">' + (_tourIdx === TOUR.length - 1 ? 'Got it' : 'Next →') + '</button> <button onclick="closeTour()" style="margin-left:6px;color:var(--ink-faint)">Skip</button>';
+    el.innerHTML = step.text + '<br><button type="button" onclick="nextTour()">' + (_tourIdx === TOUR.length - 1 ? 'Got it' : 'Next →') + '</button> <button type="button" onclick="closeTour()" style="margin-left:6px;color:var(--ink-faint)">Skip</button>';
     document.body.appendChild(el);
     var top = r.bottom + 10 + window.scrollY;
     var left = Math.max(8, Math.min(window.innerWidth - 260, r.left + window.scrollX));

--- a/scripts/improvement-loop/ledger.json
+++ b/scripts/improvement-loop/ledger.json
@@ -5,7 +5,7 @@
     "consecutiveNoShipLimit": 3,
     "requireGreenVerification": true
   },
-  "consecutiveNoShip": 1,
+  "consecutiveNoShip": 0,
   "cycles": [
     {
       "cycleId": "C001",
@@ -24,7 +24,30 @@
       "backlogTop": [],
       "outcome": "clean_no_auto_opportunities",
       "note": "Bootstrap. Built loop substrate (scan+run-cycle+JSON ledger), ran scan -> 6 candidates, VALIDATED all -> false positives (XXX in URL-param doc comments; intentional 'Coming soon' L2 capture flag). REJECTED all (no theater), hardened 2 detectors. Convex ledger graduation queued (local codegen blocked by unrelated @mistralai dep error). ScratchNode surface clean post-polish."
+    },
+    {
+      "cycleId": "C002",
+      "at": "2026-06-02T02:34:38.978Z",
+      "scan": {
+        "total": 4,
+        "autoSafe": 3,
+        "humanGated": 0
+      },
+      "selected": {
+        "id": "OPP-001",
+        "title": "Button missing type=\"button\" (implicit-submit footgun)",
+        "score": 1.7,
+        "file": "public/proto/home-v5.html:2167"
+      },
+      "outcome": "shipped",
+      "note": "Expanded detectors (+button-type with form-context safety, +target=_blank/noopener, +img-alt) and added CSS/HTML comment-masking. Scan found 4 button candidates: 1 FALSE POSITIVE (button inside a CSS comment -> hardened detector to mask comments), 3 REAL (wall sticky-delete + 2 tour buttons). Validated all 3 (onclick handlers, not in <form>) and added type=\"button\". e2e 7/7 green (output-contract + honesty). Post-fix scan clean.",
+      "shipped": {
+        "files": [
+          "public/proto/home-v5.html",
+          "scripts/improvement-loop/scan.mjs"
+        ]
+      }
     }
   ],
-  "updatedAt": "2026-06-02T01:44:09.462Z"
+  "updatedAt": "2026-06-02T02:34:38.978Z"
 }

--- a/scripts/improvement-loop/scan.mjs
+++ b/scripts/improvement-loop/scan.mjs
@@ -2,21 +2,21 @@
 /**
  * Self-Improvement Loop — Opportunity Scanner (OBSERVE phase)
  *
- * Pattern: continuous improvement flywheel (find → score → act → verify → ship → record → loop).
+ * Pattern: continuous improvement flywheel (find -> score -> act -> verify -> ship -> record -> loop).
  * Prior art:
  *   - NodeBench .claude/rules/flywheel_continuous.md, self_building_loop.md, eval_flywheel.md
- *   - Existing loops it UNIFIES rather than replaces: `dogfood:loop:auto` (Gemini QA),
- *     `dogfood:proto-live-backend` (live-backend ScratchNode dogfood), scripts/eval-harness.
+ *   - Existing loops it UNIFIES rather than replaces: dogfood:loop:auto (Gemini QA),
+ *     dogfood:proto-live-backend (live-backend ScratchNode dogfood), scripts/eval-harness.
  *
  * Emits a SCORED, EVIDENCED backlog of concrete, checkable opportunities. Every detector is
  * deterministic and cites file:line — no LLM "vibes" scoring (HONEST_SCORES). The agent brain
  * (see .claude/rules/self_improvement_loop.md) reads this backlog, picks the top auto-safe item,
- * implements, verifies, ships, and records the cycle.
+ * VALIDATES it (rejecting false positives), implements, verifies, ships, and records the cycle.
  *
  * Scoring:  score = impact(1..5) * confidence(0..1) / effort(1..5)
  *           safety='human' opportunities are QUEUED (score forced to 0) — never auto-shipped.
  *
- * Usage:    node scripts/improvement-loop/scan.mjs [--surface <glob>] [--json]
+ * Usage:    node scripts/improvement-loop/scan.mjs [--json]
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -39,16 +39,36 @@ const readLines = (rel) => {
 
 let _seq = 0;
 const opp = (o) => {
-  const impact = o.impact, confidence = o.confidence, effort = o.effort;
   const queued = o.safety === 'human';
-  const score = queued ? 0 : +(impact * confidence / effort).toFixed(3);
+  const score = queued ? 0 : +(o.impact * o.confidence / o.effort).toFixed(3);
   return { id: `OPP-${String(++_seq).padStart(3, '0')}`, score, queued, ...o };
 };
 
-/** Detector: leftover engineering markers — only the ACTIONABLE annotation form.
- *  Precision hardening (loop cycle 1): dropped `XXX` (false-positives on `?token=XXX`
- *  URL-param placeholders in docs) and require an annotation shape (`TODO:` / `FIXME(`
- *  / `HACK -`) inside a comment, so documentation that merely mentions the word is ignored. */
+// Blank out CSS and HTML comments (preserving newlines + length so file:line stays accurate),
+// so tag detectors never match example markup that lives inside a comment. Learned in cycles
+// C001/C002, where `<button>` in a CSS comment and `XXX` in doc comments were false positives.
+function maskComments(text) {
+  const blank = (m) => m.replace(/[^\n]/g, ' ');
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, blank)   // CSS / JS block comments
+    .replace(/<!--[\s\S]*?-->/g, blank);   // HTML comments
+}
+
+// Index ranges of every <form>...</form> so we can tell whether a button is inside a real form
+// (where a missing type means implicit SUBMIT — behavior-sensitive, must be human-gated).
+function formRanges(text) {
+  const ranges = [];
+  const re = /<form\b[\s\S]*?<\/form>/g;
+  let m;
+  while ((m = re.exec(text))) ranges.push([m.index, m.index + m[0].length]);
+  return ranges;
+}
+const inAnyRange = (idx, ranges) => ranges.some(([a, b]) => idx >= a && idx < b);
+const lineOf = (text, idx) => text.slice(0, idx).split('\n').length;
+
+/** Leftover engineering markers — only the ACTIONABLE annotation form, inside a comment.
+ *  Hardened C001: dropped XXX (false-positives on ?token=XXX URL-param placeholders) and require
+ *  an annotation shape (TODO: / FIXME( / HACK -) so prose mentioning the word is ignored. */
 function detectMarkers(surface, lines) {
   const out = [];
   const isComment = (s) => /(^|\s)(\/\/|\/\*|\*|<!--|#)/.test(s);
@@ -66,24 +86,22 @@ function detectMarkers(surface, lines) {
   return out;
 }
 
-/** Detector: icon-only <button> with an <svg> child but no aria-label (a11y P1). */
+/** Icon-only <button> with an <svg> child but no aria-label (a11y). */
 function detectIconButtonsWithoutLabel(surface, lines) {
   const out = [];
-  const text = lines.join('\n');
-  // crude tag matcher: <button ...> ... </button> on a manageable window
+  const text = maskComments(lines.join('\n'));
   const buttonRx = /<button\b[^>]*>[\s\S]*?<\/button>/g;
   let m;
   while ((m = buttonRx.exec(text))) {
     const tag = m[0];
     const openTag = tag.slice(0, tag.indexOf('>') + 1);
     const hasSvg = /<svg\b/.test(tag);
-    const hasText = /<\/svg>\s*[^<\s][^<]*</.test(tag) || />\s*[A-Za-z0-9]/.test(tag.replace(/<svg[\s\S]*?<\/svg>/, ''));
+    const hasText = />\s*[A-Za-z0-9]/.test(tag.replace(/<svg[\s\S]*?<\/svg>/, ''));
     const hasLabel = /aria-label\s*=/.test(openTag) || /aria-labelledby\s*=/.test(openTag);
     if (hasSvg && !hasLabel && !hasText) {
-      const line = text.slice(0, m.index).split('\n').length;
       out.push(opp({
         title: 'Icon-only button missing aria-label',
-        surface: surface.id, source: 'a11y-scan', file: `${surface.file}:${line}`,
+        surface: surface.id, source: 'a11y-scan', file: `${surface.file}:${lineOf(text, m.index)}`,
         evidence: openTag.slice(0, 140),
         impact: 3, confidence: 0.7, effort: 1, safety: 'auto',
       }));
@@ -92,27 +110,22 @@ function detectIconButtonsWithoutLabel(surface, lines) {
   return out;
 }
 
-/** Detector: @keyframes without a paired prefers-reduced-motion guard mentioning its selector.
- *  Honest heuristic — flags animations that may not be motion-safe; the agent confirms before fixing. */
+/** @keyframes used by an animation with no prefers-reduced-motion guard (motion a11y).
+ *  Lenient heuristic — a blanket reduced-motion guard counts; the agent confirms before fixing. */
 function detectUnguardedKeyframes(surface, lines) {
   const out = [];
   const text = lines.join('\n');
   const names = [...text.matchAll(/@keyframes\s+([A-Za-z0-9_-]+)/g)].map((m) => m[1]);
-  // Collect classes/selectors that reference each animation by name, then check a reduced-motion
-  // block disables animation for at least one of those selectors.
   const reducedBlocks = [...text.matchAll(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{([\s\S]*?)\}\s*\}?/g)]
     .map((m) => m[1]).join('\n');
   for (const name of new Set(names)) {
     const usedBy = [...text.matchAll(new RegExp(`animation[^;{]*\\b${name}\\b`, 'g'))].length;
-    if (usedBy === 0) continue; // defined but unused — separate concern
-    // Is there ANY reduced-motion rule that sets animation:none AND is plausibly for this animation?
-    const guarded = new RegExp(`${name}`).test(reducedBlocks) ||
-      /animation\s*:\s*none/.test(reducedBlocks); // lenient: a blanket guard counts
+    if (usedBy === 0) continue;
+    const guarded = new RegExp(name).test(reducedBlocks) || /animation\s*:\s*none/.test(reducedBlocks);
     if (!guarded) {
-      const line = text.slice(0, text.indexOf(`@keyframes ${name}`)).split('\n').length;
       out.push(opp({
         title: `Animation "${name}" may lack a prefers-reduced-motion guard`,
-        surface: surface.id, source: 'a11y-motion-scan', file: `${surface.file}:${line}`,
+        surface: surface.id, source: 'a11y-motion-scan', file: `${surface.file}:${lineOf(text, text.indexOf(`@keyframes ${name}`))}`,
         evidence: `@keyframes ${name} used ${usedBy}x; no reduced-motion rule disables it`,
         impact: 3, confidence: 0.5, effort: 2, safety: 'auto',
       }));
@@ -121,10 +134,8 @@ function detectUnguardedKeyframes(surface, lines) {
   return out;
 }
 
-/** Detector: user-facing placeholder/stale copy.
- *  Precision hardening (loop cycle 1): dropped "Coming soon" — it is intentional, honest
- *  product messaging here (e.g. `data-coming-soon="true"` for the in-development L2 capture
- *  level), NOT stale copy. Only genuine placeholders remain. */
+/** User-facing placeholder/stale copy. Hardened C001: dropped "Coming soon" — it is intentional,
+ *  honest product messaging here (e.g. the in-development L2 capture level), not stale copy. */
 function detectStaleCopy(surface, lines) {
   const out = [];
   const rx = /(Lorem ipsum|\bTBD\b|placeholder text|REPLACE ME|dummy text)/i;
@@ -141,10 +152,72 @@ function detectStaleCopy(surface, lines) {
   return out;
 }
 
-/** Detector: honesty-contract-adjacent edits are SAFETY-gated (queued for human sign-off). */
+/** <button> without an explicit type. Outside a form -> auto-safe (add type="button").
+ *  Inside a form -> HUMAN-GATED: removing the implicit submit could change behavior (SAFETY).
+ *  Comment-masked (C002) so example <button> markup in comments is not flagged. */
+function detectButtonsWithoutType(surface, lines) {
+  const out = [];
+  const text = maskComments(lines.join('\n'));
+  const ranges = formRanges(text);
+  const re = /<button\b([^>]*)>/g;
+  let m;
+  while ((m = re.exec(text))) {
+    const attrs = m[1];
+    if (/\btype\s*=/.test(attrs)) continue;
+    const within = inAnyRange(m.index, ranges);
+    out.push(opp({
+      title: within
+        ? 'Button without explicit type inside a <form> — verify submit intent'
+        : 'Button missing type="button" (implicit-submit footgun)',
+      surface: surface.id, source: 'a11y-form-scan', file: `${surface.file}:${lineOf(text, m.index)}`,
+      evidence: ('<button' + attrs + '>').slice(0, 140),
+      impact: 2, confidence: within ? 0.5 : 0.85, effort: 1,
+      safety: within ? 'human' : 'auto',
+    }));
+  }
+  return out;
+}
+
+/** target="_blank" anchors missing rel="noopener" (reverse-tabnabbing). */
+function detectUnsafeBlankLinks(surface, lines) {
+  const out = [];
+  const text = maskComments(lines.join('\n'));
+  const re = /<a\b([^>]*\btarget\s*=\s*"_blank"[^>]*)>/g;
+  let m;
+  while ((m = re.exec(text))) {
+    const attrs = m[1];
+    if (/\brel\s*=\s*"[^"]*noopener/.test(attrs)) continue;
+    out.push(opp({
+      title: 'target="_blank" link missing rel="noopener" (reverse-tabnabbing)',
+      surface: surface.id, source: 'security-scan', file: `${surface.file}:${lineOf(text, m.index)}`,
+      evidence: ('<a' + attrs + '>').slice(0, 140),
+      impact: 3, confidence: 0.9, effort: 1, safety: 'auto',
+    }));
+  }
+  return out;
+}
+
+/** <img> without an alt attribute (a11y). Decorative images should use alt="". */
+function detectImagesWithoutAlt(surface, lines) {
+  const out = [];
+  const text = maskComments(lines.join('\n'));
+  const re = /<img\b([^>]*?)\/?>/g;
+  let m;
+  while ((m = re.exec(text))) {
+    const attrs = m[1];
+    if (/\balt\s*=/.test(attrs)) continue;
+    out.push(opp({
+      title: 'Image missing alt attribute (a11y)',
+      surface: surface.id, source: 'a11y-scan', file: `${surface.file}:${lineOf(text, m.index)}`,
+      evidence: ('<img' + attrs + '>').slice(0, 140),
+      impact: 3, confidence: 0.8, effort: 1, safety: 'auto',
+    }));
+  }
+  return out;
+}
+
+/** Honesty-contract-adjacent zones — recorded so the agent knows changes there are human-gated. */
 function detectSafetyGatedZones(surface, lines) {
-  // We don't fabricate opportunities here; we record that these zones exist so the agent
-  // knows any change touching them is human-gated, not auto-shippable.
   const text = lines.join('\n');
   const zones = [];
   if (/data-sn-live-error|sendComposerMessage|seenIds|seenAnswerIds/.test(text)) {
@@ -164,10 +237,12 @@ function main() {
       ...detectIconButtonsWithoutLabel(surface, lines),
       ...detectUnguardedKeyframes(surface, lines),
       ...detectStaleCopy(surface, lines),
+      ...detectButtonsWithoutType(surface, lines),
+      ...detectUnsafeBlankLinks(surface, lines),
+      ...detectImagesWithoutAlt(surface, lines),
     );
     safetyZones[surface.id] = detectSafetyGatedZones(surface, lines);
   }
-  // Rank: auto-safe by score desc, then queued (human) items after.
   opportunities.sort((a, b) => (b.score - a.score) || a.id.localeCompare(b.id));
 
   const backlog = {
@@ -189,7 +264,7 @@ function main() {
     process.stdout.write(JSON.stringify(backlog, null, 2) + '\n');
   } else {
     console.log(`[scan] ${backlog.counts.total} opportunities (${backlog.counts.autoSafe} auto-safe, ${backlog.counts.humanGated} human-gated)`);
-    console.log(`[scan] backlog → ${OUT}`);
+    console.log(`[scan] backlog -> ${OUT}`);
     console.log('[scan] top auto-safe:');
     top.forEach((o, i) => console.log(`  ${i + 1}. [${o.score}] ${o.title}  (${o.file})`));
   }


### PR DESCRIPTION
## Self-improvement loop — cycle C002

The loop's first cycle that ships a **real product fix**, plus an expansion that makes future cycles more productive. Cadence tightened to **every 30 min**.

### Loop infra (`scripts/improvement-loop/scan.mjs`)
- **+3 detectors:** button-without-`type` (form-context aware — inside a `<form>` it's behavior-sensitive → **human-gated**, never auto-shipped), `target="_blank"` missing `rel="noopener"` (reverse-tabnabbing), `<img>` missing `alt`.
- **+CSS/HTML comment-masking** so example markup inside comments is never flagged.

### Product fix (`public/proto/home-v5.html`)
Added explicit `type="button"` to **3 validated buttons**: the Memory Wall sticky-delete button + the two onboarding-tour buttons. All have `onclick` handlers and are **not** inside the page's `<form>`, so this is a safe best-practice fix with no behavior change.

### Integrity demonstrated again
The scan surfaced **4** button candidates; I validated each and **rejected 1 false positive** (a `<button>` living inside a CSS comment) — hardening the detector instead of shipping a bogus fix. Post-fix scan is **clean** (the loop converged).

### Verification
- e2e **7/7** chromium: `home-v5-output-contract` (13-phase demo + 17 invariants) + all 6 `scratchnode-live-route-honesty` guarantees.
- Inline `<script>` blocks parse; ledger C002 recorded (`outcome: shipped`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
