### PR TITLE
feat(nodebench): real ScratchNode->NodeBench bridge route /events/:slug/wiki

### DIFF
--- a/CHANGELOG/pages/scratchnode-nodebench-bridge.md
+++ b/CHANGELOG/pages/scratchnode-nodebench-bridge.md
@@ -1,0 +1,39 @@
+# ScratchNode → NodeBench bridge
+
+Append-only lane for the conversion bridge from the disposable ScratchNode live-event
+room into the NodeBench app. Newest entries on top.
+
+## 2026-06-03 — Make the bridge REAL: a `/events/:slug/wiki` receiving route
+The bridge was broken end-to-end. ScratchNode sent users to
+`nodebenchai.com/events/<slug>/wiki`, but the `/events` matcher in `src/App.tsx`
+(`^/events/([^/]+)/?$`) **rejects trailing segments**, so the handoff **404'd** and
+fell through to the generic cockpit. No surface read the `source=scratchnode` / `room`
+params; the flashy "Now in NodeBench" overlay was hidden demo theater. That's why the
+ScratchNode wiki reader shipped *without* a "Continue in NodeBench" CTA — pointing at a
+404 would violate HONEST_STATUS.
+
+This builds the real receiving surface:
+- **`ScratchnodeWikiBridge`** (`src/features/events/views/ScratchnodeWikiBridge.tsx`) —
+  reads the slug (+ optional `source`/`room` query params), loads the PUBLIC, no-account
+  `events:getPublishedWikiBySlug`, and renders the published recap **inside the NodeBench
+  shell** with a conversion frame ("Keep this in NodeBench" → `Explore NodeBench`, plus
+  "View the public wiki" / "Open in ScratchNode" paths back). No cross-domain session is
+  needed — the slug is in the URL and the query is public.
+- **Route wired in `src/App.tsx`** — `/events/:slug/wiki` is matched **above** the
+  single-segment `/events/:eventId` route so the trailing `/wiki` is captured first (the
+  exact bug that 404'd before).
+- **Honesty + security** — unpublished / unknown slug → a real empty state (never a
+  fabricated recap); loading → a real loading state. `bodyHtml` is server-public-safe
+  (private notes excluded at publish) **and** DOMPurify-sanitized before render (defense
+  in depth against XSS in the main app).
+
+Covered by `ScratchnodeWikiBridge.test.tsx` (4 cases: published render + NodeBench CTA +
+reverse paths; unpublished → honest empty; loading; and a sanitization case asserting a
+`<script>` + `onerror` handler in `bodyHtml` never reach the DOM). 4/4 green; full-project
+tsc clean.
+
+Route-first: this ships before the ScratchNode wiki reader's "Continue in NodeBench" CTA
+is re-added, so the CTA can never dead-end. Deeper event→workspace *data carryover*
+(messages/entities/follow-ups into a NodeBench workspace) remains a follow-up.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,15 @@ const EventCorpusExplorer = lazy(() =>
     default: m.EventCorpusExplorer,
   })),
 );
+// /events/:slug/wiki — the ScratchNode -> NodeBench bridge receiving surface.
+// Renders a published ScratchNode wiki (public getPublishedWikiBySlug) inside
+// NodeBench with a conversion frame. Mounted ABOVE /events/:eventId so the
+// trailing /wiki segment is captured before the single-segment matcher.
+const ScratchnodeWikiBridge = lazy(() =>
+  import("@/features/events/views/ScratchnodeWikiBridge").then((m) => ({
+    default: m.ScratchnodeWikiBridge,
+  })),
+);
 // My Wiki — Phase 1 routes. See docs/architecture/ME_AGENT_DESIGN.md
 const WikiLandingRoute = lazy(() => import("@/features/me/components/wiki/WikiLandingRoute"));
 const WikiPageDetailRoute = lazy(() => import("@/features/me/components/wiki/WikiPageDetailRoute"));
