### PR TITLE
fix(schema): allow spreadsheetEvents.operation row_delta to unblock prod deploys

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4969,6 +4969,14 @@ export default defineSchema({
       v.literal("apply_formula"),
       v.literal("add_sheet"),
       v.literal("rename_sheet"),
+      // Additive expand to unblock prod: a shared-prod spreadsheetEvents doc carries
+      // operation "row_delta" (written out-of-band from the unmerged applyRowDelta
+      // feature, commit 8e58a265), so `convex deploy --typecheck=enable` fails
+      // schema-vs-data validation and aborts EVERY production deploy. Adding the
+      // literal makes the stray doc valid without mutating prod data (backfill-safe,
+      // reversible). Follow-up: constrain storeSpreadsheetEvent's v.any() seam
+      // (audit P1-2) so the class can't recur, then land/retire the feature.
+      v.literal("row_delta"),
     ),
     targetRange: v.optional(v.string()), // A1 notation (e.g., "A1:B5")
     payload: v.any(), // Operation-specific data (before/after)


### PR DESCRIPTION
## P0 — production deploy pipeline down ~6h (founder-approved Option A)

`scripts/vercel-build.sh` runs `convex deploy --typecheck=enable` (fail-closed, `set -euo pipefail`) **before** the build. It fails schema-vs-data validation because a **shared-prod `spreadsheetEvents` doc carries `operation: "row_delta"`** — a value not in the 8-literal union (`convex/schema.ts:4963`). So every Production deploy aborts; ~6h of merged work (incl. #500 host-write security, #499 type-scale) is NOT live (12 consecutive prod deploys ● Error).

`row_delta` appears **nowhere in main source** (`git grep = 0`) — it's stale data written out-of-band from the unmerged `applyRowDelta` feature (`8e58a265`), an inverted expand-contract (writer reached prod before reader reached main).

## Fix
Additive `v.literal("row_delta")` expand. **Backfill-safe** (the stray doc becomes valid with no prod-data mutation), reversible. This is the re-cut of closed-unmerged #502 the NodeBench audit recommended, now founder-approved.

## After merge
Prod `convex deploy` validates → the deploy pipeline flips ● Ready and the ~6h backlog ships. I'll live-verify prod recovers.

## Follow-ups (not in this PR — tracked from the audit)
- P1-2: constrain `storeSpreadsheetEvent`'s `v.any()` seam so the class can't recur.
- Add a CI `convex deploy --dry-run` schema-vs-data gate so this fails a PR, not prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)