### PR TITLE
fix(scratchnode): stop the 4 Continue-in-NodeBench CTAs from 404ing (honesty)

### DIFF
--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -2,6 +2,29 @@
 
 Append-only lane for the ScratchNode live-event prototype and production static surface.
 
+## 2026-06-03 — Honesty: stop the 4 "Continue in NodeBench" CTAs from 404'ing
+A scoping audit caught a live HONEST_STATUS lie: **four** in-room CTAs ("Continue in
+NodeBench", "Open in NodeBench", "Open NodeBench event notebook", "Continue this event
+in NodeBench") all funnel through `openNodeBenchPrivateHandoff` →
+`buildNodeBenchEventPrivateUrl`, which built `nodebenchai.com/events/<slug>/private` —
+a route that **does not exist** (the `/events` matcher rejects trailing segments), wrapped
+in `/sign-in?return=<that dead route>`. Every one of them 404'd in production.
+
+Interim honest fix (one function repoints all four): `buildNodeBenchEventPrivateUrl` now
+targets the **already-shipped** `/scratchnode-events` surface — an honest landing that
+resolves the session or shows its own sign-in prompt, never a 404 — and
+`openNodeBenchPrivateHandoff` navigates straight there (no dead `/sign-in` wrapper). The
+event context (`event`, `room`, `continuation=private-notes`, `publicArtifact=event-wiki`,
+`return`) still rides along so the *real* tokenized private route can consume it once the
+cross-domain handoff-token bridge ships. The in-page QA check `SN-LIVE-015` was updated to
+assert the shipped target (and that the dead `/events/<slug>/private` shape is gone).
+
+Covered by a new honesty case (the handoff URL targets `/scratchnode-events`, never
+`/events/<slug>/private`, and still carries continuation context). 24/24 chromium honesty
++ output-contract green.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.
+
 ## 2026-06-03 — End-event recap moment: "Your wiki is live. Share the memory."
 Closes the activation gap in the *after-event* loop. The host could publish the wiki
 (`/wiki/<slug>` reader shipped earlier the same day), but publishing only fired a

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -3920,8 +3920,16 @@ function buildNodeBenchEventPrivateUrl() {
     var room = getRoomContext();
     roomCode = (room && room.roomCode) || roomCode;
   } catch (e) {}
+  // INTERIM (honesty): the cross-domain `/events/<slug>/private` receiving route
+  // + its handoff token don't exist yet (that's the gated cross-domain bridge
+  // follow-up). Pointing here previously produced a hard 404. Until the real
+  // tokenized private route ships, target the ALREADY-SHIPPED `/scratchnode-events`
+  // surface — an honest landing (it resolves session / shows a sign-in prompt),
+  // never a 404. The event context rides along so the real private route can
+  // consume it once built.
   return WORKSPACE_BASE_URL +
-    '/events/' + encodeURIComponent(EVENT_SLUG) + '/private?source=scratchnode' +
+    '/scratchnode-events?source=scratchnode' +
+    '&event=' + encodeURIComponent(EVENT_SLUG) +
     '&room=' + encodeURIComponent(roomCode) +
     '&continuation=' + encodeURIComponent('private-notes') +
     '&noteCount=' + encodeURIComponent(String(getPrivateNoteHandoffCount())) +
@@ -3937,7 +3945,10 @@ function buildNodeBenchSignInUrl(targetUrl) {
 function openNodeBenchPrivateHandoff() {
   closeMenu();
   closeSheet();
-  window.location.assign(buildNodeBenchSignInUrl(buildNodeBenchEventPrivateUrl()));
+  // Navigate straight to the shipped `/scratchnode-events` surface — it resolves
+  // session / shows its own sign-in prompt. (Previously wrapped a dead
+  // `/events/<slug>/private` target in `/sign-in?return=…`, which 404'd.)
+  window.location.assign(buildNodeBenchEventPrivateUrl());
 }
 
 // ── Debug-gate flag for prototype helpers ──
@@ -10338,8 +10349,8 @@ window._laCueAction       = _laCueAction;
     add('SN-LIVE-013', 'share URL uses scratchnode.live-compatible public event URL', /\/e\//.test(EVENT_URL) && !/scratchnode\.com/i.test(EVENT_URL), EVENT_URL);
     fromDemo('DEMO-014', 'SN-LIVE-014', 'guest can sign in and preserve notes');
     var handoffUrl = buildNodeBenchEventPrivateUrl();
-    add('SN-LIVE-015', 'NodeBench handoff carries event + private-note continuation context',
-      /nodebenchai\.com/.test(handoffUrl) && /\/events\//.test(handoffUrl) && /continuation=private-notes/.test(handoffUrl) && /publicArtifact=event-wiki/.test(handoffUrl),
+    add('SN-LIVE-015', 'NodeBench handoff targets a SHIPPED route (no 404) + carries event continuation context',
+      /nodebenchai\.com/.test(handoffUrl) && /\/scratchnode-events/.test(handoffUrl) && !/\/events\/[^/]+\/private/.test(handoffUrl) && /continuation=private-notes/.test(handoffUrl) && /publicArtifact=event-wiki/.test(handoffUrl),
       handoffUrl);
     var passed = results.filter(function(r) { return r.pass; }).length;
     var failed = results.length - passed;

--- a/tests/e2e/scratchnode-live-route-honesty.spec.ts
+++ b/tests/e2e/scratchnode-live-route-honesty.spec.ts
@@ -779,4 +779,21 @@ test.describe("ScratchNode live route honesty", () => {
     await page.evaluate(() => (window as any)._snWikiMomentClose());
     await expect(moment).toHaveAttribute("data-open", "false");
   });
+
+  test("NodeBench handoff CTAs target a SHIPPED route, never the dead /events/<slug>/private (no 404)", async ({
+    page,
+  }) => {
+    await fulfillScratchNodePage(page);
+    await page.goto("https://scratchnode.live/e/orbital", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("body")).toHaveAttribute("data-sn-live", "true");
+
+    // The handoff URL must point at the EXISTING /scratchnode-events surface, not
+    // the route that 404s. Carries event context for the future tokenized route.
+    const url = await page.evaluate(() => (window as any).buildNodeBenchEventPrivateUrl());
+    expect(url).toContain("nodebenchai.com");
+    expect(url).toContain("/scratchnode-events");
+    expect(url).not.toMatch(/\/events\/[^/]+\/private/);
+    expect(url).toContain("continuation=private-notes");
+    expect(url).toContain("publicArtifact=event-wiki");
+  });
 });


### PR DESCRIPTION
@
## Why
The deeper-follow-up scoping audit caught a **live HONEST_STATUS lie**: four in-room CTAs ("Continue in NodeBench", "Open in NodeBench", "Open NodeBench event notebook", "Continue this event in NodeBench") all funnel through `openNodeBenchPrivateHandoff` → `buildNodeBenchEventPrivateUrl`, which built `nodebenchai.com/events/<slug>/private` — a route that **does not exist** (the `/events` matcher rejects trailing segments), wrapped in `/sign-in?return=<dead route>`. **All four 404d in production.**

## What (interim honest fix — one function repoints all four)
- `buildNodeBenchEventPrivateUrl` now targets the **already-shipped** `/scratchnode-events` surface — an honest landing (resolves session / shows its own sign-in prompt), never a 404.
- `openNodeBenchPrivateHandoff` navigates straight there (drops the dead `/sign-in` wrapper).
- The event context (`event`, `room`, `continuation=private-notes`, `publicArtifact=event-wiki`, `return`) still rides along so the **real tokenized private route** can consume it once the cross-domain handoff-token bridge ships (the gated follow-up).
- In-page QA check `SN-LIVE-015` updated to assert the shipped target + that the dead `/events/<slug>/private` shape is gone.

## Test
New honesty case: the handoff URL targets `/scratchnode-events`, **never** `/events/<slug>/private`, and still carries continuation context. **24/24 chromium honesty + output-contract green.**

This is item #1 (the quick honest win) from the deeper-follow-ups roadmap; the real cross-domain private-notes bridge (opaque stateful token) is the gated follow-up that will repoint these to the tokenized `/events/<slug>/private` route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@