### PR TITLE
feat(scratchnode): re-add wiki Continue-in-NodeBench CTA (route now real)

### DIFF
--- a/CHANGELOG/pages/proto-home-v5.md
+++ b/CHANGELOG/pages/proto-home-v5.md
@@ -2,6 +2,19 @@
 
 Append-only lane for the ScratchNode live-event prototype and production static surface.
 
+## 2026-06-03 — Re-add the wiki reader's "Continue in NodeBench" CTA (route now real)
+The public `/wiki/<slug>` reader shipped WITHOUT a "Continue in NodeBench" CTA because
+its receiving route (`nodebenchai.com/events/<slug>/wiki`) 404'd at the time. PR-D built
+that route (and the coordination ledger now lists it as the canonical NodeBench public
+receiver), so the CTA is safe to add — it can no longer dead-end. `_snRenderWiki` re-adds
+a ghost `Continue in NodeBench ↗` CTA in the footer pointing at
+`nodebenchai.com/events/<eventSlug>/wiki?source=scratchnode&room=<code>&publicArtifact=event-wiki`.
+Frontend-only (Vercel), independent of the Convex deploy incident. The wiki e2e flips from
+asserting the CTA's *absence* to asserting it targets the real route with attribution.
+3/3 wiki spec green.
+
+**Commit**: `this commit`. **Author**: Homen Shum + Claude.
+
 ## 2026-06-03 — In-room "invite more → richer wiki" memory nudge
 The viral framing ("the room becomes the memory") only appeared at create-time and in
 the publish recap — never *during* the live event, where the audit flagged it absent.

--- a/public/proto/home-v5.html
+++ b/public/proto/home-v5.html
@@ -3100,6 +3100,7 @@ function _snRenderWiki(wiki) {
     '<div class="sn-wiki__foot">' +
       '<div class="sn-wiki__foot-tag"><b>The room remembers everything.</b> This recap was built live with ScratchNode.</div>' +
       '<a class="sn-wiki__cta" href="/">Create your own room &rarr;</a>' +
+      '<a class="sn-wiki__cta sn-wiki__ghost" id="sn-wiki-nb" href="#">Continue in NodeBench &nearr;</a>' +
     '</div>';
   mainEl.querySelector('.sn-wiki__title').textContent = wiki.title || (wiki.eventName ? wiki.eventName + ' — wiki' : 'Event wiki');
   mainEl.querySelector('.sn-wiki__meta').textContent =
@@ -3108,10 +3109,16 @@ function _snRenderWiki(wiki) {
     (when ? ' · published ' + when : '');
   // bodyHtml is server-built + public-safe (private notes excluded at publish time).
   mainEl.querySelector('#sn-wiki-article').innerHTML = wiki.bodyHtml;
-  // NOTE: a "Continue in NodeBench" bridge CTA is intentionally NOT here yet — the
-  // nodebenchai.com/events/<slug>/wiki receiving route doesn't exist (the /events
-  // router rejects trailing segments), so a CTA would 404. It ships WITH its real
-  // receiving route so the link can never dead-end. See PR-D.
+  // The "Continue in NodeBench" CTA now points at the REAL receiving route
+  // (nodebenchai.com/events/<slug>/wiki, shipped in PR-D + confirmed canonical in the
+  // coordination ledger) — no longer a 404. Carries source/room for attribution.
+  var nb = document.getElementById('sn-wiki-nb');
+  if (nb) {
+    nb.href = 'https://nodebenchai.com/events/' +
+      encodeURIComponent(wiki.eventSlug || (window._sn_wiki && window._sn_wiki.slug) || '') +
+      '/wiki?source=scratchnode&room=' + encodeURIComponent(wiki.roomCode || '') +
+      '&publicArtifact=event-wiki';
+  }
 }
 
 function _snWikiShare() {

--- a/tests/e2e/scratchnode-public-wiki.spec.ts
+++ b/tests/e2e/scratchnode-public-wiki.spec.ts
@@ -94,9 +94,14 @@ test.describe("ScratchNode public /wiki/<slug> reader", () => {
     const createCta = page.locator('.sn-wiki__foot a.sn-wiki__cta', { hasText: "Create your own room" });
     await expect(createCta).toHaveAttribute("href", "/");
 
-    // HONESTY: no "Continue in NodeBench" CTA here — its receiving route doesn't
-    // exist yet (it would 404), so it ships WITH that route, not before it.
-    await expect(page.locator("#sn-wiki-nb")).toHaveCount(0);
+    // The "Continue in NodeBench" CTA now points at the REAL receiving route
+    // (PR-D's /events/<slug>/wiki) — no longer a 404 — carrying source attribution.
+    const nbCta = page.locator("#sn-wiki-nb");
+    await expect(nbCta).toHaveText(/Continue in NodeBench/);
+    const nbHref = await nbCta.getAttribute("href");
+    expect(nbHref).toContain("nodebenchai.com/events/rooftop-launch/wiki");
+    expect(nbHref).toContain("source=scratchnode");
+    expect(nbHref).toContain("publicArtifact=event-wiki");
 
     // The room shell must be hidden in wiki mode.
     await expect(page.locator("main.m")).toBeHidden();


### PR DESCRIPTION
@
Completes the bridge round-trip. The `/wiki/<slug>` reader shipped without a "Continue in NodeBench" CTA because the receiving route 404d at the time. [PR-D (#489)](https://github.com/HomenShum/nodebench-ai/pull/489) built that route (`nodebenchai.com/events/<slug>/wiki`, now the canonical NodeBench public receiver per the ledger), so the CTA can no longer dead-end.

`_snRenderWiki` re-adds a ghost `Continue in NodeBench` footer CTA → `nodebenchai.com/events/<eventSlug>/wiki?source=scratchnode&room=<code>&publicArtifact=event-wiki`. Frontend-only (Vercel) — independent of the open Convex deploy incident. Wiki e2e flips from asserting the CTA absence to asserting the real-route href + attribution. **3/3 wiki spec green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@