### PR TITLE
fix(scratchnode): tolerate lastActivityAt drift so Convex deploy passes

### DIFF
--- a/convex/schema/eventsSchema.ts
+++ b/convex/schema/eventsSchema.ts
@@ -32,6 +32,13 @@ export const liveEvents = defineTable({
   ),
   startedAt: v.number(),
   endedAt: v.optional(v.number()),
+  // Tolerated drift field: a parallel agent (Codex live-metrics) deployed a
+  // schema variant to prod that stamped `lastActivityAt` onto liveEvents rows
+  // before this branch added its indexes. Declaring it optional lets the
+  // schema validate the existing prod data so `npx convex deploy` succeeds
+  // (it was failing with "extra field `lastActivityAt` not in the validator").
+  // No current code writes it; keep until the row is rewritten or pruned.
+  lastActivityAt: v.optional(v.number()),
 })
   .index("by_slug", ["slug"])
   .index("by_roomCode", ["roomCode"])


### PR DESCRIPTION
## Why
The Convex Deploy for #476 (the landing synthesis) **failed**, which is why the synthesis isn't live yet:

```
✖ Schema validation failed. Document in table "liveEvents" contains extra
  field `lastActivityAt` that is not in the validator.
```

A parallel agent (Codex live-metrics) deployed a schema variant to the **same prod deployment** earlier that stamped `lastActivityAt` onto `liveEvents` rows. When #476 added its indexes, Convex re-validated every row and rejected the drifted demo-event document. Neither `main` nor Codex's current branch declares the field, and no code writes it — orphaned drift.

## Fix
Declare `lastActivityAt: v.optional(v.number())` so the validator accepts the existing prod data (forward-compatible, **no data migration**). This unblocks `npx convex deploy`, which then ships the synthesis indexes (`by_startedAt` / `by_status_startedAt` / `by_lastSeen`) that `events:getLandingStats` needs for the live "active now" counter — and the merge re-triggers the stuck Vercel frontend deploy.

One-line change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)