### PR TITLE
feat(scratchnode): add public room discovery

### DIFF
--- a/convex/events.runtime-boundary.test.ts
+++ b/convex/events.runtime-boundary.test.ts
@@ -93,6 +93,40 @@ describe("scratchnode public runtime boundaries", () => {
     expect(getMyEvents).toContain("hosted");
   });
 
+  it("keeps landing stats and public room discovery bounded and activity-based", () => {
+    const getLandingStats = functionBlock("getLandingStats", "query");
+    const listPublicRooms = functionBlock("listPublicRooms", "query");
+    const createEvent = functionBlock("createEvent");
+
+    expect(eventsSchemaSource).toContain("publicDiscoverable");
+    expect(eventsSchemaSource).toContain("joinPolicy");
+    expect(eventsSchemaSource).toContain("lastActivityAt");
+    expect(eventsSchemaSource).toContain("by_public_status_startedAt");
+
+    expect(getLandingStats).toContain("MAX_LANDING_EVENT_SCAN");
+    expect(getLandingStats).toContain("MAX_LANDING_SESSION_SCAN");
+    expect(getLandingStats).toContain("PUBLIC_ROOM_ACTIVE_WINDOW_MS");
+    expect(getLandingStats).toContain("getEventActivityAt");
+
+    expect(listPublicRooms).toContain("MAX_PUBLIC_ROOM_CARDS");
+    expect(listPublicRooms).toContain("MAX_PUBLIC_ROOM_CANDIDATES");
+    expect(listPublicRooms).toContain('q.eq("publicDiscoverable", true)');
+    expect(listPublicRooms).toContain("activeSessionsCapped");
+
+    expect(createEvent).toContain("publicDiscoverable: args.publicDiscoverable === true");
+    expect(createEvent).toContain('joinPolicy: args.joinPolicy || "open"');
+  });
+
+  it("does not let passive heartbeats keep public room listings warm", () => {
+    const joinEvent = functionBlock("joinEvent");
+    const sendMessage = functionBlock("sendMessage");
+    const heartbeat = functionBlock("heartbeat");
+
+    expect(joinEvent).toContain("lastActivityAt: now");
+    expect(sendMessage).toContain("lastActivityAt: now");
+    expect(heartbeat).not.toContain("lastActivityAt");
+  });
+
   it("keeps host claim idempotent for the same owner key before rejecting claimed rooms", () => {
     const claimHost = functionBlock("claimHost");
     const ownerLookup = claimHost.indexOf('withIndex("by_event_owner"');

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -6,6 +6,8 @@
  *
  * Public API surface (called from public/proto/home-v5.html):
  *   - getEventBySlug({ slug })
+ *   - getLandingStats()                            // bounded landing social proof
+ *   - listPublicRooms({ limit? })                  // opt-in, recently active public directory
  *   - getMessages({ eventId, limit? })            // realtime subscription
  *   - getMembers({ eventId })                     // realtime subscription
  *   - getMyEvents({ sessionId, ownerKey, limit? }) // lightweight account/event state
@@ -73,6 +75,10 @@ const ASK_RATE_LIMIT_PER_MIN = 12;
 const ASK_RATE_WINDOW_MS = 60_000;
 const MAX_ANSWER_LIMIT = 100;
 const MAX_MY_EVENTS_LIMIT = 50;
+const MAX_PUBLIC_ROOM_CARDS = 8;
+const MAX_PUBLIC_ROOM_CANDIDATES = 40;
+const MAX_PUBLIC_ROOM_ACTIVE_MEMBERS = 50;
+const PUBLIC_ROOM_ACTIVE_WINDOW_MS = 30 * 60 * 1000;
 const MAX_WIKI_ANSWERS = 20;
 // Phase 4 raised this from 80 -> 120 to fit HMAC-signed host tokens
 // (hk1:<eventIdShort>:<nonce>:<issuedAt>:<hmacShort> ~ 80-90 chars).
@@ -101,6 +107,10 @@ const isLikelyValidEmail = (value: string | undefined): value is string => {
   if (trimmed.length > MAX_EMAIL_LEN) return false;
   return EMAIL_REGEX.test(trimmed);
 };
+
+function getEventActivityAt(event: { startedAt: number; lastActivityAt?: number }): number {
+  return event.lastActivityAt ?? event.startedAt;
+}
 
 const DEMO_SOURCES = [
   {
@@ -836,7 +846,7 @@ const MAX_LANDING_SESSION_SCAN = 5000;
  * contributed the index-backed presence counting; this keeps the reactive +
  * honest-hide framing):
  *   - roomsCreated: every room ever made (ended rooms keep their row) — by_startedAt
- *   - liveNow:      rooms still open (status=live)                     — by_status_startedAt
+ *   - liveNow:      open rooms with recent create/join/chat activity
  *   - activeNow:    member sessions seen within the presence TTL       — by_lastSeen
  *
  * Honesty (agentic_reliability HONEST_SCORES): every number is a real row count —
@@ -862,12 +872,83 @@ export const getLandingStats = query({
       .query("liveEventMembers")
       .withIndex("by_lastSeen", (q) => q.gte("lastSeenAt", cutoff))
       .take(MAX_LANDING_SESSION_SCAN + 1);
+    const activeCutoff = Date.now() - PUBLIC_ROOM_ACTIVE_WINDOW_MS;
+    let liveNow = 0;
+    for (const row of liveRows) {
+      if (row.status === "live" && getEventActivityAt(row) >= activeCutoff) liveNow += 1;
+    }
     return {
       roomsCreated: Math.min(rooms.length, MAX_LANDING_EVENT_SCAN),
-      liveNow: Math.min(liveRows.length, MAX_LANDING_EVENT_SCAN),
+      liveNow,
       activeNow: Math.min(activeRows.length, MAX_LANDING_SESSION_SCAN),
       capped: rooms.length > MAX_LANDING_EVENT_SCAN,
       activeCapped: activeRows.length > MAX_LANDING_SESSION_SCAN,
+    };
+  },
+});
+
+/**
+ * Public room directory for the apex landing.
+ *
+ * Cost and privacy rules:
+ * - Opt-in only (`publicDiscoverable === true`); old/code-only/test rooms stay hidden.
+ * - Recently active only; an idle tab heartbeat does not refresh lastActivityAt.
+ * - Bounded candidate scan and bounded per-card presence count.
+ */
+export const listPublicRooms = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { limit }) => {
+    const safeLimit = Math.min(Math.max(limit ?? 4, 1), MAX_PUBLIC_ROOM_CARDS);
+    const activeCutoff = Date.now() - PUBLIC_ROOM_ACTIVE_WINDOW_MS;
+    const presenceCutoff = Date.now() - PRESENCE_TTL_MS;
+    const rows = await ctx.db
+      .query("liveEvents")
+      .withIndex("by_public_status_startedAt", (q) =>
+        q.eq("publicDiscoverable", true).eq("status", "live"),
+      )
+      .order("desc")
+      .take(MAX_PUBLIC_ROOM_CANDIDATES);
+
+    const rooms: Array<{
+      eventId: string;
+      slug: string;
+      name: string;
+      roomCode: string;
+      startedAt: number;
+      lastActivityAt: number;
+      activeSessions: number;
+      activeSessionsCapped: boolean;
+      joinPolicy: "open" | "request";
+    }> = [];
+
+    for (const event of rows) {
+      const lastActivityAt = getEventActivityAt(event);
+      if (lastActivityAt < activeCutoff) continue;
+      const members = await ctx.db
+        .query("liveEventMembers")
+        .withIndex("by_event_lastSeen", (q) =>
+          q.eq("eventId", event._id).gte("lastSeenAt", presenceCutoff),
+        )
+        .take(MAX_PUBLIC_ROOM_ACTIVE_MEMBERS + 1);
+      rooms.push({
+        eventId: String(event._id),
+        slug: event.slug,
+        name: event.name,
+        roomCode: event.roomCode,
+        startedAt: event.startedAt,
+        lastActivityAt,
+        activeSessions: Math.min(members.length, MAX_PUBLIC_ROOM_ACTIVE_MEMBERS),
+        activeSessionsCapped: members.length > MAX_PUBLIC_ROOM_ACTIVE_MEMBERS,
+        joinPolicy: event.joinPolicy ?? "open",
+      });
+      if (rooms.length >= safeLimit) break;
+    }
+
+    return {
+      rooms,
+      activeWindowMs: PUBLIC_ROOM_ACTIVE_WINDOW_MS,
     };
   },
 });
