### PR TITLE
feat(scratchnode): public getPublishedWikiBySlug query (shareable wiki read)

### DIFF
--- a/CHANGELOG/pages/convex-events.md
+++ b/CHANGELOG/pages/convex-events.md
@@ -1,0 +1,33 @@
+# `convex/events.ts`
+
+Append-only lane for the ScratchNode live-event backend (rooms, membership, door
+policy, /ask answers, and the published wiki). Newest entries on top.
+
+## 2026-06-03 — Public wiki read: `getPublishedWikiBySlug` (the shareable artifact)
+Added the PUBLIC, no-account query behind the shareable wiki at
+`scratchnode.live/wiki/<slug>` — the viral payoff of "the room remembers
+everything." Anyone with the link reads the published event wiki without joining
+or authenticating.
+
+`getPublishedWikiBySlug({ slug })`:
+- Resolves by slug **or** room code (reuses `resolveEventBySlugOrRoomCode`, the same
+  resolver the room uses), so any shareable identifier works.
+- Returns ONLY the latest **published** version — drafts and unpublished events
+  return `null` (HONEST: never a fabricated/empty wiki).
+- Returns only public-safe fields: `{ eventName, eventSlug, roomCode, eventStatus,
+  title, bodyHtml, version, publishedAt }` — never the host `ownerKey` or internal
+  `sourceIds` / `sourceAnswerIds`.
+- Privacy: `bodyHtml` is already public-safe — `buildWikiHtml` (publishWiki) builds
+  it from public sources + promoted /ask answers only; private notes are excluded
+  at publish time, so there is nothing private to leak at read time.
+- Bounded: single-row `by_event_status` index scan.
+
+Covered by 6 convex-test scenarios in `convex/__tests__/scratchnode.publicWiki.test.ts`
+(friend opens shared link → reads it; resolves by room code; serves the latest of
+several versions; unpublished → null; draft never served; nonexistent slug → null;
+and asserts the host ownerKey + internal ids are never returned). 6/6 green.
+
+Additive backend only — the `/wiki/<slug>` reader UI that consumes this ships
+separately (backend-first per `backend_contract_migration`).
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.

