### PR TITLE
feat(scratchnode): synthesize the best landing from two parallel agent builds

### DIFF
--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -2,6 +2,31 @@
 
 Append-only lane for the ScratchNode live-event prototype and production static surface.
 
+## 2026-06-02 — Synthesize the best landing from two parallel agent builds
+Codex and Claude independently built the create-room front-door + the live counter.
+Instead of picking a winner, cherry-picked the strongest micro-decisions from each:
+
+**From Codex's branches:** index-backed presence counting — added `by_startedAt` +
+`by_status_startedAt` (liveEvents) and `by_lastSeen` (liveEventMembers) indexes so
+`events:getLandingStats` now reports a real **"active now"** (member sessions within the
+5-min presence TTL) alongside rooms created + live rooms, each index-scanned and bounded
+(10k events / 5k sessions, "N+" when capped); a 25s poll fallback for Convex browser
+clients without `onUpdate`; and the full landing-mode chrome hide (`.h` header, `.f`
+footer, menu/sheet/shortcut overlays) — fixes a real leak where room chrome rendered
+below the apex landing and you could scroll into it.
+
+**Kept from Claude:** the "The room remembers everything" headline + OG card, honest
+hide-on-zero (never a fake "0"), and the synced-easing invariant so displayed-live never
+exceeds displayed-total during the count-up — now `animatePair` is superseded by
+`animateTrio`, extending the invariant to a 3-number trio (rooms + live + active) eased
+on one clock.
+
+The counter now shows a big "rooms created" with `● N active now · N live right now`
+chips. 14/14 honesty suite green; tsc clean; chrome-fix + chips verified in preview.
+Deferred to a follow-up: Create-first form hierarchy.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude (synthesizing Codex branch work).
+
 ## 2026-06-02 — Fix counter count-up flashing "more live than total"
 Live-DOM Tier-B check on production caught the live counter momentarily rendering
 `6 live · 4 total` during first load — impossible in steady state (live rooms are a
@@ -12,6 +37,7 @@ to be trustworthy. Fix: `animatePair()` eases both numbers from the same prior v
 with identical easing, so total ≥ live at every frame (`Math.round` is monotonic, and
 `roomsCreated ≥ liveNow` always). Guarded by a new e2e case that samples both numbers
 14× across the animation and asserts `live ≤ total` at every frame. 14/14 suite green.
+[Superseded same day by `animateTrio` in the synthesis entry above.]
 
 **Commit**: `this commit`. **Author**: Homen Shum + Claude.
 

--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -23,7 +23,12 @@ on one clock.
 
 The counter now shows a big "rooms created" with `● N active now · N live right now`
 chips. 14/14 honesty suite green; tsc clean; chrome-fix + chips verified in preview.
-Deferred to a follow-up: Create-first form hierarchy.
+
+**Hierarchy flip (founder call):** the original complaint was that a visitor couldn't
+just land and spin up a room — so **Create room is now the primary CTA** (filled accent,
+top of the form stack, "Create room →"), with **Join immediately available but secondary**
+(outline accent) below an "or join an existing room" divider. The prod artifact reads as
+one coherent landing, not a merge of two designs.
 
 **Commit**: `this commit`. **Author**: Homen Shum + Claude (synthesizing Codex branch work).
 

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -818,36 +818,56 @@ export const getEventBySlug = query({
   },
 });
 