@@ -1414,6 +1495,8 @@ export const createEvent = mutation({
     roomCode: v.optional(v.string()),
     agendaText: v.optional(v.string()),
     status: v.optional(v.union(v.literal("draft"), v.literal("live"))),
+    publicDiscoverable: v.optional(v.boolean()),
+    joinPolicy: v.optional(v.union(v.literal("open"), v.literal("request"))),
   },
   handler: async (ctx, args) => {
     // Fail before writing if production host-token env is missing.
@@ -1525,7 +1608,10 @@ export const createEvent = mutation({
       name: title,
       roomCode,
       status,
+      publicDiscoverable: args.publicDiscoverable === true,
+      joinPolicy: args.joinPolicy || "open",
       startedAt: now,
+      lastActivityAt: now,
     });
 
     const safeName = (args.displayName || "Host").slice(0, MAX_DISPLAY_NAME).trim() || "Host";
@@ -1572,6 +1658,8 @@ export const createEvent = mutation({
       name: title,
       roomCode,
       status,
+      publicDiscoverable: args.publicDiscoverable === true,
+      joinPolicy: args.joinPolicy || "open",
       ownerKey,
       hostId,
       sourceId,
@@ -1586,8 +1674,10 @@ export const updateEvent = mutation({
     title: v.optional(v.string()),
     roomCode: v.optional(v.string()),
     status: v.optional(v.union(v.literal("draft"), v.literal("live"))),
+    publicDiscoverable: v.optional(v.boolean()),
+    joinPolicy: v.optional(v.union(v.literal("open"), v.literal("request"))),
   },
-  handler: async (ctx, { eventId, ownerKey, title, roomCode, status }) => {
+  handler: async (ctx, { eventId, ownerKey, title, roomCode, status, publicDiscoverable, joinPolicy }) => {
     await requireHost(ctx, eventId, ownerKey);
     const event = await ctx.db.get(eventId);
     if (!event) {
@@ -1614,8 +1704,16 @@ export const updateEvent = mutation({
     if (status !== undefined) {
       patch.status = status;
       if (status === "live" && event.status === "draft") {
-        patch.startedAt = Date.now();
+        const now = Date.now();
+        patch.startedAt = now;
+        patch.lastActivityAt = now;
       }
+    }
+    if (publicDiscoverable !== undefined) {
+      patch.publicDiscoverable = publicDiscoverable;
+    }
+    if (joinPolicy !== undefined) {
+      patch.joinPolicy = joinPolicy;
     }
     if (roomCode !== undefined) {
       const nextRoomCode = normalizeRequestedRoomCode(roomCode);
@@ -1651,6 +1749,8 @@ export const updateEvent = mutation({
       name: updated?.name ?? event.name,
       roomCode: updated?.roomCode ?? event.roomCode,
       status: updated?.status ?? event.status,
+      publicDiscoverable: updated?.publicDiscoverable ?? event.publicDiscoverable ?? false,
+      joinPolicy: updated?.joinPolicy ?? event.joinPolicy ?? "open",
     };
   },
 });
@@ -1817,6 +1917,7 @@ export const joinEvent = mutation({
         lastSeenAt: now,
       });
     }
+    await ctx.db.patch(event._id, { lastActivityAt: now });
 
     return {
       eventId: event._id,
@@ -1926,6 +2027,7 @@ export const sendMessage = mutation({
 
     // Bump presence as a side effect of sending (saves a heartbeat round trip).
     await ctx.db.patch(member._id, { lastSeenAt: now });
+    await ctx.db.patch(args.eventId, { lastActivityAt: now });
 
     return { messageId, createdAt: now };
   },
@@ -2905,7 +3007,10 @@ export const ensureDemoEvent = mutation({
       name: "AI Infra Summit",
       roomCode: "ORBITAL",
       status: "live",
+      publicDiscoverable: false,
+      joinPolicy: "open",
       startedAt: Date.now(),
+      lastActivityAt: Date.now(),
     });
     const sourcesInserted = await ensureDemoSourcesForEvent(ctx, id);
     return { eventId: id, created: true, sourcesInserted };

--- a/convex/schema/eventsSchema.ts
+++ b/convex/schema/eventsSchema.ts
@@ -30,15 +30,16 @@ export const liveEvents = defineTable({
     v.literal("live"),
     v.literal("ended"),
   ),
+  publicDiscoverable: v.optional(v.boolean()),          // opt-in listing on the apex landing
+  joinPolicy: v.optional(v.union(
+    v.literal("open"),
+    v.literal("request"),
+  )),
   startedAt: v.number(),
-  endedAt: v.optional(v.number()),
-  // Tolerated drift field: a parallel agent (Codex live-metrics) deployed a
-  // schema variant to prod that stamped `lastActivityAt` onto liveEvents rows
-  // before this branch added its indexes. Declaring it optional lets the
-  // schema validate the existing prod data so `npx convex deploy` succeeds
-  // (it was failing with "extra field `lastActivityAt` not in the validator").
-  // No current code writes it; keep until the row is rewritten or pruned.
+  // create/join/message activity; heartbeat does not keep listings warm.
+  // Also validates existing prod rows from the earlier live-metrics drift.
   lastActivityAt: v.optional(v.number()),
+  endedAt: v.optional(v.number()),
 })
   .index("by_slug", ["slug"])
   .index("by_roomCode", ["roomCode"])
@@ -46,7 +47,8 @@ export const liveEvents = defineTable({
   // total room count and the "live rooms right now" count, so the apex counter
   // never full-scans the table. Additive — Convex builds them on deploy.
   .index("by_startedAt", ["startedAt"])
-  .index("by_status_startedAt", ["status", "startedAt"]);
+  .index("by_status_startedAt", ["status", "startedAt"])
+  .index("by_public_status_startedAt", ["publicDiscoverable", "status", "startedAt"]);
 
 // ------------------------------------------------------------------
 // liveEventMembers — anonymous presence per event

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -1693,7 +1693,15 @@ body[data-page-mode="landing"] .sheet,
 body[data-page-mode="landing"] .kbd-overlay,
 body[data-page-mode="landing"] .live-assist-scrim,
 body[data-page-mode="landing"] #live-assist-rail,
+body[data-page-mode="landing"] #live-assist-sheet,
+body[data-page-mode="landing"] #live-assist-scrim,
+body[data-page-mode="landing"] #sheet,
+body[data-page-mode="landing"] #sheet-scrim,
 body[data-page-mode="landing"] .welcome {
+  display: none !important;
+}
+body[data-page-mode="landing"] .menu-sheet:not([data-open="true"]),
+body[data-page-mode="landing"] .menu-scrim:not([data-open="true"]) {
   display: none !important;
 }
 
@@ -1918,6 +1926,23 @@ body[data-page-mode="landing"] .welcome {
   display: flex;
   gap: 8px;
 }
+.landing-discovery-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  max-width: 420px;
+  font-family: var(--ui);
+  font-size: 12px;
+  color: var(--ink-muted);
+  text-align: left;
+  cursor: pointer;
+}
+.landing-discovery-toggle input {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--accent);
+}
 .landing-create input {
   font-family: var(--ui);
   font-size: 15px;
@@ -1935,6 +1960,14 @@ body[data-page-mode="landing"] .welcome {
   box-shadow: 0 0 0 3px rgba(217,119,87,.18);
 }
 .landing-create input::placeholder { color: var(--ink-faint); }
+.landing-create .landing-discovery-toggle input {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
 /* Outline-accent so "Join" stays the single primary CTA; Create is clearly
    available but secondary in the visual hierarchy. */
 /* Create is now the PRIMARY action — filled accent. */
@@ -1968,6 +2001,79 @@ body[data-page-mode="landing"] .welcome {
 }
 .landing-create-status[data-state="busy"] { color: var(--accent); }
 .landing-create-status[data-state="error"] { color: #d98b7a; }
+.landing-public {
+  display: none;
+  width: 100%;
+  max-width: 560px;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 2px;
+}
+.landing-public[data-visible="true"] { display: flex; }
+.landing-public-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-family: var(--ui);
+}
+.landing-public-head b {
+  font-size: 12px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+.landing-public-head span {
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+.landing-public-list {
+  display: grid;
+  gap: 8px;
+}
+.landing-room-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 12px 12px 14px;
+  border: 1px solid rgba(255,255,255,.1);
+  border-radius: 8px;
+  background: rgba(255,255,255,.045);
+  text-align: left;
+}
+.landing-room-title {
+  font-family: var(--ui);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.landing-room-meta {
+  margin-top: 3px;
+  font-family: var(--ui);
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+.landing-room-join {
+  font-family: var(--ui);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent);
+  text-decoration: none;
+  border: 1px solid rgba(217,119,87,.65);
+  border-radius: 7px;
+  padding: 8px 10px;
+  white-space: nowrap;
+}
+.landing-room-join:hover,
+.landing-room-join:focus-visible {
+  background: var(--accent);
+  color: #fff;
+  outline: none;
+}
 @media (max-width: 600px) {
   .landing-hero h1 { font-size: 22px; }
   .landing-hero p { font-size: 14px; }
@@ -1975,6 +2081,8 @@ body[data-page-mode="landing"] .welcome {
   .landing-join button { width: 100%; }
   .landing-create-sub { flex-direction: column; }
   .landing-create button { width: 100%; }
+  .landing-room-card { grid-template-columns: 1fr; }
+  .landing-room-join { text-align: center; }
   .landing-pulse__big { font-size: 48px; }
   .landing-pulse__suffix { font-size: 30px; }
 }
@@ -1983,6 +2091,7 @@ body[data-page-mode="landing"] .welcome {
   .landing-join button,
   .landing-create input,
   .landing-create button,
+  .landing-room-join,
   .landing-secondary { transition: none; }
   .landing-pulse,
   .landing-pulse__dot { animation: none; }
@@ -2084,10 +2193,12 @@ async function _landingCreate(ev) {
   try { ev.preventDefault(); } catch (e) {}
   var nameEl = document.getElementById('landing-create-name');
   var codeEl = document.getElementById('landing-create-code');
+  var discoverEl = document.getElementById('landing-create-public');
   var btn = document.getElementById('landing-create-btn');
   var statusEl = document.getElementById('landing-create-status');
   var title = String((nameEl && nameEl.value) || '').trim();
   var roomCode = String((codeEl && codeEl.value) || '').trim();
+  var publicDiscoverable = !!(discoverEl && discoverEl.checked);
 
   function setStatus(msg, state) {
     if (!statusEl) return;
@@ -2151,6 +2262,8 @@ async function _landingCreate(ev) {
         displayName: displayName,
         roomCode: roomCode || undefined,
         status: 'live',
+        publicDiscoverable: publicDiscoverable,
+        joinPolicy: 'open',
       });
     } catch (e) {
       try { client.close && client.close(); } catch (_) {}
@@ -2257,6 +2370,7 @@ function _snInitLandingStats() {
       if (client.onUpdate) {
         try {
           client.onUpdate('events:getLandingStats', {}, function (stats) { try { render(stats); } catch (e) {} });
+          client.onUpdate('events:listPublicRooms', { limit: 4 }, function (rooms) { try { renderPublicRooms(rooms); } catch (e) {} });
           return;
         } catch (e) { /* fall through to polling */ }
       }
@@ -2264,9 +2378,59 @@ function _snInitLandingStats() {
         client.query('events:getLandingStats', {})
           .then(function (stats) { try { render(stats); } catch (e) {} })
           .catch(function () {});
+        client.query('events:listPublicRooms', { limit: 4 })
+          .then(function (rooms) { try { renderPublicRooms(rooms); } catch (e) {} })
+          .catch(function () {});
       };
       poll();
       window._sn_landing_stats.pollTimer = setInterval(poll, 25000);
+    }
+
+    function roomUrl(room) {
+      var slug = room && (room.slug || room.roomCode);
+      return '/e/' + encodeURIComponent(String(slug || '').toLowerCase());
+    }
+
+    function renderPublicRooms(payload) {
+      var section = document.getElementById('landing-public');
+      var list = document.getElementById('landing-public-list');
+      var countEl = document.getElementById('landing-public-count');
+      if (!section || !list) return;
+      var rooms = payload && Array.isArray(payload.rooms) ? payload.rooms : [];
+      list.innerHTML = '';
+      if (!rooms.length) {
+        section.removeAttribute('data-visible');
+        if (countEl) countEl.textContent = '';
+        return;
+      }
+      section.setAttribute('data-visible', 'true');
+      if (countEl) countEl.textContent = rooms.length === 1 ? '1 open' : rooms.length + ' open';
+      rooms.slice(0, 4).forEach(function(room) {
+        var card = document.createElement('article');
+        card.className = 'landing-room-card';
+
+        var copy = document.createElement('div');
+        var title = document.createElement('div');
+        title.className = 'landing-room-title';
+        title.textContent = String(room.name || 'Untitled room');
+        var meta = document.createElement('div');
+        meta.className = 'landing-room-meta';
+        var active = Number(room.activeSessions || 0);
+        var activeText = active > 0
+          ? active.toLocaleString('en-US') + (room.activeSessionsCapped ? '+' : '') + ' active'
+          : 'Open for guests';
+        meta.textContent = activeText + ' · code ' + String(room.roomCode || '').toUpperCase();
+        copy.appendChild(title);
+        copy.appendChild(meta);
+
+        var join = document.createElement('a');
+        join.className = 'landing-room-join';
+        join.href = roomUrl(room);
+        join.textContent = 'Request to join';
+        card.appendChild(copy);
+        card.appendChild(join);
+        list.appendChild(card);
+      });
     }
 
     function connect() {
@@ -2330,6 +2494,10 @@ if (document.readyState === 'loading') {
         <input type="text" id="landing-create-code" placeholder="Custom code (optional)" aria-label="Custom room code (optional)" maxlength="24" autocomplete="off" autocapitalize="characters" spellcheck="false">
         <button type="submit" id="landing-create-btn">Create room &rarr;</button>
       </div>
+      <label class="landing-discovery-toggle">
+        <input type="checkbox" id="landing-create-public">
+        <span>List this as an open public room</span>
+      </label>
     </form>
     <p class="landing-create-status" id="landing-create-status" role="status" aria-live="polite"></p>
     <div class="landing-or" aria-hidden="true"><span>or join an existing room</span></div>
@@ -2342,6 +2510,13 @@ if (document.readyState === 'loading') {
       <a href="/docs" class="landing-secondary">Read the docs &rarr;</a>
     </div>
   </div>
+  <section class="landing-public" id="landing-public" aria-label="Open public rooms">
+    <div class="landing-public-head">
+      <b>Open public rooms</b>
+      <span id="landing-public-count"></span>
+    </div>
+    <div class="landing-public-list" id="landing-public-list"></div>
+  </section>
   <div class="landing-trust" aria-label="Privacy posture">
     <span>No-account join.</span>
     <span>Public answers stay sourced.</span>

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -118,6 +118,10 @@ async function fulfillScratchNodePage(
               const s = window.__snLandingStats || { roomsCreated: 0, liveNow: 0, activeNow: 0, capped: false };
               setTimeout(() => cb(s), 0);
             }
+            if (name === 'events:listPublicRooms') {
+              const rooms = window.__snPublicRooms || [];
+              setTimeout(() => cb({ rooms, activeWindowMs: 1800000 }), 0);
+            }
           }
         }
       `,
@@ -347,6 +351,27 @@ test.describe("ScratchNode live route honesty", () => {
     await expect.poll(() => page.url(), { timeout: 5_000 }).toContain("/e/launch-room");
   });
 
+  test("landing create can opt a room into public discovery", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+
+    await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
+    await page.fill("#landing-create-name", "Open Demo Office Hours");
+    await page.check("#landing-create-public");
+    await page.click("#landing-create-btn");
+
+    await expect
+      .poll(
+        () => page.evaluate(() => JSON.parse(localStorage.getItem("__snCreatedEventArgs") || "{}")),
+        { timeout: 5_000 },
+      )
+      .toMatchObject({
+        title: "Open Demo Office Hours",
+        status: "live",
+        publicDiscoverable: true,
+        joinPolicy: "open",
+      });
+  });
+
   test("landing create rejects a too-short name without calling the backend", async ({ page }) => {
     await fulfillScratchNodePage(page);
 
@@ -378,6 +403,36 @@ test.describe("ScratchNode live route honesty", () => {
       await page.evaluate(() => localStorage.getItem("sn_host_owner_key_v2")),
     ).toBeNull();
     await expect(page.locator("#landing-create-btn")).toBeEnabled();
+  });
+
+  test("landing renders discoverable public rooms from real backend data", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+    await page.addInitScript(() => {
+      (window as any).__snLandingStats = { roomsCreated: 12, liveNow: 2, capped: false };
+      (window as any).__snPublicRooms = [
+        {
+          eventId: "liveEvents:open",
+          slug: "open-office-hours",
+          name: "Open Office Hours",
+          roomCode: "OFFICE",
+          startedAt: 1770000000000,
+          lastActivityAt: 1770000001000,
+          activeSessions: 6,
+          activeSessionsCapped: false,
+          joinPolicy: "open",
+        },
+      ];
+    });
+
+    await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("#landing-public")).toHaveAttribute("data-visible", "true", {
+      timeout: 6_000,
+    });
+    await expect(page.locator(".landing-room-title")).toHaveText("Open Office Hours");
+    await expect(page.locator(".landing-room-meta")).toContainText("6 active");
+    await expect(page.locator(".landing-room-meta")).toContainText("OFFICE");
+    await expect(page.locator(".landing-room-join")).toHaveText("Request to join");
+    await expect(page.locator(".landing-room-join")).toHaveAttribute("href", "/e/open-office-hours");
   });
 
   test("landing surfaces a live 'big number' room counter from real backend data", async ({ page }) => {


### PR DESCRIPTION
Adds opt-in public ScratchNode room discovery on the apex landing.

What changed:
- Create-room flow can opt a room into public discovery.
- Landing page subscribes to events:listPublicRooms and renders open room cards.
- Backend listPublicRooms is opt-in, live-only, recently active, and bounded.
- Landing stats keep roomsCreated and activeNow real while liveNow drops stale test rooms.

Verification:
- npx tsc --noEmit --pretty false
- npx tsc -p convex --noEmit --pretty false
- npx vitest run convex/events.runtime-boundary.test.ts
- npx playwright test tests/e2e/scratchnode-live-route-honesty.spec.ts --project=chromium --workers=1 --reporter=list
- npm run build

Convex production was deployed to https://agile-caribou-964.convex.cloud.