### PR TITLE
fix(scratchnode): make /ask answers actually shareable (honesty + missing lever)

### DIFF
--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -2,6 +2,31 @@
 
 Append-only lane for the ScratchNode live-event prototype and production static surface.
 
+## 2026-06-03 — Make /ask answers actually shareable (honesty fix + the missing lever)
+An audit of the full viral journey found the /ask answer "Share" button was a lie:
+`onclick="toast('Shared','Answer link copied.')"` claimed it copied a link while
+copying **nothing** (HONEST_STATUS violation) — and worse, the **live** answer
+renderer had no Share affordance at all, so real `/ask` answers (the single most
+screenshot-worthy unit in the room — "the output is the distribution") couldn't be
+shared.
+
+Fix: a real `_snShareAnswer(answerId, explicitQuestion)` helper that copies a
+genuine link — the room URL + the answer's question (`"<Q>" — answered live in
+<event> on ScratchNode\n<url>`) — via the native share sheet when available, else
+a real clipboard write that only toasts "Answer link copied" **after the write
+resolves** (and an honest "Couldn't copy" with the raw URL on failure). Wired into:
+the live answer renderer (which previously had Suggest/Promote/Pin/View-in-wiki but
+no Share), the autoplay demo renderer (parity), and the static demo card (de-lied).
+The live renderer now also caches each answer's question (`_sn_answer_q_by_id`) so
+the Share link carries the real question text.
+
+Covered by a new honesty case: asserts the lying `toast('Shared'` handler is gone
+from the shipped file and that `_snShareAnswer` writes a real room link + the
+question to the clipboard (forced clipboard path, captured write). 19→20 chromium
+honesty suite green; output-contract demo path green.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.
+
 ## 2026-06-03 — Directory viral slice: flyer cards, "● N inside" presence, one-tap request-to-join
 Closed the last gap in the viral loop on the *discovery* side. The public-rooms
 directory used to render every room as a list row with a single hardcoded

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -3141,7 +3141,7 @@ if (document.readyState === 'loading') {
         <button type="button" class="primary attendee-only" onclick="toast('Suggested for FAQ','The host will review and add it to the wiki.')">★ Suggest for FAQ</button>
         <button type="button" class="primary host-only" onclick="toast('Promoted to FAQ','Now part of the durable wiki.')">★ Promote to FAQ</button>
         <button type="button" onclick="openWiki()">View in wiki →</button>
-        <button type="button" onclick="toast('Shared','Answer link copied.')">Share</button>
+        <button type="button" onclick="_snShareAnswer('', 'What is the MCP auth timeline?')">Share</button>
         <button type="button" onclick="ask('Follow-up on MCP auth timeline')">Follow-up</button>
       </div>
     </article>
@@ -3975,6 +3975,32 @@ function copyRoom() {
     navigator.clipboard.writeText(text).then(function(){ toast('Copied join link', EVENT_ROOM_CODE + ' · paste in any chat.'); });
   } else {
     toast('Room: ' + EVENT_ROOM_CODE, 'Share this URL with attendees.');
+  }
+}
+
+// ── Share an /ask answer — the "answer IS the distribution" lever ──
+// HONEST_STATUS: copies a REAL link (the room URL) + the answer's question so a
+// recipient lands in the room that holds the answer. Never claims "copied" unless
+// the clipboard write actually resolved; the native share sheet is its own feedback.
+function _snShareAnswer(answerId, explicitQuestion) {
+  var url = (typeof EVENT_URL !== 'undefined' && EVENT_URL) ? EVENT_URL : location.href.split('#')[0];
+  var title = (typeof EVENT_TITLE !== 'undefined' && EVENT_TITLE) ? EVENT_TITLE : 'ScratchNode';
+  var q = explicitQuestion ||
+    (window._sn_answer_q_by_id && answerId && window._sn_answer_q_by_id[answerId]) || '';
+  var text = (q ? '"' + q + '" — answered live in ' + title + ' on ScratchNode'
+                : 'Answered live in ' + title + ' on ScratchNode') + '\n' + url;
+  if (navigator.share) {
+    navigator.share({ title: title + ' · ScratchNode', text: text, url: url }).catch(function(){});
+    return;
+  }
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(function(){
+      toast('Answer link copied', 'Paste it anywhere — it opens the room.');
+    }).catch(function(){
+      toast("Couldn't copy", url);
+    });
+  } else {
+    toast('Share this answer', url);
   }
 }
 
@@ -7042,7 +7068,7 @@ window._laCueAction       = _laCueAction;
       '<div class="ans-reuse" aria-label="Reuse summary"><span class="pin">' + agentLabel + '</span><span class="sep">·</span><span><b>' + sourceCount + '</b> reused</span><span class="sep">·</span><span class="pulled"><b>' + liveSearches + '</b> live searches</span><span class="sep">·</span><span>' + costLabel + '</span><span class="sep">·</span><span>' + qualityLabel + '</span><span class="sep">·</span><span class="priv">private notes excluded</span></div>' +
       '<button class="ans-show" type="button" aria-expanded="false" onclick="toggleHow(this)">Show trace &rarr;</button>' +
       '<div class="ans-how">' + trace + traceBoundary + '</div>' +
-      '<div class="ans-actions"><button type="button" class="primary attendee-only" onclick="window.snSuggestFaq && window.snSuggestFaq(\'' + answer._id + '\')">Suggest for FAQ</button><button type="button" class="primary host-only" onclick="window.snPromoteFaq && window.snPromoteFaq(\'' + answer._id + '\')">Promote to FAQ</button> <button type="button" class="sn-pin" onclick="window.snWall && window.snWall.pinAnswer(\'' + answer._id + '\')">&#128204; Pin to wall</button> <button type="button" onclick="openWiki()">View in wiki &rarr;</button> <button type="button" onclick="document.getElementById(\'ci\').focus()">Follow-up</button></div>';
+      '<div class="ans-actions"><button type="button" class="primary attendee-only" onclick="window.snSuggestFaq && window.snSuggestFaq(\'' + answer._id + '\')">Suggest for FAQ</button><button type="button" class="primary host-only" onclick="window.snPromoteFaq && window.snPromoteFaq(\'' + answer._id + '\')">Promote to FAQ</button> <button type="button" class="sn-pin" onclick="window.snWall && window.snWall.pinAnswer(\'' + answer._id + '\')">&#128204; Pin to wall</button> <button type="button" onclick="openWiki()">View in wiki &rarr;</button> <button type="button" onclick="window._snShareAnswer(\'' + answer._id + '\')">Share</button> <button type="button" onclick="document.getElementById(\'ci\').focus()">Follow-up</button></div>';
     article.querySelector('.ans-q').textContent = answer.question || '';
     article.querySelector('.ans-body').innerHTML = snEscape(answer.body || '').replace(/\n/g, '<br>');
     feedEl.appendChild(article);
@@ -7058,9 +7084,11 @@ window._laCueAction       = _laCueAction;
   });
   client.onUpdate('events:getAnswers', { eventId, limit: 100 }, (rows) => {
     if (!Array.isArray(rows)) return;
-    // Cache answer bodies so the Memory Wall can dereference answer pins.
+    // Cache answer bodies so the Memory Wall can dereference answer pins, and
+    // questions so the per-answer Share link can carry the real question text.
     window._sn_answers_by_id = window._sn_answers_by_id || {};
-    for (const a of rows) { if (a && a._id) window._sn_answers_by_id[a._id] = a.body || ''; }
+    window._sn_answer_q_by_id = window._sn_answer_q_by_id || {};
+    for (const a of rows) { if (a && a._id) { window._sn_answers_by_id[a._id] = a.body || ''; window._sn_answer_q_by_id[a._id] = a.question || ''; } }
     if (window.snWall && window.snWall._refresh) window.snWall._refresh();
     for (const answer of rows) renderAnswer(answer);
     const faqCount = rows.filter((answer) => answer && answer.faqStatus && answer.faqStatus !== 'none').length;
@@ -8745,6 +8773,7 @@ window._laCueAction       = _laCueAction;
           '<button type="button" class="primary attendee-only" onclick="window.demo&&window.demo._suggestFaq&&window.demo._suggestFaq(\'' + ansId + '\')">★ Suggest for FAQ</button>' +
           '<button type="button" class="primary host-only" onclick="window.demo&&window.demo._promoteFaq&&window.demo._promoteFaq(\'' + ansId + '\')">★ Promote to FAQ</button>' +
           '<button type="button" onclick="openWiki()">View in wiki &rarr;</button>' +
+          '<button type="button" onclick="window._snShareAnswer(\'' + ansId + '\')">Share</button>' +
         '</div>';
       ans.querySelector('.ans-q').textContent = args.question || '';
       ans.querySelector('.ans-body').textContent = args.body || '';

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -226,6 +226,35 @@ test.describe("ScratchNode live route honesty", () => {
     await expect(page.locator("#ci")).toHaveValue("this must not be local-only");
   });
 
+  test("/ask answer Share copies a REAL link (no fake 'Shared' toast)", async ({ page }) => {
+    // The old lying handler (toasted "Answer link copied" while copying nothing)
+    // must be gone from the shipped file, and the honest helper must exist.
+    expect(HOME_V5_HTML).not.toContain("toast('Shared'");
+    expect(HOME_V5_HTML).toContain("function _snShareAnswer");
+
+    await fulfillScratchNodePage(page);
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+
+    // Force the clipboard path and capture what actually gets written — proving the
+    // Share button copies a real room link + the question, not a fake success toast.
+    const written = await page.evaluate(() => {
+      // navigator.share lives on the prototype in Chromium — shadow it with an
+      // own undefined property so the helper takes the testable clipboard path.
+      Object.defineProperty(navigator, "share", { value: undefined, configurable: true });
+      let captured = "";
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: (t: string) => { captured = t; return Promise.resolve(); } },
+        configurable: true,
+      });
+      (window as any)._snShareAnswer("", "What is the MCP auth timeline?");
+      return captured;
+    });
+    expect(written).toContain("What is the MCP auth timeline?");
+    expect(written).toContain("/e/"); // a real room URL, not an empty string
+    expect(written).toContain("ScratchNode");
+  });
+
   test("live wiki and people sheets do not show stale static launch counts", async ({ page }) => {
     await fulfillScratchNodePage(page);
 


### PR DESCRIPTION
@
## Why
A full-journey viral audit found the `/ask` answer **Share** button was a lie and the highest-leverage share unit was missing in production:

- **It lied:** `onclick="toast(Shared,Answer link copied.)"` claimed it copied a link while copying **nothing** — a HONEST_STATUS violation.
- **It was absent live:** the live answer renderer (real `/e/` rooms) had Suggest / Promote / Pin / View-in-wiki / Follow-up but **no Share at all**. So real `/ask` answers — the single most screenshot-worthy unit in the room ("the output is the distribution") — couldnt be shared.

## What
New honest `_snShareAnswer(answerId, explicitQuestion)` helper:
- Copies a **real** link: the room URL + the answers question (`"<Q>" — answered live in <event> on ScratchNode\n<url>`).
- Native share sheet when available; else a real `clipboard.writeText` that only toasts **"Answer link copied"** *after the write resolves*, and an honest **"Couldnt copy"** + raw URL on failure.
- Wired into: the **live** renderer (now caches each answers question in `_sn_answer_q_by_id`), the autoplay **demo** renderer (parity), and the **static** demo card (de-lied).

## Test
New honesty case: asserts the lying `toast(Shared` handler is **gone** from the shipped file, and that `_snShareAnswer` writes a real room link + the question to the clipboard (forces the clipboard path, captures the write). **20/20 chromium honesty suite + output-contract demo path green.**

First of three PRs closing the back half of the viral loop (this = in-room share lever; next = public wiki URL + recap; then = real NodeBench bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@