-// BOUND (agentic_reliability): cap the landing-stats scan. The count is a full
-// table walk (no count aggregate in Convex); 5000 keeps it cheap even on a
-// hot landing while staying far above current room volume. When the cap is hit
-// the UI honestly renders "N+" rather than silently undercounting.
-const MAX_LANDING_STATS_SCAN = 5000;
+// BOUND (agentic_reliability): cap every landing-stats scan. There is no count
+// aggregate in Convex, so each metric is an index-ordered scan capped with a +1
+// sentinel — if we hit the cap the UI honestly renders "N+" rather than silently
+// undercounting. Limits sit far above current volume.
+const MAX_LANDING_EVENT_SCAN = 10000;
+const MAX_LANDING_SESSION_SCAN = 5000;
 
 /**
- * Live landing stats — powers the animated "big number" on the apex landing.
+ * Live landing stats — powers the animated counter on the apex landing.
  *
- * Convex queries are REACTIVE: every subscribed landing visitor's counter ticks
- * up the instant anyone creates a room — no polling, no client timers.
+ * Convex queries are REACTIVE: every subscribed landing visitor's numbers tick
+ * the instant a room is created, opens/ends, or someone joins/leaves — no client
+ * timers (the client also keeps a 25s poll fallback for older Convex browsers).
  *
- * Honesty (agentic_reliability HONEST_SCORES): every number is a real row count.
- * No hardcoded floor, no inflation. `roomsCreated` counts every room ever made
- * (ended rooms keep their row); `liveNow` counts rooms still open (status=live).
- * When the backend is unreachable the landing HIDES the stat entirely rather
- * than render a fabricated number (the client enforces the hide).
+ * Three real metrics (synthesis of the two parallel implementations — Codex
+ * contributed the index-backed presence counting; this keeps the reactive +
+ * honest-hide framing):
+ *   - roomsCreated: every room ever made (ended rooms keep their row) — by_startedAt
+ *   - liveNow:      rooms still open (status=live)                     — by_status_startedAt
+ *   - activeNow:    member sessions seen within the presence TTL       — by_lastSeen
+ *
+ * Honesty (agentic_reliability HONEST_SCORES): every number is a real row count —
+ * no hardcoded floor, no inflation. `capped`/`activeCapped` are surfaced so the UI
+ * shows "N+" instead of a wrong number. When the backend is unreachable the client
+ * HIDES the counter rather than render a fabricated number.
  */
 export const getLandingStats = query({
   args: {},
   handler: async (ctx) => {
-    const rows = await ctx.db.query("liveEvents").take(MAX_LANDING_STATS_SCAN);
-    let liveNow = 0;
-    for (const row of rows) {
-      if (row.status === "live") liveNow += 1;
-    }
+    const cutoff = Date.now() - PRESENCE_TTL_MS;
+    const rooms = await ctx.db
+      .query("liveEvents")
+      .withIndex("by_startedAt")
+      .order("desc")
+      .take(MAX_LANDING_EVENT_SCAN + 1);
+    const liveRows = await ctx.db
+      .query("liveEvents")
+      .withIndex("by_status_startedAt", (q) => q.eq("status", "live"))
+      .order("desc")
+      .take(MAX_LANDING_EVENT_SCAN + 1);
+    const activeRows = await ctx.db
+      .query("liveEventMembers")
+      .withIndex("by_lastSeen", (q) => q.gte("lastSeenAt", cutoff))
+      .take(MAX_LANDING_SESSION_SCAN + 1);
     return {
-      roomsCreated: rows.length,
-      liveNow,
-      capped: rows.length >= MAX_LANDING_STATS_SCAN,
+      roomsCreated: Math.min(rooms.length, MAX_LANDING_EVENT_SCAN),
+      liveNow: Math.min(liveRows.length, MAX_LANDING_EVENT_SCAN),
+      activeNow: Math.min(activeRows.length, MAX_LANDING_SESSION_SCAN),
+      capped: rooms.length > MAX_LANDING_EVENT_SCAN,
+      activeCapped: activeRows.length > MAX_LANDING_SESSION_SCAN,
     };
   },
 });

--- a/convex/schema/eventsSchema.ts
+++ b/convex/schema/eventsSchema.ts
@@ -34,7 +34,12 @@ export const liveEvents = defineTable({
   endedAt: v.optional(v.number()),
 })
   .index("by_slug", ["slug"])
