### PR TITLE
feat(linkedin): reformat daily brief to AINews-style roundup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           src/features/workspace/data/eventWorkspaceMemory.test.ts
           convex/__tests__/scratchnode.events.test.ts
           server/searchRoute.test.ts
+          convex/workflows/ainewsBriefFormat.test.ts
 
   scratchnode-launch-gates:
     name: ScratchNode launch gates

--- a/CHANGELOG/pages/linkedin-daily-brief.md
+++ b/CHANGELOG/pages/linkedin-daily-brief.md
@@ -1,0 +1,30 @@
+# LinkedIn daily brief — changelog
+
+Per-surface lane for the daily LinkedIn digest pipeline
+(`convex/workflows/dailyLinkedInPost.ts`, `convex/workflows/ainewsBriefFormat.ts`).
+Newest first.
+
+## 2026-06-02 — AINews-style reformat
+
+Reshaped the daily brief (06:15 UTC GENERAL post + the 09:00/15:00 persona
+lanes) to read like the Latent.Space / smol.ai "AINews" roundup.
+
+- **New module** `ainewsBriefFormat.ts` — pure, dependency-free, unit-tested
+  scaffolding: bracketed top-3 headline, one-line dek, "we scanned N stories
+  across M sources" provenance line, and a top-story prose lead.
+- **`formatDigestForLinkedIn`** (the live daily brief) Post 1 now opens with the
+  headline → dek → provenance → prose lead, then the existing number-dense signal
+  bullets (de-duped against the lead).
+- **`formatDigestForPersona`** (Deal Flow Brief / Tech Radar) gets the same
+  headline + provenance header.
+- **Provenance is honest** (HONEST_SCORES): every count printed is a real
+  measured value (`storyCount` = feed items scanned, `topSources.length`); when
+  counts are missing the line degrades to count-free phrasing rather than
+  fabricating coverage.
+- **Footer never dropped**: `briefFooterCap` reserves the `[1/3] #tags` footer's
+  budget before truncating, replacing the old tail-truncating `capPost` on the
+  posts it touches.
+- **Bug fixed en route**: `clip()` appended the ellipsis *after* slicing to `max`,
+  so it could overflow the headline/dek budgets by 3 chars — now reserves the
+  ellipsis budget first.
+- 35 scenario tests added and wired into the CI Runtime-smoke gate.