--- a/convex/__tests__/scratchnode.publicWiki.test.ts
+++ b/convex/__tests__/scratchnode.publicWiki.test.ts
@@ -53,7 +53,7 @@ async function seedWiki(
       eventId,
       version: opts.version,
       status: opts.status,
-      title: `${opts.slug ?? "Event"} Wiki`,
+      title: "Event Wiki",
       bodyHtml: opts.bodyHtml,
       sourceAnswerIds: [],
       sourceIds: [],

--- a/convex/__tests__/scratchnode.publicWiki.test.ts
+++ b/convex/__tests__/scratchnode.publicWiki.test.ts
@@ -1,0 +1,132 @@
+/// <reference types="vite/client" />
+/**
+ * Scenario tests for the PUBLIC wiki read — events:getPublishedWikiBySlug.
+ *
+ * Per .claude/rules/scenario_testing.md — each test names a persona + goal +
+ * prior state + actions + expected outcome. This query is the viral payoff of
+ * "the room remembers everything": anyone with the link reads the published wiki
+ * with NO account. The contract under test:
+ *   - latest *published* version only (drafts / unpublished -> null, never a fake)
+ *   - resolves by slug OR room code (same resolver the room uses)
+ *   - returns ONLY public-safe fields (never the host ownerKey or internal ids)
+ *
+ * Runs the real Convex transaction engine via convex-test so indexes + ordering
+ * behave exactly as in production.
+ */
+import { describe, expect, it } from "vitest";
+import { api } from "../_generated/api";
+import schema from "../schema";
+
+const convexModules = import.meta.glob("../**/*.{ts,js}");
+
+let convexTest: any;
+let convexTestAvailable = false;
+try {
+  const mod = await import(/* @vite-ignore */ "convex-test");
+  convexTest = mod.convexTest;
+  convexTestAvailable = typeof convexTest === "function";
+} catch {
+  convexTestAvailable = false;
+}
+
+const NOW = 1_700_000_000_000;
+
+async function seedEvent(t: any, opts: { slug: string; roomCode: string }) {
+  return await t.run(async (ctx: any) =>
+    ctx.db.insert("liveEvents", {
+      slug: opts.slug,
+      name: `${opts.slug} event`,
+      roomCode: opts.roomCode,
+      status: "live",
+      startedAt: NOW,
+    }),
+  );
+}
+
+async function seedWiki(
+  t: any,
+  eventId: any,
+  opts: { version: number; status: "draft" | "published"; bodyHtml: string },
+) {
+  return await t.run(async (ctx: any) =>
+    ctx.db.insert("liveEventWikiVersions", {
+      eventId,
+      version: opts.version,
+      status: opts.status,
+      title: `${opts.slug ?? "Event"} Wiki`,
+      bodyHtml: opts.bodyHtml,
+      sourceAnswerIds: [],
+      sourceIds: [],
+      createdByOwnerKey: "hk1:secret-owner-key-should-never-be-returned",
+      createdAt: NOW,
+      publishedAt: opts.status === "published" ? NOW : undefined,
+    }),
+  );
+}
+
+describe.skipIf(!convexTestAvailable)("ScratchNode public wiki — getPublishedWikiBySlug", () => {
+  it("a friend who wasn't there opens the shared link and reads the published wiki (no account)", async () => {
+    // Persona: someone who got a scratchnode.live/wiki/<slug> link in a group chat.
+    const t = convexTest(schema, convexModules);
+    const eventId = await seedEvent(t, { slug: "rooftop-launch", roomCode: "ROOF01" });
+    await seedWiki(t, eventId, {
+      version: 1,
+      status: "published",
+      bodyHtml: "<h1>Rooftop Launch</h1><p>PUBLIC_RECAP_CONTENT</p>",
+    });
+
+    const wiki = await t.query(api.events.getPublishedWikiBySlug, { slug: "rooftop-launch" });
+    expect(wiki).not.toBeNull();
+    expect(wiki.eventName).toBe("rooftop-launch event");
+    expect(wiki.eventSlug).toBe("rooftop-launch");
+    expect(wiki.roomCode).toBe("ROOF01");
+    expect(wiki.version).toBe(1);
+    expect(wiki.bodyHtml).toContain("PUBLIC_RECAP_CONTENT");
+    // PRIVACY: the public read must NEVER leak host/internal fields.
+    expect((wiki as any).createdByOwnerKey).toBeUndefined();
+    expect((wiki as any).sourceIds).toBeUndefined();
+    expect((wiki as any).sourceAnswerIds).toBeUndefined();
+  });
+
+  it("resolves by ROOM CODE too (same resolver the room uses)", async () => {
+    const t = convexTest(schema, convexModules);
+    const eventId = await seedEvent(t, { slug: "design-jam", roomCode: "JAM777" });
+    await seedWiki(t, eventId, { version: 1, status: "published", bodyHtml: "<p>jam recap</p>" });
+
+    const byCode = await t.query(api.events.getPublishedWikiBySlug, { slug: "jam777" });
+    expect(byCode).not.toBeNull();
+    expect(byCode.eventSlug).toBe("design-jam");
+  });
+
+  it("serves the LATEST published version when several exist", async () => {
+    const t = convexTest(schema, convexModules);
+    const eventId = await seedEvent(t, { slug: "weekly-sync", roomCode: "WEEK01" });
+    await seedWiki(t, eventId, { version: 1, status: "published", bodyHtml: "<p>v1 old</p>" });
+    await seedWiki(t, eventId, { version: 2, status: "published", bodyHtml: "<p>v2 NEWEST</p>" });
+
+    const wiki = await t.query(api.events.getPublishedWikiBySlug, { slug: "weekly-sync" });
+    expect(wiki.version).toBe(2);
+    expect(wiki.bodyHtml).toContain("v2 NEWEST");
+  });
+
+  it("an event with no published wiki yet returns null (honest — never a fake empty wiki)", async () => {
+    const t = convexTest(schema, convexModules);
+    await seedEvent(t, { slug: "not-published", roomCode: "NOPE01" });
+    const wiki = await t.query(api.events.getPublishedWikiBySlug, { slug: "not-published" });
+    expect(wiki).toBeNull();
+  });
+
+  it("a DRAFT wiki version is never served publicly (only published)", async () => {
+    const t = convexTest(schema, convexModules);
+    const eventId = await seedEvent(t, { slug: "draft-only", roomCode: "DRFT01" });
+    await seedWiki(t, eventId, { version: 1, status: "draft", bodyHtml: "<p>not ready</p>" });
+    const wiki = await t.query(api.events.getPublishedWikiBySlug, { slug: "draft-only" });
+    expect(wiki).toBeNull();
+  });
+
+  it("a nonexistent slug returns null (no fabricated room)", async () => {
+    const t = convexTest(schema, convexModules);
+    const wiki = await t.query(api.events.getPublishedWikiBySlug, { slug: "ghost-room-9999" });
+    expect(wiki).toBeNull();
+  });
+});

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1358,6 +1358,48 @@ export const getPublishedWiki = query({
 });
 
 /**
+ * getPublishedWikiBySlug — the PUBLIC, no-account read for the shareable wiki
+ * artifact at scratchnode.live/wiki/<slug>. This is the viral payoff of "the room
+ * remembers everything": anyone with the link can read the published event wiki
+ * without joining or authenticating.
+ *
+ * Honesty / privacy contract:
+ *   - Resolves by slug OR room code (same resolver the room uses).
+ *   - Returns ONLY the latest *published* version — drafts and unpublished events
+ *     return null (no fabricated/empty wiki).
+ *   - bodyHtml is already public-safe: `buildWikiHtml` (publishWiki) is built from
+ *     public sources + promoted /ask answers only — private notes are excluded at
+ *     publish time, so there is nothing private to leak here.
+ *   - Exposes only public-safe fields: never the host ownerKey or internal source ids.
+ * Bounded: single-row index scan.
+ */
+export const getPublishedWikiBySlug = query({
+  args: { slug: v.string() },
+  handler: async (ctx, { slug }) => {
+    if (!slug || slug.length > 120) return null;
+    const event = await resolveEventBySlugOrRoomCode(ctx, slug);
+    if (!event) return null;
+    const rows = await ctx.db
+      .query("liveEventWikiVersions")
+      .withIndex("by_event_status", (q) => q.eq("eventId", event._id).eq("status", "published"))
+      .order("desc")
+      .take(1);
+    const wiki = rows[0];
+    if (!wiki) return null;
+    return {
+      eventName: event.name,
+      eventSlug: event.slug,
+      roomCode: event.roomCode,
+      eventStatus: event.status,
+      title: wiki.title,
+      bodyHtml: wiki.bodyHtml,
+      version: wiki.version,
+      publishedAt: wiki.publishedAt ?? wiki.createdAt ?? null,
+    };
+  },
+});
+
+/**
  * Shared /ask context loader — the SINGLE source of truth for question
  * integrity, semantic-cache lookup, source corpus, and the asker's prior turns.
  *


### PR DESCRIPTION
@
## Why
ScratchNodes core promise is *"the room remembers everything"* → a shareable wiki. But the post-event wiki was `publishWiki`d into a DB table with **no public address** — `wikiId` stayed internal, no `/wiki` route, no public read. The viral payoff (the artifact that pulls new people in *after* the event) was unreachable.

## What (additive backend — backend-first)
`getPublishedWikiBySlug({ slug })` — the PUBLIC, no-account read behind `scratchnode.live/wiki/<slug>`:
- Resolves by **slug or room code** (reuses `resolveEventBySlugOrRoomCode`).
- Latest **published** version only — drafts / unpublished → `null` (honest, never a fake empty wiki).
- Returns only public-safe fields `{ eventName, eventSlug, roomCode, eventStatus, title, bodyHtml, version, publishedAt }` — **never** the host `ownerKey` or internal `sourceIds`/`sourceAnswerIds`.
- Privacy: `bodyHtml` is already public-safe — `buildWikiHtml` excludes private notes at *publish* time, so theres nothing private to leak at read time.
- Bounded single-row `by_event_status` index scan.

## Test
6 convex-test scenarios in `scratchnode.publicWiki.test.ts` (real transaction engine): friend opens shared link → reads it; resolves by room code; serves the latest of several versions; unpublished → null; **draft never served**; nonexistent slug → null; and asserts the host `ownerKey` + internal ids are **never** returned. **6/6 green.**

The `/wiki/<slug>` reader UI + end-event "your wiki is live, share it" recap that consume this ship in the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@