-  .index("by_roomCode", ["roomCode"]);
+  .index("by_roomCode", ["roomCode"])
+  // Landing live-stats (events:getLandingStats): index-ordered scans for the
+  // total room count and the "live rooms right now" count, so the apex counter
+  // never full-scans the table. Additive — Convex builds them on deploy.
+  .index("by_startedAt", ["startedAt"])
+  .index("by_status_startedAt", ["status", "startedAt"]);
 
 // ------------------------------------------------------------------
 // liveEventMembers — anonymous presence per event
@@ -54,7 +59,10 @@ export const liveEventMembers = defineTable({
 })
   .index("by_event_session", ["eventId", "sessionId"])
   .index("by_session_joined", ["sessionId", "joinedAt"])
-  .index("by_event_lastSeen", ["eventId", "lastSeenAt"]);
+  .index("by_event_lastSeen", ["eventId", "lastSeenAt"])
+  // Global presence index — powers "active now" on the landing counter
+  // (events:getLandingStats counts members with lastSeenAt within the TTL).
+  .index("by_lastSeen", ["lastSeenAt"]);
 
 // ------------------------------------------------------------------
 // liveEventMessages — public chat feed for an event

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1831,6 +1831,7 @@ body[data-page-mode="landing"] .welcome {
   box-shadow: 0 0 0 3px rgba(217,119,87,.18);
 }
 .landing-join input::placeholder { color: var(--ink-faint); }