--- a/convex/workflows/ainewsBriefFormat.test.ts
+++ b/convex/workflows/ainewsBriefFormat.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect } from "vitest";
+import {
+  type BriefDigest,
+  storyKey,
+  clip,
+  shortenForHeadline,
+  joinOxford,
+  topStoryTitles,
+  buildBriefHeadline,
+  buildBriefDek,
+  buildProvenanceLine,
+  buildTopSourcesLine,
+  buildTopStoryLead,
+  briefFooterCap,
+} from "./ainewsBriefFormat";
+
+/**
+ * Scenario-based tests (scenario_testing rule). Each scenario starts from a real
+ * digest shape the daily LinkedIn cron actually produces, then asserts the
+ * AINews-style output is honest, bounded, and LinkedIn-safe (no pipes introduced,
+ * footer never dropped).
+ *
+ * Reader: someone scanning the published LinkedIn brief on mobile, where the first
+ * line (headline) is the hook above the "see more" fold.
+ */
+
+const FULL_DIGEST: BriefDigest = {
+  narrativeThesis:
+    "NVIDIA's open-weight blitz reframes the week: the loud story is robotics, the quiet one is who controls the local AI stack.",
+  leadStory: {
+    title: "NVIDIA ships Cosmos 3, an omnimodal world model family (open weights)",
+    url: "https://example.com/cosmos3",
+    whyItMatters:
+      "It is the first credible open-weights challenger to closed video+action models, and it ships with datasets and fine-tuning recipes, not just weights.",
+  },
+  signals: [
+    {
+      title: "Nemotron 3 Ultra lands as the strongest US open-weight LLM",
+      url: "https://example.com/nemotron",
+      summary: "A 550B-A55B mixture-of-experts model that posters called the new US open SOTA.",
+      hardNumbers: "550B params, 48 Artificial Analysis score",
+    },
+    {
+      title: "RTX Spark personal AI computer announced with Microsoft",
+      url: "https://example.com/spark",
+      summary: "Grace + Blackwell desktop box aimed squarely at Apple Silicon.",
+      hardNumbers: "128GB unified memory, 1 PFLOP FP4",
+    },
+    {
+      title: "MiniMax M3 launches as open-weight 1M-context agent model",
+      url: "https://example.com/m3",
+      summary: "Headline agent benchmarks repeated across launch partners.",
+      hardNumbers: "59.0% SWE-Bench Pro, 74.2% MCP Atlas",
+    },
+    {
+      title: "Lambda first to adopt Quantum-X InfiniBand photonics",
+      url: "https://example.com/lambda",
+      summary: "Co-packaged optics to cut network power in large clusters.",
+      hardNumbers: "Q3450-LD switches",
+    },
+  ],
+  storyCount: 142,
+  topSources: ["X / Twitter", "r/LocalLlama", "NVIDIA newsroom"],
+  topCategories: ["AI hardware", "Open models"],
+};
+
+const SPARSE_DIGEST: BriefDigest = {
+  narrativeThesis: "One thing actually moved today.",
+  signals: [
+    {
+      title: "OpenAI announces Stargate Michigan data center",
+      summary: "A planned 1GW facility with closed-loop cooling.",
+    },
+  ],
+  // No leadStory, no storyCount, no topSources — the honest-degradation path.
+};
+
+const EMPTY_DIGEST: BriefDigest = {
+  narrativeThesis: "",
+  signals: [],
+  topCategories: ["AI policy"],
+};
+
+describe("storyKey / dedup", () => {
+  it("normalizes punctuation and case so lead == signal collisions are caught", () => {
+    expect(storyKey("NVIDIA Cosmos 3!")).toBe(storyKey("nvidia   cosmos 3"));
+    expect(storyKey(null)).toBe("");
+    expect(storyKey(undefined)).toBe("");
+  });
+});
+
+describe("clip", () => {
+  it("returns short text unchanged and collapses whitespace", () => {
+    expect(clip("  hello   world ", 100)).toBe("hello world");
+  });
+  it("word-clips long text with an ellipsis and never exceeds max", () => {
+    const out = clip("a".repeat(20) + " " + "b".repeat(200), 50);
+    expect(out.length).toBeLessThanOrEqual(50);
+    expect(out.endsWith("...")).toBe(true);
+  });
+});
+
+describe("shortenForHeadline", () => {
+  it("strips a trailing parenthetical and trailing punctuation", () => {
+    expect(shortenForHeadline("NVIDIA ships Cosmos 3 (open weights)")).toBe("NVIDIA ships Cosmos 3");
+    expect(shortenForHeadline("Nemotron 3 Ultra lands today.")).toBe("Nemotron 3 Ultra lands today");
+  });
+  it("cuts a descriptive sentence title at the first clause boundary into a noun phrase", () => {
+    // Comma boundary
+    expect(shortenForHeadline("NVIDIA ships Cosmos 3, an omnimodal world model family")).toBe("NVIDIA ships Cosmos 3");
+    // Subordinating connective "as"
+    expect(shortenForHeadline("Nemotron 3 Ultra lands as the strongest US open-weight LLM")).toBe("Nemotron 3 Ultra lands");
+    // Connective "with"
+    expect(shortenForHeadline("RTX Spark announced with Microsoft")).toBe("RTX Spark announced");
+  });
+
+  it("never breaks on a hyphen inside a compound word or name", () => {
+    expect(shortenForHeadline("Quantum-X InfiniBand photonics ship")).toContain("Quantum-X");
+    expect(shortenForHeadline("Open-weight model tops the leaderboard")).toContain("Open-weight");
+  });
+
+  it("never emits stray brackets or trailing punctuation, and stays under max", () => {
+    const out = shortenForHeadline("Some very long story title that runs well beyond the headline budget for a segment", 46);
+    expect(out.length).toBeLessThanOrEqual(46);
+    expect(out).not.toMatch(/[()[\]]/);
+    expect(out).not.toMatch(/[.,;:\-]\s*$/);
+  });
+});
+
+describe("joinOxford", () => {
+  it("formats 1, 2, and 3 item lists correctly", () => {
+    expect(joinOxford(["A"])).toBe("A");
+    expect(joinOxford(["A", "B"])).toBe("A and B");
+    expect(joinOxford(["A", "B", "C"])).toBe("A, B, and C");
+    expect(joinOxford(["A", "", "  ", "C"])).toBe("A and C");
+  });
+});
+
+describe("topStoryTitles", () => {
+  it("leads with leadStory then de-duped signals, capped at n", () => {
+    const titles = topStoryTitles(FULL_DIGEST, 3);
+    expect(titles).toHaveLength(3);
+    expect(titles[0]).toContain("Cosmos 3");
+  });
+
+  it("de-dups when leadStory equals the top signal", () => {
+    const d: BriefDigest = {
+      leadStory: { title: "NVIDIA Cosmos 3 launches" },
+      signals: [
+        { title: "NVIDIA Cosmos 3 launches!" },
+        { title: "Nemotron 3 Ultra" },
+      ],
+    };
+    const titles = topStoryTitles(d, 3);
+    // Cosmos appears once despite being both lead and signal[0].
+    const cosmosCount = titles.filter((t) => /cosmos/i.test(t)).length;
+    expect(cosmosCount).toBe(1);
+  });
+
+  it("stays bounded at 3 even with 100 signals (scale axis)", () => {
+    const many: BriefDigest = {
+      signals: Array.from({ length: 100 }, (_, i) => ({ title: `Story number ${i} about a model release` })),
+    };
+    expect(topStoryTitles(many, 3)).toHaveLength(3);
+  });
+});
+
+describe("buildBriefHeadline", () => {
+  it("produces a bracketed, oxford-joined top-3 headline within the LinkedIn fold budget", () => {
+    const h = buildBriefHeadline(FULL_DIGEST);
+    expect(h.startsWith("[Daily Brief] ")).toBe(true);
+    expect(h).toContain(" and ");
+    expect(h.length).toBeLessThanOrEqual(150);
+  });
+
+  it("respects a custom persona label", () => {
+    expect(buildBriefHeadline(FULL_DIGEST, "Tech Radar").startsWith("[Tech Radar] ")).toBe(true);
+  });
+
+  it("falls back to a category roundup when there are no stories", () => {
+    expect(buildBriefHeadline(EMPTY_DIGEST)).toBe("[Daily Brief] AI policy roundup");
+  });
+
+  it("falls back to a generic line when there is nothing at all", () => {
+    expect(buildBriefHeadline({ signals: [] })).toBe("[Daily Brief] What moved in AI and markets today");
+  });
+
+  it("stays bounded even when every title is enormous (adversarial)", () => {
+    const d: BriefDigest = {
+      signals: Array.from({ length: 3 }, () => ({ title: "X".repeat(300) })),
+    };
+    expect(buildBriefHeadline(d).length).toBeLessThanOrEqual(150);
+  });
+});
+
+describe("buildBriefDek", () => {
+  it("uses the narrative thesis, clipped", () => {
+    const dek = buildBriefDek(FULL_DIGEST);
+    expect(dek.length).toBeLessThanOrEqual(130);
+    expect(dek.length).toBeGreaterThan(0);
+  });
+  it("derives a dek from narrativeFraming when there is no thesis", () => {
+    const d: BriefDigest = {
+      narrativeFraming: {
+        dominantStory: "robot demos",
+        attentionShare: "70%",
+        underReportedAngle: "who owns the local AI stack",
+      },
+    };
+    expect(buildBriefDek(d)).toContain("loud story");
+  });
+  it("returns empty string when there is no narrative material", () => {
+    expect(buildBriefDek({ signals: [] })).toBe("");
+  });
+});
+
+describe("buildProvenanceLine — HONEST_SCORES", () => {
+  it("prints real scanned + source counts when both are present (plural)", () => {
+    expect(buildProvenanceLine(FULL_DIGEST, 4)).toBe(
+      "Scanned 142 stories across 3 sources today. Here are the 4 signals that actually moved:"
+    );
+  });
+
+  it("uses singular grammar for 1 story / 1 source / 1 signal", () => {
+    const d: BriefDigest = { storyCount: 1, topSources: ["X"] };
+    expect(buildProvenanceLine(d, 1)).toBe(
+      "Scanned 1 story across 1 source today. Here are the 1 signal that actually moved:"
+    );
+  });
+
+  it("never fabricates a source count when topSources is empty", () => {
+    const d: BriefDigest = { storyCount: 88, topSources: [] };
+    const line = buildProvenanceLine(d, 3);
+    expect(line).toBe("Scanned 88 stories today. Here are the 3 signals that actually moved:");
+    expect(line).not.toContain("sources");
+  });
+
+  it("never fabricates ANY count when storyCount is missing (degraded path)", () => {
+    const line = buildProvenanceLine(SPARSE_DIGEST, 1);
+    expect(line).not.toContain("Scanned");
+    expect(line).not.toContain("across");
+    expect(line).toContain("1 signal that actually moved");
+  });
+
+  it("treats 0 / negative / NaN storyCount as no honest count (no '0 stories')", () => {
+    for (const bad of [0, -5, Number.NaN]) {
+      const line = buildProvenanceLine({ storyCount: bad, topSources: ["X"] }, 2);
+      expect(line).not.toContain("Scanned");
+      expect(line).not.toMatch(/\b0 stories\b/);
+    }
+  });
+});
+
+describe("buildTopSourcesLine", () => {
+  it("lists up to 3 real sources", () => {
+    expect(buildTopSourcesLine(FULL_DIGEST)).toBe("Top sources: X / Twitter, r/LocalLlama, NVIDIA newsroom.");
+  });
+  it("is empty when there are no sources", () => {
+    expect(buildTopSourcesLine(SPARSE_DIGEST)).toBe("");
+    expect(buildTopSourcesLine({ topSources: ["", "   "] })).toBe("");
+  });
+});
+
+describe("buildTopStoryLead", () => {
+  it("renders the leadStory as prose with its URL and reports the consumed key", () => {
+    const { lines, consumedKey } = buildTopStoryLead(FULL_DIGEST);
+    expect(lines[0].startsWith("Lead: ")).toBe(true);
+    expect(lines[lines.length - 1]).toBe("https://example.com/cosmos3");
+    expect(consumedKey).toBe(storyKey(shortenForHeadline(FULL_DIGEST.leadStory!.title)));
+  });
+
+  it("falls back to the top signal when there is no leadStory", () => {
+    const { lines, consumedKey } = buildTopStoryLead(SPARSE_DIGEST);
+    expect(lines[0]).toContain("Stargate Michigan");
+    expect(consumedKey).toBe(storyKey(shortenForHeadline(SPARSE_DIGEST.signals![0].title)));
+  });
+
+  it("returns nothing when there is no story at all", () => {
+    expect(buildTopStoryLead(EMPTY_DIGEST)).toEqual({ lines: [], consumedKey: null });
+  });
+
+  it("never introduces a pipe character (LinkedIn breaks on '|')", () => {
+    const { lines } = buildTopStoryLead(FULL_DIGEST);
+    expect(lines.join("\n")).not.toContain("|");
+  });
+});
+
+describe("briefFooterCap — the footer must never be dropped", () => {
+  const footer = "[1/3] #AI #OpenModels";
+
+  it("appends the footer after a blank line for short posts", () => {
+    const out = briefFooterCap(["line one", "line two"], footer, 1450);
+    expect(out).toBe(`line one\nline two\n\n${footer}`);
+  });
+
+  it("keeps the post within max AND preserves the exact footer when the body is huge", () => {
+    const body = Array.from({ length: 80 }, (_, i) => `signal ${i} ` + "x".repeat(40));
+    const out = briefFooterCap(body, footer, 1450);
+    expect(out.length).toBeLessThanOrEqual(1450);
+    expect(out.endsWith(footer)).toBe(true);
+  });
+
+  it("emits no footer block when the footer is empty", () => {
+    expect(briefFooterCap(["body"], "", 1450)).toBe("body");
+    expect(briefFooterCap(["body"], "   ", 1450)).toBe("body");
+  });
+
+  it("collapses 3+ consecutive blank lines from optional sections", () => {
+    const out = briefFooterCap(["a", "", "", "", "b"], footer, 1450);
+    expect(out).toBe(`a\n\nb\n\n${footer}`);
+  });
+});
+
+describe("end-to-end Post 1 shape (integration of the scaffolding)", () => {
+  it("assembles a complete, bounded, footer-preserving Post 1 from a full digest", () => {
+    const lines: string[] = [];
+    lines.push(buildBriefHeadline(FULL_DIGEST));
+    lines.push("");
+    const dek = buildBriefDek(FULL_DIGEST);
+    if (dek) {
+      lines.push(dek);
+      lines.push("");
+    }
+    lines.push(buildProvenanceLine(FULL_DIGEST, 4));
+    const ts = buildTopSourcesLine(FULL_DIGEST);
+    if (ts) lines.push(ts);
+    lines.push("");
+    const lead = buildTopStoryLead(FULL_DIGEST);
+    lines.push(...lead.lines);
+
+    const post = briefFooterCap(lines, "[1/3] #AIhardware #OpenModels", 1450);
+
+    expect(post.startsWith("[Daily Brief] ")).toBe(true);
+    expect(post).toContain("Scanned 142 stories across 3 sources today");
+    expect(post).toContain("Top sources:");
+    expect(post).toContain("Lead: ");
+    expect(post.endsWith("[1/3] #AIhardware #OpenModels")).toBe(true);
+    expect(post.length).toBeLessThanOrEqual(1450);
+    expect(post).not.toContain("|");
+  });
+});

