### PR TITLE
feat(goals): Self-Directed Development OS for ScratchNode + NodeBench

### DIFF
--- a/.claude/rules/self_improvement_loop.md
+++ b/.claude/rules/self_improvement_loop.md
@@ -4,6 +4,25 @@ The agent brain for NodeBench's continuous improvement flywheel. Read this on ev
 (manual or scheduled). The deterministic substrate is `scripts/improvement-loop/`; this rule is
 how the agent drives it. Canonical design: `docs/architecture/SELF_IMPROVEMENT_LOOP.md`.
 
+## Operating model: bounded + goal-driven (NOT "never stop")
+
+This loop is governed by the Self-Directed Development OS in [`goals/README.md`](../../goals/README.md)
+and the hard gates in [`goals/HARD_GATES.md`](../../goals/HARD_GATES.md). The lesson is **not**
+"let the agent run forever" — it is: closed goal, reviewable definition of done, focused subagents,
+hard gates, batch feedback.
+
+```
+✅ goal-driven autonomy · subagent fan-out · batched queues · critic review · explicit DoD
+❌ unbounded "never stop" production agents · blind deploys · raw DB mutations · no-test vibe coding
+```
+
+- **Cadence:** daily small-loop (propose ONE bounded next step; only tiny CI-gated detector fixes
+  auto-ship, ≤3/day) + weekly self-review (propose issues/cuts/goals, never auto-add features).
+  Substantive work becomes a Goal Card (`goals/<surface>/NNN-slug.md`) the founder approves.
+- **Operating rule:** Human sets the *why* + boundary; agent explores the *how*; tests decide; docs preserve.
+- **Hard gates:** prod deploy, destructive migrations, auth, billing, public/private permission
+  rules, data deletion, legal/privacy copy, wiki publish, host/mod privileges, secrets → propose only.
+
 ## When to activate
 - A scheduled "improvement-loop" routine fires.
 - User says "run the loop", "improve forever", "self-drive", "find opportunities".

