### PR TITLE
feat(scratchnode): self-serve "Create a room" front-door on the landing

### DIFF
--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -2,6 +2,28 @@
 
 Append-only lane for the ScratchNode live-event prototype and production static surface.
 
+## 2026-06-02 — Add a self-serve "Create a room" front-door to the landing
+The apex landing only offered a "Join with a code" form — a first-time visitor had
+no way to actually create a room. `events:createEvent` existed in the backend and a
+create flow lived in the in-room host console, but the live-backend module bails early
+on the apex (`if (!slugMatch) return`), so creation was never wired on the landing.
+
+Added a `.landing-create` form (event name + optional custom room code) beside Join,
+plus a self-contained `_landingCreate()` handler that lazily bootstraps a Convex client
+(same `/api/scratchnode-config` + esm.sh paths the room module uses), calls
+`events:createEvent`, persists the issued host token (`sn_host_owner_key_v2`), and
+navigates the new host into `/e/<slug>`. Join stays the single primary accent CTA;
+Create is outline-accent (secondary in the hierarchy).
+
+Honesty contract preserved: every failure (config down, client load fail, taken code,
+rate limit) surfaces a real inline error and re-enables the button — never a fake
+success, and `data-sn-live` stays untouched so the apex reads honestly "not live" until
+the host lands in their room. Covered by 4 new cases in
+`tests/e2e/scratchnode-live-route-honesty.spec.ts` (happy path, auto-code, short-name
+rejection, honest config-failure). 10/10 honesty suite green.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.
+
 ## 2026-06-02 — Add ScratchNode motion polish
 Centralized lightweight motion tokens and added a visual polish pass across the ScratchNode room: ambient backdrop, composer focus/private-mode cues, chat and answer reveals, Live Assist card choreography, and tactile Memory Wall note transitions. The change keeps the existing public/private behavior contract intact while making the demo feel more premium on desktop and mobile.
 

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1805,15 +1805,100 @@ body[data-page-mode="landing"] .welcome {
   margin-left: 14px;
   color: var(--ink-faint);
 }