--- a/convex/workflows/ainewsBriefFormat.ts
+++ b/convex/workflows/ainewsBriefFormat.ts
@@ -1,0 +1,235 @@
+/**
+ * AINews-style daily-brief scaffolding for the LinkedIn pipeline.
+ *
+ * Pattern: provenance-first, number-dense newsletter digest.
+ * Prior art:
+ *   - Latent.Space / smol.ai "AINews" daily roundup
+ *     https://www.latent.space/p/ainews-nvidia-cosmos-3-nemotron-3
+ *     Borrowed mechanisms (not vibe):
+ *       1. Bracketed top-3 headline  -> "[AINews] NVIDIA Cosmos 3, Nemotron 3 Ultra, and RTX Spark"
+ *       2. The "we checked N sources" provenance line (the signature trust move)
+ *       3. A top-story prose lead before the structured recap
+ *       4. Number-first bullets with inline source links
+ *   - NodeBench-original: maps that shape onto a LinkedIn 3-post thread under the
+ *     GENERAL practitioner voice + LinkedIn sanitization constraints (no raw
+ *     parens, no pipes — see CLAUDE.md "LinkedIn API posting rules").
+ *
+ * This module is intentionally dependency-free and pure so it can be unit-tested
+ * in isolation (scenario_testing rule). The Convex action in dailyLinkedInPost.ts
+ * composes these fragments into the final posts.
+ *
+ * See: CLAUDE.md "LinkedIn post pipeline" + "Voice principles (GENERAL persona)".
+ */
+
+/**
+ * Structural subset of AgentDigestOutput that the brief scaffolding reads.
+ * AgentDigestOutput is structurally assignable to this — callers pass the digest
+ * directly. Keeping it local (not an import) keeps this module test-portable.
+ */
+export interface BriefDigest {
+  narrativeThesis?: string;
+  leadStory?: {
+    title: string;
+    url?: string;
+    whyItMatters?: string;
+  } | null;
+  signals?: Array<{
+    title: string;
+    url?: string;
+    summary?: string;
+    hardNumbers?: string;
+    directQuote?: string;
+  }>;
+  narrativeFraming?: {
+    dominantStory: string;
+    attentionShare: string;
+    underReportedAngle: string;
+  } | null;
+  storyCount?: number;
+  topSources?: string[];
+  topCategories?: string[];
+}
+
+/** Normalize a title to a stable de-dup key (lead vs signal collision). */
+export function storyKey(title: string | undefined | null): string {
+  return (title ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/** Collapse whitespace + clip to `max` chars at a word boundary, adding an ellipsis. */
+export function clip(text: string | undefined | null, max: number): string {
+  const t = (text ?? "").replace(/\s+/g, " ").trim();
+  if (t.length <= max) return t;
+  // Reserve room for the trailing ellipsis so output never exceeds `max`.
+  const hardMax = Math.max(1, max - 3);
+  const cut = t.slice(0, hardMax);
+  const lastSpace = cut.lastIndexOf(" ");
+  const body = lastSpace > hardMax * 0.6 ? cut.slice(0, lastSpace) : cut;
+  return body.replace(/[.,;:\-\s]+$/, "").trimEnd() + "...";
+}
+
+/**
+ * Reduce a full signal/story title to a short noun phrase for the headline.
+ * Strips trailing parentheticals/brackets and punctuation, then word-clips.
+ * No ellipsis — a headline segment should read as a clean name, not a fragment.
+ */
+export function shortenForHeadline(title: string | undefined | null, max = 44): string {
+  let t = (title ?? "").replace(/\s+/g, " ").trim();
+  // Drop a single trailing parenthetical / bracketed aside: "Cosmos 3 (omnimodal)" -> "Cosmos 3"
+  t = t.replace(/\s*[([][^)\]]*[)\]]\s*$/, "").trim();
+  // Signal titles are full sentences ("NVIDIA ships Cosmos 3, an omnimodal...").
+  // AINews headlines are short noun phrases. Cut at the first clause boundary —
+  // a comma/colon/semicolon or a subordinating connective — so we keep the head
+  // noun phrase and drop the descriptive tail. NOTE: never break on a hyphen
+  // (it lives inside "open-weight", "Quantum-X").
+  const clauseBreak = t.match(/^(.*?)(?:[,:;]| (?:as|that|which|after|amid|with|while) )/i);
+  if (clauseBreak && clauseBreak[1].trim().split(/\s+/).length >= 2) {
+    t = clauseBreak[1].trim();
+  }
+  t = t.replace(/[.,;:\-\s]+$/, "").trim();
+  if (t.length <= max) return t;
+  // Word-clip to max. No ellipsis — a headline segment should read as a name.
+  const cut = t.slice(0, max);
+  const lastSpace = cut.lastIndexOf(" ");
+  const body = lastSpace > max * 0.5 ? cut.slice(0, lastSpace) : cut;
+  return body.replace(/[.,;:\-\s]+$/, "").trim();
+}
+
+/** Oxford-comma join: [a] -> "a"; [a,b] -> "a and b"; [a,b,c] -> "a, b, and c". */
+export function joinOxford(items: string[]): string {
+  const a = items.filter((s) => Boolean(s && s.trim()));
+  if (a.length === 0) return "";
+  if (a.length === 1) return a[0];
+  if (a.length === 2) return `${a[0]} and ${a[1]}`;
+  return `${a.slice(0, -1).join(", ")}, and ${a[a.length - 1]}`;
+}
+
+/** Top story titles for the headline: leadStory first, then de-duped signals. */
+export function topStoryTitles(d: BriefDigest, n = 3): string[] {
+  const titles: string[] = [];
+  const seen = new Set<string>();
+  const push = (raw: string | undefined) => {
+    if (!raw || titles.length >= n) return;
+    const short = shortenForHeadline(raw);
+    const key = storyKey(short);
+    if (!short || !key || seen.has(key)) return;
+    seen.add(key);
+    titles.push(short);
+  };
+  push(d.leadStory?.title ?? undefined);
+  for (const s of d.signals ?? []) {
+    if (titles.length >= n) break;
+    push(s.title);
+  }
+  return titles;
+}
+
+/**
+ * AINews-style headline. `label` brands the brief lane
+ * (e.g. "Daily Brief", "Deal Flow Brief", "Tech Radar").
+ */
+export function buildBriefHeadline(d: BriefDigest, label = "Daily Brief"): string {
+  const titles = topStoryTitles(d, 3);
+  if (titles.length === 0) {
+    const cat = (d.topCategories ?? []).find((c) => Boolean(c && c.trim()));
+    return cat ? `[${label}] ${clip(cat, 60)} roundup` : `[${label}] What moved in AI and markets today`;
+  }
+  return clip(`[${label}] ${joinOxford(titles)}`, 150);
+}
+
+/** One-line "so what" dek under the headline. */
+export function buildBriefDek(d: BriefDigest, max = 130): string {
+  const framingDek = d.narrativeFraming
+    ? `${d.narrativeFraming.dominantStory} is the loud story. ${d.narrativeFraming.underReportedAngle} is the one that matters.`
+    : "";
+  const dek =
+    (d.narrativeThesis && d.narrativeThesis.trim()) ||
+    framingDek ||
+    (d.leadStory?.whyItMatters ?? "") ||
+    "";
+  return clip(dek, max);
+}
+
+/**
+ * The signature AINews provenance line. HONEST_SCORES: every number printed is a
+ * real measured count from the digest — never fabricated. If `storyCount` is
+ * missing/zero we degrade to a count-free phrasing rather than invent coverage.
+ *
+ * @param shownCount how many signals the post actually surfaces.
+ */
+export function buildProvenanceLine(d: BriefDigest, shownCount: number): string {
+  const scanned =
+    typeof d.storyCount === "number" && Number.isFinite(d.storyCount) && d.storyCount > 0
+      ? Math.floor(d.storyCount)
+      : null;
+  const sourceN = (d.topSources ?? []).filter((s) => Boolean(s && s.trim())).length;
+  const shown = Math.max(1, Math.floor(shownCount) || 1);
+  const noun = shown === 1 ? "signal" : "signals";
+
+  if (scanned && sourceN > 0) {
+    const storyWord = scanned === 1 ? "story" : "stories";
+    const sourceWord = sourceN === 1 ? "source" : "sources";
+    return `Scanned ${scanned} ${storyWord} across ${sourceN} ${sourceWord} today. Here are the ${shown} ${noun} that actually moved:`;
+  }
+  if (scanned) {
+    const storyWord = scanned === 1 ? "story" : "stories";
+    return `Scanned ${scanned} ${storyWord} today. Here are the ${shown} ${noun} that actually moved:`;
+  }
+  return `Here are today's ${shown} ${noun} that actually moved, with the numbers and the sources:`;
+}
+
+/** "Top sources:" provenance footer. Empty string when no sources are known. */
+export function buildTopSourcesLine(d: BriefDigest, max = 3): string {
+  const sources = (d.topSources ?? []).filter((s) => Boolean(s && s.trim())).slice(0, max);
+  if (sources.length === 0) return "";
+  return `Top sources: ${sources.join(", ")}.`;
+}
+
+/**
+ * Prose lead for the single biggest story (leadStory, else the top signal).
+ * Returns the line(s) plus the de-dup key of the title it consumed, so the
+ * caller can skip re-listing that story in the numbered bullets.
+ */
+export function buildTopStoryLead(d: BriefDigest): { lines: string[]; consumedKey: string | null } {
+  const lead = d.leadStory;
+  const signals = d.signals ?? [];
+  let title: string | undefined;
+  let why: string | undefined;
+  let url: string | undefined;
+
+  if (lead?.title) {
+    title = lead.title;
+    why = lead.whyItMatters;
+    url = lead.url;
+  } else if (signals[0]?.title) {
+    title = signals[0].title;
+    why = signals[0].summary;
+    url = signals[0].url;
+  }
+
+  if (!title) return { lines: [], consumedKey: null };
+
+  const lines: string[] = [];
+  const head = why ? `Lead: ${clip(title, 90)} -- ${clip(why, 200)}` : `Lead: ${clip(title, 130)}`;
+  lines.push(clip(head, 300));
+  if (url && url.trim()) lines.push(url.trim());
+
+  return { lines, consumedKey: storyKey(shortenForHeadline(title)) };
+}
+
+/**
+ * Join body lines into a post, guaranteeing the footer (e.g. "[1/3] #tags")
+ * always survives. Plain length-cap truncation drops the footer when a post runs
+ * long — this reserves the footer's budget first. Collapses 3+ blank lines.
+ */
+export function briefFooterCap(bodyLines: string[], footer: string, max = 1450): string {
+  const footerBlock = footer && footer.trim() ? `\n\n${footer.trim()}` : "";
+  let body = bodyLines.join("\n").replace(/\n{3,}/g, "\n\n").replace(/[ \t]+\n/g, "\n").trimEnd();
+  const budget = max - footerBlock.length;
+  if (body.length > budget) {
+    body = body.slice(0, Math.max(0, budget - 3)).trimEnd() + "...";
+  }
+  return body + footerBlock;
+}

