### PR TITLE
feat(scratchnode): directory viral slice — flyer cards, presence cue, one-tap request-to-join

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -34,12 +34,7 @@ Keep entries short and honest. Newest on top within each section.
 
 ## Active claims (who is editing what RIGHT NOW)
 
-- **2026-06-02 · Claude →** `public/proto/home-v5.html#directory` (`.landing-public*`):
-  flyer-card redesign of the public-room list + "● N inside" presence cue + wiring the
-  existing "Request to join" label to `events:requestJoinEvent`. Branch
-  `feat/scratchnode-directory-viral` (queued). **Codex: please claim a different region
-  of home-v5.html (room shell / door host-panel) or ping the human if you're mid-flight
-  on the directory.**
+- _(none right now — `home-v5.html#directory` released; shipped, see Recently shipped.)_
 
 ## Hand-offs (built + ready for the other agent to call)
 
@@ -68,6 +63,7 @@ Keep entries short and honest. Newest on top within each section.
 
 ## Recently shipped (this ScratchNode session)
 
+- **Claude** — directory viral slice (`home-v5.html#directory`): flyer cards + "● N inside" presence cue + policy-aware action (open → "Join now"; request → "Request to join" `<button>` wired to `events:requestJoinEvent`, watching `getMyJoinRequest` for approval, on the **same `sn_session_id`** so approval carries through the `joinEvent` door gate). 18/18 chromium honesty suite; desktop + mobile verified. (This consumes the Codex 8c3a0cc9 "Request to join" label hand-off.)
 - **#481 Claude** — post-create viral *share moment* (home-v5.html landing): invite card + QR + copy + Text/Email + "Enter your room →".
 - **#480 Claude** — door-policy *backend* (`convex/events.ts` + `eventsSchema.ts`): request table, gate, request/approve/deny, advisory LLM bouncer. 6/6 scenario tests.
 - **#477 Claude** — schema-drift hotfix: tolerate `lastActivityAt` so Convex deploy passed.

--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -2,6 +2,37 @@
 
 Append-only lane for the ScratchNode live-event prototype and production static surface.
 
