### PR TITLE
fix(schema): allow spreadsheetEvents.operation row_delta to unblock prod Convex deploy

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4969,6 +4969,11 @@ export default defineSchema({
       v.literal("apply_formula"),
       v.literal("add_sheet"),
       v.literal("rename_sheet"),
+      // Forward-ported from PR #498 (spreadsheets applyRowDelta) to unblock prod:
+      // an out-of-band write to shared prod created a spreadsheetEvents doc with
+      // operation "row_delta" before #498's schema addition merged, so every
+      // `convex deploy` failed schema validation. Additive/expand — non-destructive.
+      v.literal("row_delta"),
     ),
     targetRange: v.optional(v.string()), // A1 notation (e.g., "A1:B5")
     payload: v.any(), // Operation-specific data (before/after)


### PR DESCRIPTION
## P0 — production deploys broken since ~18:37 UTC

`vercel-build.sh` runs `convex deploy` on every production build. It has been **failing schema validation**:

```
Schema validation failed. Document in table spreadsheetEvents does not match: Path: .operation
Value: "row_delta"
Validator: v.union(set_cell, insert_row, delete_row, add_column, delete_column, apply_formula, add_sheet, rename_sheet)
Error: Command "bash scripts/vercel-build.sh" exited with 1
```

The live CDN is serving bytes from the last *successful* deploy (`Last-Modified 18:37`, ~3.7h stale). **Everything merged since 18:37 — #496, #497, #500 (host-write security), #501, #499 (type-scale) — is NOT live.**

## Root cause

`row_delta` is a legitimate operation introduced by **PR #498** (`spreadsheets.ts applyRowDelta` + schema literal + test). That feature was run against **shared prod Convex out-of-band** (the AGENT_COORDINATION hazard), writing a `spreadsheetEvents` doc with `operation: "row_delta"` — but #498's schema addition never reached `main`, so main's validator rejects the doc and blocks all deploys.

## Fix

Forward-port the exact literal #498 adds: `v.literal("row_delta")` into main's union. **Additive / expand pattern** — non-destructive, reversible, zero conflict when #498 merges (same line). Direct precedent: #477 'tolerate lastActivityAt'.

## Verification plan
- CI green (preview Convex deployment has no stray doc, so it always passed — which is why this slipped past CI).
- **Real proof:** the post-merge production Convex deploy validates the stray doc and succeeds → live URL flips to the new bytes. I'll live-DOM verify after merge.

## Follow-ups (flagged, not in this PR)
- The stray prod doc + the out-of-band-write that created it should be reviewed (founder): either let #498 land (brings the emitting code) or clean the doc + contract the literal.
- AGENT_COORDINATION reminder: never run `convex dev`/deploy against shared prod from a feature worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)