### PR TITLE
docs(goals): inaugural weekly self-review + 3 grounded Goal Cards

### DIFF
--- a/CHANGELOG/goals.md
+++ b/CHANGELOG/goals.md
@@ -6,3 +6,8 @@ Append-only lane for the goal-driven development operating system.
 Codified the bounded, goal-driven operating system for ScratchNode + NodeBench: `goals/README.md` (meta-system, flywheel, operating rule, do/don't, subagent roles, cadence, regression oracle), `_TEMPLATE.md` (Goal Card), `HARD_GATES.md` (no-autonomy zones + product invariants), `prompts/` (daily small-loop, weekly self-review, design critic), and 3 seed Goal Cards (scratchnode first-time clarity, nodebench event handoff, runtime public/private boundary). Aligned `.claude/rules/self_improvement_loop.md` to the bounded model and **replaced the 15-min "never-stop" auto-shipper crons with a daily small-loop (propose; tiny CI-gated fixes only) + weekly self-review (propose only)**. The lesson encoded: closed goal + reviewable DoD + focused subagents + hard gates + batch feedback — never "do everything forever."
 
 **Commit**: `this commit`. **Author**: Homen Shum + Claude.
+
+## 2026-06-02 — Inaugural weekly self-review output
+First OS self-review (5 lenses + reducer, 29 findings -> top 10) recorded to goals/reviews/2026-06-02-weekly.md. Queued 3 grounded Goal Cards: scratchnode/002 (host public-write consistency — reviewer claimed P0, analyst-verified to P1 since backend requireHost already gates; hard-gate, human-approve), scratchnode/003 (privacy-boundary honesty tests, tests-only/auto-safe), nodebench/002 (loop liveSignal + Convex honesty). Demo oracle green; no features added.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.

--- a/goals/nodebench/002-self-improvement-loop-live-signal-convex.md
+++ b/goals/nodebench/002-self-improvement-loop-live-signal-convex.md
@@ -1,0 +1,26 @@
+# Goal: Loop honesty — record liveSignal + stop pointing --push-convex at a phantom function
+
+Two gaps in the self-improvement loop's own integrity: (1) cycle C002 records `outcome:'shipped'`
+with no `liveSignal`, despite the manual requiring a live-DOM signal after `verify-live.ts`;
+(2) `run-cycle.mjs:72` calls `convex run improvementLoop:recordCycle`, but that function only exists
+in `convex-improvementLoop.ts.pending` (never deployed) → `--push-convex` degrades to a 404 path.
+
+- **status:** proposed
+- **surface:** nodebench (meta-loop / runtime)
+- **severity:** P1 (HONEST_STATUS / live_dom_verification — the ledger must not claim "shipped" without proof)
+
+## Scope
+- **Allowed:** `scripts/improvement-loop/run-cycle.mjs` (capture `liveSignal`; require it before `outcome:'shipped'`; make `pushConvex` honest when the endpoint is absent); `scripts/improvement-loop/ledger.json` (add `liveSignal` field; backfill C001-C004 honestly — `null` where not actually verified, never fabricated); `convex/improvementLoop.ts` + `convex/schema.ts` **only if** graduating the `.pending` Convex table; `convex-improvementLoop.ts.pending`
+- **Forbidden:** `public/proto/home-v5.html`; any ScratchNode honesty-contract test or live send/render path; any new surface
+- **Core-loop flow:** the meta-loop that ships fixes TO the core loop — honest ledger + working observability keep it trustworthy
+- **Invariant that must NOT break:** never claim `shipped` without a recorded `liveSignal` (or explicit honest `liveVerified:false` + reason); `pushConvex` must never fake success — if Convex absent, record `{ok:false, reason:'endpoint-not-deployed'}`; run-cycle.mjs stays observe/score/record only (never edits product code)
+
+## Definition of done
+- [ ] Cycle records carry `liveSignal`; `run-cycle.mjs` refuses (or warns + records `liveVerified:false`) on `outcome:'shipped'` without a live signal.
+- [ ] C001-C004 backfilled honestly (null where no verification was actually run — no invented signals).
+- [ ] Either `convex/improvementLoop.ts` + `improvementLoopCycles` table exist and `--push-convex` records a cycle (verifiable in Convex dashboard) **OR** `pushConvex` cleanly reports `endpoint-not-deployed` (no phantom call). NB: the original Convex graduation was deferred because `convex codegen` couldn't be validated locally (`@mistralai` dep error) — re-attempt in CI or keep the honest no-op.
+- [ ] `node -e` syntax check passes; if Convex graduated, `npx convex codegen` clean.
+
+## Constraints
+- No new surface/route. HONEST_STATUS/HONEST_SCORES: no faked signals, no fabricated backfill.
+- Do NOT add the redundant "SELECT never checks safety" control — that gate already exists (`run-cycle.mjs` filters `!o.queued`; `scan.mjs` sets `queued = safety==='human'`).

--- a/goals/reviews/2026-06-02-weekly.md
+++ b/goals/reviews/2026-06-02-weekly.md
@@ -1,0 +1,48 @@
+# Weekly self-review — 2026-06-02 (inaugural)
+
+First run of the OS self-review (`goals/prompts` → weekly). 5 reviewer lenses (product-scope,
+ScratchNode-UX, privacy/safety, runtime/cost, docs/eval) → critic/reducer. 29 raw findings → top 10.
+Propose-only; no features added. Demo oracle (`home-v5-output-contract`): **green** (no P0 blocker).
+
+## Severity correction (analyst pass — do not inflate)
+
+The reviewer rated finding #1 **P0 (guest can write to the public wiki)**. **Verified against the full
+stack: it is P1, not P0.** The frontend weakness is real (`snPromoteFaq`/`snPublishWiki` use the weak
+`_snReadHostOwnerKey()` which falls back to `sessionId`), **but the backend independently gates both**
+mutations via `requireHost` (`convex/events.ts:439`, called at 2626 + 2642): a bare `sessionId` is not
+an `hk1:` token and matches no `liveEventHosts` row → rejected server-side. So **no public write occurs**.
+The genuine issue is a frontend **consistency + UX-honesty + defense-in-depth** gap, fixed by Goal Card
+`scratchnode/002`. (The reducer also already caught + downgraded a separate FALSE reviewer claim that
+"SELECT never checks the safety field" — the gate exists at `run-cycle.mjs:94` + `scan.mjs:42`.)
+
+## Top issues (ranked)
+
+| # | Sev | Issue | Where |
+|---|-----|-------|-------|
+| 1 | **P1** (was claimed P0) | `snPromoteFaq`/`snPublishWiki` use weak `_snReadHostOwnerKey()` (→ `sessionId`) vs strict `_snRequireVerifiedHostOwnerKey()` used by the other 5 host actions. Backend `requireHost` is the real gate → no breach, but inconsistent UX + weak defense-in-depth. → **Card scratchnode/002** | home-v5.html:6377,6584,6591 |
+| 2 | P1 | 6 privacy-boundary gates (SN-LIVE-006..-012) defined but **zero tested** — the core safety contract is unverified by CI. → **Card scratchnode/003** | scratchnode-live-route-honesty.spec.ts |
+| 3 | P1 | Demo FAQ buttons (2821, 4427) call `toast()` only, never the real handlers — fake success + the demo never regression-tests the real path. | home-v5.html:2821,4427 |
+| 4 | P1 | NodeBench workspace overlay (Home/Reports/Chat/Inbox/Me demo) ships in the live ScratchNode HTML (CSS 1142-1194, markup ~7053-7068) — prototype surface leaking into prod, violates the boundary doc. | home-v5.html |
+| 5 | P1 | Mobile (<540px) public/private indicator collapses to an unlabeled 7px dot (`#c-mode-label` sr-only) — the most safety-relevant affordance loses its visible cue at the point of action. | home-v5.html:1000-1002 |
+| 6 | P1 | `/ask` discoverable only via the placeholder; vanishes once typing starts — first-timers never learn the sourced-answer affordance. | home-v5.html:2582-2585 |
+| 7 | P1 | Three overlapping first-load explanations (landing/welcome/hero) compete for the <10s clarity budget; landing lead copy mismatches the meta framing. | home-v5.html:1889-1953 |
+| 8 | P2 | Sensitive event-mode vs per-message lock share near-identical UX; the stronger event-level guardrail isn't visually distinct. | home-v5.html:2838-2858 |
+| 9 | P2 | Demo trace hardcodes "0 new searches · Linkup skipped" but never exercises `searchLinkup`; a `shouldProbeLiveSearch` regression (real Linkup firing) wouldn't be caught → masks external-search cost regressions. | home-v5.html + convex/events.ts:~510 |
+| 10 | P1 | Loop records `outcome:'shipped'` (C002) with no `liveSignal`; `run-cycle.mjs:72` calls `improvementLoop:recordCycle` which only exists in `.pending` (never deployed) → `--push-convex` points at a 404. → **Card nodebench/002** | ledger.json + run-cycle.mjs |
+
+## Recommended cuts
+
+1. **Cut/extract** the NodeBench workspace overlay from the live ScratchNode HTML (demo-only file or `data-page-mode='demo'` gate) — it parses on every production room load.
+2. **Gate** the welcome banner behind `?tutorial=1`; make the hero the single first-load source of truth.
+3. **Replace** the "Bring your Luma/Slack/Eventbrite crowd" landing lead with the code-first join narrative (align to the meta "disposable sidecar room").
+4. **Wire or remove** the demo FAQ buttons' fake-success `toast()` path.
+5. **Do NOT** add net-new schema fields/signals in this pass (review, not build).
+6. **Drop** the redundant "safety-gating honor system" remediation — the gate already exists.
+
+## Queued Goal Cards (founder approves before any run)
+
+- `goals/scratchnode/002-host-public-write-verification.md` — **P1**, frontend consistency + defense-in-depth + a regression test. (Permission-adjacent → hard-gate: human approves the merge.)
+- `goals/scratchnode/003-privacy-boundary-honesty-gates.md` — **P1**, tests-only; makes the 6 boundary gates CI-enforced. (Auto-safe candidate — no product code change.)
+- `goals/nodebench/002-self-improvement-loop-live-signal-convex.md` — **P1**, loop honesty: record `liveSignal`; stop pointing `--push-convex` at a phantom function.
+
+**Recommended order:** #003 first (tests-only, locks the safety contract before any boundary edits), then #002 (the consistency fix, now provably backed by tests), then nodebench/002 (loop honesty). #002 needs your approval (hard-gate zone).

--- a/goals/scratchnode/002-host-public-write-verification.md
+++ b/goals/scratchnode/002-host-public-write-verification.md
@@ -1,0 +1,28 @@
+# Goal: Host public-write actions fail cleanly (frontend consistency + defense-in-depth)
+
+`snPromoteFaq` (home-v5.html:6584) and `snPublishWiki` (6591) call `_snReadHostOwnerKey()`, which
+falls back to `sessionId` (6377-6383), while the other 5 host mutations use the strict
+`_snRequireVerifiedHostOwnerKey()` (6233) that returns null + a "Host verification required" toast.
+Make the two public-write actions consistent with the rest, and add a regression test.
+
+- **status:** proposed
+- **surface:** scratchnode
+- **severity:** **P1** (NOT P0). **Verified:** the backend `requireHost` (`convex/events.ts:439`,
+  called at 2626 + 2642) already rejects a bare `sessionId` server-side → **no public write occurs**.
+  This is a frontend consistency + UX-honesty + defense-in-depth fix, not a breach.
+- **HARD GATE:** touches host-action gating (a permission rule) → **human approves the merge** (HARD_GATES.md). Do not auto-merge.
+
+## Scope
+- **Allowed:** `public/proto/home-v5.html` (`snPromoteFaq` ~6583, `snPublishWiki` ~6590, and `_snReadHostOwnerKey` ~6377 if needed); `tests/e2e/scratchnode-live-route-honesty.spec.ts` (regression test)
+- **Forbidden:** `convex/**` (backend already enforces — out of scope here); any demo/runDemoFull path; any new surface/route; the `sessionId` bootstrap used by `getHostStatus` boot (~6600) — only the two public-WRITE callers change
+- **Core-loop flow:** `/ask → answer → FAQ suggestion → host promotion → public wiki` (the private→public crossing steps)
+- **Invariant that must NOT break:** the verified-host happy path keeps working (token in `sn_host_owner_key_v2`, `_sn_live.hostVerified===true`); the existing `verified host can manage room metadata` e2e stays green.
+
+## Definition of done
+- [ ] `snPromoteFaq` + `snPublishWiki` early-return with "Host verification required" when `_snRequireVerifiedHostOwnerKey()` returns null (mirror `snUpdateEventFromHostSheet` at 6242), instead of attempting the mutation with a `sessionId`.
+- [ ] Browser-reviewable: in a guest session (no `sn_host_owner_key_v2`), calling `window.snPromoteFaq('x')`/`window.snPublishWiki()` shows the toast and fires NO `events:promoteAnswerToFaq`/`events:publishWiki` mutation (verify via the mock-mutation log).
+- [ ] New e2e case: no host key set → invoke both → assert mutation log contains neither `promoteAnswerToFaq` nor `publishWiki`. Existing verified-host CRUD test still green.
+- [ ] `tsc --noEmit` clean; targeted Playwright suite green; `home-v5-output-contract` still green.
+
+## Constraints
+- No new surface/route/helper — reuse `_snRequireVerifiedHostOwnerKey`. This card tightens the boundary; never weakens it.

--- a/goals/scratchnode/003-privacy-boundary-honesty-gates.md
+++ b/goals/scratchnode/003-privacy-boundary-honesty-gates.md
@@ -1,0 +1,26 @@
+# Goal: Make the public/private safety contract testable (boundary honesty gates)
+
+`SCRATCHNODE_NODEBENCH_BOUNDARY.md` defines gates SN-LIVE-006..-012, but the honesty spec only
+covers config/join/send/staleness/host-CRUD — **none assert the actual data boundary** (private
+notes never leak into the public feed, the agent trace, or the published wiki). Add the missing
+scenario tests so a regression that leaks a private note is caught by CI, not by users.
+
+- **status:** proposed
+- **surface:** scratchnode
+- **severity:** P1 (the core safety contract is currently unverified by CI)
+- **auto-safe:** tests-only, no product code change → eligible for the loop's auto-safe path once approved.
+
+## Scope
+- **Allowed:** `tests/e2e/scratchnode-live-route-honesty.spec.ts` (add `describe`/`test` blocks; extend the Convex mock in `fulfillScratchNodePage` to record `notes:*` + `events:suggestAnswerForFaq` calls and expose a queryable userNotes / liveEventMessages split)
+- **Forbidden:** `public/proto/home-v5.html` (no product change — assert CURRENT behavior; a failing gate becomes its own fix card); `convex/**`; any new surface
+- **Core-loop flow:** `public chat → /ask → sourced answer → private note → FAQ suggestion → public wiki`
+- **Invariant that must NOT break:** tests assert on mocked Convex **state** (which mutation/query, what args) — not merely visible UI text (text can be honest while the write leaks). Each test names its gate id inline.
+
+## Definition of done
+- [ ] 6 named cases: SN-LIVE-006 (answer `.ans-how` trace has no private-note text), -007 (private send recorded as a private note, NOT in `events:sendMessage`/`liveEventMessages` mock), -008 (private send present in userNotes/notebook mock), -009 (attendee sees "Suggest for FAQ"), -010 (host sees "Promote to FAQ"), -012 (published-wiki body excludes private-note text).
+- [ ] Each test maps to a boundary-doc line via comment; run output lists all six gate names.
+- [ ] `tsc --noEmit` clean; suite green — OR a legitimate gate failure is reported as a found bug (feeds a new fix card), not silenced.
+
+## Constraints
+- Tests-only; no product behavior change in this card. No new surface/route.
+- Scenario-based per project rule: set identity, exercise the real composer/answer path, inspect data boundaries — no shallow text-only checks.


### PR DESCRIPTION
First OS self-review run (workflow fan-out, 5 lenses + reducer, 29 findings). Records goals/reviews/2026-06-02-weekly.md and queues 3 Goal Cards. Analyst correction: reviewer's #1 claimed P0 (guest writes public wiki) -> verified P1 (backend requireHost at convex/events.ts:439 already rejects a bare sessionId; no breach; it's a frontend consistency/defense-in-depth gap). Docs-only. 🤖 Generated with Claude Code