+## 2026-06-03 — Directory viral slice: flyer cards, "● N inside" presence, one-tap request-to-join
+Closed the last gap in the viral loop on the *discovery* side. The public-rooms
+directory used to render every room as a list row with a single hardcoded
+"Request to join" link that just navigated to `/e/<slug>` — it ignored the room's
+actual `joinPolicy` and never touched the door-policy backend. Three changes:
+
+- **Flyer feel + live presence.** Each card now leads with a **"● N inside"**
+  presence cue — a pulsing green dot + the real `activeSessions` count ("friends
+  are inside"), then `· code XXXX`. Rooms with zero presence read "Open for guests".
+  Request-policy cards get a subtle terracotta wash so the two policies are
+  visually distinct. Reduced-motion disables the dot pulse.
+- **Policy-aware action.** **Open** rooms → a `Join now` `<a>` that navigates
+  straight in. **Request** rooms → a real `Request to join` `<button>` wired to
+  the live `events:requestJoinEvent` mutation.
+- **One-tap request, honest waiting.** The button files the request using the
+  **same `sn_session_id`** the room will use — so a host approval carries through
+  the `joinEvent` door gate when the guest lands in `/e/<slug>`. It then shows an
+  honest **"Requested ✓"** state (never a fake entry) and watches
+  `events:getMyJoinRequest` reactively: on **approved** it carries the guest into
+  the room; on **denied** it says "Request declined". A missing live client falls
+  back to a plain navigate (the room's own door handles the gate); any backend
+  error resets the button and surfaces a toast.
+
+Covered by an updated directory case (open room → "Join now" + "● 6 inside") and a
+new request-policy case in `scratchnode-live-route-honesty.spec.ts` (button files
+a real request with a ≥8-char sessionId, shows "Requested ✓" with no navigation,
+then a host approval carries the guest into `/e/<slug>`). 18/18 chromium honesty
+suite green; desktop + mobile (375px) flyer cards screenshot-verified.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.
+
 ## 2026-06-02 — Post-create "viral" share moment
 The shortest path from useful product to viral loop: after a host creates a room,
 they no longer drop straight into it — they land on a **"Your event is live. Invite

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -2246,6 +2246,31 @@ body[data-page-mode="landing"] .menu-scrim:not([data-open="true"]) {
   color: #fff;
   outline: none;
 }
+.landing-room-join { cursor: pointer; background: transparent; }
+/* Flyer feel for request-to-join rooms + the "● N inside" presence cue. */
+.landing-room-card[data-policy="request"] {
+  border-color: rgba(217,119,87,.28);
+  background: linear-gradient(180deg, rgba(217,119,87,.05), rgba(255,255,255,.02));
+}
+.landing-room-meta b { color: var(--ink); font-weight: 700; }
+.landing-room-meta .dot-inside {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #4ade80;
+  margin-right: 5px;
+  box-shadow: 0 0 0 0 rgba(74,222,128,.55);
+  animation: landing-pulse-dot 2.4s ease-out infinite;
+}
+.landing-room-join[data-state="pending"] { opacity: .7; pointer-events: none; }
+.landing-room-join[data-state="requested"] {
+  color: #7fe0a8;
+  border-color: rgba(74,222,128,.5);
+  background: rgba(74,222,128,.08);
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) { .landing-room-meta .dot-inside { animation: none; } }
 @media (max-width: 600px) {
   .landing-hero h1 { font-size: 22px; }
   .landing-hero p { font-size: 14px; }
@@ -2699,21 +2724,135 @@ function _snInitLandingStats() {
         var meta = document.createElement('div');
         meta.className = 'landing-room-meta';
         var active = Number(room.activeSessions || 0);
-        var activeText = active > 0
-          ? active.toLocaleString('en-US') + (room.activeSessionsCapped ? '+' : '') + ' active'
-          : 'Open for guests';
-        meta.textContent = activeText + ' · code ' + String(room.roomCode || '').toUpperCase();
+        var codeText = ' code ' + String(room.roomCode || '').toUpperCase();
+        if (active > 0) {
+          // "● N inside" — live presence cue ("friends are inside").
+          var dot = document.createElement('span');
+          dot.className = 'dot-inside';
+          dot.setAttribute('aria-hidden', 'true');
+          var strong = document.createElement('b');
+          strong.textContent = active.toLocaleString('en-US') + (room.activeSessionsCapped ? '+' : '');
+          meta.appendChild(dot);
+          meta.appendChild(strong);
+          meta.appendChild(document.createTextNode(' inside ·' + codeText));
+        } else {
+          meta.textContent = 'Open for guests ·' + codeText;
+        }
         copy.appendChild(title);
         copy.appendChild(meta);
 
-        var join = document.createElement('a');
+        // Open rooms navigate straight in; request rooms file a one-tap request
+        // against the live door-policy backend (events:requestJoinEvent).
+        var isRequest = room.joinPolicy === 'request';
+        card.setAttribute('data-policy', isRequest ? 'request' : 'open');
+        var join;
+        if (isRequest) {
+          join = document.createElement('button');
+          join.type = 'button';
+          join.textContent = 'Request to join';
+          (function (slug, btn) {
+            btn.onclick = function () { _landingRequestJoin(slug, btn); return false; };
+          })(room.slug, join);
+        } else {
+          join = document.createElement('a');
+          join.href = roomUrl(room);
+          join.textContent = 'Join now';
+        }
         join.className = 'landing-room-join';
-        join.href = roomUrl(room);
-        join.textContent = 'Request to join';
         card.appendChild(copy);
         card.appendChild(join);
         list.appendChild(card);
       });
+    }
+
+    // --- One-tap "Request to join" from the public directory -----------------
+    // Files a request against the live door-policy backend (events:requestJoinEvent)
+    // using the SAME sn_session_id the room will use, so a host approval carries
+    // through the joinEvent door gate when the guest lands in /e/<slug>. Honest:
+    // a config/backend failure resets the button and never fakes entry.
+    function _landingSessionId() {
+      var sid;
+      try {
+        sid = localStorage.getItem('sn_session_id');
+        if (!sid) {
+          sid = (window.crypto && crypto.randomUUID)
+            ? crypto.randomUUID()
+            : 'sess_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+          localStorage.setItem('sn_session_id', sid);
+        }
+      } catch (e) {
+        sid = 'sess_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+      }
+      return sid;
+    }
+
+    function _landingGoToRoom(slug) {
+      location.href = '/e/' + encodeURIComponent(String(slug || '').toLowerCase());
+    }
+
+    function _landingRequestJoin(slug, btn) {
+      var stats = window._sn_landing_stats;
+      var client = stats && stats.client;
+      // No live client yet: just navigate; the room's own door handles the gate.
+      if (!client || !client.mutation) { _landingGoToRoom(slug); return; }
+      var sessionId = _landingSessionId();
+      var displayName = (window._userName && String(window._userName).trim()) || 'Guest';
+      btn.setAttribute('data-state', 'pending');
+      btn.textContent = 'Requesting…';
+      client.mutation('events:requestJoinEvent', { slug: slug, sessionId: sessionId, displayName: displayName })
+        .then(function (res) {
+          var status = res && res.status;
+          if (status === 'open' || status === 'already_member' || status === 'approved') {
+            btn.textContent = 'Opening…';
+            _landingGoToRoom((res && res.slug) || slug);
+            return;
+          }
+          // pending — host must approve. Honest waiting state + watch for the decision.
+          btn.setAttribute('data-state', 'requested');
+          btn.textContent = 'Requested ✓';
+          _landingWatchRequest(slug, sessionId, btn);
+        })
+        .catch(function (e) {
+          btn.removeAttribute('data-state');
+          btn.textContent = 'Request to join';
+          if (typeof toast === 'function') {
+            try { toast('Could not send request', (e && e.message) || 'Please try again.'); } catch (_) {}
+          }
+        });
+    }
+
+    function _landingWatchRequest(slug, sessionId, btn) {
+      var stats = window._sn_landing_stats;
+      var client = stats && stats.client;
+      if (!client) return;
+      var done = false, unsub = null, timer = null;
+      var finish = function () {
+        if (typeof unsub === 'function') { try { unsub(); } catch (_) {} }
+        if (timer) { clearInterval(timer); timer = null; }
+      };
+      var apply = function (st) {
+        if (done || !st) return;
+        if (st.isMember || st.status === 'approved') {
+          done = true; finish();
+          btn.textContent = 'Approved — opening…';
+          _landingGoToRoom(st.slug || slug);
+        } else if (st.status === 'denied') {
+          done = true; finish();
+          btn.setAttribute('data-state', 'pending');
+          btn.textContent = 'Request declined';
+        }
+      };
+      if (client.onUpdate) {
+        try {
+          unsub = client.onUpdate('events:getMyJoinRequest', { slug: slug, sessionId: sessionId }, function (st) { try { apply(st); } catch (_) {} });
+          return;
+        } catch (e) { /* fall through to poll */ }
+      }
+      timer = setInterval(function () {
+        client.query('events:getMyJoinRequest', { slug: slug, sessionId: sessionId })
+          .then(function (st) { try { apply(st); } catch (_) {} })
+          .catch(function () {});
+      }, 4000);
     }
 
     function connect() {

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -98,6 +98,19 @@ async function fulfillScratchNodePage(
               localStorage.setItem('__snEndedEventArgs', JSON.stringify(args));
               return Promise.resolve({ ok: true, eventId: args.eventId, status: 'ended' });
             }
+            if (name === 'events:requestJoinEvent') {
+              window.__snRequestJoinArgs = args;
+              localStorage.setItem('__snRequestJoinArgs', JSON.stringify(args));
+              const mode = window.__snRequestJoinMode || 'pending';
+              const terminal = (mode === 'open' || mode === 'already_member' || mode === 'approved');
+              return Promise.resolve({
+                ok: true,
+                status: terminal ? mode : 'pending',
+                eventId: 'liveEvents:req',
+                slug: args.slug,
+                requestId: 'liveEventJoinRequests:1',
+              });
+            }
             return Promise.resolve({});
           }
           query(name) {
@@ -121,6 +134,22 @@ async function fulfillScratchNodePage(
             if (name === 'events:listPublicRooms') {
               const rooms = window.__snPublicRooms || [];
               setTimeout(() => cb({ rooms, activeWindowMs: 1800000 }), 0);
+            }
+            if (name === 'events:getMyJoinRequest') {
+              const tick = () => {
+                const status = window.__snJoinRequestStatus || 'pending';
+                cb({
+                  eventId: 'liveEvents:req',
+                  slug: _args && _args.slug,
+                  joinPolicy: 'request',
+                  isMember: status === 'approved',
+                  status,
+                  guestMessage: null,
+                });
+              };
+              setTimeout(tick, 0);
+              const iv = setInterval(tick, 50);
+              return () => clearInterval(iv);
             }
           }
         }
@@ -472,10 +501,61 @@ test.describe("ScratchNode live route honesty", () => {
       timeout: 6_000,
     });
     await expect(page.locator(".landing-room-title")).toHaveText("Open Office Hours");
-    await expect(page.locator(".landing-room-meta")).toContainText("6 active");
+    // "● N inside" presence cue (live dot + count), not a bare "active" label.
+    await expect(page.locator(".landing-room-meta")).toContainText("6 inside");
     await expect(page.locator(".landing-room-meta")).toContainText("OFFICE");
-    await expect(page.locator(".landing-room-join")).toHaveText("Request to join");
+    await expect(page.locator(".landing-room-meta .dot-inside")).toBeVisible();
+    // Open-policy room → one-tap navigate (<a>), no approval needed.
+    await expect(page.locator(".landing-room-join")).toHaveText("Join now");
     await expect(page.locator(".landing-room-join")).toHaveAttribute("href", "/e/open-office-hours");
+  });
+
+  test("request-policy room files a one-tap join request against the live door backend", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+    await page.addInitScript(() => {
+      (window as any).__snLandingStats = { roomsCreated: 12, liveNow: 2, capped: false };
+      (window as any).__snRequestJoinMode = "pending";
+      (window as any).__snJoinRequestStatus = "pending";
+      (window as any).__snPublicRooms = [
+        {
+          eventId: "liveEvents:req",
+          slug: "rooftop-launch",
+          name: "Rooftop Launch Party",
+          roomCode: "ROOFTOP",
+          startedAt: 1770000000000,
+          lastActivityAt: 1770000001000,
+          activeSessions: 9,
+          activeSessionsCapped: false,
+          joinPolicy: "request",
+        },
+      ];
+    });
+
+    await page.goto("https://scratchnode.live/", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("#landing-public")).toHaveAttribute("data-visible", "true", {
+      timeout: 6_000,
+    });
+    const join = page.locator(".landing-room-join");
+    // Request-policy room → a real <button> wired to the backend, not a navigate <a>.
+    await expect(join).toHaveText("Request to join");
+    await expect(join).toHaveJSProperty("tagName", "BUTTON");
+
+    await join.click();
+    // Honest pending state — never a fake entry; the real door request was filed.
+    await expect(join).toHaveText("Requested ✓", { timeout: 6_000 });
+    await expect(join).toHaveAttribute("data-state", "requested");
+    expect(page.url()).toBe("https://scratchnode.live/");
+    const reqArgs = await page.evaluate(() => (window as any).__snRequestJoinArgs);
+    expect(reqArgs.slug).toBe("rooftop-launch");
+    expect(typeof reqArgs.sessionId).toBe("string");
+    expect(reqArgs.sessionId.length).toBeGreaterThanOrEqual(8);
+
+    // Host approves → the guest is carried into the room on the SAME sn_session_id,
+    // so the joinEvent door gate lets them through.
+    await page.evaluate(() => {
+      (window as any).__snJoinRequestStatus = "approved";
+    });
+    await page.waitForURL("https://scratchnode.live/e/rooftop-launch", { timeout: 6_000 });
   });
 
   test("landing surfaces a live 'big number' room counter from real backend data", async ({ page }) => {


### PR DESCRIPTION
@
## What

Closes the last gap in the viral loop on the **discovery** side. The public-rooms directory rendered every room as a list row with a single hardcoded `Request to join` link that just navigated to `/e/<slug>` — it ignored the rooms actual `joinPolicy` and never touched the door-policy backend (#480).

## Changes (`public/proto/home-v5.html`, `renderPublicRooms` + `.landing-room-*`)

- **Flyer feel + live presence** — each card leads with a **"● N inside"** cue: a pulsing green dot + the real `activeSessions` count ("friends are inside") + `· code XXXX`. Zero-presence rooms read "Open for guests". Request-policy cards get a subtle terracotta wash. Reduced-motion disables the dot pulse.
- **Policy-aware action** — **open** rooms → a `Join now` `<a>` (navigate); **request** rooms → a real `Request to join` `<button>` wired to `events:requestJoinEvent`.
- **One-tap request, honest waiting** — the request uses the **same `sn_session_id`** the room will use, so a host approval carries through the `joinEvent` door gate when the guest lands in `/e/<slug>`. Shows an honest **"Requested ✓"** (never a fake entry), watches `events:getMyJoinRequest` reactively → carries the guest in on **approved**, "Request declined" on **denied**. No live client → plain navigate (room handles its own door); backend error → reset + toast.

## Honesty contract preserved

No fabricated state, no fake entry. The apex stays `data-sn-live=null`; the only paths into a room are a real navigate (open) or a real backend-confirmed approval (request).

## Tests

`tests/e2e/scratchnode-live-route-honesty.spec.ts`:
- Updated directory case: open room → `Join now` + "● 6 inside" presence + visible dot.
- New request-policy case: button files a real `requestJoinEvent` with a ≥8-char sessionId, shows "Requested ✓" with **no navigation**, then a host approval (`getMyJoinRequest` → approved) carries the guest into `/e/rooftop-launch`.

**18/18 chromium honesty suite green.** Desktop + mobile (375px) flyer cards screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@