### PR TITLE
feat: ship ScratchNode public wiki loop

### DIFF
--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -38,6 +38,28 @@ Keep entries short and honest. Newest on top within each section.
 
 ## Hand-offs (built + ready for the other agent to call)
 
+- **2026-06-03 · Codex → Claude/Codex next builder** — Viral journey audit after #483:
+  - **Not end-to-end yet.** Entry/create, landing big number, post-create share moment,
+    public directory, open-room join, and request-card plumbing are live on
+    `scratchnode.live`. The back half is still incomplete.
+  - **Highest-leverage next slice:** public post-event wiki payoff. Build a public
+    route only for host-published wiki versions, with private notes excluded. Current
+    `scratchnode.live/e/:slug/wiki` still rewrites to the SPA shell; docs still mark
+    SEO wiki + OG + sitemap as future work.
+  - **Fast honesty fix:** answer-card `Share` buttons currently toast "Link copied"
+    without copying or generating a URL. Either copy a real event/answer deep link or
+    change the UI text until the route exists.
+  - **NodeBench bridge gap:** ScratchNode builds
+    `nodebenchai.com/sign-in?return=/events/:slug/private?...`, but live NodeBench has
+    no matching `/sign-in` or `/events/:slug/private` consumer. Existing real route is
+    `/scratchnode-events`; `/events/:eventId` is a corpus placeholder. Do not claim
+    ScratchNode to NodeBench continuation is live until the returned context renders in
+    NodeBench with the event, public wiki artifact, and private-note continuation.
+  - **Bouncer self-serve gap:** backend supports `joinPolicy: "request"` and the
+    directory can request approval, but the landing create form still hardcodes
+    `joinPolicy: "open"`. Add a host-facing create/control toggle before calling this
+    request-room flow self-serve.
+
 - **2026-06-02 · Claude →** Door-policy **backend is LIVE on prod** (#480). Frontend can wire:
   - `events:requestJoinEvent({ slug, sessionId, displayName, note? })`
     → `{ ok, status: 'open' | 'pending' | 'approved' | 'already_member', requestId?, eventId, slug }`

--- a/AGENT_COORDINATION.md
+++ b/AGENT_COORDINATION.md
@@ -34,9 +34,27 @@ Keep entries short and honest. Newest on top within each section.
 
 ## Active claims (who is editing what RIGHT NOW)
 
-- _(none right now — `home-v5.html#directory` released; shipped, see Recently shipped.)_
+- _(Released: Codex packaged `codex/scratchnode-public-wiki-loop` for PR review; no active edit lock remains.)_
+
+- **Codex · `home-v5.html#wiki-share`, `convex/events.ts#wiki-public-read`, `vercel.json#scratchnode-wiki-route`, `tests/e2e/scratchnode-live-route-honesty.spec.ts#wiki-route` · build published-only public wiki payoff + honest answer share · branch `codex/scratchnode-public-wiki-loop`.**
 
 ## Hand-offs (built + ready for the other agent to call)
+
+- **2026-06-03 - Codex -> Claude/Codex next builder** - Public wiki payoff ready on
+  branch `codex/scratchnode-public-wiki-loop`:
+  - Convex public read: `events:getPublishedWikiBySlug({ slug })` returns only the
+    latest `status: "published"` wiki snapshot for a slug or room code:
+    `{ event: { eventId, slug, name, roomCode, status }, wiki: { wikiId, version, title, bodyHtml, sourceAnswerCount, sourceCount, publishedAt } }`.
+  - Vercel route: `scratchnode.live/e/:slug/wiki` rewrites to
+    `api/scratchnode-wiki.js`; unpublished/missing rooms return a 404 "No public
+    wiki yet" shell and does not expose room data.
+  - Room UI: after `snPublishWiki`, the Share sheet surfaces "Public wiki is live"
+    with a copyable `/wiki` URL; wiki sheet has open/copy public actions.
+  - Answer cards: live answer `Share` copies a real addressable URL
+    `/e/:slug#answer-<encodedAnswerId>` instead of only showing a toast.
+  - Verification: `npx vitest run convex/__tests__/scratchnode.publicWikiRead.test.ts`,
+    `npx playwright test tests/e2e/scratchnode-live-route-honesty.spec.ts --project=chromium --workers=1`,
+    `npx tsc --noEmit --pretty false`, `npm run build`.
 
 - **2026-06-03 · Codex → Claude/Codex next builder** — Viral journey audit after #483:
   - **Not end-to-end yet.** Entry/create, landing big number, post-create share moment,

--- a/api/scratchnode-wiki.js
+++ b/api/scratchnode-wiki.js
@@ -1,0 +1,196 @@
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../convex/_generated/api.js";
+
+let convexClient = null;
+
+function getConvexClient() {
+  const convexUrl = process.env.CONVEX_URL || process.env.VITE_CONVEX_URL || "";
+  if (!convexUrl) return null;
+  if (!convexClient) convexClient = new ConvexHttpClient(convexUrl);
+  return convexClient;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function stripHtml(value) {
+  return String(value ?? "")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function wikiUrl(slug) {
+  return `https://scratchnode.live/e/${encodeURIComponent(slug)}/wiki`;
+}
+
+function renderShell({ title, statusCode, body, description, canonicalUrl }) {
+  const safeTitle = escapeHtml(title || "ScratchNode Wiki");
+  const safeDescription = escapeHtml(
+    description ||
+      "A public ScratchNode event wiki generated from host-published public answers and public sources.",
+  );
+  const safeCanonical = escapeHtml(canonicalUrl || "https://scratchnode.live/");
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${safeTitle}</title>
+  <meta name="description" content="${safeDescription}">
+  <link rel="canonical" href="${safeCanonical}">
+  <meta property="og:site_name" content="ScratchNode">
+  <meta property="og:title" content="${safeTitle}">
+  <meta property="og:description" content="${safeDescription}">
+  <meta property="og:url" content="${safeCanonical}">
+  <meta property="og:image" content="https://scratchnode.live/og-scratchnode.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <style>
+    :root { color-scheme: dark; --bg:#11100f; --paper:#1b1816; --ink:#f5f0eb; --muted:#a79b94; --faint:#756b65; --line:#302a27; --accent:#d97757; }
+    * { box-sizing: border-box; }
+    body { margin:0; min-height:100vh; background:var(--bg); color:var(--ink); font-family:Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .page { max-width:980px; margin:0 auto; padding:32px 20px 56px; }
+    .top { display:flex; justify-content:space-between; gap:16px; align-items:center; padding-bottom:24px; border-bottom:1px solid var(--line); }
+    .brand { color:var(--ink); text-decoration:none; font-weight:800; letter-spacing:-.01em; }
+    .brand span { color:var(--accent); }
+    .back { color:var(--muted); text-decoration:none; font-size:13px; }
+    .hero { padding:42px 0 26px; }
+    .eyebrow { color:var(--accent); font:700 11px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing:.12em; text-transform:uppercase; }
+    h1 { margin:10px 0 10px; font-size:clamp(30px,5vw,54px); line-height:1.02; letter-spacing:0; }
+    .lead { max-width:680px; color:var(--muted); font-size:16px; line-height:1.6; }
+    .meta { display:flex; flex-wrap:wrap; gap:8px; margin-top:18px; }
+    .chip { border:1px solid var(--line); background:rgba(255,255,255,.03); color:var(--muted); border-radius:999px; padding:6px 10px; font-size:12px; }
+    .chip strong { color:var(--ink); }
+    .wiki { display:grid; grid-template-columns:minmax(0,1fr) 220px; gap:28px; align-items:start; }
+    article { min-width:0; padding:28px; background:var(--paper); border:1px solid var(--line); border-radius:8px; }
+    article h1 { font-size:30px; line-height:1.15; margin:0 0 8px; }
+    article h2 { margin:28px 0 10px; padding-top:18px; border-top:1px solid var(--line); font-size:19px; }
+    article h3 { margin:18px 0 6px; font-size:15px; color:var(--ink); }
+    article p, article li { color:var(--muted); line-height:1.65; }
+    article ul { padding-left:20px; }
+    article strong { color:var(--ink); }
+    aside { position:sticky; top:20px; padding:16px; border:1px solid var(--line); border-radius:8px; color:var(--muted); font-size:13px; line-height:1.5; }
+    aside a { display:block; margin-top:12px; color:var(--accent); text-decoration:none; }
+    .empty { padding:48px 28px; background:var(--paper); border:1px solid var(--line); border-radius:8px; }
+    .empty p { color:var(--muted); line-height:1.6; }
+    @media (max-width: 800px) { .top { align-items:flex-start; flex-direction:column; } .wiki { grid-template-columns:1fr; } aside { position:static; } article { padding:22px 18px; } }
+  </style>
+</head>
+<body data-scratchnode-wiki="${statusCode}">
+  <main class="page">${body}</main>
+</body>
+</html>`;
+}
+
+function renderPublished(payload) {
+  const event = payload.event;
+  const wiki = payload.wiki;
+  const title = wiki.title || `${event.name} Wiki`;
+  const description = stripHtml(wiki.bodyHtml).slice(0, 180) ||
+    "Host-published public wiki from ScratchNode.";
+  const canonicalUrl = wikiUrl(event.slug);
+  const publishedDate = wiki.publishedAt ? new Date(wiki.publishedAt).toISOString().slice(0, 10) : "published";
+  const body = `
+    <header class="top">
+      <a class="brand" href="https://scratchnode.live/">Scratch<span>Node</span></a>
+      <a class="back" href="https://scratchnode.live/e/${encodeURIComponent(event.slug)}">Open live room</a>
+    </header>
+    <section class="hero">
+      <div class="eyebrow">Public event wiki</div>
+      <h1>${escapeHtml(title)}</h1>
+      <p class="lead">A host-published record built from public room answers and public sources. Private notes are excluded.</p>
+      <div class="meta">
+        <span class="chip">Room <strong>${escapeHtml(event.roomCode)}</strong></span>
+        <span class="chip">Version <strong>${escapeHtml(wiki.version)}</strong></span>
+        <span class="chip">${escapeHtml(publishedDate)}</span>
+        <span class="chip">${escapeHtml(wiki.sourceAnswerCount)} public answers</span>
+        <span class="chip">${escapeHtml(wiki.sourceCount)} sources</span>
+      </div>
+    </section>
+    <section class="wiki">
+      <article>${wiki.bodyHtml}</article>
+      <aside>
+        <strong>Privacy boundary</strong><br>
+        This page only serves published wiki snapshots. Private notes and private asks are not in the public artifact.
+        <a href="https://scratchnode.live/e/${encodeURIComponent(event.slug)}">Join the room</a>
+      </aside>
+    </section>`;
+  return renderShell({ title, description, canonicalUrl, statusCode: "published", body });
+}
+
+function renderUnavailable(slug) {
+  const safeSlug = escapeHtml(slug || "room");
+  const body = `
+    <header class="top">
+      <a class="brand" href="https://scratchnode.live/">Scratch<span>Node</span></a>
+      <a class="back" href="https://scratchnode.live/e/${encodeURIComponent(slug || "")}">Back to room</a>
+    </header>
+    <section class="hero">
+      <div class="eyebrow">Wiki not published</div>
+      <h1>No public wiki yet</h1>
+      <p class="lead">The room <strong>${safeSlug}</strong> has no host-published wiki snapshot available at this URL.</p>
+    </section>
+    <section class="empty">
+      <p>Hosts can publish the public event wiki from the ScratchNode room. Until then, this route does not expose room data.</p>
+    </section>`;
+  return renderShell({
+    title: "ScratchNode wiki not published",
+    statusCode: "unpublished",
+    body,
+    description: "This ScratchNode room has no host-published public wiki yet.",
+    canonicalUrl: `https://scratchnode.live/e/${encodeURIComponent(slug || "")}/wiki`,
+  });
+}
+
+export default async function handler(req, res) {
+  const url = new URL(req.url || "/", "https://scratchnode.live");
+  const slug = String(url.searchParams.get("slug") || "").trim();
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  if (!slug || slug.length > 120) {
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.status(404).send(renderUnavailable(slug));
+    return;
+  }
+  const client = getConvexClient();
+  if (!client) {
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.status(503).send(renderUnavailable(slug));
+    return;
+  }
+  try {
+    const payload = await client.query(api.events.getPublishedWikiBySlug, { slug });
+    if (url.searchParams.get("format") === "json") {
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader("Cache-Control", "public, max-age=60, s-maxage=300");
+      res.status(payload ? 200 : 404).json(payload || { ok: false, status: "unpublished" });
+      return;
+    }
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("Cache-Control", "public, max-age=60, s-maxage=300");
+    if (!payload) {
+      res.status(404).send(renderUnavailable(slug));
+      return;
+    }
+    res.status(200).send(renderPublished(payload));
+  } catch (error) {
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.status(500).send(renderShell({
+      title: "ScratchNode wiki unavailable",
+      statusCode: "error",
+      description: "ScratchNode could not load this public wiki.",
+      canonicalUrl: `https://scratchnode.live/e/${encodeURIComponent(slug)}/wiki`,
+      body: `
+        <header class="top"><a class="brand" href="https://scratchnode.live/">Scratch<span>Node</span></a></header>
+        <section class="hero"><div class="eyebrow">Wiki unavailable</div><h1>Could not load this wiki</h1><p class="lead">${escapeHtml(error?.message || "Unexpected wiki route error.")}</p></section>
+      `,
+    }));
+  }
+}

--- a/convex/__tests__/scratchnode.publicWikiRead.test.ts
+++ b/convex/__tests__/scratchnode.publicWikiRead.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import { getPublishedWikiBySlug } from "../events";
+
+type Row = Record<string, any>;
+type Tables = Record<string, Row[]>;
+
+class MockIndexBuilder {
+  private filters: Array<{ field: string; value: unknown }> = [];
+
+  eq(field: string, value: unknown) {
+    this.filters.push({ field, value });
+    return this;
+  }
+
+  getFilters() {
+    return this.filters;
+  }
+}
+
+class MockQueryChain {
+  private orderDirection: "asc" | "desc" = "asc";
+
+  constructor(
+    private readonly rows: Row[],
+    private readonly filters: Array<{ field: string; value: unknown }>,
+  ) {}
+
+  order(direction: "asc" | "desc") {
+    this.orderDirection = direction;
+    return this;
+  }
+
+  async first() {
+    const rows = await this.take(1);
+    return rows[0] ?? null;
+  }
+
+  async take(limit: number) {
+    const filtered = this.rows.filter((row) =>
+      this.filters.every((filter) => row[filter.field] === filter.value),
+    );
+    const sorted = [...filtered].sort((a, b) => {
+      const left = sortValue(a);
+      const right = sortValue(b);
+      return this.orderDirection === "desc" ? right - left : left - right;
+    });
+    return sorted.slice(0, limit);
+  }
+}
+
+function sortValue(row: Row) {
+  return row.version ?? row.publishedAt ?? row.createdAt ?? 0;
+}
+
+class MockDb {
+  constructor(private readonly tables: Tables) {}
+
+  query(table: string) {
+    const rows = this.tables[table] ?? [];
+    return {
+      withIndex: (
+        _indexName: string,
+        build: (builder: MockIndexBuilder) => MockIndexBuilder,
+      ) => {
+        const builder = build(new MockIndexBuilder());
+        return new MockQueryChain(rows, builder.getFilters());
+      },
+    };
+  }
+}
+
+function createCtx(tables: Tables) {
+  return { db: new MockDb(tables) };
+}
+
+async function getPublicWiki(ctx: ReturnType<typeof createCtx>, slug: string) {
+  return await (getPublishedWikiBySlug as any)._handler(ctx, { slug });
+}
+
+describe("getPublishedWikiBySlug", () => {
+  it("returns the latest published snapshot without exposing draft/private-note data", async () => {
+    const ctx = createCtx({
+      liveEvents: [
+        {
+          _id: "liveEvents:public1",
+          slug: "demo-day",
+          name: "Demo Day",
+          roomCode: "ORBITAL",
+          status: "ended",
+        },
+      ],
+      liveEventWikiVersions: [
+        {
+          _id: "liveEventWikiVersions:old",
+          eventId: "liveEvents:public1",
+          version: 1,
+          status: "published",
+          title: "Older Wiki",
+          bodyHtml: "<p>Older public snapshot.</p>",
+          sourceAnswerIds: ["liveEventAnswers:old"],
+          sourceIds: ["liveEventSources:old"],
+          createdAt: 1770000000000,
+          publishedAt: 1770000000001,
+        },
+        {
+          _id: "liveEventWikiVersions:new",
+          eventId: "liveEvents:public1",
+          version: 2,
+          status: "published",
+          title: "Demo Day Wiki",
+          bodyHtml: "<h1>Demo Day Wiki</h1><p>Public answer only.</p>",
+          sourceAnswerIds: ["liveEventAnswers:1", "liveEventAnswers:2"],
+          sourceIds: ["liveEventSources:1", "liveEventSources:2"],
+          createdAt: 1770000001000,
+          publishedAt: 1770000001001,
+        },
+        {
+          _id: "liveEventWikiVersions:draft",
+          eventId: "liveEvents:public1",
+          version: 3,
+          status: "draft",
+          title: "Draft Wiki",
+          bodyHtml: "<p>PRIVATE LATENCY SECRET</p>",
+          sourceAnswerIds: ["liveEventAnswers:private"],
+          sourceIds: ["liveEventSources:private"],
+          createdAt: 1770000002000,
+        },
+      ],
+      userNotes: [
+        {
+          _id: "userNotes:private",
+          eventId: "liveEvents:public1",
+          body: "PRIVATE LATENCY SECRET",
+        },
+      ],
+    });
+
+    const bySlug = await getPublicWiki(ctx, "demo-day");
+    const byRoomCode = await getPublicWiki(ctx, " orbital ");
+
+    expect(bySlug?.event.slug).toBe("demo-day");
+    expect(bySlug?.wiki.version).toBe(2);
+    expect(bySlug?.wiki.sourceAnswerCount).toBe(2);
+    expect(bySlug?.wiki.sourceCount).toBe(2);
+    expect(bySlug?.wiki.bodyHtml).toContain("Public answer only");
+    expect(bySlug?.wiki.bodyHtml).not.toContain("PRIVATE LATENCY SECRET");
+    expect(byRoomCode?.wiki.wikiId).toBe("liveEventWikiVersions:new");
+  });
+
+  it("returns null when the event is missing or only has draft wiki rows", async () => {
+    const ctx = createCtx({
+      liveEvents: [
+        {
+          _id: "liveEvents:draftOnly",
+          slug: "draft-only",
+          name: "Draft Only",
+          roomCode: "DRAFT",
+          status: "live",
+        },
+      ],
+      liveEventWikiVersions: [
+        {
+          _id: "liveEventWikiVersions:draft",
+          eventId: "liveEvents:draftOnly",
+          version: 1,
+          status: "draft",
+          title: "Draft Wiki",
+          bodyHtml: "<p>not public</p>",
+          sourceAnswerIds: [],
+          sourceIds: [],
+          createdAt: 1770000000000,
+        },
+      ],
+    });
+
+    await expect(getPublicWiki(ctx, "draft-only")).resolves.toBeNull();
+    await expect(getPublicWiki(ctx, "missing-room")).resolves.toBeNull();
+  });
+});

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1376,8 +1376,9 @@ export const getPublishedWiki = query({
 export const getPublishedWikiBySlug = query({
   args: { slug: v.string() },
   handler: async (ctx, { slug }) => {
-    if (!slug || slug.length > 120) return null;
-    const event = await resolveEventBySlugOrRoomCode(ctx, slug);
+    const cleanSlug = String(slug || "").trim().toLowerCase();
+    if (!cleanSlug || cleanSlug.length > 120) return null;
+    const event = await resolveEventBySlugOrRoomCode(ctx, cleanSlug);
     if (!event) return null;
     const rows = await ctx.db
       .query("liveEventWikiVersions")
@@ -1386,6 +1387,9 @@ export const getPublishedWikiBySlug = query({
       .take(1);
     const wiki = rows[0];
     if (!wiki) return null;
+    const sourceAnswerIds = Array.isArray(wiki.sourceAnswerIds) ? wiki.sourceAnswerIds : [];
+    const sourceIds = Array.isArray(wiki.sourceIds) ? wiki.sourceIds : [];
+    const publishedAt = wiki.publishedAt ?? wiki.createdAt ?? null;
     return {
       eventName: event.name,
       eventSlug: event.slug,
@@ -1394,7 +1398,23 @@ export const getPublishedWikiBySlug = query({
       title: wiki.title,
       bodyHtml: wiki.bodyHtml,
       version: wiki.version,
-      publishedAt: wiki.publishedAt ?? wiki.createdAt ?? null,
+      publishedAt,
+      event: {
+        eventId: event._id,
+        slug: event.slug,
+        name: event.name,
+        roomCode: event.roomCode,
+        status: event.status,
+      },
+      wiki: {
+        wikiId: wiki._id,
+        version: wiki.version,
+        title: wiki.title,
+        bodyHtml: wiki.bodyHtml,
+        sourceAnswerCount: sourceAnswerIds.length,
+        sourceCount: sourceIds.length,
+        publishedAt,
+      },
     };
   },
 });

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -3578,6 +3578,41 @@ function refreshEventUrl() {
   EVENT_URL = PUBLIC_BASE_URL + '/e/' + encodeURIComponent(EVENT_SLUG);
 }
 
+function getPublicWikiUrl() {
+  refreshEventUrl();
+  return EVENT_URL + '/wiki';
+}
+
+function copyTextOrToast(text, successTitle, successDetail) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text).then(function() {
+      toast(successTitle || 'Copied', successDetail || text);
+      haptic && haptic();
+      return true;
+    }).catch(function() {
+      toast('Copy unavailable', text);
+      return false;
+    });
+  }
+  toast('Copy unavailable', text);
+  return Promise.resolve(false);
+}
+
+function answerAnchorId(answerId) {
+  return 'answer-' + encodeURIComponent(String(answerId || '').trim() || 'current');
+}
+
+function shareAnswerLink(answerId) {
+  refreshEventUrl();
+  var id = String(answerId || '').trim();
+  var url = EVENT_URL + (id ? '#' + answerAnchorId(id) : '');
+  return copyTextOrToast(url, 'Answer link copied', url);
+}
+
+function copyPublicWikiUrl() {
+  return copyTextOrToast(getPublicWikiUrl(), 'Wiki link copied', 'Share the public event wiki.');
+}
+
 function setScratchNodeLiveEventContext(event) {
   if (!event) return;
   EVENT_SLUG = event.slug || EVENT_SLUG;
@@ -3891,7 +3926,7 @@ function streamAgentAnswer(intent, identity, time) {
       '<div class="ans-reuse" aria-label="Reuse summary"><span class="pin">Answered from event wiki</span><span class="sep">·</span><span><b>' + sim + '</b> similar</span><span class="sep">·</span><span><b>' + reused + '</b> reused</span><span class="sep">·</span><span class="pulled"><b>0</b> new searches</span><span class="sep">·</span><span class="priv">' + privBadge + '</span></div>' +
       '<button class="ans-show" type="button" aria-expanded="false" onclick="toggleHow(this)">Show trace →</button>' +
       '<div class="ans-how"><div class="step"><span class="c">✓</span><span>Checked event wiki cache · sourceBundle fresh</span></div><div class="step"><span class="c">✓</span><span>Matched ' + sim + ' similar questions in semantic cache</span></div><div class="step"><span class="c">✓</span><span>Reused ' + reused + ' sources from event corpus</span></div><div class="step"><span class="c">✓</span><span>0 new searches · Linkup skipped</span></div><div class="step"><span class="c">✓</span><span>' + traceLastStep + '</span></div></div>' +
-      '<div class="ans-actions"><button type="button" class="primary attendee-only" onclick="toast(\'Suggested for FAQ\',\'The host will review and add it to the wiki.\')">★ Suggest for FAQ</button><button type="button" class="primary host-only" onclick="toast(\'Promoted to FAQ\',\'Now in the wiki.\')">★ Promote to FAQ</button> <button type="button" onclick="openWiki()">View in wiki →</button> <button type="button" onclick="toast(\'Shared\',\'Link copied.\')">Share</button> <button type="button" onclick="document.getElementById(\'ci\').focus()">Follow-up</button></div>';
+      '<div class="ans-actions"><button type="button" class="primary attendee-only" onclick="toast(\'Suggested for FAQ\',\'The host will review and add it to the wiki.\')">★ Suggest for FAQ</button><button type="button" class="primary host-only" onclick="toast(\'Promoted to FAQ\',\'Now in the wiki.\')">★ Promote to FAQ</button> <button type="button" onclick="openWiki()">View in wiki →</button> <button type="button" onclick="shareAnswerLink(\'demo-answer\')">Share</button> <button type="button" onclick="document.getElementById(\'ci\').focus()">Follow-up</button></div>';
     ans.querySelector('.ans-q').textContent = intent.clean;
     feed.appendChild(ans);
     try { if (typeof ans.scrollIntoView === 'function') ans.scrollIntoView({ behavior: 'smooth', block: 'end' }); } catch (e) {}
@@ -3984,11 +4019,13 @@ function copyRoom() {
 // the clipboard write actually resolved; the native share sheet is its own feedback.
 function _snShareAnswer(answerId, explicitQuestion) {
   var url = (typeof EVENT_URL !== 'undefined' && EVENT_URL) ? EVENT_URL : location.href.split('#')[0];
+  var shareUrl = answerId ? (url + '#' + answerAnchorId(answerId)) : url;
+  url = shareUrl;
   var title = (typeof EVENT_TITLE !== 'undefined' && EVENT_TITLE) ? EVENT_TITLE : 'ScratchNode';
   var q = explicitQuestion ||
     (window._sn_answer_q_by_id && answerId && window._sn_answer_q_by_id[answerId]) || '';
   var text = (q ? '"' + q + '" — answered live in ' + title + ' on ScratchNode'
-                : 'Answered live in ' + title + ' on ScratchNode') + '\n' + url;
+                : 'Answered live in ' + title + ' on ScratchNode') + '\n' + shareUrl;
   if (navigator.share) {
     navigator.share({ title: title + ' · ScratchNode', text: text, url: url }).catch(function(){});
     return;
@@ -4485,6 +4522,9 @@ var SHEET_RENDERERS = {
 
   share: function() {
     var url = EVENT_URL;
+    var wikiLink = window._sn_published_wiki_body
+      ? '<div class="sheet-section"><h3>Public wiki is live</h3><p class="sheet-sub">Share the post-event artifact: public Q&amp;A, sources, and what changed. Private notes stay out.</p><div class="share-url-box"><code>' + getPublicWikiUrl() + '</code><button type="button" onclick="copyPublicWikiUrl()">Copy wiki</button></div></div>'
+      : '';
     return '<div class="sheet-head"><h2 id="sheet-title">Share ' + escapeHtml(EVENT_TITLE) + '</h2><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
       '<div class="share-url-box"><code>' + url + '</code><button type="button" onclick="copyShareUrl()">Copy</button></div>' +
       '<div class="share-grid">' +
@@ -4493,6 +4533,7 @@ var SHEET_RENDERERS = {
       '<button type="button" class="share-tile" onclick="shareTo(\'email\')"><span class="icon">&#9993;</span><span>Email</span></button>' +
       '<button type="button" class="share-tile" onclick="shareTo(\'native\')"><span class="icon">&#10548;</span><span>More&hellip;</span></button>' +
       '</div>' +
+      wikiLink +
       '<div class="sheet-section"><h3>Or scan to join on mobile</h3>' +
       '<div style="display:flex;justify-content:center;padding:16px;background:#fff;border-radius:var(--r-sm)"><img src="https://api.qrserver.com/v1/create-qr-code/?size=140x140&amp;margin=4&amp;data=' + encodeURIComponent(url + '#room=' + EVENT_ROOM_CODE) + '" alt="QR code" width="140" height="140" loading="lazy" /></div></div>' +
       '<div style="margin-top:12px;font-size:11px;color:var(--ink-faint);text-align:center;font-family:var(--mono)">Live room code ' + escapeHtml(EVENT_ROOM_CODE) + ' &middot; realtime chat backed by Convex</div>';
@@ -4524,9 +4565,9 @@ var SHEET_RENDERERS = {
   wiki: function() {
     if (window._sn_published_wiki_body) {
       return '<div class="sheet-head"><h2 id="sheet-title">' + escapeHtml(EVENT_TITLE) + ' &middot; Wiki</h2><span class="badge">live Convex</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
-        '<div class="wiki-shell"><aside class="wiki-toc" aria-label="Table of contents"><div class="wiki-toc-label">Source</div><a class="wiki-toc-link active">Published snapshot</a></aside>' +
+        '<div class="wiki-shell"><aside class="wiki-toc" aria-label="Table of contents"><div class="wiki-toc-label">Source</div><a class="wiki-toc-link active">Published snapshot</a><a class="wiki-toc-link" href="' + getPublicWikiUrl() + '" target="_blank" rel="noopener">Open public URL</a></aside>' +
         '<article class="wiki-article" id="wiki-article">' + window._sn_published_wiki_body + '</article>' +
-        '<aside class="wiki-onpage" aria-label="Actions"><div class="wiki-onpage-label">Actions</div><a onclick="window.snPublishWiki && window.snPublishWiki()">Republish</a></aside></div>';
+        '<aside class="wiki-onpage" aria-label="Actions"><div class="wiki-onpage-label">Actions</div><a href="' + getPublicWikiUrl() + '" target="_blank" rel="noopener">Open public wiki</a><a onclick="copyPublicWikiUrl()">Copy public link</a><a onclick="window.snPublishWiki && window.snPublishWiki()">Republish</a></aside></div>';
     }
     if (window._sn_live && window._sn_live.eventId) {
       return '<div class="sheet-head"><h2 id="sheet-title">' + escapeHtml(EVENT_TITLE) + ' &middot; Wiki</h2><span class="badge">not published</span><button type="button" class="sheet-close" onclick="closeSheet()" aria-label="Close">&times;</button></div>' +
@@ -5244,9 +5285,7 @@ function refreshNotesBadge() {
 // ── Share platform handlers ──
 function copyShareUrl() {
   refreshEventUrl();
-  if (navigator.clipboard) {
-    navigator.clipboard.writeText(EVENT_URL).then(function() { toast('Copied', EVENT_URL); haptic(); });
-  }
+  return copyTextOrToast(EVENT_URL, 'Copied join link', EVENT_URL);
 }
 function shareTo(p) {
   refreshEventUrl();
@@ -5523,7 +5562,7 @@ if (_DEBUG_HELPERS_ON) window.simAsk = function(name, question, answerText, sour
       '<div class="ans-reuse" aria-label="Reuse summary"><span class="pin">Answered from event wiki</span><span class="sep">·</span><span><b>' + sim + '</b> similar</span><span class="sep">·</span><span><b>' + reused + '</b> reused</span><span class="sep">·</span><span class="pulled"><b>0</b> new searches</span><span class="sep">·</span><span class="priv">🔒 no private notes</span></div>' +
       '<button class="ans-show" type="button" aria-expanded="false" onclick="toggleHow(this)">Show trace &rarr;</button>' +
       '<div class="ans-how"><div class="step"><span class="c">&check;</span><span>Checked event wiki cache · sourceBundle fresh</span></div><div class="step"><span class="c">&check;</span><span>Matched ' + sim + ' similar questions in semantic cache</span></div><div class="step"><span class="c">&check;</span><span>Reused ' + reused + ' sources from event corpus</span></div><div class="step"><span class="c">&check;</span><span>0 new searches · Linkup skipped</span></div><div class="step"><span class="c">&check;</span><span>No private notes used · public layer only</span></div></div>' +
-      '<div class="ans-actions"><button type="button" class="primary attendee-only" onclick="toast(\'Suggested for FAQ\',\'The host will review and add it to the wiki.\'); haptic();">★ Suggest for FAQ</button><button type="button" class="primary host-only" onclick="toast(\'Promoted to FAQ\',\'Now in the wiki.\'); haptic();">★ Promote to FAQ</button> <button type="button" onclick="openWiki()">View in wiki &rarr;</button> <button type="button" onclick="toast(\'Shared\',\'Link copied.\'); haptic();">Share</button> <button type="button" onclick="document.getElementById(\'ci\').focus()">Follow-up</button></div>';
+      '<div class="ans-actions"><button type="button" class="primary attendee-only" onclick="toast(\'Suggested for FAQ\',\'The host will review and add it to the wiki.\'); haptic();">★ Suggest for FAQ</button><button type="button" class="primary host-only" onclick="toast(\'Promoted to FAQ\',\'Now in the wiki.\'); haptic();">★ Promote to FAQ</button> <button type="button" onclick="openWiki()">View in wiki &rarr;</button> <button type="button" onclick="shareAnswerLink(\'demo-answer\')">Share</button> <button type="button" onclick="document.getElementById(\'ci\').focus()">Follow-up</button></div>';
     ans.querySelector('.ans-q').textContent = question;
     ans.querySelector('.ans-body').textContent = answerText;
     feed.appendChild(ans);
@@ -7022,6 +7061,7 @@ window._laCueAction       = _laCueAction;
     seenAnswerIds.add(answer._id);
     const article = document.createElement('article');
     article.className = 'ans';
+    article.id = answerAnchorId(answer._id);
     article.setAttribute('data-answer-id', answer._id);
     const sourceCount = (answer.sources || []).length || (answer.sourceIds || []).length || 0;
     const sourceChips = (answer.sources || []).slice(0, 5).map((source) =>
@@ -7684,11 +7724,15 @@ window._laCueAction       = _laCueAction;
     const ownerKey = _snReadHostOwnerKey();
     client.mutation('events:publishWiki', { eventId, ownerKey })
       .then((res) => {
-        toast('Wiki published', 'Version ' + res.version + ' is now live.');
+        window._sn_public_wiki_url = getPublicWikiUrl();
+        toast('Wiki published', 'Version ' + res.version + ' is live at the public wiki URL.');
         return client.query('events:getPublishedWiki', { eventId });
       })
       .then((wiki) => {
-        if (wiki) window._sn_published_wiki_body = wiki.bodyHtml;
+        if (wiki) {
+          window._sn_published_wiki_body = wiki.bodyHtml;
+          window._sn_public_wiki_url = getPublicWikiUrl();
+        }
       })
       .catch((e) => toast('Wiki publish blocked', e.message || String(e)));
   };
@@ -7715,7 +7759,10 @@ window._laCueAction       = _laCueAction;
 
   client.query('events:getPublishedWiki', { eventId })
     .then((wiki) => {
-      if (wiki) window._sn_published_wiki_body = wiki.bodyHtml;
+      if (wiki) {
+        window._sn_published_wiki_body = wiki.bodyHtml;
+        window._sn_public_wiki_url = getPublicWikiUrl();
+      }
     })
     .catch(() => {});
 

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -98,6 +98,11 @@ async function fulfillScratchNodePage(
               localStorage.setItem('__snEndedEventArgs', JSON.stringify(args));
               return Promise.resolve({ ok: true, eventId: args.eventId, status: 'ended' });
             }
+            if (name === 'events:publishWiki') {
+              window.__snWikiPublished = true;
+              localStorage.setItem('__snWikiPublishArgs', JSON.stringify(args));
+              return Promise.resolve({ ok: true, version: 1, wikiId: 'liveEventWikiVersions:1' });
+            }
             if (name === 'events:requestJoinEvent') {
               window.__snRequestJoinArgs = args;
               localStorage.setItem('__snRequestJoinArgs', JSON.stringify(args));
@@ -115,7 +120,18 @@ async function fulfillScratchNodePage(
           }
           query(name) {
             if (name === 'events:getMyEvents') return Promise.resolve({ joined: [], hosted: [] });
-            if (name === 'events:getPublishedWiki') return Promise.resolve(null);
+            if (name === 'events:getPublishedWiki') {
+              if (!window.__snWikiPublished) return Promise.resolve(null);
+              return Promise.resolve({
+                version: 1,
+                title: 'AI Infra Summit Wiki',
+                bodyHtml: '<h1>AI Infra Summit Wiki</h1><p>Published public memory.</p>',
+                sourceAnswerIds: ['liveEventAnswers:share1'],
+                sourceIds: ['liveEventSources:1'],
+                createdAt: 1770000000000,
+                publishedAt: 1770000001000,
+              });
+            }
             if (name === 'events:getHostStatus') {
               const token = localStorage.getItem('sn_host_owner_key_v2');
               return Promise.resolve(token ? { isHost: true, role: 'owner', displayName: 'Mock Host' } : { isHost: false });
@@ -134,6 +150,10 @@ async function fulfillScratchNodePage(
             if (name === 'events:listPublicRooms') {
               const rooms = window.__snPublicRooms || [];
               setTimeout(() => cb({ rooms, activeWindowMs: 1800000 }), 0);
+            }
+            if (name === 'events:getAnswers') {
+              const answers = window.__snAnswers || [];
+              setTimeout(() => cb(answers), 0);
             }
             if (name === 'events:getMyJoinRequest') {
               const tick = () => {
@@ -271,6 +291,72 @@ test.describe("ScratchNode live route honesty", () => {
     await expect(page.locator("#sheet-title")).toContainText("People in the room");
     await expect(page.locator("#sheet-content")).toContainText("Mock Host");
     await expect(page.locator("#sheet-content")).not.toContainText("318 joined");
+  });
+
+  test("published wiki exposes a real public wiki URL in the share sheet", async ({ page }) => {
+    await fulfillScratchNodePage(page);
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "sn_host_owner_key_v2",
+        "hk1:liveEvents:1:nonce:1770000000000:abcdefabcdefabcdefabcdefabcdef12",
+      );
+    });
+
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+    await expect
+      .poll(() => page.evaluate(() => typeof (window as any).snPublishWiki), { timeout: 5_000 })
+      .toBe("function");
+
+    await page.evaluate(() => (window as any).snPublishWiki());
+    await expect
+      .poll(() => page.evaluate(() => (window as any)._sn_published_wiki_body || ""), {
+        timeout: 5_000,
+      })
+      .toContain("Published public memory");
+
+    await page.evaluate(() => (window as any).openShare());
+    await expect(page.locator("#sheet-content")).toContainText("Public wiki is live");
+    await expect(page.locator("#sheet-content code").filter({ hasText: "/wiki" })).toContainText(
+      "/e/ai-infra-summit-2026/wiki",
+    );
+
+    await page.getByRole("button", { name: "Copy wiki" }).click();
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(
+      "/e/ai-infra-summit-2026/wiki",
+    );
+  });
+
+  test("answer share copies an addressable answer URL instead of only showing a toast", async ({
+    page,
+  }) => {
+    await fulfillScratchNodePage(page);
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.addInitScript(() => {
+      (window as any).__snAnswers = [
+        {
+          _id: "liveEventAnswers:share1",
+          question: "What did we decide?",
+          body: "We agreed to ship the public wiki loop.",
+          sourceIds: ["liveEventSources:1"],
+          sources: [{ title: "Agenda", uri: "doc://agenda", excerpt: "Public agenda source." }],
+          createdAt: 1770000000000,
+          agentMode: "deterministic",
+          cacheHit: false,
+        },
+      ];
+    });
+
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+    const answer = page.locator('[data-answer-id="liveEventAnswers:share1"]');
+    await expect(answer).toContainText("We agreed to ship the public wiki loop.");
+
+    await answer.getByRole("button", { name: "Share" }).click();
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(
+      "/e/ai-infra-summit-2026#answer-liveEventAnswers%3Ashare1",
+    );
   });
 
   test("host create event uses live mutation and navigates to the created room", async ({ page }) => {

--- a/vercel.json
+++ b/vercel.json
@@ -50,6 +50,9 @@
     },
     "api/voice.js": {
       "maxDuration": 60
+    },
+    "api/scratchnode-wiki.js": {
+      "maxDuration": 10
     }
   },
   "redirects": [
@@ -127,6 +130,16 @@
         }
       ],
       "destination": "/proto/home-v5.html"
+    },
+    {
+      "source": "/e/:slug/wiki",
+      "has": [
+        {
+          "type": "host",
+          "value": "scratchnode.live"
+        }
+      ],
+      "destination": "/api/scratchnode-wiki?slug=:slug"
     },
     {
       "source": "/e/:slug*",


### PR DESCRIPTION
## What changed
- Adds a published-only public ScratchNode wiki route at `scratchnode.live/e/:slug/wiki`.
- Adds `events:getPublishedWikiBySlug({ slug })` so the public route can read the latest published wiki by slug or room code without exposing drafts/private notes.
- Wires post-publish room UI to surface/copy the public wiki URL from Share and Wiki sheets.
- Fixes answer `Share` buttons to copy real addressable answer URLs instead of only showing a toast.
- Leaves an agent coordination handoff with the new query/route contract.

## Verification
- `npx vitest run convex/__tests__/scratchnode.publicWikiRead.test.ts`
- `npx playwright test tests/e2e/scratchnode-live-route-honesty.spec.ts --project=chromium --workers=1`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- Local in-app browser smoke: `http://127.0.0.1:5198/proto/home-v5.html` loaded with no console errors.

## Notes
This branch includes the coordination-audit commit from #484 and then closes the two highest-leverage gaps from that audit: public wiki payoff and honest answer sharing.