+/* "or host your own" divider between Join and Create. */
+.landing-or {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 420px;
+  font-family: var(--ui);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.landing-or::before,
+.landing-or::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+/* Create-a-room form — name (required) + optional custom code + submit. */
+.landing-create {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 420px;
+}
+.landing-create-sub {
+  display: flex;
+  gap: 8px;
+}
+.landing-create input {
+  font-family: var(--ui);
+  font-size: 15px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  outline: none;
+  transition: border-color .15s ease;
+}
+.landing-create #landing-create-code { flex: 1; min-width: 0; }
+.landing-create input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(217,119,87,.18);
+}
+.landing-create input::placeholder { color: var(--ink-faint); }
+/* Outline-accent so "Join" stays the single primary CTA; Create is clearly
+   available but secondary in the visual hierarchy. */
+.landing-create button {
+  font-family: var(--ui);
+  font-weight: 600;
+  font-size: 15px;
+  padding: 12px 20px;
+  border-radius: 8px;
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background .15s ease, color .15s ease;
+}
+.landing-create button:hover { background: var(--accent); color: #fff; }
+.landing-create button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(217,119,87,.35);
+}
+.landing-create button:disabled { opacity: .65; cursor: progress; }
+.landing-create-status {
+  display: none;
+  font-family: var(--ui);
+  font-size: 13px;
+  line-height: 1.4;
+  margin: 0;
+  max-width: 420px;
+  color: var(--ink-muted);
+}
+.landing-create-status[data-state="busy"] { color: var(--accent); }
+.landing-create-status[data-state="error"] { color: #d98b7a; }
 @media (max-width: 600px) {
   .landing-hero h1 { font-size: 22px; }
   .landing-hero p { font-size: 14px; }
   .landing-join { flex-direction: column; }
   .landing-join button { width: 100%; }
+  .landing-create-sub { flex-direction: column; }
+  .landing-create button { width: 100%; }
 }
 @media (prefers-reduced-motion: reduce) {
   .landing-join input,
   .landing-join button,
+  .landing-create input,
+  .landing-create button,
   .landing-secondary { transition: none; }
 }
 
@@ -1888,6 +1973,130 @@ function _landingJoin(ev) {
   location.href = '/e/' + encodeURIComponent(code);
   return false;
 }
+
+/**
+ * _landingCreate — handler for the landing-mode "Create a room" form.
+ *
+ * WHY this exists on the landing (not just the in-room host console):
+ *   The live-backend module below (PHASE 1 LIVE BACKEND) bails early on the
+ *   apex landing (`if (!slugMatch) return`), so its `client` / sessionId /
+ *   `snCreateEventFromHostSheet` are NEVER wired here. A first-time visitor
+ *   therefore had no front-door to create a room — only a "Join" form. This
+ *   handler is a self-contained, lazily-bootstrapped create path: it spins up
+ *   a Convex client on click (same /api/scratchnode-config + esm.sh paths the
+ *   room module + e2e mocks use), calls events:createEvent, persists the
+ *   issued host token, and navigates the new host into /e/<slug>.
+ *
+ * Honesty contract (.claude/rules/agentic_reliability HONEST_STATUS, and the
+ * scratchnode-live-route-honesty e2e): every failure surfaces a real inline
+ * error and re-enables the button — we NEVER fake success or navigate on a
+ * failed create. `data-sn-live` is left untouched (only the in-room module
+ * may set it), so the apex stays honestly "not live" until the host lands in
+ * their room.
+ */
+async function _landingCreate(ev) {
+  try { ev.preventDefault(); } catch (e) {}
+  var nameEl = document.getElementById('landing-create-name');
+  var codeEl = document.getElementById('landing-create-code');
+  var btn = document.getElementById('landing-create-btn');
+  var statusEl = document.getElementById('landing-create-status');
+  var title = String((nameEl && nameEl.value) || '').trim();
+  var roomCode = String((codeEl && codeEl.value) || '').trim();
+
+  function setStatus(msg, state) {
+    if (!statusEl) return;
+    statusEl.textContent = msg || '';
+    statusEl.style.display = msg ? 'block' : 'none';
+    if (state) statusEl.setAttribute('data-state', state);
+    else statusEl.removeAttribute('data-state');
+  }
+  function fail(msg) {
+    setStatus(msg, 'error');
+    if (btn) { btn.disabled = false; btn.textContent = 'Create room & enter →'; }
+    if (typeof toast === 'function') { try { toast('Could not create room', msg); } catch (e) {} }
+    return false;
+  }
+
+  if (title.length < 3) {
+    if (nameEl) { try { nameEl.focus(); } catch (e) {} }
+    return fail('Give your event a name (at least 3 characters).');
+  }
+
+  if (btn) { btn.disabled = true; btn.textContent = 'Creating your room…'; }
+  setStatus('Spinning up your live room…', 'busy');
+
+  // Stable anonymous session id — shared with the in-room module so the host
+  // is recognized as a member the moment they land in /e/<slug>.
+  var sessionId;
+  try {
+    sessionId = localStorage.getItem('sn_session_id');
+    if (!sessionId) {
+      sessionId = (window.crypto && crypto.randomUUID)
+        ? crypto.randomUUID()
+        : 'sess_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+      localStorage.setItem('sn_session_id', sessionId);
+    }
+  } catch (e) {
+    sessionId = 'sess_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+  }
+
+  try {
+    var r = await fetch('/api/scratchnode-config', { cache: 'no-store' });
+    if (!r.ok) return fail('Could not load room config (HTTP ' + r.status + '). Refresh and try again.');
+    var cfg = await r.json();
+    if (!cfg || !cfg.convexUrl) return fail('Live backend is not configured right now. Try again shortly.');
+
+    var ConvexClient;
+    try {
+      var mod = await import('https://esm.sh/convex@1.29.0/browser');
+      ConvexClient = mod.ConvexClient;
+    } catch (e) {
+      return fail('Could not load the realtime client. Refresh and try again.');
+    }
+    if (!ConvexClient) return fail('Could not load the realtime client. Refresh and try again.');
+
+    var client = new ConvexClient(cfg.convexUrl);
+    var displayName = (window._userName && String(window._userName).trim()) || 'Host';
+    var res;
+    try {
+      res = await client.mutation('events:createEvent', {
+        title: title,
+        sessionId: sessionId,
+        displayName: displayName,
+        roomCode: roomCode || undefined,
+        status: 'live',
+      });
+    } catch (e) {
+      try { client.close && client.close(); } catch (_) {}
+      var errCode = (e && e.data && e.data.code) || '';
+      if (errCode === 'room_code_taken') {
+        return fail('That room code is taken — pick another, or leave it blank for an auto code.');
+      }
+      if (errCode === 'invalid_room_code') {
+        return fail('Room code must be 2-24 letters, numbers, or dashes.');
+      }
+      if (errCode === 'rate_limited' || /rate.?limit/i.test(String((e && e.message) || ''))) {
+        return fail('You’ve created several rooms recently. Wait a minute, then try again.');
+      }
+      return fail((e && e.message) || 'Create failed. Try again.');
+    }
+
+    if (!res || !res.eventId || !res.ownerKey || !(res.slug || res.roomCode)) {
+      try { client.close && client.close(); } catch (_) {}
+      return fail('The server did not return a usable room. Try again.');
+    }
+
+    // Persist the issued host token so the room boot marks this device as host
+    // (getHostStatus reads sn_host_owner_key_v2). Same key the host console uses.
+    try { localStorage.setItem('sn_host_owner_key_v2', res.ownerKey); } catch (e) {}
+    try { client.close && client.close(); } catch (_) {}
+    setStatus('Room ' + (res.roomCode || res.slug) + ' is live — opening…', 'busy');
+    location.href = '/e/' + encodeURIComponent(res.slug || res.roomCode);
+    return false;
+  } catch (e) {
+    return fail((e && e.message) || 'Unexpected error creating the room.');
+  }
+}
 </script>
 
 <!-- Landing-mode hero — visible only when data-page-mode === "landing" -->
@@ -1900,6 +2109,15 @@ function _landingJoin(ev) {
       <input type="text" placeholder="Enter room code (e.g. ORBITAL)" aria-label="Room code" maxlength="60" autocomplete="off" autocapitalize="off" spellcheck="false">
       <button type="submit">Join &rarr;</button>
     </form>
+    <div class="landing-or" aria-hidden="true"><span>or host your own</span></div>
+    <form class="landing-create" onsubmit="return _landingCreate(event)" aria-label="Create a new room for your event">
+      <input type="text" id="landing-create-name" placeholder="Name your event (e.g. Sarah&#39;s Birthday)" aria-label="Event name" maxlength="90" autocomplete="off" required>
+      <div class="landing-create-sub">
+        <input type="text" id="landing-create-code" placeholder="Custom code (optional)" aria-label="Custom room code (optional)" maxlength="24" autocomplete="off" autocapitalize="characters" spellcheck="false">
+        <button type="submit" id="landing-create-btn">Create room &amp; enter &rarr;</button>
+      </div>
+    </form>
+    <p class="landing-create-status" id="landing-create-status" role="status" aria-live="polite"></p>
     <div class="landing-cta-row">
       <a href="/demo_ver1" class="landing-secondary">See the demo &rarr;</a>
       <a href="/docs" class="landing-secondary">Read the docs &rarr;</a>

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -290,4 +290,89 @@ test.describe("ScratchNode live route honesty", () => {
     await expect(page.locator("#sn-manage-event-output")).toContainText("Session ended");
     await expect(page.locator("#ev-mode-label")).toContainText("ended");
   });
+
+  test("landing 'Create a room' creates a live room and enters it as host", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+
+    await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-page-mode", "landing");
+    // Apex must stay honestly "not live" until the host lands in the room.
+    await expect(page.locator("body")).not.toHaveAttribute("data-sn-live", "true");
+    await expect(page.locator("#landing-create-btn")).toBeVisible();
+
+    await page.fill("#landing-create-name", "Sarah's Birthday");
+    await page.fill("#landing-create-code", "BIRTHDAY");
+    await page.click("#landing-create-btn");
+
+    await expect
+      .poll(
+        () => page.evaluate(() => JSON.parse(localStorage.getItem("__snCreatedEventArgs") || "{}")),
+        { timeout: 5_000 },
+      )
+      .toMatchObject({
+        title: "Sarah's Birthday",
+        roomCode: "BIRTHDAY",
+        status: "live",
+      });
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toContain("/e/launch-room");
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("sn_host_owner_key_v2")), {
+        timeout: 5_000,
+      })
+      .toContain("hk1:");
+  });
+
+  test("landing create works with no custom code (auto-generated room code)", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+
+    await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
+    await page.fill("#landing-create-name", "Friday Demo Night");
+    await page.click("#landing-create-btn");
+
+    await expect
+      .poll(
+        () => page.evaluate(() => JSON.parse(localStorage.getItem("__snCreatedEventArgs") || "{}")),
+        { timeout: 5_000 },
+      )
+      .toMatchObject({ title: "Friday Demo Night", status: "live" });
+    // roomCode omitted (undefined) so the server auto-generates one.
+    const sentRoomCode = await page.evaluate(
+      () => JSON.parse(localStorage.getItem("__snCreatedEventArgs") || "{}").roomCode ?? null,
+    );
+    expect(sentRoomCode).toBeNull();
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toContain("/e/launch-room");
+  });
+
+  test("landing create rejects a too-short name without calling the backend", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+
+    await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
+    await page.fill("#landing-create-name", "ab");
+    await page.click("#landing-create-btn");
+
+    await expect(page.locator("#landing-create-status")).toContainText("at least 3 characters");
+    // No createEvent call should have fired — the page never left the landing.
+    await expect(page.locator("body")).toHaveAttribute("data-page-mode", "landing");
+    expect(
+      await page.evaluate(() => localStorage.getItem("__snCreatedEventArgs")),
+    ).toBeNull();
+    expect(page.url()).toBe("https://scratchnode.live/");
+  });
+
+  test("landing create fails honestly when the backend config is unavailable", async ({ page }) => {
+    await fulfillScratchNodePage(page, { configStatus: 500 });
+
+    await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
+    await page.fill("#landing-create-name", "Conference Sidecar");
+    await page.click("#landing-create-btn");
+
+    await expect(page.locator("#landing-create-status")).toHaveAttribute("data-state", "error");
+    await expect(page.locator("#landing-create-status")).toContainText("Could not load room config");
+    // Honest failure: no navigation, no host token persisted.
+    expect(page.url()).toBe("https://scratchnode.live/");
+    expect(
+      await page.evaluate(() => localStorage.getItem("sn_host_owner_key_v2")),
+    ).toBeNull();
+    await expect(page.locator("#landing-create-btn")).toBeEnabled();
+  });
 });