--- a/convex/workflows/dailyLinkedInPost.ts
+++ b/convex/workflows/dailyLinkedInPost.ts
@@ -31,6 +31,16 @@ import {
   type SignalForecastMatch,
   type FindingForecastMatch,
 } from "../domains/forecasting/signalMatcher";
+import {
+  buildBriefHeadline,
+  buildBriefDek,
+  buildProvenanceLine,
+  buildTopSourcesLine,
+  buildTopStoryLead,
+  briefFooterCap,
+  storyKey,
+  shortenForHeadline,
+} from "./ainewsBriefFormat";
 
 type LinkedInCompetingExplanation = {
   title: string;
@@ -193,32 +203,43 @@ function formatDigestForLinkedIn(
   const domain = extractDomain(digest.leadStory?.title || signals[0]?.title || "tech");
   const totalPosts = (findings.length > 0 || actions.length > 0) ? 3 : 2;
 
-  function capPost(text: string): string {
-    if (text.length <= maxPerPost) return text;
-    return text.slice(0, maxPerPost - 3).trimEnd() + "...";
-  }
-
   const explanations = (digest.competingExplanations ?? []) as LinkedInCompetingExplanation[];
-  const framing = digest.narrativeFraming;
 
   // ── Post 1: WHAT'S HAPPENING ──
   // Factual lead. Data. Key developments. Competing explanations as prose.
   const p1: string[] = [];
+  const shownSignalCount = Math.min(signals.length, 4);
 
-  // Hook: use narrative framing if DRANE data is available
-  if (framing) {
-    p1.push(truncateAtSentenceBoundary(
-      `While ${framing.dominantStory} dominates ${framing.attentionShare} of social feeds this week, ${framing.underReportedAngle}.`,
-      280
-    ));
-  } else {
-    const leadHook = digest.leadStory?.whyItMatters
-      || digest.narrativeThesis
-      || signals[0]?.summary
-      || `Key developments in ${domain} today that aren't getting enough attention.`;
-    p1.push(truncateAtSentenceBoundary(leadHook, 220));
-  }
+  // AINews-style brief header: bracketed top-3 headline + one-line "so what" dek.
+  p1.push(buildBriefHeadline(digest));
   p1.push("");
+  const dek = buildBriefDek(digest);
+  if (dek) {
+    p1.push(dek);
+    p1.push("");
+  }
+
+  // Provenance line -- "scanned N stories across M sources" (honest, real counts).
+  p1.push(buildProvenanceLine(digest, shownSignalCount));
+  const topSourcesLine = buildTopSourcesLine(digest);
+  if (topSourcesLine) p1.push(topSourcesLine);
+  p1.push("");
+
+  // Top-story prose lead -- only when leadStory is distinct from the top signal,
+  // so the numbered list below never repeats it.
+  const leadTitleKey = digest.leadStory?.title
+    ? storyKey(shortenForHeadline(digest.leadStory.title))
+    : null;
+  const topSignalKey = signals[0]?.title
+    ? storyKey(shortenForHeadline(signals[0].title))
+    : null;
+  if (leadTitleKey && leadTitleKey !== topSignalKey) {
+    const lead = buildTopStoryLead(digest);
+    if (lead.lines.length > 0) {
+      p1.push(...lead.lines);
+      p1.push("");
+    }
+  }
 
   // Build signal→forecast Δ badge lookup (max 2 badges per post)
   const signalMatchMap = new Map<number, SignalForecastMatch>();
@@ -274,8 +295,7 @@ function formatDigestForLinkedIn(
   }
   p1.push("");
   p1.push(`Which of these are you tracking?`);
-  p1.push("");
-  p1.push(`[1/${totalPosts}] ${specificTags}`);
+  const footer1 = `[1/${totalPosts}] ${specificTags}`;
 
   // ── Post 2: WHAT IT MEANS ──
   // Fact-checks with evidence grades, context, signal vs noise.
@@ -346,8 +366,7 @@ function formatDigestForLinkedIn(
   p2.push(`I built a system that fact-checks and scores evidence automatically. Above is what it found today.`);
   p2.push("");
   p2.push(`What's one claim you've seen this week that you'd want fact-checked?`);
-  p2.push("");
-  p2.push(`[2/${totalPosts}] ${specificTags}`);
+  const footer2 = `[2/${totalPosts}] ${specificTags}`;
 
   // ── Post 3: PRACTICAL GUIDE ──
   // Specific actions. Skills to learn. Forecast cards. Falsification criteria.
@@ -441,12 +460,11 @@ function formatDigestForLinkedIn(
   p3.push(`This runs daily. I'll keep publishing what it finds. If you spot a claim worth checking, drop it below.`);
   p3.push("");
   p3.push(`What are you building or investigating this week?`);
-  p3.push("");
-  p3.push(`[3/3] ${specificTags}`);
+  const footer3 = `[3/3] ${specificTags}`;
 
   const posts = totalPosts === 3
-    ? [capPost(p1.join("\n")), capPost(p2.join("\n")), capPost(p3.join("\n"))]
-    : [capPost(p1.join("\n")), capPost(p2.join("\n"))];
+    ? [briefFooterCap(p1, footer1, maxPerPost), briefFooterCap(p2, footer2, maxPerPost), briefFooterCap(p3, footer3, maxPerPost)]
+    : [briefFooterCap(p1, footer1, maxPerPost), briefFooterCap(p2, footer2, maxPerPost)];
   for (let i = 0; i < posts.length; i++) {
     console.log(`[formatDigestForLinkedIn] Post ${i + 1}/${posts.length}: ${posts[i].length} chars`);
   }
@@ -1839,7 +1857,6 @@ function formatDigestForPersona(
   const tags = personaTags();
   const domain = extractDomain(digest.leadStory?.title || signals[0]?.title || "tech");
   const explanations = (digest.competingExplanations ?? []) as LinkedInCompetingExplanation[];
-  const framing = digest.narrativeFraming;
 
   function capPost(text: string): string {
     if (text.length <= maxPerPost) return text;
@@ -1848,6 +1865,21 @@ function formatDigestForPersona(
 
   // ── Post 1: WHAT'S HAPPENING (persona-specific lens) ──
   const p1: string[] = [];
+
+  // AINews-style brief header + provenance, shared across persona lenses.
+  const briefLabel =
+    personaId === "VC_INVESTOR" ? "Deal Flow Brief"
+      : personaId === "TECH_BUILDER" ? "Tech Radar"
+      : "Daily Brief";
+  p1.push(buildBriefHeadline(digest, briefLabel));
+  p1.push("");
+  p1.push(buildProvenanceLine(digest, Math.min(signals.length, 4)));
+  {
+    const ts = buildTopSourcesLine(digest);
+    if (ts) p1.push(ts);
+  }
+  p1.push("");
+  const footer1 = `[1/${totalPosts}] ${tags}`;
 
   if (personaId === "VC_INVESTOR") {
     const hook = digest.leadStory?.whyItMatters || digest.narrativeThesis || signals[0]?.summary
@@ -1879,8 +1911,7 @@ function formatDigestForPersona(
     }
     p1.push("");
     p1.push("Which of these are you tracking for your portfolio?");
-    p1.push("");
-    p1.push(`[1/${totalPosts}] ${tags}`);
+    // [1/N] footer is appended via briefFooterCap during assembly.
   } else if (personaId === "TECH_BUILDER") {
     const hook = digest.leadStory?.whyItMatters || digest.narrativeThesis || signals[0]?.summary
       || `Technical developments in ${domain} worth evaluating today.`;
@@ -1910,8 +1941,7 @@ function formatDigestForPersona(
     }
     p1.push("");
     p1.push("Which of these have you evaluated?");
-    p1.push("");
-    p1.push(`[1/${totalPosts}] ${tags}`);
+    // [1/N] footer is appended via briefFooterCap during assembly.
   } else {
     // GENERAL
     const hook = digest.leadStory?.whyItMatters || digest.narrativeThesis || signals[0]?.summary
@@ -1943,8 +1973,7 @@ function formatDigestForPersona(
     }
     p1.push("");
     p1.push("Which of these are you tracking?");
-    p1.push("");
-    p1.push(`[1/${totalPosts}] ${tags}`);
+    // [1/N] footer is appended via briefFooterCap during assembly.
   }
 
   // ── Post 2: WHAT IT MEANS (verification, context, signal vs noise) ──
@@ -2068,8 +2097,8 @@ function formatDigestForPersona(
   p3.push(`[3/3] ${tags}`);
 
   const posts = totalPosts === 3
-    ? [capPost(p1.join("\n")), capPost(p2.join("\n")), capPost(p3.join("\n"))]
-    : [capPost(p1.join("\n")), capPost(p2.join("\n"))];
+    ? [briefFooterCap(p1, footer1, maxPerPost), capPost(p2.join("\n")), capPost(p3.join("\n"))]
+    : [briefFooterCap(p1, footer1, maxPerPost), capPost(p2.join("\n"))];
   for (let i = 0; i < posts.length; i++) {
     console.log(`[formatDigestForPersona] ${personaId} Post ${i + 1}/${posts.length}: ${posts[i].length} chars`);
   }


### PR DESCRIPTION
## What

Reshapes the daily LinkedIn brief to read like the [Latent.Space / smol.ai "AINews" roundup](https://www.latent.space/p/ainews-nvidia-cosmos-3-nemotron-3) the user pointed at.

**Before** Post 1 opened with a single hook line + a numbered signal list.
**After** it opens AINews-style:

```
[Daily Brief] NVIDIA ships Cosmos 3, Nemotron 3 Ultra lands, and RTX Spark personal AI computer announced

NVIDIA's open-weight blitz reframes the week: the loud story is robotics, the quiet one is who controls the local AI stack.

Scanned 142 stories across 3 sources today. Here are the 4 signals that actually moved:
Top sources: X / Twitter, r/LocalLlama, NVIDIA newsroom.

Lead: NVIDIA ships Cosmos 3, an omnimodal world model family (open weights) -- First credible open-weights challenger ...
https://x.com/...

1. Nemotron 3 Ultra lands as the strongest US open-weight LLM -- 550B params, 48 Artificial Analysis score
   ...
```

The four AINews signatures borrowed: **bracketed top-3 headline**, the **"we scanned N sources" provenance line**, a **top-story prose lead**, and **number-dense bullets with inline source links**.

## Where

- **`convex/workflows/ainewsBriefFormat.ts`** (new) — pure, dependency-free, unit-tested scaffolding: `buildBriefHeadline` / `buildBriefDek` / `buildProvenanceLine` / `buildTopSourcesLine` / `buildTopStoryLead` / `briefFooterCap`.
- **`dailyLinkedInPost.ts`** — `formatDigestForLinkedIn` (the live 06:15 UTC GENERAL brief) Post 1 rebuilt; `formatDigestForPersona` (Deal Flow Brief / Tech Radar at 09:00/15:00) gets the headline + provenance header.
- **`ainewsBriefFormat.test.ts`** (new) — 35 scenario tests (happy / sparse / empty / adversarial / 100-signal scale / footer-budget), wired into the CI Runtime-smoke gate.

## Honesty & safety

- **HONEST_SCORES** — every provenance number is a real measured count (`storyCount` = feed items scanned, `topSources.length`). When counts are missing the line degrades to count-free phrasing instead of fabricating coverage. Tested for `storyCount` = 0 / negative / NaN / undefined.
- **Footer never dropped** — `briefFooterCap` reserves the `[1/3] #tags` budget before truncating (the old `capPost` cut the tail, which could drop the footer on long posts).
- **LinkedIn-safe** — output introduces no `|` (pipes break posts); the existing `cleanLinkedInText()` paren-sanitizer still runs downstream.
- **Bug fixed en route** — `clip()` appended the ellipsis after slicing to `max`, so it could overflow the headline/dek budgets by 3 chars. Now reserves the ellipsis budget first.

## Verification

- `npx tsc --noEmit` (app) + `npx tsc -p convex` — clean
- `npx vitest run convex/workflows/ainewsBriefFormat.test.ts` — 35/35 pass
- `npm run build` — clean
- Sample Post 1 rendered end-to-end: 1419 chars, under the 1450 cap, footer intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)