+/* Join is now the SECONDARY action — outline accent. */
 .landing-join button {
   font-family: var(--ui);
   font-weight: 600;
@@ -1838,12 +1839,13 @@ body[data-page-mode="landing"] .welcome {
   padding: 12px 20px;
   border-radius: 8px;
   border: 1px solid var(--accent);
-  background: var(--accent);
-  color: #fff;
+  background: transparent;
+  color: var(--accent);
   cursor: pointer;
-  transition: background .15s ease;
+  white-space: nowrap;
+  transition: background .15s ease, color .15s ease;
 }
-.landing-join button:hover { background: #c46a4e; }
+.landing-join button:hover { background: var(--accent); color: #fff; }
 .landing-join button:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px rgba(217,119,87,.35);
@@ -1935,6 +1937,7 @@ body[data-page-mode="landing"] .welcome {
 .landing-create input::placeholder { color: var(--ink-faint); }
 /* Outline-accent so "Join" stays the single primary CTA; Create is clearly
    available but secondary in the visual hierarchy. */
+/* Create is now the PRIMARY action — filled accent. */
 .landing-create button {
   font-family: var(--ui);
   font-weight: 600;
@@ -1942,13 +1945,13 @@ body[data-page-mode="landing"] .welcome {
   padding: 12px 20px;
   border-radius: 8px;
   border: 1px solid var(--accent);
-  background: transparent;
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
   cursor: pointer;
   white-space: nowrap;
   transition: background .15s ease, color .15s ease;
 }
-.landing-create button:hover { background: var(--accent); color: #fff; }
+.landing-create button:hover { background: #c46a4e; }
 .landing-create button:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px rgba(217,119,87,.35);
@@ -2095,7 +2098,7 @@ async function _landingCreate(ev) {
   }
   function fail(msg) {
     setStatus(msg, 'error');
-    if (btn) { btn.disabled = false; btn.textContent = 'Create room & enter →'; }
+    if (btn) { btn.disabled = false; btn.textContent = 'Create room →'; }
     if (typeof toast === 'function') { try { toast('Could not create room', msg); } catch (e) {} }
     return false;
   }
@@ -2318,19 +2321,22 @@ if (document.readyState === 'loading') {
     <span class="landing-logo">Scratch<span>Node</span></span>
     <h1>The room remembers everything.</h1>
     <p>Drop a code, chat live, hit <code style="font-family:var(--mono);background:rgba(217,119,87,.12);color:var(--accent);padding:1px 6px;border-radius:3px">/ask</code> for sourced answers — and walk away with a wiki of everything that happened. No account, no app.</p>
-    <form class="landing-join" onsubmit="return _landingJoin(event)" aria-label="Join an event by room code">
-      <input type="text" placeholder="Enter room code (e.g. ORBITAL)" aria-label="Room code" maxlength="60" autocomplete="off" autocapitalize="off" spellcheck="false">
-      <button type="submit">Join &rarr;</button>
-    </form>
-    <div class="landing-or" aria-hidden="true"><span>or host your own</span></div>
+    <!-- Create is the PRIMARY action: the original complaint was that a visitor
+         couldn't just land and spin up a room. Join stays immediately available
+         but secondary (outline) below an "or join" divider. -->
     <form class="landing-create" onsubmit="return _landingCreate(event)" aria-label="Create a new room for your event">
       <input type="text" id="landing-create-name" placeholder="Name your event (e.g. Sarah&#39;s Birthday)" aria-label="Event name" maxlength="90" autocomplete="off" required>
       <div class="landing-create-sub">
         <input type="text" id="landing-create-code" placeholder="Custom code (optional)" aria-label="Custom room code (optional)" maxlength="24" autocomplete="off" autocapitalize="characters" spellcheck="false">
-        <button type="submit" id="landing-create-btn">Create room &amp; enter &rarr;</button>
+        <button type="submit" id="landing-create-btn">Create room &rarr;</button>
       </div>
     </form>
     <p class="landing-create-status" id="landing-create-status" role="status" aria-live="polite"></p>
+    <div class="landing-or" aria-hidden="true"><span>or join an existing room</span></div>
+    <form class="landing-join" onsubmit="return _landingJoin(event)" aria-label="Join an event by room code">
+      <input type="text" placeholder="Enter room code (e.g. ORBITAL)" aria-label="Room code" maxlength="60" autocomplete="off" autocapitalize="off" spellcheck="false">
+      <button type="submit">Join &rarr;</button>
+    </form>
     <div class="landing-cta-row">
       <a href="/demo_ver1" class="landing-secondary">See the demo &rarr;</a>
       <a href="/docs" class="landing-secondary">Read the docs &rarr;</a>

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1674,12 +1674,24 @@ body[data-event-mode="sensitive"] .c-helpline::before {
 .landing { display: none; }
 body[data-page-mode="landing"] .landing { display: flex; }
 
-/* When in landing mode, hide the event-room shell entirely so the
-   apex does NOT read as "the demo is running on the live site". */
+/* When in landing mode, hide the event-room shell ENTIRELY so the apex does
+   not read as "the demo is running on the live site" and you can't scroll into
+   stray room chrome. The header (.h) and footer (.f) render AFTER the landing
+   in the DOM, so without this they leak below the fold — plus the room-context
+   menu/sheet/shortcut overlays must never open from the apex. (Cherry-picked
+   from Codex's create-room branch, which caught this leak.) */
 body[data-page-mode="landing"] .event-strip,
+body[data-page-mode="landing"] .h,
+body[data-page-mode="landing"] .f,
 body[data-page-mode="landing"] main.m,
 body[data-page-mode="landing"] .h-code,
 body[data-page-mode="landing"] .h-live,
+body[data-page-mode="landing"] .menu-scrim,
+body[data-page-mode="landing"] .menu-sheet,
+body[data-page-mode="landing"] .sheet-scrim,
+body[data-page-mode="landing"] .sheet,
+body[data-page-mode="landing"] .kbd-overlay,
+body[data-page-mode="landing"] .live-assist-scrim,
 body[data-page-mode="landing"] #live-assist-rail,
 body[data-page-mode="landing"] .welcome {
   display: none !important;
@@ -1736,16 +1748,23 @@ body[data-page-mode="landing"] .welcome {
   text-transform: uppercase;
   color: var(--ink-muted);
 }
-.landing-pulse__live {
+.landing-pulse__chips {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.landing-pulse__chip {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  margin-top: 6px;
   font-family: var(--ui);
   font-size: 13px;
   color: var(--ink-faint);
 }
-.landing-pulse__live #landing-pulse-live { color: var(--ink); font-weight: 600; }
+.landing-pulse__chip strong { color: var(--ink); font-weight: 600; }
 .landing-pulse__dot {
   width: 7px;
   height: 7px;
@@ -2185,40 +2204,37 @@ function _snInitLandingStats() {
     var wrap = document.getElementById('landing-pulse');
     var numEl = document.getElementById('landing-pulse-num');
     var liveEl = document.getElementById('landing-pulse-live');
+    var activeEl = document.getElementById('landing-pulse-active');
     var sufEl = document.getElementById('landing-pulse-suffix');
     if (!wrap || !numEl || !liveEl) return;
     var reduce = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
-    var shownRooms = 0;
-    var shownLive = 0;
+    var shownRooms = 0, shownLive = 0, shownActive = 0;
     var raf = null;
 
-    // Animate rooms AND liveNow together with identical easing. Live rooms are
-    // always a subset of total rooms (liveNow <= roomsCreated), but if only the
-    // rooms count animated up from 0 while liveNow was set instantly, the first
-    // ~750ms could show "6 live · 4 total" — which reads as a broken/fake number
-    // on the one stat that must be trustworthy. Easing both from the same prior
-    // values keeps rooms >= live at every frame.
-    function animatePair(roomsTarget, liveTarget) {
+    // Ease all three numbers from their prior values on ONE clock. rooms/live
+    // share a subset invariant (liveNow <= roomsCreated), so identical easing
+    // keeps displayed-live <= displayed-rooms at every frame (never a "6 live ·
+    // 4 total" flash). activeNow is a different unit (sessions) and may exceed
+    // rooms — that's fine, it just rides the same clock.
+    function animateTrio(roomsT, liveT, activeT) {
       if (raf) { cancelAnimationFrame(raf); raf = null; }
-      if (reduce || (shownRooms === roomsTarget && shownLive === liveTarget)) {
-        numEl.textContent = _snFmtStat(roomsTarget);
-        liveEl.textContent = _snFmtStat(liveTarget);
-        shownRooms = roomsTarget;
-        shownLive = liveTarget;
+      if (reduce || (shownRooms === roomsT && shownLive === liveT && shownActive === activeT)) {
+        numEl.textContent = _snFmtStat(roomsT);
+        liveEl.textContent = _snFmtStat(liveT);
+        if (activeEl) activeEl.textContent = _snFmtStat(activeT);
+        shownRooms = roomsT; shownLive = liveT; shownActive = activeT;
         return;
       }
-      var fromR = shownRooms;
-      var fromL = shownLive;
-      var start = null;
-      var dur = 750;
+      var fR = shownRooms, fL = shownLive, fA = shownActive, start = null, dur = 750;
       function step(ts) {
         if (start === null) start = ts;
         var p = Math.min(1, (ts - start) / dur);
-        var eased = 1 - Math.pow(1 - p, 3);
-        numEl.textContent = _snFmtStat(Math.round(fromR + (roomsTarget - fromR) * eased));
-        liveEl.textContent = _snFmtStat(Math.round(fromL + (liveTarget - fromL) * eased));
+        var e = 1 - Math.pow(1 - p, 3);
+        numEl.textContent = _snFmtStat(Math.round(fR + (roomsT - fR) * e));
+        liveEl.textContent = _snFmtStat(Math.round(fL + (liveT - fL) * e));
+        if (activeEl) activeEl.textContent = _snFmtStat(Math.round(fA + (activeT - fA) * e));
         if (p < 1) { raf = requestAnimationFrame(step); }
-        else { raf = null; shownRooms = roomsTarget; shownLive = liveTarget; }
+        else { raf = null; shownRooms = roomsT; shownLive = liveT; shownActive = activeT; }
       }
       raf = requestAnimationFrame(step);
     }
@@ -2229,7 +2245,25 @@ function _snInitLandingStats() {
       if (rooms < 1) { wrap.hidden = true; return; }  // honest: hide empty, never fake
       wrap.hidden = false;
       if (sufEl) sufEl.textContent = stats.capped ? '+' : '';
-      animatePair(rooms, Math.max(0, stats.liveNow || 0));
+      animateTrio(rooms, Math.max(0, stats.liveNow || 0), Math.max(0, stats.activeNow || 0));
+    }
+
+    function subscribe(client) {
+      // Reactive first — ticks the instant the backend changes. Fall back to a
+      // 25s poll for older Convex browser clients that lack onUpdate.
+      if (client.onUpdate) {
+        try {
+          client.onUpdate('events:getLandingStats', {}, function (stats) { try { render(stats); } catch (e) {} });
+          return;
+        } catch (e) { /* fall through to polling */ }
+      }
+      var poll = function () {
+        client.query('events:getLandingStats', {})
+          .then(function (stats) { try { render(stats); } catch (e) {} })
+          .catch(function () {});
+      };
+      poll();
+      window._sn_landing_stats.pollTimer = setInterval(poll, 25000);
     }
 
     function connect() {
@@ -2242,9 +2276,7 @@ function _snInitLandingStats() {
             if (!ConvexClient) throw new Error('noclient');
             var client = new ConvexClient(cfg.convexUrl);
             window._sn_landing_stats = { client: client };
-            client.onUpdate('events:getLandingStats', {}, function (stats) {
-              try { render(stats); } catch (e) {}
-            });
+            subscribe(client);
           });
         })
         .catch(function () { /* honest: backend unreachable -> stat stays hidden */ });
@@ -2272,9 +2304,15 @@ if (document.readyState === 'loading') {
         <span id="landing-pulse-num">0</span><span class="landing-pulse__suffix" id="landing-pulse-suffix"></span>
       </div>
       <div class="landing-pulse__label">rooms spun up on ScratchNode</div>
-      <div class="landing-pulse__live">
-        <span class="landing-pulse__dot" aria-hidden="true"></span>
-        <span id="landing-pulse-live">0</span> live right now
+      <div class="landing-pulse__chips">
+        <span class="landing-pulse__chip">
+          <span class="landing-pulse__dot landing-pulse__dot--active" aria-hidden="true"></span>
+          <strong id="landing-pulse-active">0</strong> active now
+        </span>
+        <span class="landing-pulse__chip">
+          <span class="landing-pulse__dot" aria-hidden="true"></span>
+          <strong id="landing-pulse-live">0</strong> live right now
+        </span>
       </div>
     </div>
     <span class="landing-logo">Scratch<span>Node</span></span>

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -115,7 +115,7 @@ async function fulfillScratchNodePage(
               setTimeout(() => cb([{ displayName: 'Mock Host' }, { displayName: 'Mock Guest' }]), 0);
             }
             if (name === 'events:getLandingStats') {
-              const s = window.__snLandingStats || { roomsCreated: 0, liveNow: 0, capped: false };
+              const s = window.__snLandingStats || { roomsCreated: 0, liveNow: 0, activeNow: 0, capped: false };
               setTimeout(() => cb(s), 0);
             }
           }
@@ -383,16 +383,17 @@ test.describe("ScratchNode live route honesty", () => {
   test("landing surfaces a live 'big number' room counter from real backend data", async ({ page }) => {
     await fulfillScratchNodePage(page);
     await page.addInitScript(() => {
-      (window as any).__snLandingStats = { roomsCreated: 1342, liveNow: 7, capped: false };
+      (window as any).__snLandingStats = { roomsCreated: 1342, liveNow: 7, activeNow: 18, capped: false };
     });
 
     await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
     await expect(page.locator("#landing-pulse")).toBeVisible({ timeout: 6_000 });
-    // The big number is the EXACT reactive backend count — never a marketing figure.
+    // Every number is the EXACT reactive backend count — never a marketing figure.
     await expect
       .poll(() => page.locator("#landing-pulse-num").textContent(), { timeout: 6_000 })
       .toBe("1,342");
     await expect(page.locator("#landing-pulse-live")).toHaveText("7");
+    await expect(page.locator("#landing-pulse-active")).toHaveText("18");
     await expect(page.locator("#landing-pulse-suffix")).toHaveText("");
   });
 
@@ -428,17 +429,16 @@ test.describe("ScratchNode live route honesty", () => {
   test("landing counter never shows more 'live' than 'total' during the count-up", async ({ page }) => {
     await fulfillScratchNodePage(page);
     await page.addInitScript(() => {
-      // liveNow close to (but <=) total — the regression flashed "6 live · 4 total"
-      // because rooms animated from 0 while liveNow was set instantly.
-      (window as any).__snLandingStats = { roomsCreated: 8, liveNow: 6, capped: false };
+      // liveNow close to (but <=) total — live rooms are a subset of total, so the
+      // displayed live count must never exceed the displayed total at any frame.
+      (window as any).__snLandingStats = { roomsCreated: 8, liveNow: 6, activeNow: 40, capped: false };
     });
 
     await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
     await expect(page.locator("#landing-pulse")).toBeVisible({ timeout: 6_000 });
 
-    // Sample both numbers repeatedly across the ~750ms count-up. Live rooms are a
-    // subset of total rooms, so the displayed live count must NEVER exceed the
-    // displayed total at any frame.
+    // Sample both numbers repeatedly across the ~750ms count-up. The displayed
+    // live count must NEVER exceed the displayed total at any frame.
     const parse = (s: string | null) => parseInt((s || "0").replace(/,/g, ""), 10);
     for (let i = 0; i < 14; i++) {
       const { rooms, live } = await page.evaluate(() => ({
@@ -454,5 +454,7 @@ test.describe("ScratchNode live route honesty", () => {
     // …and it settles on the exact real values.
     await expect.poll(() => page.locator("#landing-pulse-num").textContent()).toBe("8");
     await expect(page.locator("#landing-pulse-live")).toHaveText("6");
+    // activeNow is a different unit (sessions) and is allowed to exceed rooms.
+    await expect(page.locator("#landing-pulse-active")).toHaveText("40");
   });
 });


### PR DESCRIPTION
## What
A **cognitive synthesis** of the two parallel landing implementations (Codex + Claude) — cherry-picking the strongest micro-decisions from each into one prod landing, rather than picking a winner.

## Cherry-picked from Codex's branches
- **Real "active now" counting** (the thing I originally punted on): added `by_startedAt` + `by_status_startedAt` (liveEvents) and `by_lastSeen` (liveEventMembers) indexes so `events:getLandingStats` reports **member sessions within the 5-min presence TTL** alongside rooms-created + live-rooms — each index-scanned and bounded (10k events / 5k sessions, surfaced as "N+" when capped).
- **25s poll fallback** for Convex browser clients that lack `onUpdate`.
- **Full landing-mode chrome hide** (`.h` header, `.f` footer, menu/sheet/shortcut overlays) — **fixes a real leak** where room chrome rendered below the apex landing and you could scroll into it.

## Kept from Claude
- The viral **"The room remembers everything"** headline + matching OG card.
- **Honest hide-on-zero** (never a fabricated "0").
- The **synced-easing invariant** — superseded `animatePair` with `animateTrio`, easing all three numbers (rooms + live + active) on one clock so displayed-live never exceeds displayed-total during the count-up.

The counter now shows a big **rooms-created** with `● N active now · N live right now` chips.

## Verification
- **tsc** clean (exit 0); rebased cleanly on top of #475.
- **14/14** honesty suite green (incl. the trio invariant test + a new `activeNow` assertion).
- Preview: chrome-leak fix confirmed (header/footer `display:none` on the landing) + chips render.

## Note
- Schema change is **additive indexes only** — no data migration; Convex builds them on deploy.
- **Deferred to a follow-up:** Create-first form hierarchy (lower value / higher risk to the working create flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)