### PR DESCRIPTION
## Re your ask
> "wait so i currently cannot just hop on the live site and create a room for my event or my friends and I? make it happen and shipped and tested live"

Correct — you couldn't. This adds the missing front-door.

## Root cause (5 whys)
1. You can't create a room from scratchnode.live → 2. the landing hero only renders a **Join** form → 3. the create flow (`snCreateEventFromHostSheet`) lives inside the *in-room* host console → 4. the entire Convex client module bails early on the apex (`if (!slugMatch) return`), so `events:createEvent` was **never wired** on the landing → 5. the apex was built "join-first"; `createEvent` shipped later (Phase 4) but never got a front-door. The backend was fully ready (rate-limited 5/10min, issues an HMAC host token, auto-generates a room code).

## What changed (`public/proto/home-v5.html`)
- A `.landing-create` form beside Join: **event name** (required) + **optional custom room code**.
- A self-contained `_landingCreate()` handler that lazily bootstraps a Convex client (same `/api/scratchnode-config` + `esm.sh` paths the room module uses), calls `events:createEvent`, persists the issued host token (`sn_host_owner_key_v2`), and navigates the new host into `/e/<slug>` — where the room boot recognizes them as host.
- Hierarchy: **Join** stays the single primary accent CTA; **Create** is outline-accent (secondary), with an "or host your own" divider.

## Honesty contract preserved
Every failure (config down, client load fail, taken code, rate limit) surfaces a **real inline error** and re-enables the button — never a fake success. `data-sn-live` is left untouched so the apex stays honestly "not live" until the host lands in their room.

## Verification
- **tsc** `--noEmit`: clean (exit 0)
- **e2e**: `scratchnode-live-route-honesty.spec.ts` 10/10 green, incl. 4 new landing-create cases (happy path, auto-code, short-name rejection, honest config-failure)
- **Live preview** (`public/proto` static server): desktop + mobile (375px, no overflow) render clean, zero console errors; real-environment honesty confirmed — a valid-name submit with no API present shows "Could not load room config (HTTP 404)", no navigation, no host token persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)