@@ -462,6 +471,30 @@ function App() {
   // See viewRegistry.ts "event-corpus" entry — that entry exists so Cmd-K
   // and other discovery surfaces know about the route, but the actual
   // rendering happens here.
+  // /events/:slug/wiki — ScratchNode → NodeBench bridge. MUST come before the
+  // single-segment /events/:eventId matcher below (which rejects trailing
+  // segments and would otherwise let this 404 — the original broken-bridge bug).
+  const eventWikiRouteMatch = location.pathname.match(/^\/events\/([^/]+)\/wiki\/?$/);
+  if (eventWikiRouteMatch) {
+    const slug = decodeURIComponent(eventWikiRouteMatch[1] ?? "");
+    const params = new URLSearchParams(location.search);
+    return (
+      <ThemeProvider>
+        <ErrorBoundary title="Event recap failed to load">
+          <Suspense fallback={<ViewSkeleton />}>
+            <div key={`event-wiki-${slug}`} className="route-fade-in">
+              <ScratchnodeWikiBridge
+                slug={slug}
+                source={params.get("source")}
+                roomCode={params.get("room")}
+              />
+            </div>
+          </Suspense>
+        </ErrorBoundary>
+      </ThemeProvider>
+    );
+  }
+
   const eventsRouteMatch = location.pathname.match(/^\/events\/([^/]+)\/?$/);
   if (eventsRouteMatch) {
     const eventId = decodeURIComponent(eventsRouteMatch[1] ?? "");

--- a/src/features/events/views/ScratchnodeWikiBridge.test.tsx
+++ b/src/features/events/views/ScratchnodeWikiBridge.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Scenario tests for the ScratchNode -> NodeBench bridge receiving surface.
+ * Persona: a guest who clicked "Continue in NodeBench" from a ScratchNode wiki.
+ * Verifies the route renders the public recap, frames the conversion, stays
+ * honest on unpublished/loading, and SANITIZES the wiki body (XSS defense).
+ */
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const useQueryMock = vi.fn();
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+import { ScratchnodeWikiBridge } from "./ScratchnodeWikiBridge";
+
+const WIKI = {
+  eventName: "Rooftop Launch Party",
+  eventSlug: "rooftop-launch",
+  roomCode: "ROOFTOP",
+  eventStatus: "ended",
+  title: "Rooftop Launch Party Wiki",
+  bodyHtml: "<h1>Rooftop Launch</h1><p>PUBLIC_RECAP_BODY</p>",
+  version: 2,
+  publishedAt: 1770000000000,
+};
+
+afterEach(() => {
+  cleanup();
+  useQueryMock.mockReset();
+});
+
+describe("ScratchnodeWikiBridge", () => {
+  it("renders a published wiki with a NodeBench conversion CTA", () => {
+    useQueryMock.mockReturnValue(WIKI);
+    render(<ScratchnodeWikiBridge slug="rooftop-launch" source="scratchnode" roomCode="ROOFTOP" />);
+
+    expect(screen.getByTestId("scratchnode-wiki-bridge-body")).toHaveTextContent("PUBLIC_RECAP_BODY");
+    // Conversion CTA points into the NodeBench app (a real, working route).
+    const cta = screen.getByTestId("scratchnode-wiki-bridge-cta-nodebench");
+    expect(cta).toHaveAttribute("href", "/");
+    // Reverse paths back to ScratchNode are present and well-formed.
+    expect(screen.getByText("View the public wiki")).toHaveAttribute(
+      "href",
+      "https://scratchnode.live/wiki/rooftop-launch",
+    );
+    expect(screen.getByText("Open in ScratchNode →")).toHaveAttribute(
+      "href",
+      "https://scratchnode.live/e/rooftop",
+    );
+  });
+
+  it("shows an honest empty state for an unpublished/unknown room (never a fake recap)", () => {
+    useQueryMock.mockReturnValue(null);
+    render(<ScratchnodeWikiBridge slug="not-published" />);
+
+    expect(screen.getByTestId("scratchnode-wiki-bridge-empty")).toHaveTextContent(
+      "hasn’t published its wiki yet",
+    );
+    // No recap body is fabricated.
+    expect(screen.queryByTestId("scratchnode-wiki-bridge-body")).toBeNull();
+  });
+
+  it("shows a loading state while the query resolves (no premature empty/error)", () => {
+    useQueryMock.mockReturnValue(undefined);
+    render(<ScratchnodeWikiBridge slug="rooftop-launch" />);
+
+    expect(screen.getByTestId("scratchnode-wiki-bridge-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("scratchnode-wiki-bridge-empty")).toBeNull();
+  });
+
+  it("SANITIZES the wiki body — script/handlers are stripped before render (XSS defense)", () => {
+    useQueryMock.mockReturnValue({
+      ...WIKI,
+      bodyHtml:
+        "<p>KEEP_THIS</p><script>window.__xss=1</script><img src=x onerror=\"window.__xss=1\">",
+    });
+    const { container } = render(<ScratchnodeWikiBridge slug="rooftop-launch" />);
+
+    const body = screen.getByTestId("scratchnode-wiki-bridge-body");
+    expect(body).toHaveTextContent("KEEP_THIS");
+    // The dangerous bits never reach the DOM.
+    expect(container.querySelector("script")).toBeNull();
+    expect(body.innerHTML).not.toContain("onerror");
+    expect(body.innerHTML).not.toContain("window.__xss");
+  });
+});

--- a/src/features/events/views/ScratchnodeWikiBridge.tsx
+++ b/src/features/events/views/ScratchnodeWikiBridge.tsx
@@ -1,0 +1,202 @@
+/**
+ * ScratchnodeWikiBridge — the REAL ScratchNode -> NodeBench bridge receiving
+ * surface for `/events/:slug/wiki`.
+ *
+ * Why this exists: the ScratchNode wiki reader (scratchnode.live/wiki/<slug>)
+ * wants a "Continue in NodeBench" CTA, but an audit found the handoff URL
+ * `nodebenchai.com/events/<slug>/wiki` had NO route — it 404'd (the `/events`
+ * matcher rejects trailing segments). Shipping a CTA onto a 404 violates the
+ * HONEST_STATUS contract, so the CTA is withheld until this route exists.
+ *
+ * What it does: reads the slug from the path (+ optional `source`/`room` query
+ * params), loads the PUBLIC, no-account `events:getPublishedWikiBySlug`, renders
+ * the published recap inside the NodeBench shell, and frames it as a conversion
+ * moment ("keep this in NodeBench"). No cross-domain session is needed — the
+ * slug is in the URL and the query is public.
+ *
+ * Honesty: unpublished / unknown slug -> a real empty state with a link back to
+ * ScratchNode, never a fabricated recap. `bodyHtml` is server-built + public-safe
+ * (private notes excluded at publish) and is DOMPurify-sanitized before render.
+ *
+ * Prior art: pattern mirrors src/features/redesign/surfaces/ScratchnodeEventsSurface.tsx
+ * (the existing read-only ScratchNode handoff surface).
+ */
+
+import { useMemo } from "react";
+import { useQuery } from "convex/react";
+import DOMPurify from "dompurify";
+import { api } from "../../../../convex/_generated/api";
+
+type PublishedWiki = {
+  eventName: string;
+  eventSlug: string;
+  roomCode: string;
+  eventStatus: string;
+  title: string;
+  bodyHtml: string;
+  version: number;
+  publishedAt: number | null;
+};
+
+const SCRATCHNODE_ORIGIN = "https://scratchnode.live";
+
+function formatDate(ms: number | null): string {
+  if (!ms) return "";
+  try {
+    return new Date(ms).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return "";
+  }
+}
+
+interface Props {
+  slug: string;
+  /** From `?source=scratchnode` — telemetry/attribution only. */
+  source?: string | null;
+  /** From `?room=<CODE>` — lets "Open in ScratchNode" deep-link the room. */
+  roomCode?: string | null;
+}
+
+export function ScratchnodeWikiBridge({ slug, roomCode }: Props) {
+  const wiki = useQuery(
+    // `as any` — getPublishedWikiBySlug may not be in _generated/api.d.ts on this
+    // branch yet; codegen runs at deploy (same pattern as ScratchnodeEventsSurface).
+    (api as any).events.getPublishedWikiBySlug,
+    slug ? { slug } : "skip",
+  ) as PublishedWiki | null | undefined;
+
+  const isLoading = wiki === undefined;
+
+  const safeBody = useMemo(
+    () => (wiki?.bodyHtml ? DOMPurify.sanitize(wiki.bodyHtml) : ""),
+    [wiki?.bodyHtml],
+  );
+
+  const publicWikiUrl = `${SCRATCHNODE_ORIGIN}/wiki/${encodeURIComponent(slug)}`;
+  const roomUrl = `${SCRATCHNODE_ORIGIN}/e/${encodeURIComponent(
+    String(roomCode || wiki?.roomCode || slug).toLowerCase(),
+  )}`;
+
+  return (
+    <div
+      data-testid="scratchnode-wiki-bridge"
+      className="rd-stack"
+      style={{ padding: "32px 28px 80px", maxWidth: 760, margin: "0 auto", gap: 22 }}
+    >
+      <header className="rd-stack" style={{ gap: 6 }}>
+        <div className="rd-eyebrow">ScratchNode → NodeBench</div>
+        <h1 className="rd-h1" style={{ fontSize: 28 }}>
+          {wiki?.eventName ? `${wiki.eventName} — recap` : "Event recap"}
+        </h1>
+        <p className="rd-soft" style={{ fontSize: 14, maxWidth: 640, margin: 0 }}>
+          This event’s wiki, brought into NodeBench. The room remembers everything —
+          here’s what happened.
+        </p>
+      </header>
+
+      {isLoading ? (
+        <div
+          data-testid="scratchnode-wiki-bridge-loading"
+          aria-live="polite"
+          className="rd-card rd-card__pad rd-faint"
+          style={{ textAlign: "center", fontSize: 13 }}
+        >
+          Loading the event recap…
+        </div>
+      ) : wiki === null ? (
+        <div
+          data-testid="scratchnode-wiki-bridge-empty"
+          className="rd-card rd-card__pad"
+          style={{ textAlign: "center" }}
+        >
+          <p style={{ fontSize: 14, color: "var(--rd-ink-strong)", margin: "0 0 8px", fontWeight: 500 }}>
+            This room hasn’t published its wiki yet.
+          </p>
+          <p className="rd-soft" style={{ fontSize: 13, margin: "0 0 20px", lineHeight: 1.5 }}>
+            When the host publishes the recap, it shows up here. Double-check the link,
+            or open the room on ScratchNode.
+          </p>
+          <a
+            href={roomUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="rd-btn rd-btn--primary"
+            style={{ display: "inline-flex", padding: "8px 16px", fontSize: 13, fontWeight: 500 }}
+          >
+            Open in ScratchNode →
+          </a>
+        </div>
+      ) : (
+        <>
+          <div className="rd-card rd-card__pad rd-stack" style={{ gap: 14 }}>
+            <div className="rd-mono" style={{ fontSize: 12, color: "var(--rd-ink-faint)" }}>
+              {[
+                wiki.title || `${wiki.eventName} Wiki`,
+                wiki.roomCode ? `code ${String(wiki.roomCode).toUpperCase()}` : "",
+                typeof wiki.version === "number" ? `v${wiki.version}` : "",
+                formatDate(wiki.publishedAt) ? `published ${formatDate(wiki.publishedAt)}` : "",
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </div>
+            {/* bodyHtml is server-built + public-safe (private notes excluded at
+                publish) AND DOMPurify-sanitized here — defense in depth. */}
+            <div
+              data-testid="scratchnode-wiki-bridge-body"
+              className="rd-soft"
+              style={{ fontSize: 14, lineHeight: 1.62 }}
+              dangerouslySetInnerHTML={{ __html: safeBody }}
+            />
+          </div>
+
+          {/* The conversion moment — keep this recap in NodeBench. */}
+          <div
+            data-testid="scratchnode-wiki-bridge-upsell"
+            className="rd-card rd-card__pad rd-stack"
+            style={{ gap: 12, borderColor: "var(--rd-accent)", background: "var(--rd-accent-soft)" }}
+          >
+            <p style={{ fontSize: 14, color: "var(--rd-ink-strong)", margin: 0, fontWeight: 590 }}>
+              Keep this in NodeBench.
+            </p>
+            <p className="rd-soft" style={{ fontSize: 13, margin: 0, lineHeight: 1.5 }}>
+              Turn this recap into living operating memory — entities, follow-ups, and a
+              workspace that compounds across every event you run.
+            </p>
+            <div className="rd-row" style={{ gap: 8, flexWrap: "wrap" }}>
+              <a
+                data-testid="scratchnode-wiki-bridge-cta-nodebench"
+                href="/"
+                className="rd-btn rd-btn--primary"
+                style={{ display: "inline-flex", padding: "8px 16px", fontSize: 13, fontWeight: 500 }}
+              >
+                Explore NodeBench →
+              </a>
+              <a
+                href={publicWikiUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="rd-btn rd-btn--quiet rd-btn--sm"
+              >
+                View the public wiki
+              </a>
+              <a
+                href={roomUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="rd-btn rd-btn--quiet rd-btn--sm"
+              >
+                Open in ScratchNode →
+              </a>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ScratchnodeWikiBridge;


### PR DESCRIPTION
@
## Why
The ScratchNode → NodeBench bridge was **broken end-to-end** (found during the viral audit): `nodebenchai.com/events/<slug>/wiki` **404d** — the `src/App.tsx` `/events` matcher `^/events/([^/]+)/?$` rejects trailing segments, no surface read the `source=scratchnode`/`room` params, and the "Now in NodeBench" overlay was hidden demo theater. Thats exactly why the ScratchNode wiki reader ([#487](https://github.com/HomenShum/nodebench-ai/pull/487)) shipped **without** a "Continue in NodeBench" CTA — pointing at a 404 violates HONEST_STATUS.

## What (the real receiving surface)
- **`ScratchnodeWikiBridge`** — reads the slug (+ optional `source`/`room`), loads the PUBLIC, no-account `events:getPublishedWikiBySlug` ([#486](https://github.com/HomenShum/nodebench-ai/pull/486), live), and renders the recap **inside the NodeBench shell** with a conversion frame ("Keep this in NodeBench" → `Explore NodeBench`, plus "View the public wiki" / "Open in ScratchNode"). No cross-domain session needed — slug is in the URL, query is public.
- **Route in `App.tsx`** — `/events/:slug/wiki` matched **above** the single-segment `/events/:eventId` route so the trailing `/wiki` is captured first (the exact 404 bug).
- **Honesty + security** — unpublished/unknown → real empty state (no fake recap); loading state; `bodyHtml` is server-public-safe (private notes excluded at publish) **and** DOMPurify-sanitized before render (XSS defense in the main app).

## Tests
`ScratchnodeWikiBridge.test.tsx` — 4 cases: published render + NodeBench CTA + reverse paths; unpublished → honest empty; loading; and a **sanitization** case asserting a `<script>` + `onerror` handler in `bodyHtml` never reach the DOM. 4/4 green; full-project `tsc` clean.

**Route-first**: ships before the wiki readers "Continue in NodeBench" CTA is re-added (follow-up), so the CTA can never dead-end. Deeper event→workspace data carryover remains a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@