### PR TITLE
docs(governance): record DIRTY-drift lesson + mark scratchnode/002 shipping

### DIFF
--- a/goals/GOVERNANCE.md
+++ b/goals/GOVERNANCE.md
@@ -60,3 +60,26 @@ HIGH-risk no-autonomy zone, they are **proposed for founder approval** — see
 ## The governance sentence (operating rule, restated)
 Human sets the *why* + boundary and approves HIGH-risk merges. Agent self-directs the *how* inside a
 closed Goal Card. CI + evals + visual artifacts + GitHub rulesets decide what reaches `main`.
+
+## Operational lessons (from real loop runs — append-only)
+
+### 2026-06-03 — Open PRs go DIRTY while the loop keeps shipping; land or rebase within a day
+**What happened.** While the daily small-loop shipped ~10 changes to `public/proto/home-v5.html`,
+two reviewable PRs left open against it — #469 (host public-write verification) and the type-scale
+work (#499) — both went `DIRTY`/`CONFLICTING`. Squash-merges rewrote the base they branched from,
+so each intervening ship widened the gap. #469 could not be cleanly rebased and had to be **rebuilt
+fresh on current `main` as #500**; the type-scale work had to be re-landed via a clean cherry-pick.
+Recovery cost more than the original change.
+
+**Rule.** A PR that touches a hot file (`home-v5.html`, `convex/events.ts`, the honesty spec, the
+ScratchNode e2e specs) must be **landed or rebased within one working day**. If it is human-gated and
+can't land same-day, rebase it onto `main` daily (`git fetch && git merge origin/main` → re-run the
+oracle `home-v5-output-contract` + `scratchnode-live-route-honesty`) until it does — or **close it and
+re-cut from `main`** when the gate clears. Never let a reviewable PR sit behind multiple loop ships;
+the rebase cost grows superlinearly with each squash-merge.
+
+**Mechanic (≥2 PRs on the same hot file).** **Serialize.** `strict: true` branch protection makes the
+"behind main" ping-pong explicit: land one, then immediately `git merge origin/main` into the next,
+re-verify the oracle, push, let it merge. Update the loser the moment the winner lands — do not leave
+both armed-but-behind. (Both #499 and #500 went `BEHIND` the instant #496 merged; each needed a same-pass
+`merge origin/main` + oracle re-run + push to clear it.)

--- a/goals/scratchnode/002-host-public-write-verification.md
+++ b/goals/scratchnode/002-host-public-write-verification.md
@@ -5,7 +5,7 @@ falls back to `sessionId` (6377-6383), while the other 5 host mutations use the 
 `_snRequireVerifiedHostOwnerKey()` (6233) that returns null + a "Host verification required" toast.
 Make the two public-write actions consistent with the rest, and add a regression test.
 
-- **status:** proposed
+- **status:** shipping — **PR #500** (founder-approved "land #469"; CI-gated auto-merge under the HomenShum account, satisfying the host-action-gating HARD GATE). Rebuilt fresh on `main` after the original #469 went DIRTY. Verified: honesty 27/27 + output-contract green.
 - **surface:** scratchnode
 - **severity:** **P1** (NOT P0). **Verified:** the backend `requireHost` (`convex/events.ts:439`,
   called at 2626 + 2642) already rejects a bare `sessionId` server-side → **no public write occurs**.


### PR DESCRIPTION
## What

Records an operational lesson in `goals/GOVERNANCE.md` (new append-only **Operational lessons** section) from today's loop run, and updates `goals/scratchnode/002` status to reflect it shipped via #500.

## The lesson

While the daily small-loop shipped ~10 changes to `public/proto/home-v5.html`, two reviewable PRs left open against it — #469 (host public-write) and the type-scale work (#499) — both went **DIRTY/CONFLICTING**. Squash-merges rewrote their base; each intervening ship widened the gap. #469 had to be **rebuilt fresh on current main as #500**.

**Rule codified:** land or rebase any PR touching a hot file (`home-v5.html`, `convex/events.ts`, honesty spec, ScratchNode e2e specs) **within one working day**; if human-gated, rebase onto main daily + re-run the oracle until it lands, or close + re-cut from main. **Serialize** ≥2 PRs on the same hot file — `strict: true` makes the 'behind main' ping-pong explicit (both #499 and #500 went BEHIND the instant #496 merged).

Docs-only. LOW risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)