### PR TITLE
feat(scratchnode): end-event recap moment (Your wiki is live. Share the memory.)

### DIFF
--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -2,6 +2,32 @@
 
 Append-only lane for the ScratchNode live-event prototype and production static surface.
 
+## 2026-06-03 — End-event recap moment: "Your wiki is live. Share the memory."
+Closes the activation gap in the *after-event* loop. The host could publish the wiki
+(`/wiki/<slug>` reader shipped earlier the same day), but publishing only fired a
+toast — the host never learned the **public address existed**, so the artifact that
+pulls people in after the event never circulated.
+
+Now a successful `events:publishWiki` opens a recap moment (reusing the post-create
+share-moment + invite-card styling): **"Your wiki is live."** + a screenshot-worthy
+invite card (brand · event name · QR · `scratchnode.live/wiki/<slug>` · "the room
+remembers everything"), a copy-able link, native **Share** when available, and
+**Open the wiki →**. `_snShowWikiLiveMoment(slug, name)` is called only from the
+*confirmed* publish path — HONESTY: it only ever shows the real published URL, never a
+speculative one, and it's a read-only moment (`data-sn-live` untouched). Escape / Done
+closes it. The native share + clipboard reuse the existing `_shareCopy` plumbing.
+
+Covered by a new honesty case (publish → recap moment opens with a real
+`/wiki/<slug>` URL, the backend mutation actually ran, Done closes it) plus a scope
+fix to the create-moment test (both moments now share `.share-moment*`/`.invite-card*`
+classes, so its selectors are scoped to `#share-moment`). 21/21 chromium honesty +
+output-contract green; recap moment screenshot-verified.
+
+Still deferred (route-first): the wiki reader's "Continue in NodeBench" CTA, which
+ships once the `/events/:slug/wiki` receiving route is live.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.
+
 ## 2026-06-03 — Public `/wiki/<slug>` reader: give the "room remembers everything" a real address
 The viral audit found ScratchNode's core promise was a dead end: `publishWiki`
 wrote the recap into a DB table with **no public URL**, so the artifact that should

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -2669,6 +2669,53 @@ document.addEventListener('keydown', function (e) {
 });
 window._showShareMoment = _showShareMoment;
 
+// ── End-event recap moment: "Your wiki is live. Share the memory." ──────────
+// Shown after a host PUBLISHES the wiki, so they actually learn the public
+// /wiki/<slug> address exists and can circulate it. This is the activation of
+// the after-event loop. HONEST: only ever the real published URL, and only
+// triggered on a confirmed publish (never speculatively). Reuses the share-moment
+// + invite-card styling.
+var _wikiMomentState = { url: '', slug: '', name: '' };
+function _snShowWikiLiveMoment(slug, name) {
+  try {
+    slug = String(slug || '').toLowerCase();
+    if (!slug) return;
+    name = String(name || 'Your event').trim() || 'Your event';
+    var base = (typeof PUBLIC_BASE_URL === 'string' && PUBLIC_BASE_URL)
+      ? PUBLIC_BASE_URL : (location.origin || 'https://scratchnode.live');
+    var url = base.replace(/\/+$/, '') + '/wiki/' + encodeURIComponent(slug);
+    _wikiMomentState = { url: url, slug: slug, name: name };
+    var set = function (id, fn) { var el = document.getElementById(id); if (el) fn(el); };
+    set('wiki-live-name', function (el) { el.textContent = name; });
+    set('wiki-live-slug', function (el) { el.textContent = slug; });
+    set('wiki-live-input', function (el) { el.value = url; });
+    set('wiki-live-qr', function (el) {
+      el.onerror = function () { var w = el.parentNode; if (w && w.style) w.style.display = 'none'; };
+      el.src = 'https://api.qrserver.com/v1/create-qr-code/?size=280x280&margin=0&data=' + encodeURIComponent(url);
+    });
+    set('wiki-live-native', function (el) { if (navigator.share) el.hidden = false; });
+    var m = document.getElementById('wiki-live-moment');
+    if (m) {
+      m.setAttribute('data-open', 'true');
+      try { var c = document.getElementById('wiki-live-copy'); if (c) c.focus(); } catch (e) {}
+    }
+  } catch (e) { /* never break the host console */ }
+}
+function _snWikiMomentCopy() { _shareCopy(_wikiMomentState.url, document.getElementById('wiki-live-copy'), 'Link copied!'); }
+function _snWikiMomentNative() {
+  if (navigator.share) {
+    navigator.share({ title: _wikiMomentState.name + ' — wiki · ScratchNode', text: _wikiMomentState.name + ' — the room remembers everything.', url: _wikiMomentState.url }).catch(function () {});
+  } else { _snWikiMomentCopy(); }
+}
+function _snWikiMomentOpen() { if (_wikiMomentState.url) window.open(_wikiMomentState.url, '_blank', 'noopener'); }
+function _snWikiMomentClose() { var m = document.getElementById('wiki-live-moment'); if (m) m.setAttribute('data-open', 'false'); }
+document.addEventListener('keydown', function (e) {
+  if (e.key !== 'Escape') return;
+  var m = document.getElementById('wiki-live-moment');
+  if (m && m.getAttribute('data-open') === 'true') { _snWikiMomentClose(); }
+});
+window._snShowWikiLiveMoment = _snShowWikiLiveMoment;
+
 /**
  * _snInitLandingStats — the live "big number" on the apex landing.
  *
@@ -3165,6 +3212,36 @@ if (document.readyState === 'loading') {
     </div>
 
     <button type="button" class="share-enter" id="share-enter-btn" onclick="_shareEnterRoom()">Enter your room &rarr;</button>
+  </div>
+</div>
+
+<!-- End-event recap moment — shown after the host publishes the wiki, so they
+     learn the public /wiki/<slug> address and can share the memory. -->
+<div class="share-moment" id="wiki-live-moment" role="dialog" aria-modal="true" aria-labelledby="wiki-live-title">
+  <div class="share-moment__panel">
+    <span class="share-moment__spark" aria-hidden="true">&#10022;</span>
+    <h2 id="wiki-live-title">Your wiki is live.</h2>
+    <p class="share-moment__sub">Anyone can read the recap &mdash; no account, no app. Share the memory.</p>
+
+    <div class="invite-card" id="wiki-live-card">
+      <div class="invite-card__brand">Scratch<span>Node</span></div>
+      <div class="invite-card__name" id="wiki-live-name">Your event</div>
+      <div class="invite-card__qr"><img id="wiki-live-qr" alt="Scan to read the wiki" width="140" height="140"></div>
+      <div class="invite-card__code">scratchnode.live/wiki/<b id="wiki-live-slug">slug</b></div>
+      <div class="invite-card__tag">the room remembers everything</div>
+    </div>
+
+    <div class="share-link">
+      <input type="text" id="wiki-live-input" readonly aria-label="Wiki link" onfocus="this.select()">
+      <button type="button" id="wiki-live-copy" onclick="_snWikiMomentCopy()">Copy</button>
+    </div>
+
+    <div class="share-actions">
+      <button type="button" class="share-btn share-btn--primary" id="wiki-live-native" onclick="_snWikiMomentNative()" hidden>Share&hellip;</button>
+      <button type="button" class="share-btn share-btn--wide" onclick="_snWikiMomentOpen()">Open the wiki &rarr;</button>
+    </div>
+
+    <button type="button" class="share-enter" id="wiki-live-done" onclick="_snWikiMomentClose()">Done</button>
   </div>
 </div>
 
@@ -7876,6 +7953,13 @@ window._laCueAction       = _laCueAction;
     client.mutation('events:publishWiki', { eventId, ownerKey })
       .then((res) => {
         toast('Wiki published', 'Version ' + res.version + ' is now live.');
+        // Activation of the after-event loop: surface the public /wiki/<slug>
+        // address so the host can actually share the memory (not just a toast).
+        try {
+          if (typeof _snShowWikiLiveMoment === 'function') {
+            _snShowWikiLiveMoment(EVENT_SLUG, typeof EVENT_TITLE !== 'undefined' ? EVENT_TITLE : '');
+          }
+        } catch (e) {}
         return client.query('events:getPublishedWiki', { eventId });
       })
       .then((wiki) => {

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -111,6 +111,10 @@ async function fulfillScratchNodePage(
                 requestId: 'liveEventJoinRequests:1',
               });
             }
+            if (name === 'events:publishWiki') {
+              window.__snPublishWikiArgs = args;
+              return Promise.resolve({ ok: true, wikiId: 'liveEventWikiVersions:1', version: 3 });
+            }
             return Promise.resolve({});
           }
           query(name) {
@@ -432,9 +436,10 @@ test.describe("ScratchNode live route honesty", () => {
     await page.click("#landing-create-btn");
     await expect(page.locator("#share-moment")).toHaveAttribute("data-open", "true");
 
-    // The reason-to-share copy + the screenshot-worthy invite card.
-    await expect(page.locator(".share-moment__sub")).toContainText("shared memory");
-    await expect(page.locator(".invite-card__tag")).toContainText("remembers everything");
+    // The reason-to-share copy + the screenshot-worthy invite card. Scoped to
+    // #share-moment — the wiki-live recap moment reuses the same classes.
+    await expect(page.locator("#share-moment .share-moment__sub")).toContainText("shared memory");
+    await expect(page.locator("#share-moment .invite-card__tag")).toContainText("remembers everything");
 
     // Copy link writes the room URL to the clipboard + flashes confirmation.
     await page.click("#share-link-copy");
@@ -663,5 +668,32 @@ test.describe("ScratchNode live route honesty", () => {
     await expect(page.locator("#landing-pulse-live")).toHaveText("6");
     // activeNow is a different unit (sessions) and is allowed to exceed rooms.
     await expect(page.locator("#landing-pulse-active")).toHaveText("40");
+  });
+
+  test("publishing the wiki surfaces an end-event recap moment with the public /wiki link", async ({
+    page,
+  }) => {
+    await fulfillScratchNodePage(page);
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+
+    // Host publishes the wiki (the real success path) — should open the recap
+    // moment so they learn the public address, not just a toast.
+    await page.evaluate(() => (window as any).snPublishWiki());
+
+    const moment = page.locator("#wiki-live-moment");
+    await expect(moment).toHaveAttribute("data-open", "true", { timeout: 6_000 });
+    // HONESTY: the moment shows the REAL public /wiki/<slug> URL (never fabricated).
+    const link = await page.locator("#wiki-live-input").inputValue();
+    expect(link).toMatch(/\/wiki\/[a-z0-9-]+$/i);
+    await expect(moment).toContainText("Your wiki is live");
+    await expect(moment).toContainText("the room remembers everything");
+    // It was a confirmed publish — the backend mutation actually ran.
+    const published = await page.evaluate(() => (window as any).__snPublishWikiArgs);
+    expect(published).toBeTruthy();
+
+    // The recap is honest about state — the apex/room never falsely flips to a fake value.
+    await page.evaluate(() => (window as any)._snWikiMomentClose());
+    await expect(moment).toHaveAttribute("data-open", "false");
   });
 });


### PR DESCRIPTION
@
## Why
Closes the **activation** gap in the after-event loop. A host could publish the wiki (the [`/wiki/<slug>` reader](https://github.com/HomenShum/nodebench-ai/pull/487) shipped earlier today), but publishing only fired a toast — the host never learned the **public address existed**, so the artifact that pulls people in *after* the event never circulated.

## What
A confirmed `events:publishWiki` now opens a recap moment (reusing the post-create share-moment + invite-card styling):
- **"Your wiki is live."** + a screenshot-worthy invite card: brand · event name · **QR** · `scratchnode.live/wiki/<slug>` · *"the room remembers everything"*.
- A copy-able link, native **Share** when available, and **Open the wiki →**.
- `_snShowWikiLiveMoment(slug, name)` fires **only** from the confirmed publish path — HONESTY: only ever the real published URL, never speculative; read-only (`data-sn-live` untouched). Escape / Done closes it; reuses the existing `_shareCopy` plumbing.

## Tests
New honesty case: publish → recap moment opens with a **real** `/wiki/<slug>` URL, the backend mutation actually ran, Done closes it. Plus a scope fix to the create-moment test (both moments now share `.share-moment*`/`.invite-card*` classes, so its selectors are scoped to `#share-moment`). **21/21 chromium honesty + output-contract green**; recap moment screenshot-verified.

## Route-first
The wiki readers "Continue in NodeBench" CTA is **not** here — it ships once the [`/events/:slug/wiki` receiving route (#489)](https://github.com/HomenShum/nodebench-ai/pull/489) is live, so it can never dead-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@