--- a/CHANGELOG/goals.md
+++ b/CHANGELOG/goals.md
@@ -1,0 +1,8 @@
+# `goals/` — Self-Directed Development OS
+
+Append-only lane for the goal-driven development operating system.
+
+## 2026-06-02 — Bootstrap: the Self-Directed Development OS
+Codified the bounded, goal-driven operating system for ScratchNode + NodeBench: `goals/README.md` (meta-system, flywheel, operating rule, do/don't, subagent roles, cadence, regression oracle), `_TEMPLATE.md` (Goal Card), `HARD_GATES.md` (no-autonomy zones + product invariants), `prompts/` (daily small-loop, weekly self-review, design critic), and 3 seed Goal Cards (scratchnode first-time clarity, nodebench event handoff, runtime public/private boundary). Aligned `.claude/rules/self_improvement_loop.md` to the bounded model and **replaced the 15-min "never-stop" auto-shipper crons with a daily small-loop (propose; tiny CI-gated fixes only) + weekly self-review (propose only)**. The lesson encoded: closed goal + reviewable DoD + focused subagents + hard gates + batch feedback — never "do everything forever."
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.

--- a/goals/HARD_GATES.md
+++ b/goals/HARD_GATES.md
@@ -1,0 +1,50 @@
+# Hard Gates — no-autonomy zones
+
+These zones are **propose-only**. An agent may draft a patch and open a PR, but a **human must
+approve** before it merges. Runtime goals are stricter than design goals — **never** put a
+"never stop until done" clause on backend/security work.
+
+## Never auto-ship (human approval required)
+
+```
+production deploy
+database migrations with destructive writes
+auth / session changes
+billing / rate-limit changes
+public/private permission rules
+data deletion
+legal / privacy copy
+public wiki publish
+host / mod privilege changes
+secret / API-key handling
+```
+
+## ScratchNode product invariants (release blockers — must never regress)
+
+- Private notes **never** create public `eventMessages` rows.
+- Public `/ask` **never** includes private notes.
+- Public traces state **"No private notes used."**
+- Normal chat **never** invokes the agent (only `/ask` does).
+- Agent answers show their parent `/ask`.
+- Attendees **suggest** FAQ; only hosts **promote**.
+- Host-only controls are never exposed to guests.
+
+These are enforced by `tests/e2e/scratchnode-live-route-honesty.spec.ts` +
+`tests/e2e/home-v5-output-contract.spec.ts`. A red oracle is **P0** — fix or flag before anything else.
+
+## The operating rule (why this is safe)
+
+> Human sets the *why* and the *boundary*. Agent explores the *how*. Tests decide whether it
+> worked. Docs preserve the learning.
+
+A self-directed agent amplifies the prompt:
+
+```
+clear goal      → useful progress
+vague goal      → expensive confusion
+bad architecture→ faster bad architecture
+no evals        → polished wrong thing
+```
+
+So the autonomy is always bounded by: a closed Goal Card, a reviewable definition of done,
+focused subagents, these hard gates, a budget/ship cap, and a CI-gated merge.

--- a/goals/README.md
+++ b/goals/README.md
@@ -1,0 +1,126 @@
+# Self-Directed Development OS — ScratchNode + NodeBench
+
+The operating system for how agents improve this product. Founder-authored; this file is the
+contract every autonomous run obeys.
+
+## The one uncomfortable rule
+
+The lesson from the "build it in a day" demos is **not** "let the agent do everything forever."
+It is: **give the agent a closed goal, a reviewable definition of done, focused subagents,
+hard gates, and a batch feedback loop.** A self-directed agent *amplifies the prompt* —
+clear goal → useful progress; vague goal → expensive confusion; no evals → a polished wrong thing.
+
+```
+✅ Do use                      ❌ Do not use
+- goal-driven autonomy         - unbounded "never stop" production agents
+- subagent fan-out             - blind autonomous deploys
+- batched bug queues           - raw DB mutations
+- playtest / dogfood loops     - no-test vibe coding
+- critic / skeptic review      - new top-level surfaces by default
+- explicit definition of done  - breaking the public/private boundary
+```
+
+## The meta-system: two products + one shared runtime
+
+```
+ScratchNode Live   = public live room   (room code, chat, /ask, private notes, public wiki)
+NodeBench AI       = private workspace  (notebooks, artifacts, daily brief, memory, reports, traces)
+NodeBench Runtime  = shared engine      (Convex, pi-ai, Linkup, Typesense, Redis/cache, evals, traces)
+```
+
+The loop improves all three — **not with one giant prompt**, but as a sequence of bounded goals.
+
+## The operating rule
+
+> **Human sets the *why* and the *boundary*. Agent explores the *how*. Tests decide whether it
+> worked. Docs preserve the learning.**
+
+| Human owns | Agent owns | Tests/evals decide |
+|---|---|---|
+| product direction, user pain, privacy rules, what to cut, what "done" means | implementation options, code patches, QA scripts, docs drafts, eval generation | privacy boundary, /ask behavior, trace honesty, source support, cost, UI flow |
+
+Your job is to become the best **goal setter and evaluator** for this product — not the fastest coder.
+
+## The flywheel (every cycle)
+
+```
+Goal → Spec → Subagents → Critic → Patch → Demo → Evals → Docs → Next Goal
+```
+
+1. **Observe** — what did users do, where did they hesitate, what broke?
+2. **Classify** — product / UX / backend / privacy / cost / eval issue.
+3. **Generate goals** — turn issues into bounded Goal Cards (`goals/<surface>/NNN-slug.md`).
+4. **Fan out** — focused subagents (one narrow job each — see roles below).
+5. **Synthesize** — one critic removes bad ideas and *reduces scope*.
+6. **Patch** — the smallest working change.
+7. **Verify** — Playwright, evals, trace checks, screenshot/video, manual dogfood.
+8. **Promote** — update docs/demo, queue the next goal.
+
+## Cadence (how it actually runs)
+
+| Driver | When | What it does | Auto-ships? |
+|---|---|---|---|
+| **Daily small-loop** (`nodebench-self-improvement-loop` cron, 09:17) | daily | cheap scan; proposes ONE bounded next step as a Goal Card | only tiny pre-validated CI-gated detector fixes (≤3/day) |
+| **Weekly self-review** (`nodebench-weekly-self-review` cron, Mon 09:25) | weekly | broad fan-out review; top-10 issues + recommended cuts + 3 Goal Cards | no — proposes only |
+| **Founder-initiated goal** | any time | you pick a Goal Card → agent fans out → critic → patch → verify → ship | CI-gated PR |
+
+Substantive work is **never** auto-shipped — it becomes a Goal Card the founder approves.
+The deterministic substrate is `scripts/improvement-loop/`; the agent manual is
+[`.claude/rules/self_improvement_loop.md`](../.claude/rules/self_improvement_loop.md).
+
+## Subagent roles (one narrow job each — never generic)
+
+The strongest pattern from the source analysis: **one subagent per focused unit, wide leeway inside it.**
+
+| Role | Job |
+|---|---|
+| Product Scope Critic | does this help the core loop or derail it? what to cut? |
+| ScratchNode UX | live room, composer, feed, /ask, private note, wiki flow |
+| NodeBench UX | notebook, library, chat, daily brief, traces, artifacts |
+| Frontend Impl | React/CSS/components |
+| Backend/Convex | schema, mutations, permissions, data model |
+| Agent Runtime | pi-ai tools, context router, Linkup, semantic cache |
+| Privacy/Safety | public/private boundary, host roles, risk/attack tests |
+| Cost/Performance | cache reuse, search avoidance, latency, rate limits |
+| QA | Playwright, demo scripts, mobile, accessibility |
+| Docs/Repo | README, docs, positioning, prototype-vs-production notes |
+
+## The core loop everything serves
+
+```
+guest joins ScratchNode → chats publicly → uses /ask → gets a sourced shared answer
+→ saves a private note → host promotes FAQ → wiki publishes
+→ user opens NodeBench → private notes + event artifact are ready
+```
+
+Every improvement must make that loop **clearer, safer, faster, or cheaper.**
+
+## The regression oracle
+
+`run_demo_full` (the `tests/e2e/home-v5-output-contract.spec.ts` 13-phase demo) is the public
+"does the product still make sense?" check. **If a patch breaks the demo, it is not an improvement.**
+
+## Hard gates
+
+Some zones are propose-only — agents draft patches, a **human approves**. See
+[`HARD_GATES.md`](HARD_GATES.md). Never auto-ship: prod deploy, destructive migrations, auth,
+billing, public/private permission rules, data deletion, legal/privacy copy, wiki publish,
+host/mod privileges, secrets.
+
+## Directory map
+
+```
+goals/
+  README.md          ← this file (the OS)
+  _TEMPLATE.md       ← Goal Card template
+  HARD_GATES.md      ← no-autonomy zones + operating rule
+  prompts/           ← weekly-self-review, daily-small-loop, design-critic
+  reviews/           ← dated weekly self-review outputs
+  scratchnode/       ← ScratchNode Goal Cards (NNN-slug.md)
+  nodebench/         ← NodeBench Goal Cards
+  runtime/           ← shared-runtime Goal Cards (stricter gates)
+```
+
+Prior art: this OS distills the public "ultracode/dynamic-workflows" demos (Anthropic dynamic
+workflows; the one-day MOBA build) into a *bounded* practice. See
+[`docs/architecture/SELF_IMPROVEMENT_LOOP.md`](../docs/architecture/SELF_IMPROVEMENT_LOOP.md).

--- a/goals/_TEMPLATE.md
+++ b/goals/_TEMPLATE.md
@@ -1,0 +1,31 @@
+# Goal: <one-line bounded outcome>
+
+Improve [surface/system] so that [user/persona] can [job] with less confusion/cost/risk.
+
+- **status:** proposed | approved | in_progress | shipped | parked
+- **surface:** scratchnode | nodebench | runtime
+- **owner/agent:**
+
+## Scope
+- **Files/surfaces allowed:**
+- **Files/surfaces forbidden:**
+- **User flow being improved:** (which part of the core loop)
+- **Product invariant that must NOT break:**
+
+## Definition of done
+- [ ] UI state is reviewable in the browser (screenshot/video captured)
+- [ ] Tests pass (`tsc` + targeted e2e; `run_demo_full` / home-v5-output-contract still green)
+- [ ] Docs updated
+- [ ] Known gaps listed
+
+## Constraints
+- Do not add a new top-level surface
+- Do not break the public/private boundary
+- Do not expose host-only controls to guests
+- Do not call external search if cache/wiki can answer
+- (any goal-specific constraints)
+
+## Notes
+- tests to add:
+- known gaps:
+- next goal:

--- a/goals/nodebench/001-event-handoff.md
+++ b/goals/nodebench/001-event-handoff.md
@@ -1,0 +1,34 @@
+# Goal: NodeBench handoff view for a completed ScratchNode event
+
+When a user signs in after an event (e.g. AI Infra Summit), NodeBench should show one event they
+can open and immediately understand what was captured **publicly vs privately**.
+
+- **status:** proposed
+- **surface:** nodebench
+- **owner/agent:** (unassigned — founder to approve)
+
+## Scope
+- **Files/surfaces allowed:** the NodeBench event-handoff view + its data read path
+- **Files/surfaces forbidden:** CRM export; full graph view; any new top-level surface; auth/session
+- **User flow being improved:** open NodeBench after the event (the bottom of the core loop)
+- **Product invariant that must NOT break:** public vs private separation is visually unambiguous; private notes are owner-only
+
+## Must show
+1. the public event artifact (wiki/FAQ),
+2. the user's private notes,
+3. linked people / companies / topics,
+4. saved `/ask` answers,
+5. a Daily Brief delta.
+
+## Definition of done
+- [ ] A user can open ONE event and understand public-vs-private capture at a glance (screenshot)
+- [ ] `tsc` + targeted tests green; no Convex schema change without the migration gate
+- [ ] Docs updated; known gaps listed
+
+## Constraints
+- Do NOT build CRM export yet. Do NOT build the full graph view. Keep it to one openable event.
+- This keeps NodeBench from exploding into every possible feature.
+
+## Notes
+- Fan-out: NodeBench-UX · Frontend-Impl · Backend/Convex (read-only derivation first) · Privacy/Safety · QA · Docs.
+- next goal: 002 — Daily Brief deltas

--- a/goals/prompts/README.md
+++ b/goals/prompts/README.md
@@ -1,0 +1,50 @@
+# Canonical prompts
+
+Copy-paste these into Claude Code. The daily/weekly ones are mirrored by the scheduled crons
+(`nodebench-self-improvement-loop`, `nodebench-weekly-self-review`) — keep them in sync.
+
+---
+
+## Daily small-loop (run when overwhelmed)
+
+```
+/goal Find the smallest useful next step.
+
+Context: ScratchNode Live is the public room; NodeBench AI is the private workspace.
+We are shipping the shortest real loop. Review current state and propose EXACTLY ONE next task that:
+- improves the core loop (join → chat → /ask → answer → private note → FAQ → wiki → open NodeBench),
+- can be completed today,
+- has a visible demo outcome,
+- does NOT add a new surface.
+
+Output: 1) task  2) why it matters  3) files likely affected  4) definition of done  5) what NOT to touch.
+Write it as a Goal Card in goals/<surface>/NNN-slug.md (status: proposed). Only tiny pre-validated,
+CI-gated detector fixes may auto-ship (≤3/day); everything substantive waits for founder approval.
+Respect goals/HARD_GATES.md.
+```
+
+## Weekly self-review (large ambiguous review → fan out)
+
+```
+/goal Weekly architecture and product self-review. (You may use a workflow for the fan-out.)
+
+Review ScratchNode, NodeBench, docs, evals, and the demo oracle (home-v5-output-contract = run_demo_full).
+You are NOT allowed to add features by default. Find:
+1) broken invariants, 2) duplicated surfaces, 3) prototype-only code leaking into prod,
+4) missing tests, 5) confusing UI states, 6) runtime cost risks, 7) docs drift.
+
+Output to goals/reviews/<date>-weekly.md: top 10 issues, recommended cuts, the 3 highest-leverage
+Goal Cards (write each to goals/<surface>/NNN-slug.md, status: proposed), files affected, tests to add.
+Do NOT implement. If the demo oracle is red, flag P0 at the top.
+```
+
+## Design critic (constraint-bounded, no new features)
+
+```
+/goal Critique [ScratchNode v5 | NodeBench workspace] against the core loop.
+
+Core loop: Join → Chat → /ask → Answer → Private note → FAQ → Wiki → open NodeBench.
+Do NOT propose new features. Find where the UI makes this loop unclear. Rank issues by:
+1) first-time user confusion, 2) privacy risk, 3) interaction friction, 4) visual noise, 5) mobile.
+Output only: issue · why it matters · smallest fix · test case.
+```

--- a/goals/reviews/.gitkeep
+++ b/goals/reviews/.gitkeep
@@ -1,0 +1,1 @@
+# weekly self-review outputs land here (goals/reviews/<date>-weekly.md)

--- a/goals/runtime/001-public-private-boundary.md
+++ b/goals/runtime/001-public-private-boundary.md
@@ -1,0 +1,36 @@
+# Goal: Enforce + test the public/private write boundary
+
+Every ScratchNode composer send must route to exactly one branch — and the boundary must be
+covered by tests, not just intent. Runtime goals are **stricter** than design goals: no
+"never stop" clause, human approves the merge (see HARD_GATES.md — this touches permission rules).
+
+- **status:** proposed
+- **surface:** runtime
+- **owner/agent:** (unassigned — founder approval REQUIRED; this is a hard-gate zone)
+
+## Scope
+- **Files/surfaces allowed:** the composer send dispatch + its tests (`scratchnode-live-route-honesty.spec.ts`, `home-v5-output-contract.spec.ts`)
+- **Files/surfaces forbidden:** anything outside the send/route path; UI redesign
+- **User flow being improved:** chat / `/ask` / private-note routing (the trust spine of the core loop)
+- **Product invariant that must NOT break:** the three release-blocker invariants below
+
+## The contract (must hold)
+The composer must route to exactly one of:
+1. **public chat**, 2. **public `/ask`**, 3. **private note**.
+- Private notes must **never** create `eventMessages` rows.
+- Public `/ask` must **never** include private notes.
+- Public traces must state **"No private notes used."**
+
+## Definition of done
+- [ ] Unit test per branch + an integration test + a Playwright public/private check, all green
+- [ ] `tsc` green; no destructive migration
+- [ ] Trace honesty asserted (output matches the L1/L2/L3 schema; trace matches actual calls)
+- [ ] Human-approved PR (hard-gate zone) — not auto-shipped
+
+## Constraints
+- HARD GATE: permission/boundary rules → propose a patch + tests, human approves the merge.
+- Prefer extending the existing honesty-contract tests over building a parallel harness.
+
+## Notes
+- Fan-out: Agent-Runtime · Privacy/Safety · QA. Critic reduces scope to the boundary only.
+- next goal: 002 — semantic cache (avoid external search when wiki/cache can answer)

--- a/goals/scratchnode/001-first-time-user-clarity.md
+++ b/goals/scratchnode/001-first-time-user-clarity.md
@@ -1,0 +1,30 @@
+# Goal: ScratchNode Live first-time user clarity in <10s
+
+Improve ScratchNode Live so that a first-time guest who lands on `scratchnode.live/e/<event>` with
+no context understands, in under 10 seconds: (1) what event they're in, (2) how to chat, (3) how to
+ask the agent, (4) whether they're public or private, (5) where the answer goes afterward.
+
+- **status:** proposed
+- **surface:** scratchnode
+- **owner/agent:** (unassigned — founder to approve)
+
+## Scope
+- **Files/surfaces allowed:** `public/proto/home-v5.html` (composer `#ci`, feed, `.ans` answer cards, event-strip, private-mode badge, `/ask` helpline, landing)
+- **Files/surfaces forbidden:** any new top-level surface; any sidebar; the live send/render path + `seenIds` dedup; backend/Convex
+- **User flow being improved:** join → first chat / first `/ask` (the top of the core loop)
+- **Product invariant that must NOT break:** private notes never enter the public feed; public `/ask` never includes private notes; normal chat never invokes the agent
+
+## Definition of done
+- [ ] Browser-reviewable: 5-second comprehension test passes for a cold user (screenshot)
+- [ ] `tsc`/inline-scripts parse + e2e `home-v5-output-contract` + `scratchnode-live-route-honesty` green
+- [ ] Playwright desktop + mobile 375px (no overflow) + reduced-motion captured
+- [ ] CHANGELOG/pages/proto-home-v5 entry; known gaps listed
+
+## Constraints
+- No new surface, no sidebar. Don't break private-note behavior (private send must resolve before any public feed insert).
+- Clarity via copy + hierarchy, not new chrome.
+
+## Notes
+- Fan-out: ScratchNode-UX (copy/hierarchy) · Frontend-Impl (composer/feed patch) · Privacy/Safety (private-mode return-before-public-insert) · QA (5-click flow) · Docs.
+- known gaps: TBD by review
+- next goal: 002 — private-note anchors clarity


### PR DESCRIPTION
Codifies the bounded, goal-driven dev OS the founder specified. Agents get a closed goal + reviewable DoD + focused subagents + hard gates + batch feedback — NOT 'never stop'. Adds goals/ (README/template/HARD_GATES/prompts + 3 seed Goal Cards), aligns the self_improvement_loop rule to the bounded model. Crons reconciled separately: 15-min never-stop shipper -> daily small-loop (propose; tiny CI-gated fixes only) + weekly self-review (propose only). Docs-only; the inaugural weekly self-review (running as a workflow) will append goals/reviews/ + more grounded cards. 🤖 Generated with Claude Code